### PR TITLE
pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+    -   id: black
+-   repo: https://github.com/PyCQA/flake8
+    rev: 3.8.4
+    hooks:
+    -   id: flake8
+        args: ['--ignore=E,W']
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+    -   id: check-yaml


### PR DESCRIPTION
No more [CircleCI linter/ensure_formatting failures](https://github.com/OpenCTI-Platform/connectors/pulls?q=is%3Apr+status%3Afailure) with  `pre-commit` :) 

```
$ pip install pre-commit
$ pre-commit install
$ git add .pre-commit-config.yaml 
$ git commit -m "pre-commit setup"
black................................................(no files to check)Skipped
flake8...............................................(no files to check)Skipped
Check Yaml...............................................................Passed
[precommit 5be35e3] pre-commit setup
 1 file changed, 14 insertions(+)
 create mode 100644 .pre-commit-config.yaml
```



