### PR TITLE
[misp] added config switch to disable tag removal.

### DIFF
--- a/misp/config.json
+++ b/misp/config.json
@@ -22,6 +22,11 @@
 			"description": "Tag for events that have to be imported",
 			"default": ""
 		},
+		"untag_event": {
+			"type": "switch",
+			"description": "Remove the tag given above from the event",
+			"default": true
+		},
 		"cron": {
 			"type": "select",
 			"multiple": false,

--- a/misp/misp.py
+++ b/misp/misp.py
@@ -78,7 +78,8 @@ class Misp:
                     self.process_attribute(report_id, author_id, event_threats, event_markings, attribute)
 
             self.misp.tag(event['Event']['uuid'], 'OpenCTI: Imported')
-            self.misp.untag(event['Event']['uuid'], self.config['misp']['tag'])
+            if self.config['misp']['untag_event']:
+                self.misp.untag(event['Event']['uuid'], self.config['misp']['tag'])
 
     def process_attribute(self, report_id, author_id, event_threats, event_markings, attribute):
         type = self.resolve_type(attribute['type'], attribute['value'])


### PR DESCRIPTION
This allows to disable the removal of OpenCTI import tags.