### PR TITLE
Use tag given in the config instead of a hardcoded one for searching events

### DIFF
--- a/misp/misp.py
+++ b/misp/misp.py
@@ -34,7 +34,7 @@ class Misp:
 
     def run(self):
         added_threats = []
-        result = self.misp.search('events', tags=['OpenCTI: Import'])
+        result = self.misp.search('events', tags=[self.config['misp']['tag']])
         for event in result['response']:
             # Default values
             author = Identity(name=event['Event']['Orgc']['name'], identity_class='organization')


### PR DESCRIPTION
The latest commit uses the hardcoded "OpenCTI: Import" tag for searching events in MISP instead of the tag given in the config.