### PR TITLE
move lastinfosec cti feed to stix2.1 version

### DIFF
--- a/lastinfosec/Dockerfile
+++ b/lastinfosec/Dockerfile
@@ -5,7 +5,7 @@ COPY src /opt/opencti-connector-lastinfosec
 
 # Install Python modules
 # hadolint ignore=DL3003
-RUN apk --no-cache add git build-base libmagic libffi-dev && \
+RUN apk --no-cache add git build-base libmagic && \
     cd /opt/opencti-connector-lastinfosec && \
     pip3 install --no-cache-dir git+https://github.com/OpenCTI-Platform/client-python@4.1.2 && \
     pip3 install --no-cache-dir -r requirements.txt && \

--- a/lastinfosec/Dockerfile
+++ b/lastinfosec/Dockerfile
@@ -5,7 +5,7 @@ COPY src /opt/opencti-connector-lastinfosec
 
 # Install Python modules
 # hadolint ignore=DL3003
-RUN apk --no-cache add git build-base libmagic && \
+RUN apk --no-cache add git build-base libmagic libffi-dev && \
     cd /opt/opencti-connector-lastinfosec && \
     pip3 install --no-cache-dir git+https://github.com/OpenCTI-Platform/client-python@4.1.2 && \
     pip3 install --no-cache-dir -r requirements.txt && \

--- a/lastinfosec/README.md
+++ b/lastinfosec/README.md
@@ -1,13 +1,14 @@
 # ![Image of LastInfoSec](https://www.lastinfosec.com/img/logolastinfosec.png) LastInfoSec Connector for OpenCTI !
 
-OpenCTI LastInfoSec connector will use the `/v2/stix2/getlasthour` API.
+OpenCTI LastInfoSec connector will use the `/v2/stix21/getlasthour` API.
 
-This LastInfosec's Threat Feed contains STIXv2 reports update hourly with URLs, Hashs, Domains Indicators.  
+This LastInfosec's Threat Feed contains STIXv2.1 reports update hourly with URLs, Hashs, Domains Indicators.  
 
 Requirement : if you want to use LastInfoSec's intelligence, you need an API key. You could contact LastInfoSec's team at contact@lastinfosec.com
 
+LastInfosec has beed acquired by Gatewatcher. 
 LastInfoSec's Threat Feed is a data feed that makes it easier to detect threats within the information system. It contains enriched compromised evidences in order to reduce the time of threat analysis once detected.
-https://www.lastinfosec.com/en/
+https://www.gatewatcher.com/en/nos-produits/last-info-sec
 
 
 ## Configuration
@@ -19,5 +20,6 @@ The connector can be configured with the following variables:
 | `url`             | `OPENCTI_URL`              | `ChangeMe` |    OpenCTI URL, example: `http://localhost:8080`    |
 | `token`             | `OPENCTI_TOKEN`              | `ChangeMe`                                        | token OpenCTI      |
 | `id`         | `CONNECTOR_ID`          | `Changeme`                                     | ID Connector     |
-| `api_key`        | `CONFIG_LIS_APIKEY`         | `ChangeMe`                                     | LastinfoSec API Key  
-
+| `api_key_cti`        | `CONFIG_LIS_APIKEY_CTI`         | `ChangeMe`                                     | LastinfoSec API Key  
+| `proxy_http`        | `PROXY_HTTP`         | None                                     | HTTP Proxy (Optional)  
+| `proxy_https`        | `PROXY_HTTPS`         | None                                     | HTTPS Proxy (Optional)  

--- a/lastinfosec/README.md
+++ b/lastinfosec/README.md
@@ -6,7 +6,7 @@ This LastInfosec's Threat Feed contains STIXv2.1 reports update hourly with URLs
 
 Requirement : if you want to use LastInfoSec's intelligence, you need an API key. You could contact LastInfoSec's team at contact@lastinfosec.com
 
-LastInfosec has beed acquired by Gatewatcher. 
+LastInfosec has been acquired by Gatewatcher. 
 LastInfoSec's Threat Feed is a data feed that makes it easier to detect threats within the information system. It contains enriched compromised evidences in order to reduce the time of threat analysis once detected.
 https://www.gatewatcher.com/en/nos-produits/last-info-sec
 

--- a/lastinfosec/docker-compose.yml
+++ b/lastinfosec/docker-compose.yml
@@ -12,6 +12,6 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=3
       - CONNECTOR_UPDATE_EXISTING_DATA=true
       - CONNECTOR_LOG_LEVEL=info
-      - CONFIG_LIS_URL=https://api.client.lastinfosec.com/v2/stix2/getlasthour?api_key=
-      - CONFIG_LIS_APIKEY=ChangeMe
+      - CONFIG_LIS_URL_CTI=https://api.client.lastinfosec.com/v2/stix21/getlasthour?api_key=
+      - CONFIG_LIS_APIKEY_CTI=ChangeMe
     restart: always

--- a/lastinfosec/src/config.yml.sample
+++ b/lastinfosec/src/config.yml.sample
@@ -7,9 +7,10 @@ connector:
   type: 'EXTERNAL_IMPORT'
   name: 'lastinfosec-cti'
   scope: 'cyber threat intelligence'
