### PR TITLE
[MISP] process_note + text fallback + import MISP objects

### DIFF
--- a/misp/README.md
+++ b/misp/README.md
@@ -29,6 +29,7 @@ If you are using it independently, remember that the connector will try to conne
 | `misp_ssl_verify`                 | `MISP_SSL_VERIFY`                 | Yes          | A boolean (`True` or `False`), check if the SSL certificate is valid when using `https`.            |
 | `misp_datetime_attribute`         | `MISP_DATETIME_ATTRIBUTE`         | Yes          | The attribute to be used in filter to query new MISP events.                                        |
 | `misp_create_reports`             | `MISP_CREATE_REPORTS`             | Yes          | A boolean (`True` or `False`), create reports for each imported MISP event.                         |
+| `misp_create_object_observables`         | `MISP_CREATE_OBJECT_OBSERVABLES`         | Yes          | A boolean (`True` or `False`), create a text observable for each imported MISP object.               |
 | `misp_create_observables`         | `MISP_CREATE_OBSERVABLES`         | Yes          | A boolean (`True` or `False`), create an observable for each imported MISP attribute.               |
 | `misp_create_indicators`          | `MISP_CREATE_INDICATORS`          | Yes          | A boolean (`True` or `False`), create an indicator for each imported MISP attribute.                |
 | `misp_report_class`               | `MISP_REPORT_CLASS`               | No           | If `create_reports` is `True`, specify the `report_class` (category), default is `MISP Event`       |

--- a/misp/src/config.yml.sample
+++ b/misp/src/config.yml.sample
@@ -20,6 +20,7 @@ misp:
   create_reports: True # Required, create report for MISP event
   create_indicators: True # Required, create indicators for attributes
   create_observables: True # Required, create observables for attributes
+  create_object_observables: True # Required, create text observables for MISP objects
   report_class: 'misp-event' # Optional, report_class if creating report for event
   import_from_date: '2010-01-01' # Optional, import all event from this date
   import_tags: 'opencti:import,type:osint' # Optional, list of tags used for import events

--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -1,3 +1,4 @@
+import re
 import os
 import yaml
 import time
@@ -69,6 +70,7 @@ OPENCTISTIX2 = {
         "type": "x509-certificate",
         "path": ["serial_number"],
     },
+    "text": {"type": "x-opencti-text", "path": ["value"]},
 }
 FILETYPES = ["file-name", "file-md5", "file-sha1", "file-sha256"]
 
@@ -103,6 +105,11 @@ class Misp:
         )
         self.misp_create_observables = get_config_variable(
             "MISP_CREATE_OBSERVABLES", ["misp", "create_observables"], config
+        )
+        self.misp_create_object_observables = get_config_variable(
+            "MISP_CREATE_OBJECT_OBSERVABLES",
+            ["misp", "create_object_observables"],
+            config,
         )
         self.misp_report_type = (
             get_config_variable("MISP_REPORT_TYPE", ["misp", "report_type"], config)
@@ -356,13 +363,14 @@ class Misp:
             ### Get indicators
             event_external_references = [event_external_reference]
             indicators = []
-            # Get attributes
+            # Get attributes of event
             for attribute in event["Event"]["Attribute"]:
                 indicator = self.process_attribute(
                     author,
                     event_elements,
                     event_markings,
                     event_tags,
+                    None,
                     [],
                     attribute,
                     event["Event"]["threat_level_id"],
@@ -378,8 +386,10 @@ class Misp:
                 if indicator is not None:
                     indicators.append(indicator)
             # Get attributes of objects
+            indicators_relationships = []
             objects_relationships = []
-            uuid_dict = {}
+            objects_observables = []
+            event_threat_level = event["Event"]["threat_level_id"]
             for object in event["Event"]["Object"]:
                 attribute_external_references = []
                 for attribute in object["Attribute"]:
@@ -391,6 +401,30 @@ class Misp:
                                 url=attribute["value"],
                             )
                         )
+                object_observable = None
+                if self.misp_create_object_observables is not None:
+                    unique_key = ""
+                    if len(object["Attribute"]) > 0:
+                        unique_key = (
+                            " ("
+                            + object["Attribute"][0]["type"]
+                            + "="
+                            + object["Attribute"][0]["value"]
+                            + ")"
+                        )
+
+                    object_observable = SimpleObservable(
+                        id="x-opencti-simple-observable--" + object["uuid"],
+                        key="X-OpenCTI-Text.value",
+                        value=object["name"] + unique_key,
+                        description=object["description"],
+                        x_opencti_score=self.threat_level_to_score(event_threat_level),
+                        labels=event_tags,
+                        created_by_ref=author,
+                        object_marking_refs=event_markings,
+                        external_references=attribute_external_references,
+                    )
+                    objects_observables.append(object_observable)
                 object_attributes = []
                 for attribute in object["Attribute"]:
                     indicator = self.process_attribute(
@@ -398,15 +432,13 @@ class Misp:
                         event_elements,
                         event_markings,
                         event_tags,
+                        object_observable,
                         attribute_external_references,
                         attribute,
                         event["Event"]["threat_level_id"],
                     )
                     if indicator is not None:
                         indicators.append(indicator)
