### PR TITLE
Add hygiene connector

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ jobs:
           name: Build Docker image opencti/connector-export-file-csv
           command: docker build -t opencti/connector-export-file-csv:latest . && docker tag opencti/connector-export-file-csv:latest opencti/connector-export-file-csv:${CIRCLE_TAG}
       - run:
+          working_directory: ~/opencti/hygiene
+          name: Build Docker image opencti/connector-hygiene
+          command: docker build -t opencti/connector-hygiene:latest . && docker tag opencti/connector-hygiene:latest opencti/connector-hygiene:${CIRCLE_TAG}
+      - run:
           working_directory: ~/opencti/alienvault
           name: Build Docker image opencti/connector-alienvault
           command: docker build -t opencti/connector-alienvault:latest . && docker tag opencti/connector-alienvault:latest opencti/connector-alienvault:${CIRCLE_TAG}
@@ -47,7 +51,7 @@ jobs:
       - run:
           working_directory: ~/opencti/mitre
           name: Build Docker image opencti/connector-mitre
-          command: docker build -t opencti/connector-mitre:latest . && docker tag opencti/connector-mitre:latest opencti/connector-mitre:${CIRCLE_TAG}          
+          command: docker build -t opencti/connector-mitre:latest . && docker tag opencti/connector-mitre:latest opencti/connector-mitre:${CIRCLE_TAG}
       - run:
           working_directory: ~/opencti/opencti
           name: Build Docker image opencti/connector-opencti
@@ -80,6 +84,8 @@ jobs:
             docker push opencti/connector-export-file-stix:${CIRCLE_TAG}
             docker push opencti/connector-export-file-csv:latest
             docker push opencti/connector-export-file-csv:${CIRCLE_TAG}
+            docker push opencti/connector-hygiene:latest
+            docker push opencti/connector-hygiene:${CIRCLE_TAG}
             docker push opencti/connector-alienvault:latest
             docker push opencti/connector-alienvault:${CIRCLE_TAG}
             docker push opencti/connector-crowdstrike:latest
@@ -125,6 +131,10 @@ jobs:
           working_directory: ~/opencti/export-file-csv
           name: Build Docker image opencti/connector-export-file-csv
           command: docker build -t opencti/connector-export-file-csv:rolling .
+      - run:
+          working_directory: ~/opencti/hygiene
+          name: Build Docker image opencti/connector-hygiene
+          command: docker build -t opencti/connector-hygiene:rolling .
       - run:
           working_directory: ~/opencti/alienvault
           name: Build Docker image opencti/connector-alienvault
@@ -177,6 +187,7 @@ jobs:
             docker push opencti/connector-import-file-pdf-observables:rolling
             docker push opencti/connector-export-file-stix:rolling
             docker push opencti/connector-export-file-csv:rolling
+            docker push opencti/connector-hygiene:rolling
             docker push opencti/connector-alienvault:rolling
             docker push opencti/connector-crowdstrike:rolling
             docker push opencti/connector-cryptolaemus:rolling

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 __pycache__
 *.log
 *.iml

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ The following repository is used to store the OpenCTI connectors for the platfor
 
 ### Internal enrichment connectors
 
-| Connector                         | Description                                                 | Status                    | Last version                    |
-| ----------------------------------|-------------------------------------------------------------|---------------------------|---------------------------------|
-| [IpInfo](ipinfo)                  | Enrich IP addresses with geolocation                        | Released                  | 3.1.0                           |
-| [VirusTotal](virustotal)          | Enrich file hashes with corresponding hashes and file names | Released                  | 3.1.0                           |
-| [Hygiene](hygiene)                | Add hygiene tags to observables that are on warning-lists   | In development            | -                               |
+| Connector                         | Description                                                        | Status                    | Last version                    |
+| ----------------------------------|--------------------------------------------------------------------|---------------------------|---------------------------------|
+| [IpInfo](ipinfo)                  | Enrich IP addresses with geolocation                               | Released                  | 3.1.0                           |
+| [VirusTotal](virustotal)          | Enrich file hashes with corresponding hashes and file names        | Released                  | 3.1.0                           |
+| [Hygiene](hygiene)                | Add hygiene information to observables that are on warning-lists   | In development            | -                               |
 
 ### Internal export files connectors
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The following repository is used to store the OpenCTI connectors for the platfor
 
 ## Connectors list and statuses
 
