### PR TITLE
[MISP] Fixed ERROR:root:search() keywords must be string

### DIFF
--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -206,6 +206,7 @@ class Misp:
                 self.helper.log_info(
                     "Fetching MISP events with args: " + json.dumps(kwargs)
                 )
+                kwargs = json.loads(json.dumps(kwargs))
                 events = []
                 try:
                     events = self.misp.search("events", **kwargs)


### PR DESCRIPTION
Fixes #291 
It would pass a broken json/dict object to ExpandedPyMISP
I would appreciate someone else reproducing the same findings before merging this pull request