### PR TITLE
Move all connectors to python 3.8

### DIFF
--- a/alienvault/Dockerfile
+++ b/alienvault/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-alienvault

--- a/amitt/Dockerfile
+++ b/amitt/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-amitt

--- a/crowdstrike/Dockerfile
+++ b/crowdstrike/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-crowdstrike

--- a/cryptolaemus/Dockerfile
+++ b/cryptolaemus/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-cryptolaemus

--- a/cve/Dockerfile
+++ b/cve/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-cve

--- a/cyber-threat-coalition/Dockerfile
+++ b/cyber-threat-coalition/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-cyber-threat-coalition

--- a/export-file-csv/Dockerfile
+++ b/export-file-csv/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the worker
 COPY src /opt/opencti-connector-export-file-csv

--- a/export-file-stix/Dockerfile
+++ b/export-file-stix/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the worker
 COPY src /opt/opencti-connector-export-file-stix

--- a/hygiene/Dockerfile
+++ b/hygiene/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the worker
 COPY src /opt/opencti-connector-hygiene

--- a/import-file-pdf-observables/Dockerfile
+++ b/import-file-pdf-observables/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-import-file-pdf-observables

--- a/import-file-stix/Dockerfile
+++ b/import-file-stix/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-import-file-stix

--- a/ipinfo/Dockerfile
+++ b/ipinfo/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the worker
 COPY src /opt/opencti-connector-ipinfo

--- a/lastinfosec/Dockerfile
+++ b/lastinfosec/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-lastinfosec

--- a/malpedia/Dockerfile
+++ b/malpedia/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-malpedia

--- a/misp/Dockerfile
+++ b/misp/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-misp

--- a/mitre/Dockerfile
+++ b/mitre/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-mitre

--- a/opencti/Dockerfile
+++ b/opencti/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the connector
 COPY src /opt/opencti-connector-opencti

--- a/virustotal/Dockerfile
+++ b/virustotal/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 # Copy the worker
 COPY src /opt/opencti-connector-virustotal


### PR DESCRIPTION
As suggested by @2xyo there is no reason to stick with python 3.7 and move to 3.8 instead.