### PR TITLE
[import-file-stix] Add maec to requirments.txt

### DIFF
--- a/import-file-stix/src/requirements.txt
+++ b/import-file-stix/src/requirements.txt
@@ -1,2 +1,3 @@
 pycti==4.4.3
+maec
 stix2-elevator


### PR DESCRIPTION
Avoid import error: ModuleNotFoundError: No module named 'maec'

* https://maecproject.github.io/
* https://github.com/MAECProject/python-maec/
