### PR TITLE
Update docker image  of CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   ensure_formatting:
     docker:
-      - image: circleci/python:3.7.7
+      - image: cimg/python:3.9
     working_directory: ~/repo
     steps:
       - checkout
@@ -28,7 +28,7 @@ jobs:
   build:
     working_directory: ~/opencti
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: cimg/base:stable
     steps:
       - checkout
       - setup_remote_docker
@@ -189,7 +189,7 @@ jobs:
   build_rolling:
     working_directory: ~/opencti
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: cimg/base:stable
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - run:
           name: install dependencies
-          command: sudo pip3 install black
+          command: sudo python -m pip install black
       - run:
           name: confirm black version
           command: black --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - run:
           name: install dependencies
-          command: sudo python -m pip install black
+          command: python -m pip install black
       - run:
           name: confirm black version
           command: black --version


### PR DESCRIPTION
CircleCi  announced a "next-generation convenience images" which are "smaller, faster, more deterministic", see https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/ 


- `circleci/python:3.7.7 `-> `cimg/python:3.9` ([Python 3.9 has been released in October 2020](https://www.python.org/dev/peps/pep-0596/#id7)) 
- `circleci/buildpack-deps:stretch` -> `cimg/base:stable` ([Ubuntu 20.04 witch docker](https://github.com/CircleCI-Public/cimg-base/blob/master/20.04/Dockerfile))
