### PR TITLE
Fixed operator

### DIFF
--- a/cve/src/cve.py
+++ b/cve/src/cve.py
@@ -98,7 +98,7 @@ class Cve:
                 ):
                     self.convert_and_send(self.cve_nvd_data_feed)
                     # If import history and never run
-                    if last_run is None and self.cve_import_history:
+                    if last_run is None or self.cve_import_history:
                         now = datetime.now()
                         years = list(range(2002, now.year + 1))
                         for year in years:


### PR DESCRIPTION
## Problem to be solved
History starts for newly created OpenCTI platforms, but not for existing ones.

## Fixed
Fixed operator `AND` preventing history launch for OpenCTI platforms already installed once.