### PR TITLE
fixed MISP event creation date and modification date

### DIFF
--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -597,7 +597,8 @@ class Misp:
                         int(event["Event"]["publish_timestamp"])
                     ),
                     created=datetime.utcfromtimestamp(
-                        int(datetime.strptime(str(event["Event"]["date"]), '%Y-%m-%d').timestamp())
+                        int(datetime.strptime(
+                            str(event["Event"]["date"]), '%Y-%m-%d').timestamp())
                     ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     modified=datetime.utcfromtimestamp(
                         int(event["Event"]["timestamp"])

--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -594,10 +594,10 @@ class Misp:
                     name=event["Event"]["info"],
                     description=event["Event"]["info"],
                     published=datetime.utcfromtimestamp(
-                        int(event["Event"]["timestamp"])
+                        int(event["Event"]["publish_timestamp"])
                     ),
                     created=datetime.utcfromtimestamp(
-                        int(event["Event"]["timestamp"])
+                        int(datetime.strptime(str(event["Event"]["date"]), '%Y-%m-%d').timestamp())
                     ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     modified=datetime.utcfromtimestamp(
                         int(event["Event"]["timestamp"])

--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -610,7 +610,6 @@ class Misp:
                     modified=datetime.utcfromtimestamp(
                         int(event["Event"]["timestamp"])
                     ).strftime("%Y-%m-%dT%H:%M:%SZ"),
-
                     report_types=[self.misp_report_type],
                     created_by_ref=author,
                     object_marking_refs=event_markings,

--- a/misp/src/misp.py
+++ b/misp/src/misp.py
@@ -594,15 +594,23 @@ class Misp:
                     name=event["Event"]["info"],
                     description=event["Event"]["info"],
                     published=datetime.utcfromtimestamp(
-                        int(event["Event"]["publish_timestamp"])
+                        int(
+                            datetime.strptime(
+                                str(event["Event"]["date"]), "%Y-%m-%d"
+                            ).timestamp()
+                        )
                     ),
                     created=datetime.utcfromtimestamp(
-                        int(datetime.strptime(
-                            str(event["Event"]["date"]), '%Y-%m-%d').timestamp())
+                        int(
+                            datetime.strptime(
+                                str(event["Event"]["date"]), "%Y-%m-%d"
+                            ).timestamp()
+                        )
                     ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     modified=datetime.utcfromtimestamp(
                         int(event["Event"]["timestamp"])
                     ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+
                     report_types=[self.misp_report_type],
                     created_by_ref=author,
                     object_marking_refs=event_markings,


### PR DESCRIPTION
Fixed an issue with wrong creation date for MISP event ingestion.
I kept the use of datetime.utcfromtimestamp, after a little research it seems that this method is not quite safe.
According to https://docs.python.org/3/library/datetime.html, this is the safe method: 
datetime.fromtimestamp(timestamp, timezone.utc) 
timezone should be also imported from datetime in order for this to work.