-### External import connectors 
+### External import connectors
 
 | Connector                               | Description                                   | Status                    | Last version                    |
 | ----------------------------------------|-----------------------------------------------|---------------------------|---------------------------------|
@@ -36,6 +36,7 @@ The following repository is used to store the OpenCTI connectors for the platfor
 | ----------------------------------|-------------------------------------------------------------|---------------------------|---------------------------------|
 | [IpInfo](ipinfo)                  | Enrich IP addresses with geolocation                        | Released                  | 3.1.0                           |
 | [VirusTotal](virustotal)          | Enrich file hashes with corresponding hashes and file names | Released                  | 3.1.0                           |
+| [Hygiene](hygiene)                | Add hygiene tags to observables that are on warning-lists   | In development            | -                               |
 
 ### Internal export files connectors
 

--- a/hygiene/.dockerignore
+++ b/hygiene/.dockerignore
@@ -1,0 +1,4 @@
+src/config.yml
+src/__pycache__
+src/logs
+src/*.gql

--- a/hygiene/.gitignore
+++ b/hygiene/.gitignore
@@ -1,0 +1,4 @@
+config.yml
+__pycache__
+logs
+*.gql

--- a/hygiene/Dockerfile
+++ b/hygiene/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.7.4-alpine3.10
+
+# Copy the worker
+COPY src /opt/opencti-connector-hygiene
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk --no-cache add git build-base libmagic && \
+    cd /opt/opencti-connector-hygiene && \
+    pip3 install --no-cache-dir git+https://github.com/OpenCTI-Platform/client-python@master && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/hygiene/Dockerfile
+++ b/hygiene/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the worker
 COPY src /opt/opencti-connector-hygiene

--- a/hygiene/Readme.md
+++ b/hygiene/Readme.md
@@ -7,6 +7,15 @@ detection:
 
 * [misp-warninglists](https://github.com/MISP/misp-warninglists)
 
+The connector works for the following OpenCTI observable types:
+
+* ipv4-addr
+* ipv6-addr
+* domain
+* file-md5
+* file-sha1
+* file-sha256
+
 ## Installation
 
 Enabling this connector could be done by launching the Python process directly

--- a/hygiene/Readme.md
+++ b/hygiene/Readme.md
@@ -33,4 +33,4 @@ No special configuration is needed.
 ## Behavior
 
 1. Adds a `Hygiene` tag on items that correspond to a warning list entry.
-2. Adds an external reference that points to the warning list.
+2. Adds an external reference for every matching warning list.

--- a/hygiene/Readme.md
+++ b/hygiene/Readme.md
@@ -32,5 +32,5 @@ No special configuration is needed.
 
 ## Behavior
 
-The connector adds a `Hygiene:$Info` tag on items that correspond to a warning
-list entry.
+1. Adds a `Hygiene` tag on items that correspond to a warning list entry.
+2. Adds an external reference that points to the warning list.

--- a/hygiene/Readme.md
+++ b/hygiene/Readme.md
@@ -1,0 +1,27 @@
+# OpenCTI Hygiene Connector
+
+this is an internal enrichment connector that uses the following external
+projects to look for oberservable values in the database that you might want to
+delete / decay because they are known to lead to alse-positives when used for
+detection:
+
+* [misp-warninglists](https://github.com/MISP/misp-warninglists)
+
+## Installation
+
+Enabling this connector could be done by launching the Python process directly
+after providing the correct configuration in the `config.yml` file or within a
+Docker with the image `opencti/connector-hygiene:latest`.
+
+We provide an example of [`docker-compose.yml`](docker-compose.yml) file that
+could be used independently or integrated to the global `docker-compose.yml`
+file of OpenCTI.
+
+## Configuration
+
+No special configuration is needed.
+
+## Behavior
+
+The connector adds a `Hygiene:$Info` tag on items that correspond to a warning
+list entry.

--- a/hygiene/docker-compose.yml
+++ b/hygiene/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  connector-hygiene:
+    image: opencti/connector-hygiene:3.1.0
+    environment:
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=ChangeMe
+      - CONNECTOR_ID=ChangeMe
+      - CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+      - CONNECTOR_NAME=Hygiene
+      - CONNECTOR_SCOPE='ipv4-addr,ipv6-addr,domain'
+      - CONNECTOR_CONFIDENCE_LEVEL=3
+      - CONNECTOR_LOG_LEVEL=info
+    restart: always

--- a/hygiene/docker-compose.yml
+++ b/hygiene/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - CONNECTOR_ID=ChangeMe
       - CONNECTOR_TYPE=INTERNAL_ENRICHMENT
       - CONNECTOR_NAME=Hygiene
-      - CONNECTOR_SCOPE='ipv4-addr,ipv6-addr,domain'
+      - CONNECTOR_SCOPE='ipv4-addr,ipv6-addr,domain,file-md5,file-sha1,file-sha256'
       - CONNECTOR_CONFIDENCE_LEVEL=3
       - CONNECTOR_LOG_LEVEL=info
     restart: always

--- a/hygiene/docker-compose.yml
+++ b/hygiene/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - CONNECTOR_ID=ChangeMe
       - CONNECTOR_TYPE=INTERNAL_ENRICHMENT
       - CONNECTOR_NAME=Hygiene
-      - CONNECTOR_SCOPE='ipv4-addr,ipv6-addr,domain,file-md5,file-sha1,file-sha256'
+      - CONNECTOR_SCOPE=ipv4-addr,ipv6-addr,domain,file-md5,file-sha1,file-sha256
       - CONNECTOR_CONFIDENCE_LEVEL=3
       - CONNECTOR_LOG_LEVEL=info
     restart: always

--- a/hygiene/entrypoint.sh
+++ b/hygiene/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Go to the right directory
+cd /opt/opencti-connector-hygiene
+
+# Launch the worker
+python3 hygiene.py

--- a/hygiene/src/config.yml.sample
+++ b/hygiene/src/config.yml.sample
@@ -6,6 +6,6 @@ connector:
   id: 'ChangeMe'
   type: 'INTERNAL_ENRICHMENT'
   name: 'Hygiene'
-  scope: 'ipv4-addr,ipv6-addr,domain'
+  scope: 'ipv4-addr,ipv6-addr,domain,file-md5,file-sha1,file-sha256'
   confidence_level: 3
   log_level: 'info'

--- a/hygiene/src/config.yml.sample
+++ b/hygiene/src/config.yml.sample
@@ -1,0 +1,11 @@
+opencti:
+  url: 'http://localhost:8080'
+  token: 'ChangeMe'
+
+connector:
+  id: 'ChangeMe'
+  type: 'INTERNAL_ENRICHMENT'
+  name: 'Hygiene'
+  scope: 'ipv4-addr,ipv6-addr,domain'
+  confidence_level: 3
+  log_level: 'info'

--- a/hygiene/src/hygiene.py
+++ b/hygiene/src/hygiene.py
@@ -50,7 +50,9 @@ class HygieneConnector:
 
         # Check for supported types
         observable_type = observable["entity_type"]
-        if "ipv4-addr" or "ipv6-addr" or "domain" in observable_type:
+        supported_types = ['ipv4-addr','ipv6-addr','domain','file-md5','file-sha1','file-sha256']
+
+        if any(word in observable_type for word in supported_types):
             return self._process_observable(observable)
 
     # Start the main loop

--- a/hygiene/src/hygiene.py
+++ b/hygiene/src/hygiene.py
@@ -1,0 +1,65 @@
+import yaml
+import os
+import json
+
+from pymispwarninglists import WarningLists
+from stix2 import Relationship, Identity, Bundle
+from pycti import OpenCTIConnectorHelper, get_config_variable
+
+
+class HygieneConnector:
+    def __init__(self):
+        # Instantiate the connector helper from config
+        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
+        config = (
+            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
+            if os.path.isfile(config_file_path)
+            else {}
+        )
+        self.helper = OpenCTIConnectorHelper(config)
+        self.warninglists = WarningLists()
+
+    def _process_observable(self, observable):
+        # Extract IPv4, IPv6 and Domain from entity data
+        observable_value = observable["observable_value"]
+
+        # Search in warninglist
+        r = self.warninglists.search(observable_value)
+
+        # Iterate over the hits
+        if r:
+            self.helper.log_info(
+                "Hit found for %s in warninglists" % (observable_value)
+            )
+
+            for hit in r:
+                self.helper.log_info(
+                    " %s %s %s %s" % (hit.type, hit.name, hit.version, hit.description)
+                )
+                # Create Hygiene Tag
+                tag_hygiene = self.helper.api.tag.create(
+                    tag_type="Hygiene", value="Hygiene:" + hit.name, color="#fc0341",
+                )
+
+                self.helper.api.stix_entity.add_tag(
+                    id=observable, tag_id=tag_hygiene["id"]
+                )
+            return ["observable value found on warninglist and tagged accordingly"]
+
+    def _process_message(self, data):
+        entity_id = data["entity_id"]
+        observable = self.helper.api.stix_observable.read(id=entity_id)
+
+        # Check for supported types
+        observable_type = observable["entity_type"]
+        if "ipv4-addr" or "ipv6-addr" or "domain" in observable_type:
+            return self._process_observable(observable)
+
+    # Start the main loop
+    def start(self):
+        self.helper.listen(self._process_message)
+
+
+if __name__ == "__main__":
+    HygieneInstance = HygieneConnector()
+    HygieneInstance.start()

--- a/hygiene/src/hygiene.py
+++ b/hygiene/src/hygiene.py
@@ -50,7 +50,14 @@ class HygieneConnector:
 
         # Check for supported types
         observable_type = observable["entity_type"]
-        supported_types = ['ipv4-addr','ipv6-addr','domain','file-md5','file-sha1','file-sha256']
+        supported_types = [
+            "ipv4-addr",
+            "ipv6-addr",
+            "domain",
+            "file-md5",
+            "file-sha1",
+            "file-sha256",
+        ]
 
         if any(word in observable_type for word in supported_types):
             return self._process_observable(observable)

--- a/hygiene/src/hygiene.py
+++ b/hygiene/src/hygiene.py
@@ -4,6 +4,65 @@ import yaml
 from pymispwarninglists import WarningLists
 from pycti import OpenCTIConnectorHelper
 
+# At the moment it is not possible to map lists to their upstream path.
+# Thus we need to have our own mapping here.
+# Reference: https://github.com/MISP/misp-warninglists/issues/142
+LIST_MAPPING = {
+    "List of known gmail sending IP ranges": "/lists/google-gmail-sending-ips/list.json",
+    "List of known domains to know external IP": "/lists/whats-my-ip/list.json",
+    "Top 500 domains and pages from https://moz.com/top500": "/lists/moz-top500/list.json",
+    "List of known Windows 10 connection endpoints": "/lists/microsoft-win10-connection-endpoints/list.json",
+    "List of known security providers/vendors blog domain": "/lists/security-provider-blogpost/list.json",
+    "List of known hashes with common false-positives (based on Florian Roth input list)": "/lists/common-ioc-false-positive/list.json",
+    "Specialized list of IPv4 addresses belonging to common VPN providers and datacenters": "/lists/vpn-ipv4/list.json",
+    "List of known Office 365 IP address ranges in China": "/lists/microsoft-office365-cn/list.json",
+    "List of RFC 5735 CIDR blocks": "/lists/rfc5735/list.json",
+    "List of RFC 5771 multicast CIDR blocks": "/lists/multicast/list.json",
+    "CRL Warninglist": "/lists/crl-ip-hostname/list.json",
+    "List of RFC 1918 CIDR blocks": "/lists/rfc1918/list.json",
+    "Top 1000 website from Alexa": "/lists/alexa/list.json",
+    "List of known Office 365 URLs address ranges": "/lists/microsoft-office365/list.json",
+    "List of known bank domains": "/lists/bank-website/list.json",
+    "List of known IPv6 public DNS resolvers": "/lists/public-dns-v6/list.json",
+    "List of known google domains": "/lists/google/list.json",
+    "List of known microsoft domains": "/lists/microsoft/list.json",
+    "List of known Ovh Cluster IP": "/lists/ovh-cluster/list.json",
+    "List of known domains used by automated malware analysis services & security vendors": "/lists/automated-malware-analysis/list.json",
+    "List of known Cloudflare IP ranges": "/lists/cloudflare/list.json",
+    "List of known hashes for empty files": "/lists/empty-hashes/list.json",
+    "Common contact e-mail addresses": "/lists/common-contact-emails/list.json",
+    "Fingerprint of trusted CA certificates": "/lists/mozilla-CA/list.json",
+    "Covid-19 Cyber Threat Coalition's Whitelist": "/lists/covid-19-cyber-threat-coalition-whitelist/list.json",
+    "List of known Akamai IP ranges": "/lists/akamai/list.json",
+    "Specialized list of IPv6 addresses belonging to common VPN providers and datacenters": "/lists/vpn-ipv6/list.json",
+    "List of known Microsoft Azure Datacenter IP Ranges": "/lists/microsoft-azure/list.json",
+    "List of IPv6 link local blocks": "/lists/ipv6-linklocal/list.json",
+    "List of known public DNS resolvers expressed as hostname": "/lists/public-dns-hostname/list.json",
+    "Top 1000 website from Cisco Umbrella": "/lists/cisco_top1000/list.json",
+    "List of hashes for EICAR test virus": "/lists/eicar.com/list.json",
+    "University domains": "/lists/university_domains/list.json",
+    "List of known Office 365 IP address ranges": "/lists/microsoft-office365-ip/list.json",
+    "List of known Amazon AWS IP address ranges": "/lists/amazon-aws/list.json",
+    "List of known Googlebot IP ranges": "/lists/googlebot/list.json",
+    "TLDs as known by IANA": "/lists/tlds/list.json",
+    "List of RFC 3849 CIDR blocks": "/lists/rfc3849/list.json",
+    "List of known Office 365 Attack Simulator used for phishing awareness campaigns": "/lists/microsoft-attack-simulator/list.json",
+    "List of RFC 6761 Special-Use Domain Names": "/lists/rfc6761/list.json",
+    "List of RFC 6598 CIDR blocks": "/lists/rfc6598/list.json",
+    "List of known IPv4 public DNS resolvers": "/lists/public-dns-v4/list.json",
+    "List of known dax30 webpages": "/lists/dax30/list.json",
+    "List of disposable email domains": "/lists/disposable-email/list.json",
+    "Top 1,000,000 most-used sites from Tranco": "/lists/tranco/list.json",
+    "Valid covid-19 related domains": "/lists/covid/list.json",
+    "Top 10K websites from Majestic Million": "/lists/majestic_million/list.json",
+    "List of known URL Shorteners domains": "/lists/url-shortener/list.json",
+    "Covid-19 Krassi's Whitelist": "/lists/covid-19-krassi-whitelist/list.json",
+    "List of known Wikimedia address ranges": "/lists/wikimedia/list.json",
+    "List of known sinkholes": "/lists/sinkholes/list.json",
+    "Second level TLDs as known by Mozilla Foundation": "/lists/second-level-tlds/list.json",
+    "Fingerprint of known intermedicate of trusted certificates": "/lists/mozilla-IntermediateCA/list.json",
+}
+
 
 class HygieneConnector:
     def __init__(self):
@@ -48,7 +107,8 @@ class HygieneConnector:
                 # Create external references
                 external_reference_id = self.helper.api.external_reference.create(
                     source_name="misp-warninglist",
-                    url="https://github.com/MISP/misp-warninglists",
+                    url="https://github.com/MISP/misp-warninglists/tree/master"
+                    + LIST_MAPPING[hit.name],
                     external_id=hit.name,
                     description=hit.description,
                 )

--- a/hygiene/src/hygiene.py
+++ b/hygiene/src/hygiene.py
@@ -32,7 +32,8 @@ class HygieneConnector:
 
             for hit in result:
                 self.helper.log_info(
-                    " %s %s %s %s" % (hit.type, hit.name, hit.version, hit.description)
+                    "Type: %s | Name: %s | Version: %s | Descr: %s"
+                    % (hit.type, hit.name, hit.version, hit.description)
                 )
                 # Create Hygiene Tag
                 tag_hygiene = self.helper.api.tag.create(
@@ -40,27 +41,14 @@ class HygieneConnector:
                 )
 
                 self.helper.api.stix_entity.add_tag(
-                    id=observable['id'], tag_id=tag_hygiene["id"]
+                    id=observable["id"], tag_id=tag_hygiene["id"]
                 )
             return ["observable value found on warninglist and tagged accordingly"]
 
     def _process_message(self, data):
         entity_id = data["entity_id"]
         observable = self.helper.api.stix_observable.read(id=entity_id)
-
-        # Check for supported types
-        observable_type = observable["entity_type"]
-        supported_types = [
-            "ipv4-addr",
-            "ipv6-addr",
-            "domain",
-            "file-md5",
-            "file-sha1",
-            "file-sha256",
-        ]
-
-        if any(word in observable_type for word in supported_types):
-            return self._process_observable(observable)
+        return self._process_observable(observable)
 
     # Start the main loop
     def start(self):

--- a/hygiene/src/hygiene.py
+++ b/hygiene/src/hygiene.py
@@ -40,7 +40,7 @@ class HygieneConnector:
                 )
 
                 self.helper.api.stix_entity.add_tag(
-                    id=observable, tag_id=tag_hygiene["id"]
+                    id=observable['id'], tag_id=tag_hygiene["id"]
                 )
             return ["observable value found on warninglist and tagged accordingly"]
 

--- a/hygiene/src/hygiene.py
+++ b/hygiene/src/hygiene.py
@@ -1,10 +1,8 @@
-import yaml
 import os
-import json
+import yaml
 
 from pymispwarninglists import WarningLists
-from stix2 import Relationship, Identity, Bundle
-from pycti import OpenCTIConnectorHelper, get_config_variable
+from pycti import OpenCTIConnectorHelper
 
 
 class HygieneConnector:
@@ -24,15 +22,15 @@ class HygieneConnector:
         observable_value = observable["observable_value"]
 
         # Search in warninglist
-        r = self.warninglists.search(observable_value)
+        result = self.warninglists.search(observable_value)
 
         # Iterate over the hits
-        if r:
+        if result:
             self.helper.log_info(
                 "Hit found for %s in warninglists" % (observable_value)
             )
 
-            for hit in r:
+            for hit in result:
                 self.helper.log_info(
                     " %s %s %s %s" % (hit.type, hit.name, hit.version, hit.description)
                 )

--- a/hygiene/src/requirements.txt
+++ b/hygiene/src/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML
 pycti
+pika
 pymispwarninglists

--- a/hygiene/src/requirements.txt
+++ b/hygiene/src/requirements.txt
@@ -1,4 +1,3 @@
-PyYAML
-pycti
-pika
-pymispwarninglists
+PyYAML=5.3.1
+pycti=3.1.2
+pymispwarninglists=1.0

--- a/hygiene/src/requirements.txt
+++ b/hygiene/src/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML
+pycti
+pymispwarninglists


### PR DESCRIPTION
This pull request adds the hygiene connector to OpenCTI.

The connector adds the following information for observables:

* `Hygiene` tag to observables if they are on [misp-warninglists](https://github.com/MISP/misp-warninglists)
* external references for every matching warninglist

Due to descriptive tags this can be used to get rid of indicators that might lead to false positive when used for detection by searching for the `Hygiene` tag.

Possible future features:
* also decrease score for all indicators (needs work on `Indicator` class in pycti)