### PR TITLE
[MISP] Fixed invalid time, hostname support, ...

### DIFF
--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -4,7 +4,6 @@ import time
 import json
 
 from datetime import datetime
-from dateutil.parser import parse
 from pymisp import ExpandedPyMISP
 from stix2 import (
     Bundle,
@@ -493,7 +492,9 @@ class Misp:
                     id="report--" + event["Event"]["uuid"],
                     name=event["Event"]["info"],
                     description=event["Event"]["info"],
-                    published=parse(event["Event"]["date"]),
+                    published=published=datetime.utcfromtimestamp(
+                        int(event["Event"]["timestamp"])
+                    ),
                     report_types=[self.misp_report_type],
                     created_by_ref=author,
                     object_marking_refs=event_markings,

--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -488,7 +488,7 @@ class Misp:
                 bundle_objects.append(object_relationship)
 
             # Create the report if needed
-            if self.misp_create_report and len(object_refs) > 0:
+            if self.misp_create_report:
                 report = Report(
                     id="report--" + event["Event"]["uuid"],
                     name=event["Event"]["info"],

--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -41,6 +41,7 @@ OPENCTISTIX2 = {
         "transform": {"operation": "remove_string", "value": "AS"},
     },
     "mac-addr": {"type": "mac-addr", "path": ["value"]},
+    "hostname": {"type": "x-opencti-hostname", "path": ["value"]},
     "domain": {"type": "domain-name", "path": ["value"]},
     "ipv4-addr": {"type": "ipv4-addr", "path": ["value"]},
     "ipv6-addr": {"type": "ipv6-addr", "path": ["value"]},

--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -492,7 +492,7 @@ class Misp:
                     id="report--" + event["Event"]["uuid"],
                     name=event["Event"]["info"],
                     description=event["Event"]["info"],
-                    published=published=datetime.utcfromtimestamp(
+                    published=datetime.utcfromtimestamp(
                         int(event["Event"]["timestamp"])
                     ),
                     report_types=[self.misp_report_type],


### PR DESCRIPTION
- Fix invalid time for creation date:
When a new events get imported, it used to omit the time part.
In the timezone UTC+2 it would report the event creation date in OpenCTI as `April 2, 2021, 2:00:00 AM`
Even though I created the event at 5:16:20.
This is because we parse e.g. `2021-04-02` from MISP which doesn't include the time.
Fixed by looking at "timestamp" misp attribute instead of "date"

- Added support to import hostnames:
Previously, hostnames would be ignored when importing an event

- Fixed #310 requirement for a mitre-galaxy tag to import:
If you would create a barebones event in MISP with only observables, it wouldn't import. Now it does