### PR TITLE
Add control over URLhaus indicator creation [#290]

### DIFF
--- a/urlhaus/src/config.yml.sample
+++ b/urlhaus/src/config.yml.sample
@@ -8,6 +8,7 @@ connector:
   name: 'Abuse.ch URLhaus'
   scope: 'urlhaus'
   confidence_level: 40 # From 0 (Unknown) to 100 (Fully trusted)
+  create_indicator: False
   update_existing_data: True
   log_level: 'info'
 

--- a/urlhaus/src/urlhaus.py
+++ b/urlhaus/src/urlhaus.py
@@ -51,6 +51,11 @@ class URLhaus:
             name="Abuse.ch",
             description="abuse.ch is operated by a random swiss guy fighting malware for non-profit, running a couple of projects helping internet service providers and network operators protecting their infrastructure from malware.",
         )
+        self.create_indicator = get_config_variable(
+            "CONNECTOR_CREATE_INDICATORS",
+            ["connector", "create_indicator"],
+            config,
+        )
 
     def get_interval(self):
         return int(self.urlhaus_interval) * 60 * 60 * 24
@@ -122,7 +127,7 @@ class URLhaus:
                                     object_marking_refs=[TLP_WHITE],
                                     labels=row[5].split(","),
                                     created_by_ref=self.identity["standard_id"],
-                                    x_opencti_create_indicator=True,
+                                    x_opencti_create_indicator=self.create_indicator,
                                     external_references=[external_reference],
                                 )
                                 bundle_objects.append(stix_observable)


### PR DESCRIPTION
This PR resolves the issue #290 by adding the ability to control indicator creation (True/False) through config file in OpenCTI