-                        if indicator["indicator"] is not None:
-                            # we want to map the OpenCTI ids to MISP ids to do a lookup later
-                            uuid_dict[object["uuid"]] = indicator["indicator"]["id"]
                         if (
                             indicator["indicator"] is not None
                             and object["meta-category"] == "file"
@@ -415,23 +447,6 @@ class Misp:
                         ):
                             object_attributes.append(indicator)
                 # TODO Extend observable
-            # Reiterate after we have all the OpenCTI ids to create Relationships with those
-            for object in event["Event"]["Object"]:
-                for ref in object["ObjectReference"]:
-                    ref_src = uuid_dict.get(ref["source_uuid"], None)
-                    ref_target = uuid_dict.get(ref["referenced_uuid"], None)
-                    if ref_src is not None and ref_target is not None:
-                        objects_relationships.append(
-                            Relationship(
-                                id="relationship--" + ref["uuid"],
-                                relationship_type=ref["relationship_type"]
-                                or "related-to",
-                                created_by_ref=author,
-                                description=ref["comment"],
-                                source_ref=ref_src,
-                                target_ref=ref_target,
-                            )
-                        )
 
             ### Prepare the bundle
             bundle_objects = [author]
@@ -503,8 +518,39 @@ class Misp:
                         added_entities.append(attribute_element["name"])
                 # Add attribute relationships
                 for relationship in indicator["relationships"]:
-                    object_refs.append(relationship)
-                    bundle_objects.append(relationship)
+                    indicators_relationships.append(relationship)
+
+            # We want to make sure these are added as lasts, so we're sure all the related objects are created
+            for indicator_relationship in indicators_relationships:
+                objects_relationships.append(indicator_relationship)
+            # Add MISP objects_observables
+            for object_observable in objects_observables:
+                object_refs.append(object_observable)
+                bundle_objects.append(object_observable)
+
+            # Link all objects with each other, now so we can find the correct entity type prefix in bundle_objects
+            for object in event["Event"]["Object"]:
+                for ref in object["ObjectReference"]:
+                    ref_src = ref.get("source_uuid")
+                    ref_target = ref.get("referenced_uuid")
+
+                    src_result = self.find_type_by_uuid(ref_src, bundle_objects)
+                    target_result = self.find_type_by_uuid(ref_target, bundle_objects)
+
+                    if src_result is not None and target_result is not None:
+                        objects_relationships.append(
+                            Relationship(
+                                id="relationship--" + ref["uuid"],
+                                relationship_type="related-to",
+                                created_by_ref=author,
+                                description="Original Relationship: "
+                                + ref["relationship_type"]
+                                + "  \nComment: "
+                                + ref["comment"],
+                                source_ref=src_result["entity"]["id"],
+                                target_ref=target_result["entity"]["id"],
+                            )
+                        )
             # Add object_relationships
             for object_relationship in objects_relationships:
                 object_refs.append(object_relationship)
@@ -544,7 +590,7 @@ class Misp:
                         created_by_ref=author,
                         object_marking_refs=event_markings,
                         abstract=note["name"],
-                        content=note["content"],
+                        content=self.process_note(note["content"], bundle_objects),
                         object_refs=[report],
                     )
                     bundle_objects.append(note)
@@ -560,6 +606,7 @@ class Misp:
         event_elements,
         event_markings,
         event_labels,
+        object_observable,
         attribute_external_references,
         attribute,
         event_threat_level,
@@ -633,19 +680,12 @@ class Misp:
                 )
                 pattern = genuine_pattern
 
