### PR TITLE
[MISP] Bugfix: wrong date format

### DIFF
--- a/misp/README.md
+++ b/misp/README.md
@@ -2,9 +2,9 @@
 
 ## Installation
 
-The MISP connector is a standalone Python process that must have access to the OpenCTI platform and the RabbitMQ. RabbitMQ credentials and connection parameters are provided by the API directly, as configured in the platform settings. 
+The MISP connector is a standalone Python process that must have access to the OpenCTI platform and the RabbitMQ. RabbitMQ credentials and connection parameters are provided by the API directly, as configured in the platform settings.
 
-Enabling this connector could be done by launching the Python process directly after providing the correct configuration in the `config.yml` file or within a Docker with the image `opencti/connector-misp:latest`. We provide an example of [`docker-compose.yml`](docker-compose.yml) file that could be used independently or integrated to the global `docker-compose.yml` file of OpenCTI. 
+Enabling this connector could be done by launching the Python process directly after providing the correct configuration in the `config.yml` file or within a Docker with the image `opencti/connector-misp:latest`. We provide an example of [`docker-compose.yml`](docker-compose.yml) file that could be used independently or integrated to the global `docker-compose.yml` file of OpenCTI.
 
 If you are using it independently, remember that the connector will try to connect to the RabbitMQ on the port configured in the OpenCTI platform.
 
@@ -12,23 +12,24 @@ If you are using it independently, remember that the connector will try to conne
 
 | Parameter                        | Docker envvar                    | Mandatory    | Description                                                                                         |
 | -------------------------------- | -------------------------------- | ------------ | --------------------------------------------------------------------------------------------------- |
-| `opencti-url`                    | `OPENCTI_URL`                    | Yes          | The URL of the OpenCTI platform.                                                                    |
-| `opencti-token`                  | `OPENCTI_TOKEN`                  | Yes          | The default admin token configured in the OpenCTI platform parameters file.                         |
-| `connector-id`                   | `CONNECTOR_ID`                   | Yes          | A valid arbitrary `UUIDv4` that must be unique for this connector.                                  |
-| `connector-type`                 | `CONNECTOR_TYPE`                 | Yes          | Must be `EXTERNAL_IMPORT` (this is the connector type).                                             |
-| `connector-name`                 | `CONNECTOR_NAME`                 | Yes          | The name of the MISP instance, to identify it if you have multiple MISP connectors.                 |
-| `connector-scope`                | `CONNECTOR_SCOPE`                | Yes          | Must be `misp`, not used in this connector.                                                         |
-| `connector-confidence_level`     | `CONNECTOR_CONFIDENCE_LEVEL`     | Yes          | The default confidence level for created relationships (a number between 1 and 4).                  |
-| `connector-update_existing_data` | `CONNECTOR_UPDATE_EXISTING_DATA` | Yes          | If an entity already exists, update its attributes with information provided by this connector.     |
-| `connector-log_level`            | `CONNECTOR_LOG_LEVEL`            | Yes          | The log level for this connector, could be `debug`, `info`, `warn` or `error` (less verbose).       |
-| `misp-url`                       | `MISP_URL`                       | Yes          | The MISP instance URL.                                                                              |
-| `misp-key`                       | `MISP_KEY`                       | Yes          | The MISP instance key.                                                                              |           
-| `misp-ssl_verify`                | `MISP_SSL_VERIFY`                | Yes          | A boolean (`True` or `False`), check if the SSL certificate is valid when using `https`.            |
-| `misp-create_reports`            | `MISP_CREATE_REPORTS`            | Yes          | A boolean (`True` or `False`), create reports for each imported MISP event.                         |
-| `misp-report_class`              | `MISP_REPORT_CLASS`              | No           | If `create_reports` is `True`, specify the `report_class` (category), default is `MISP Event`       |
-| `misp-import_from_date`          | `MISP_IMPORT_FROM_DATE`          | No           | A date formatted `YYYY-MM-DD`, only import events created after this date.                          | 
-| `misp-import_tags`               | `MISP_IMPORT_TAGS`               | No           | A list of tags separated with `,`, only import events with these tags.                              |
-| `misp-interval`                  | `MISP_INTERVAL`                  | Yes          | Check for new event to import every `n` minutes.                                                    |
+| `opencti_url`                    | `OPENCTI_URL`                    | Yes          | The URL of the OpenCTI platform.                                                                    |
+| `opencti_token`                  | `OPENCTI_TOKEN`                  | Yes          | The default admin token configured in the OpenCTI platform parameters file.                         |
+| `connector_id`                   | `CONNECTOR_ID`                   | Yes          | A valid arbitrary `UUIDv4` that must be unique for this connector.                                  |
+| `connector_type`                 | `CONNECTOR_TYPE`                 | Yes          | Must be `EXTERNAL_IMPORT` (this is the connector type).                                             |
+| `connector_name`                 | `CONNECTOR_NAME`                 | Yes          | The name of the MISP instance, to identify it if you have multiple MISP connectors.                 |
+| `connector_scope`                | `CONNECTOR_SCOPE`                | Yes          | Must be `misp`, not used in this connector.                                                         |
+| `connector_confidence_level`     | `CONNECTOR_CONFIDENCE_LEVEL`     | Yes          | The default confidence level for created relationships (a number between 1 and 4).                  |
+| `connector_update_existing_data` | `CONNECTOR_UPDATE_EXISTING_DATA` | Yes          | If an entity already exists, update its attributes with information provided by this connector.     |
+| `connector_log_level`            | `CONNECTOR_LOG_LEVEL`            | Yes          | The log level for this connector, could be `debug`, `info`, `warn` or `error` (less verbose).       |
+| `misp_url`                       | `MISP_URL`                       | Yes          | The MISP instance URL.                                                                              |
+| `misp_key`                       | `MISP_KEY`                       | Yes          | The MISP instance key.                                                                              |
+| `misp_ssl_verify`                | `MISP_SSL_VERIFY`                | Yes          | A boolean (`True` or `False`), check if the SSL certificate is valid when using `https`.            |
+| `misp_create_reports`            | `MISP_CREATE_REPORTS`            | Yes          | A boolean (`True` or `False`), create reports for each imported MISP event.                         |
+| `misp_report_class`              | `MISP_REPORT_CLASS`              | No           | If `create_reports` is `True`, specify the `report_class` (category), default is `MISP Event`       |
+| `misp_import_from_date`          | `MISP_IMPORT_FROM_DATE`          | No           | A date formatted `YYYY-MM-DD`, only import events created after this date.                          |
+| `misp_import_tags`               | `MISP_IMPORT_TAGS`               | No           | A list of tags separated with `,`, only import events with these tags.                              |
+| `misp_import_tags_not`           | `MISP_IMPORT_TAGS_NOT`           | No           | A list of tags separated with `,`, to exclude from import.                                          |
+| `misp_interval`                  | `MISP_INTERVAL`                  | Yes          | Check for new event to import every `n` minutes.                                                    |
 
 ## Behavior
 

