### PR TITLE
Unify the base images for all connectors

### DIFF
--- a/alienvault/Dockerfile
+++ b/alienvault/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.6-alpine3.11
+FROM python:3.7-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-alienvault

--- a/amitt/Dockerfile
+++ b/amitt/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-amitt

--- a/crowdstrike/Dockerfile
+++ b/crowdstrike/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.6-alpine3.11
+FROM python:3.7-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-crowdstrike

--- a/cryptolaemus/Dockerfile
+++ b/cryptolaemus/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-cryptolaemus

--- a/cve/Dockerfile
+++ b/cve/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-cve

--- a/cyber-threat-coalition/Dockerfile
+++ b/cyber-threat-coalition/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-cyber-threat-coalition

--- a/export-file-csv/Dockerfile
+++ b/export-file-csv/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the worker
 COPY src /opt/opencti-connector-export-file-csv

--- a/export-file-stix/Dockerfile
+++ b/export-file-stix/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the worker
 COPY src /opt/opencti-connector-export-file-stix

--- a/import-file-pdf-observables/Dockerfile
+++ b/import-file-pdf-observables/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-import-file-pdf-observables

--- a/import-file-stix/Dockerfile
+++ b/import-file-stix/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-import-file-stix

--- a/ipinfo/Dockerfile
+++ b/ipinfo/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the worker
 COPY src /opt/opencti-connector-ipinfo

--- a/malpedia/Dockerfile
+++ b/malpedia/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-malpedia

--- a/misp/Dockerfile
+++ b/misp/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-misp

--- a/mitre/Dockerfile
+++ b/mitre/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-mitre

--- a/opencti/Dockerfile
+++ b/opencti/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-opencti

--- a/virustotal/Dockerfile
+++ b/virustotal/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 # Copy the worker
 COPY src /opt/opencti-connector-virustotal


### PR DESCRIPTION
I propose we unify the base image for all current connectors.
The current base images are diverse and somewhat behind in fixes and might include security bugs.

By also removing the python and alpine minor versions we ensure the latest security and bug-fix releases will be used for OpenCTI docker releases.

This PR changes all base images to `python:3.7-alpine`.
