### PR TITLE
[MISP] Added object relationships + report support

### DIFF
--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -507,7 +507,8 @@ class Misp:
                 bundle_objects.append(object_relationship)
 
             # Create the report if needed
-            if self.misp_create_report:
+            # Report in STIX must have at least one object_refs
+            if self.misp_create_report and len(object_refs) > 0:
                 report = Report(
                     id="report--" + event["Event"]["uuid"],
                     name=event["Event"]["info"],

--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -501,6 +501,7 @@ class Misp:
                     bundle_objects.append(relationship)
             # Add object_relationships
             for object_relationship in objects_relationships:
+                object_refs.append(object_relationship)
                 bundle_objects.append(object_relationship)
 
             # Create the report if needed


### PR DESCRIPTION
If you created objects and relationships between them in MISP, they wouldn't be imported into OpenCTI.
I thought this was an important feature, so now it links the relevant indicators.

In MISP you can have "Reports". These can be auto generated or manually submitted.
I've also added support for this. It gets added as a Note with a reference to the report.