--- a/misp/docker-compose.yml
+++ b/misp/docker-compose.yml
@@ -19,5 +19,6 @@ services:
       - MISP_REPORT_CLASS=MISP Event # Optional, report_class if creating report for event
       - MISP_IMPORT_FROM_DATE=2000-01-01 # Optional, import all event from this date
       - MISP_IMPORT_TAGS=opencti:import,type:osint # Optional, list of tags used for import events
+      - MISP_IMPORT_TAGS_NOT= # Optional, list of tags to not include
       - MISP_INTERVAL=1 # Required, in minutes
     restart: always

--- a/misp/src/config.yml.sample
+++ b/misp/src/config.yml.sample
@@ -20,5 +20,4 @@ misp:
   import_from_date: '2010-01-01' # Optional, import all event from this date
   import_tags: 'opencti:import,type:osint' # Optional, list of tags used for import events
   import_tags_not: '' # Optional, list of tags to not include
-  import_threat_levels: '1,2,3,4'
   interval: 1 # Required, in minutes

--- a/misp/src/config.yml.sample
+++ b/misp/src/config.yml.sample
@@ -16,8 +16,9 @@ misp:
   key: 'ChangeMe' # Required
   ssl_verify: False # Required
   create_reports: True # Required, create report for MISP event
-  report_class: 'MISP event' # Optional, report_class if creating report for event
+  report_class: 'MISP Event' # Optional, report_class if creating report for event
   import_from_date: '2010-01-01' # Optional, import all event from this date
   import_tags: 'opencti:import,type:osint' # Optional, list of tags used for import events
+  import_tags_not: '' # Optional, list of tags to not include
   import_threat_levels: '1,2,3,4'
   interval: 1 # Required, in minutes

--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -140,7 +140,7 @@ class Misp:
             import_from_date = None
             if self.misp_import_from_date is not None:
                 import_from_date = parse(self.misp_import_from_date).strftime(
-                    "%Y-%m-%d %H:%M:%S"
+                    "%Y-%m-%d"
                 )
 
             # Prepare the query

--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -176,7 +176,7 @@ class Misp:
             if last_run is not None:
                 kwargs["timestamp"] = int(last_run.timestamp())
             elif import_from_date is not None:
-                kwargs["date_from"] = int(import_from_date.timestamp())
+                kwargs["date_from"] = import_from_date.strftime("%Y-%m-%d")
 
             # Query with pagination of 100
             current_page = 1

--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -137,13 +137,16 @@ class Misp:
                 or_parameters = []
                 not_parameters = []
 
-                for tag in self.misp_import_tags.split(","):
-                    or_parameters.append(tag.strip())
-                for ntag in self.misp_import_tags_not.split(","):
-                    not_parameters.append(ntag.strip())
+                if self.misp_import_tags:
+                    for tag in self.misp_import_tags.split(","):
+                        or_parameters.append(tag.strip())
+                if self.misp_import_tags_not:
+                    for ntag in self.misp_import_tags_not.split(","):
+                        not_parameters.append(ntag.strip())
 
                 complex_query_tag = self.misp.build_complex_query(
-                    or_parameters=or_parameters, not_parameters=not_parameters
+                    or_parameters=or_parameters if len(or_parameters) > 0 else None,
+                    not_parameters=not_parameters if len(not_parameters) > 0 else None,
                 )
 
             # If import from a specific date

--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -98,6 +98,7 @@ class Misp:
         )
         self.misp_import_tags_not = get_config_variable(
             "MISP_IMPORT_TAGS_NOT", ["misp", "import_tags_not"], config
+        )
         self.import_creator_orgs = get_config_variable(
             "MISP_IMPORT_CREATOR_ORGS", ["misp", "import_creator_orgs"], config
         )

--- a/misp/src/requirements.txt
+++ b/misp/src/requirements.txt
@@ -1,6 +1,6 @@
 pycti==3.3.2
 PyYAML==5.3.1
 urllib3==1.25.9
-pymisp==2.4.124
+pymisp==2.4.128
 python-dateutil==2.8.1
 stix2==1.4.0


### PR DESCRIPTION
The `misp_import_from` date should be in YYYY-MM-DD format.

This PR ensures that the pymisp functions always use timestamps as is the MISP default.

In addition this PR adds support for `NOT` tags.

Reference: #102