### PR TITLE
Fix typo and add a default interval of one hour

### DIFF
--- a/taxii2/src/taxii2.py
+++ b/taxii2/src/taxii2.py
@@ -56,7 +56,7 @@ class Taxii2Connector:
         )
 
         self.interval = get_config_variable(
-            "TAXII2_INTERVAl", ["taxii2", "interval"], config, True
+            "TAXII2_INTERVAL", ["taxii2", "interval"], config, True, 1
         )
 
         self.update_existing_data = get_config_variable(


### PR DESCRIPTION
Quick PR, not tested :grimacing:  ! 

Should fix:

```
INFO:root:Run Complete. Sleeping until next run in None hours
Traceback (most recent call last):
  File "taxii2.py", line 245, in <module>
    raise (e)
  File "taxii2.py", line 243, in <module>
    CONNECTOR.run()
  File "taxii2.py", line 134, in run
    time.sleep(self.get_interval())
  File "taxii2.py", line 93, in get_interval
    return int(self.interval) * 3600
```