### PR TITLE
[riskiq] set report's tlp as AMBER if not all IoC's are WHITE

### DIFF
--- a/external-import/riskiq/src/riskiq/article_importer.py
+++ b/external-import/riskiq/src/riskiq/article_importer.py
@@ -57,7 +57,7 @@ class ArticleImporter:
         """
         indicator_type = indicator["type"]
         values = indicator["values"]
-        tlp_marking = TLP_AMBER if indicator["source"] != "public" else TLP_WHITE
+        tlp_marking = TLP_WHITE if indicator["source"] == "public" else TLP_AMBER
 
         if indicator_type == "hash_md5":
             return [
@@ -198,6 +198,11 @@ class ArticleImporter:
 
         self.helper.log_debug(f"Number of indicators: {len(indicators)}")
 
+        # Check if all indicators' TLP marking are `TLP_WHITE`.
+        report_tlp = TLP_WHITE
+        if TLP_AMBER in [i["object_marking_refs"][0] for i in indicators]:
+            report_tlp = TLP_AMBER
+
         report = Report(
             type="report",
             name=self.article.get("title", "RiskIQ Threat Report"),
@@ -209,7 +214,7 @@ class ArticleImporter:
             lang="en",
             labels=self.article["tags"],
             object_refs=indicators,
-            object_marking_refs=TLP_AMBER,
+            object_marking_refs=report_tlp,
             external_references=[
                 {
                     "source_name": "riskiq",


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Instead of setting the TLP_marking of the report as AMBER, look at the IoC's TLPs:
  If all IoC's TLPs are WHITE, the report is WHITE, otherwise it is AMBER.

### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
