### PR TITLE
[Hygiene] Add tag to indicators as well

### DIFF
--- a/hygiene/Readme.md
+++ b/hygiene/Readme.md
@@ -34,4 +34,5 @@ No special configuration is needed.
 
 1. Adds a `Hygiene` tag on items that correspond to a warning list entry.
 2. Adds an external reference for every matching warning list.
-3. Sets the observable score to `10`.
+3. Sets the score of all related indicators to a value based on the number of
+   reported entries (1:15, >=3:10, >=5:5, default:20).

--- a/hygiene/Readme.md
+++ b/hygiene/Readme.md
@@ -34,3 +34,4 @@ No special configuration is needed.
 
 1. Adds a `Hygiene` tag on items that correspond to a warning list entry.
 2. Adds an external reference for every matching warning list.
+3. Sets the observable score to `10`.

--- a/hygiene/src/hygiene.py
+++ b/hygiene/src/hygiene.py
@@ -100,6 +100,20 @@ class HygieneConnector:
                     % (hit.type, hit.name, hit.version, hit.description)
                 )
 
+                # We set the score based on the number of warning list entries
+                if len(result) >= 5:
+                    score = "5"
+                elif len(result) >= 3:
+                    score = "10"
+                elif len(result) == 1:
+                    score = "15"
+                else:
+                    score = "20"
+
+                self.helper.log_info(
+                    f"number of hits ({len(result)}) setting score to {score}"
+                )
+
                 self.helper.api.stix_entity.add_tag(
                     id=observable["id"], tag_id=self.tag_hygiene["id"]
                 )
@@ -108,10 +122,9 @@ class HygieneConnector:
                     self.helper.api.stix_entity.add_tag(
                         id=indicator_id, tag_id=self.tag_hygiene["id"]
                     )
-
-                self.helper.api.stix_observable.update_field(
-                    id=observable["id"], key="score", value=10,
-                )
+                    self.helper.api.stix_domain_entity.update_field(
+                        id=indicator_id, key="score", value=score,
+                    )
 
                 # Create external references
                 external_reference_id = self.helper.api.external_reference.create(

--- a/hygiene/src/hygiene.py
+++ b/hygiene/src/hygiene.py
@@ -81,7 +81,7 @@ class HygieneConnector:
             tag_type="Hygiene", value="Hygiene", color="#fc0341",
         )
 
-    def _process_observable(self, observable):
+    def _process_observable(self, observable) -> list:
         # Extract IPv4, IPv6 and Domain from entity data
         observable_value = observable["observable_value"]
 
@@ -104,6 +104,15 @@ class HygieneConnector:
                     id=observable["id"], tag_id=self.tag_hygiene["id"]
                 )
 
+                for indicator_id in observable["indicatorsIds"]:
+                    self.helper.api.stix_entity.add_tag(
+                        id=indicator_id, tag_id=self.tag_hygiene["id"]
+                    )
+
+                self.helper.api.stix_observable.update_field(
+                    id=observable["id"], key="score", value=10,
+                )
+
                 # Create external references
                 external_reference_id = self.helper.api.external_reference.create(
                     source_name="misp-warninglist",
@@ -120,7 +129,7 @@ class HygieneConnector:
 
             return ["observable value found on warninglist and tagged accordingly"]
 
-    def _process_message(self, data):
+    def _process_message(self, data) -> list:
         entity_id = data["entity_id"]
         observable = self.helper.api.stix_observable.read(id=entity_id)
         return self._process_observable(observable)


### PR DESCRIPTION
With this PR the Hygiene connector also tags all Indicators of a warning-list detection with an observable.

In addition it sets a weighted indicator score below 20 based on the number of warning-list entries for the parent observable (1:15, >=3:10, >=5:5, default:20).