### PR TITLE
Make it possible to run Malpedia without token

### DIFF
--- a/malpedia/Readme.md
+++ b/malpedia/Readme.md
@@ -37,6 +37,10 @@ default = 'https://malpedia.caad.fkie.fraunhofer.de/'
 API authentication key. Can be retreived with a valid account from:
 https://malpedia.caad.fkie.fraunhofer.de/settings
 
+If you leave this variable undefined or as empty string (`""`) only public,
+TLP:WHITE entities are imported. So this connector can also be used without an
+account.
+
 default = 'ChangeMe'
 
 #### MALPEDIA_INTERVAL_SEC
@@ -70,3 +74,4 @@ default = False
 #### CONNECTOR_CONFIDENCE_LEVEL
 
 The confidence level you give to the connector.
+

--- a/malpedia/src/malpedia/client.py
+++ b/malpedia/src/malpedia/client.py
@@ -21,11 +21,15 @@ class MalpediaClient:
 
     def query(self, url_path: str) -> Any:
         try:
-            r = requests.get(
-                self.api_url + url_path,
-                headers={"Authorization": "apitoken " + self.api_key},
-            )
-            data = r.json()
+            if self.api_key == None or self.api_key == "":
+                r = requests.get(self.api_url + url_path,)
+                data = r.json()
+            else:
+                r = requests.get(
+                    self.api_url + url_path,
+                    headers={"Authorization": "apitoken " + self.api_key},
+                )
+                data = r.json()
         except requests.exceptions.RequestException as e:
             logger.error(f"error in malpedia query: {e}")
             return None


### PR DESCRIPTION
This PR enables the Malpedia connector without using a token and thus needing a Malpedia account.
If API_KEY is left empty or undefined only TLP:WHITE entities are imported from the public API without authentication.