-            if event_threat_level == "1":
-                score = 90
-            elif event_threat_level == "2":
-                score = 60
-            elif event_threat_level == "3":
-                score = 30
-            else:
-                score = 50
+            score = self.threat_level_to_score(event_threat_level)
 
             indicator = None
             if self.misp_create_indicators:
                 indicator = Indicator(
-                    id=OpenCTIStix2Utils.generate_random_stix_id("indicator"),
+                    id="indicator--" + attribute["uuid"],
                     name=name,
                     description=attribute["comment"],
                     confidence=self.helper.connect_confidence_level,
@@ -673,9 +713,7 @@ class Misp:
             observable = None
             if self.misp_create_observables and observable_type is not None:
                 observable = SimpleObservable(
-                    id=OpenCTIStix2Utils.generate_random_stix_id(
-                        "x-opencti-simple-observable"
-                    ),
+                    id="x-opencti-simple-observable--" + attribute["uuid"],
                     key=observable_type
                     + "."
                     + ".".join(OPENCTISTIX2[observable_resolver]["path"]),
@@ -742,6 +780,21 @@ class Misp:
                         created_by_ref=author,
                         source_ref=indicator.id,
                         target_ref=observable.id,
+                    )
+                )
+            ### Create relationship between MISP attribute (indicator or observable) and MISP object (observable)
+            if object_observable is not None and (
+                indicator is not None or observable is not None
+            ):
+                relationships.append(
+                    Relationship(
+                        id=OpenCTIStix2Utils.generate_random_stix_id("relationship"),
+                        relationship_type="related-to",
+                        created_by_ref=author,
+                        source_ref=object_observable.id,
+                        target_ref=observable.id
+                        if (observable is not None)
+                        else indicator.id,
                     )
                 )
             # Event threats
@@ -1256,6 +1309,14 @@ class Misp:
                         else None
                     )
                 return [{"resolver": resolver_0, "type": type_0, "value": value}]
+        # If not found, return text observable as a fallback
+        return [
+            {
+                "resolver": "text",
+                "type": "X-OpenCTI-Text",
+                "value": value + " (type=" + type + ")",
+            }
+        ]
 
     def detect_ip_version(self, value, type=False):
         if len(value) > 16:
@@ -1333,6 +1394,53 @@ class Misp:
                     tag_value = tag_value.replace('="', "-")[:-1]
                 opencti_tags.append(tag_value)
         return opencti_tags
+
+    def find_type_by_uuid(self, uuid, bundle_objects):
+        # filter by uuid
+        l_find = lambda o: o.id.endswith("--" + uuid)
+        result = list(filter(l_find, bundle_objects))
+
+        if len(result) > 0:
+            uuid = result[0]["id"]
+            return {
+                "entity": result[0],
+                "type": uuid[: uuid.index("--")],
+            }
+        return None
+
+    # Markdown object, attribute & tag links should be converted from MISP links to OpenCTI links
+    def process_note(self, content, bundle_objects):
+        def reformat(match):
+            type = match.group(1)
+            uuid = match.group(2)
+            result = self.find_type_by_uuid(uuid, bundle_objects)
+            if result is None:
+                return "[{}:{}](/dashboard/search/{})".format(type, uuid, uuid)
+            if result["type"] == "indicator":
+                name = result["entity"]["pattern"]
+            else:
+                name = result["entity"]["value"]
+            return "[{}:{}](/dashboard/search/{})".format(
+                type, name, result["entity"]["id"]
+            )
+
+        r_object = r"@\[(object|attribute)\]\(([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\)"
+        r_tag = r'@\[tag\]\(([a-zA-Z:"\'0-9\-=]+)\)'
+
+        content = re.sub(r_object, reformat, content, flags=re.MULTILINE)
+        content = re.sub(r_tag, r"tag:\1", content, flags=re.MULTILINE)
+        return content
+
+    def threat_level_to_score(self, threat_level):
+        if threat_level == "1":
+            score = 90
+        elif threat_level == "2":
+            score = 60
+        elif threat_level == "3":
+            score = 30
+        else:
+            score = 50
+        return score
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- When a MISP EventReport gets imported, we change the @object and @attribute links to OpenCTI links.
MISP:
![MicrosoftTeams-image (5)](https://user-images.githubusercontent.com/5853564/119148333-abf25b80-ba4c-11eb-93b1-ee942a694025.png)
OCTI:
![MicrosoftTeams-image (6)](https://user-images.githubusercontent.com/5853564/119148355-b01e7900-ba4c-11eb-89da-d020f94b3ef4.png)
- When we imported a MISP object with attributes, we omitted the MISP object, now we create it as a OCTI Text Observable
MISP:
![image](https://user-images.githubusercontent.com/5853564/119148533-dba16380-ba4c-11eb-9c6a-31b82ad63c47.png)
OCTI Before:
![image](https://user-images.githubusercontent.com/5853564/119148544-dfcd8100-ba4c-11eb-841d-ea5b9cbd33dc.png)
OCTI After:
![image](https://user-images.githubusercontent.com/5853564/119148723-10adb600-ba4d-11eb-8efd-6a55c4b9e6df.png)
- Relationships between MISP objects & MISP attributes are now also correctly reflected:
![image](https://user-images.githubusercontent.com/5853564/119148813-2ae79400-ba4d-11eb-9232-daab5ffffc4c.png)
- When the connector can't find the correct observable (e.g. cookie) it will import it as a OpenCTI-Text observable. In the value it'll also give its real type
![image](https://user-images.githubusercontent.com/5853564/119149158-887be080-ba4d-11eb-96e0-6dc388f747ef.png)
