### PR TITLE
Change pymisp requirement

### DIFF
--- a/misp/src/requirements.txt
+++ b/misp/src/requirements.txt
@@ -1,5 +1,5 @@
 pycti==4.2.1
 urllib3==1.26.3
-pymisp==2.4.138
+pymisp
 python-dateutil==2.8.1
 stix2==2.1.0


### PR DESCRIPTION
Pymisp changed to install last release and align it automatically to last Misp version