### PR TITLE
Add config option to respect detection toggle

### DIFF
--- a/threatbus/README.md
+++ b/threatbus/README.md
@@ -21,7 +21,8 @@ The connector requires a configuration file or certain environment variables to 
 | `connector.confidence_level`    | `CONNECTOR_CONFIDENCE_LEVEL`  | Yes       | The confidence_level of relationships created by the connector. Unused. |
 | `connector.log_level`           | `CONNECTOR_LOG_LEVEL`         | Yes       | The log level for this connector, could be `debug`, `info`, `warn` or `error`. |
 | `connector.entity_name`         | `CONNECTOR_ENTITY_NAME`       | Yes       | The name for a STIX-2 entity (e.g., the organization in which the connector is used). Used to report Sightings of Indicators as part of this STIX-2 entity.|
-| `connector.entity_description`  | `CONNECTOR_ENTITY_DESCRIPTION`| Yes       | The description for the STIX-2 entity. See above.
+| `connector.entity_description`  | `CONNECTOR_ENTITY_DESCRIPTION`| Yes       | The description for the STIX-2 entity. See above.|
+| `connector.forward_all_iocs`    | `CONNECTOR_FORWARD_ALL_IOCS`  | Yes       | Set to `true` to forward all Indicators from OpenCTI to Threat Bus. Set to `false` to forward only those whith the `detection` attribute toggled on (`x_opencti_detection = true`).|
 | `threatbus.zmq_host`            | `THREATBUS_ZMQ_HOST`          | Yes       | The Threat Bus host (IP address or hostname). |
 | `threatbus.zmq_port`            | `THREATBUS_ZMQ_PORT`          | Yes       | The Threat Bus ZMQ management port spawned by the [ZMQ-App plugin](https://docs.tenzir.com/threatbus/plugins/apps/zmq-app). |
 

--- a/threatbus/src/config.yml.sample
+++ b/threatbus/src/config.yml.sample
@@ -11,6 +11,7 @@ connector:
   log_level: info
   entity_name: ChangeMe
   entity_description: ChangeMe
+  forward_all_iocs: false
 
 threatbus:
   zmq_host: localhost

--- a/threatbus/src/connector.py
+++ b/threatbus/src/connector.py
@@ -27,6 +27,9 @@ class ThreatBusConnector(object):
         self.entity_desc = get_config_variable(
             "CONNECTOR_ENTITY_DESCRIPTION", ["connector", "entity_description"], config
         )
+        self.forward_all_iocs = get_config_variable(
+            "CONNECTOR_FORWARD_ALL_IOCS", ["connector", "forward_all_iocs"], config
+        )
         self.threatbus_entity = None
 
         # Custom configuration for Threat Bus ZeroMQ-App plugin endpoint
@@ -134,6 +137,11 @@ class ThreatBusConnector(object):
         indicator: dict = self.opencti_helper.api.indicator.read(id=opencti_id)
         if not indicator:
             # we are only interested in indicators at this time
+            return
+        detection_enabled: bool = indicator.get("x_opencti_detection", False)
+        if not detection_enabled and self.forward_all_iocs is not True:
+            # only propagate indicators that are toggled for detection or the
+            # user enabled forwarding of all indicators regardless of the toggle
             return
         # overwrite custom OpenCTI ID
         indicator["id"] = indicator.get("standard_id")


### PR DESCRIPTION
This PR adds a config option to the Threat Bus connector, so users can decide to either forward all Indicators from OpenCTI or only those that have the `detection` toggle set to `true`.