### PR TITLE
use correct naming scheme when retrieving interval value

### DIFF
--- a/cybercrime-tracker/src/cybercrime-tracker.py
+++ b/cybercrime-tracker/src/cybercrime-tracker.py
@@ -56,7 +56,7 @@ class Cybercrimetracker:
             config,
         )
         self.interval = get_config_variable(
-            "CYBERCRIMETRACKER_INTERVAL",
+            "CYBERCRIME_TRACKER_INTERVAL",
             ["cybercrime-tracker", "interval"],
             config,
             isNumber=True,


### PR DESCRIPTION
Fixing this typo ensures `self.interval` gets populated:

https://github.com/OpenCTI-Platform/connectors/blob/d95edd27bd3f6ef826eaeb2d629f57885d4957ba/cybercrime-tracker/docker-compose.yml#L17

If `self.interval` is None then this line fails:

https://github.com/OpenCTI-Platform/connectors/blob/d95edd27bd3f6ef826eaeb2d629f57885d4957ba/cybercrime-tracker/src/cybercrime-tracker.py#L163

fixes #213 