### PR TITLE
Clarify log messages

### DIFF
--- a/threatbus/src/connector.py
+++ b/threatbus/src/connector.py
@@ -108,8 +108,8 @@ class ThreatBusConnector(object):
         elif type(stix_msg) is Indicator:
             self._handle_indicator(stix_msg)
         else:
-            self.opencti_helper.log_error(
-                f"Received STIX object with unexpected type from Threat Bus: {type(stix_msg)}"
+            self.opencti_helper.log_warning(
+                f"Discarding Threat Bus message with unsupported type: {type(stix_msg)}. Hint: SnapshotRequests are not yet supported."
             )
 
     def _handle_indicator(self, indicator: Indicator):

--- a/threatbus/src/threatbus_connector_helper.py
+++ b/threatbus/src/threatbus_connector_helper.py
@@ -179,7 +179,7 @@ class ThreatBusConnectorHelper(Thread):
                 try:
                     self._register_to_threatbus()
                 except Exception as e:
-                    self.log_error(f"Error: {e}")
+                    self.log_error(e)
             await asyncio.sleep(5)  # heartbeat every 5 secs
 
     def _register_to_threatbus(self):


### PR DESCRIPTION
Clarify some log messages and use the proper log level for a warning.