### PR TITLE
Fixes to mitre connector to address urllib changes in Python >=3.6

### DIFF
--- a/cve/src/cve.py
+++ b/cve/src/cve.py
@@ -6,6 +6,8 @@ import time
 import urllib.request
 import gzip
 import shutil
+import certifi
+import ssl
 
 from datetime import datetime
 from pycti import OpenCTIConnectorHelper, get_config_variable
@@ -56,9 +58,14 @@ class Cve:
         try:
             # Downloading json.gz file
             self.helper.log_info("Requesting the file " + url)
-            urllib.request.urlretrieve(
-                url, os.path.dirname(os.path.abspath(__file__)) + "/data.json.gz"
+            response = urllib.request.urlopen(
+                url, context=ssl.create_default_context(cafile=certifi.where())
             )
+            image = response.read()
+            with open(
+                os.path.dirname(os.path.abspath(__file__)) + "/data.json.gz", "wb"
+            ) as file:
+                file.write(image)
             # Unzipping the file
             self.helper.log_info("Unzipping the file")
             with gzip.open("data.json.gz", "rb") as f_in:

--- a/cve/src/requirements.txt
+++ b/cve/src/requirements.txt
@@ -2,3 +2,4 @@ pycti==3.3.3
 PyYAML==5.3.1
 urllib3==1.25.9
 python-dateutil==2.8.1
+certifi==2020.6.20

--- a/mitre/src/mitre.py
+++ b/mitre/src/mitre.py
@@ -8,6 +8,7 @@ import ssl
 from datetime import datetime
 from pycti import OpenCTIConnectorHelper, get_config_variable
 
+
 class Mitre:
     def __init__(self):
         # Instantiate the connector helper from config
@@ -36,10 +37,13 @@ class Mitre:
             ["connector", "update_existing_data"],
             config,
         )
+
     def get_interval(self):
         return int(self.mitre_interval) * 60 * 60 * 24
+
     def next_run(self, seconds):
         return
+
     def run(self):
         self.helper.log_info("Fetching MITRE datasets...")
         while True:
@@ -144,6 +148,7 @@ class Mitre:
             except Exception as e:
                 self.helper.log_error(str(e))
                 time.sleep(60)
+
 
 if __name__ == "__main__":
     try:

--- a/mitre/src/mitre.py
+++ b/mitre/src/mitre.py
@@ -8,7 +8,6 @@ import ssl
 from datetime import datetime
 from pycti import OpenCTIConnectorHelper, get_config_variable
 
-
 class Mitre:
     def __init__(self):
         # Instantiate the connector helper from config
@@ -37,13 +36,10 @@ class Mitre:
             ["connector", "update_existing_data"],
             config,
         )
-
     def get_interval(self):
         return int(self.mitre_interval) * 60 * 60 * 24
-
     def next_run(self, seconds):
         return
-
     def run(self):
         self.helper.log_info("Fetching MITRE datasets...")
         while True:
@@ -70,7 +66,12 @@ class Mitre:
                     self.helper.log_info("Connector will run!")
                     try:
                         enterprise_data = (
-                            urllib.request.urlopen(self.mitre_enterprise_file_url, context=ssl.create_default_context(cafile=certifi.where()))
+                            urllib.request.urlopen(
+                                self.mitre_enterprise_file_url,
+                                context=ssl.create_default_context(
+                                    cafile=certifi.where()
+                                ),
+                            )
                             .read()
                             .decode("utf-8")
                         )
@@ -83,7 +84,12 @@ class Mitre:
                         self.helper.log_error(str(e))
                     try:
                         pre_attack_data = (
-                            urllib.request.urlopen(self.mitre_pre_attack_file_url, context=ssl.create_default_context(cafile=certifi.where()))
+                            urllib.request.urlopen(
+                                self.mitre_pre_attack_file_url,
+                                context=ssl.create_default_context(
+                                    cafile=certifi.where()
+                                ),
+                            )
                             .read()
                             .decode("utf-8")
                         )
@@ -96,7 +102,12 @@ class Mitre:
                         self.helper.log_error(str(e))
                     try:
                         mobile_attack_data = (
-                            urllib.request.urlopen(self.mitre_mobile_attack_file_url, context=ssl.create_default_context(cafile=certifi.where()))
+                            urllib.request.urlopen(
+                                self.mitre_mobile_attack_file_url,
+                                context=ssl.create_default_context(
+                                    cafile=certifi.where()
+                                ),
+                            )
                             .read()
                             .decode("utf-8")
                         )
@@ -133,7 +144,6 @@ class Mitre:
             except Exception as e:
                 self.helper.log_error(str(e))
                 time.sleep(60)
-
 
 if __name__ == "__main__":
     try:

--- a/mitre/src/mitre.py
+++ b/mitre/src/mitre.py
@@ -2,6 +2,8 @@ import os
 import yaml
 import time
 import urllib.request
+import certifi
+import ssl
 
 from datetime import datetime
 from pycti import OpenCTIConnectorHelper, get_config_variable
@@ -68,7 +70,7 @@ class Mitre:
                     self.helper.log_info("Connector will run!")
                     try:
                         enterprise_data = (
-                            urllib.request.urlopen(self.mitre_enterprise_file_url)
+                            urllib.request.urlopen(self.mitre_enterprise_file_url, context=ssl.create_default_context(cafile=certifi.where()))
                             .read()
                             .decode("utf-8")
                         )
@@ -81,7 +83,7 @@ class Mitre:
                         self.helper.log_error(str(e))
                     try:
                         pre_attack_data = (
-                            urllib.request.urlopen(self.mitre_pre_attack_file_url)
+                            urllib.request.urlopen(self.mitre_pre_attack_file_url, context=ssl.create_default_context(cafile=certifi.where()))
                             .read()
                             .decode("utf-8")
                         )
@@ -94,7 +96,7 @@ class Mitre:
                         self.helper.log_error(str(e))
                     try:
                         mobile_attack_data = (
-                            urllib.request.urlopen(self.mitre_mobile_attack_file_url)
+                            urllib.request.urlopen(self.mitre_mobile_attack_file_url, context=ssl.create_default_context(cafile=certifi.where()))
                             .read()
                             .decode("utf-8")
                         )

--- a/mitre/src/requirements.txt
+++ b/mitre/src/requirements.txt
@@ -2,3 +2,4 @@ pycti==3.3.3
 PyYAML==5.3.1
 urllib3==1.25.9
 python-dateutil==2.8.1
+certifi==2020.6.20


### PR DESCRIPTION
The behavior of urllib changes in Python 3.6 as noted, here:

https://stackoverflow.com/questions/27835619/urllib-and-ssl-certificate-verify-failed-error

These changes address that issue.