+  confidence_level: 50
   update_existing_data: True
   log_level: 'info'
 
 lastinfosec:
-  api_url: 'https://api.client.lastinfosec.com/v2/stix2/getlasthour?api_key='
-  api_key: 'ChangeMe'
+  api_url_cti: 'https://api.client.lastinfosec.com/v2/stix21/getlasthour?api_key='
+  api_key_cti: 'ChangeMe'

--- a/lastinfosec/src/lastinfosec.py
+++ b/lastinfosec/src/lastinfosec.py
@@ -17,11 +17,12 @@ class LastInfoSec:
             else {}
         )
         self.helper = OpenCTIConnectorHelper(config)
+
         self.lastinfosec_url = get_config_variable(
-            "CONFIG_LIS_URL", ["lastinfosec", "api_url"], config
+            "CONFIG_LIS_URL_CTI", ["lastinfosec", "api_url_cti"], config
         )
         self.lastinfosec_apikey = get_config_variable(
-            "CONFIG_LIS_APIKEY", ["lastinfosec", "api_key"], config
+            "CONFIG_LIS_APIKEY_CTI", ["lastinfosec", "api_key_cti"], config
         )
         self.opencti_url = get_config_variable(
             "OPENCTI_URL", ["opencti", "url"], config
@@ -29,8 +30,31 @@ class LastInfoSec:
         self.opencti_id = get_config_variable(
             "OPENCTI_TOKEN", ["opencti", "token"], config
         )
+        self.proxy_http = get_config_variable(
+            "PROXY_HTTP", ["opencti", "proxy_http"], config
+        )
+        self.proxy_https = get_config_variable(
+            "PROXY_HTTPS", ["opencti", "proxy_https"], config
+        )
         self.update_existing_data = True
         self.api = OpenCTIApiClient(self.opencti_url, self.opencti_id)
+
+    def push_data(self, lastinfosec_data, timestamp, work_id):
+        if "message" in lastinfosec_data.keys():
+            for data in lastinfosec_data["message"]:
+                sdata = json.dumps(data)
+                self.helper.send_stix2_bundle(sdata, work_id=work_id)
+                # Store the current timestamp as a last run
+                message = ("Connector successfully run, storing last_run as {0}".format(timestamp))
+                self.helper.set_state({"last_run": timestamp})
+                self.helper.api.work.to_processed(work_id, message)
+                self.helper.log_info(message)
+        else:
+            message = ("Connector error run, storing last_run as {0}".format(timestamp))
+            self.helper.set_state({"last_run": timestamp})
+            self.helper.api.work.to_processed(work_id, message)
+            self.helper.log_info(message)
+            time.sleep(300)
 
     def run(self):
         self.helper.log_info("Fetching lastinfosec datasets...")
@@ -39,37 +63,24 @@ class LastInfoSec:
                 # Get the current timestamp and check
                 timestamp = int(time.time())
                 now = datetime.datetime.utcfromtimestamp(timestamp)
-                friendly_name = "MITRE run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
+                friendly_name = "LastInfoSec CTI run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
                 work_id = self.helper.api.work.initiate_work(
                     self.helper.connect_id, friendly_name
                 )
-                lastinfosec_data = requests.get(
-                    self.lastinfosec_url + self.lastinfosec_apikey
-                ).json()
-                if "message" in lastinfosec_data.keys():
-                    for data in lastinfosec_data["message"]:
-                        sdata = json.dumps(data)
-                        self.helper.send_stix2_bundle(sdata, work_id=work_id)
-                    # Store the current timestamp as a last run
-                    message = (
-                        "Connector successfully run, storing last_run as {0}".format(
-                            timestamp
-                        )
-                    )
-                    self.helper.set_state({"last_run": timestamp})
-                    self.helper.api.work.to_processed(work_id, message)
-                    self.helper.log_info(message)
-                    time.sleep(3500)
+
+                proxy_dic = {}
+                if self.proxy_http is not None:
+                    proxy_dic["http"] = self.proxy_http
+                if self.proxy_https is not None:
+                    proxy_dic["https"] = self.proxy_https
+                
+                if self.lastinfosec_url is not None and self.lastinfosec_apikey is not None:
+                    lastinfosec_data = requests.get(self.lastinfosec_url + self.lastinfosec_apikey,
+                                                    proxies=proxy_dic).json()
+                    self.push_data(lastinfosec_data, timestamp, work_id)
                 else:
-                    message = (
-                        "Connector successfully run, storing last_run as {0}".format(
-                            timestamp
-                        )
-                    )
-                    self.helper.set_state({"last_run": timestamp})
-                    self.helper.api.work.to_processed(work_id, message)
-                    self.helper.log_info(message)
-                    time.sleep(300)
+                    self.helper.log_info("CTI Feed not configured")
+                time.sleep(3500)
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 exit(0)
@@ -84,5 +95,5 @@ if __name__ == "__main__":
         lastInfoSecConnector.run()
     except Exception as e:
         print(e)
-        time.sleep(10)
+        time.sleep(100)
         exit(0)


### PR DESCRIPTION
Hello,

We have made some changes in our lastinfosec connector to use our stix2.1 api rather than stix 2.0

Best regards,

Rémy DEWAILLY