### PR TITLE
[riskiq] add prometheus metrics

### DIFF
--- a/external-import/riskiq/docker-compose.yml
+++ b/external-import/riskiq/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - CONNECTOR_SCOPE=riskiq
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_EXPOSE_METRICS=false
       - RISKIQ_BASE_URL=https://api.riskiq.net/pt/v2
       - RISKIQ_USER=ChangeMe
       - RISKIQ_PASSWORD=ChangeMe

--- a/external-import/riskiq/src/config.yml.sample
+++ b/external-import/riskiq/src/config.yml.sample
@@ -10,6 +10,7 @@ connector:
   confidence_level: 15  # 0 (Unknown) or from 1 to 100 (Fully trusted)
   update_existing_data: False
   log_level: 'info'
+  expose_metrics: False
 
 riskiq:
   base_url: "https://api.riskiq.net/pt/v2/"

--- a/external-import/riskiq/src/requirements.txt
+++ b/external-import/riskiq/src/requirements.txt
@@ -1,3 +1,3 @@
-pycti==5.0.2
+pycti==5.0.3
 stix2==2.1.0
 urllib3==1.26.6

--- a/external-import/riskiq/src/riskiq/article_importer.py
+++ b/external-import/riskiq/src/riskiq/article_importer.py
@@ -238,3 +238,4 @@ class ArticleImporter:
     def _send_bundle(self, bundle: Bundle) -> None:
         serialized_bundle = bundle.serialize()
         self.helper.send_stix2_bundle(serialized_bundle, work_id=self.work_id)
+        self.helper.metric_inc("record_send", len(bundle.objects))

--- a/external-import/riskiq/src/riskiq/riskiq.py
+++ b/external-import/riskiq/src/riskiq/riskiq.py
@@ -47,7 +47,12 @@ class RiskIQConnector:
             "RISKIQ_PASSWORD", ["riskiq", "password"], config
         )
         # Initialization of the client
-        self.client = RiskIQClient(self.base_url, user, password)
+        self.client = RiskIQClient(
+            self.base_url,
+            user,
+            password,
+            self.helper.metrics if self.helper.metrics else None,
+        )
 
     @staticmethod
     def _current_unix_timestamp() -> int:
@@ -128,6 +133,8 @@ class RiskIQConnector:
                     current_state, self._STATE_LATEST_RUN_TIMESTAMP
                 )
                 if self._is_scheduled(last_run, timestamp):
+                    self.helper.metric_inc("run_count")
+                    self.helper.metric_state("running")
                     work_id = self._initiate_work(timestamp)
                     new_state = current_state.copy()
                     last_article = self._get_state_value(
@@ -174,11 +181,15 @@ class RiskIQConnector:
                     self.helper.log_info(
                         f"[RiskIQ] Connector will not run, next run in {run_interval} seconds"
                     )
-
+                # Set the state as `idle` before sleeping.
+                self.helper.metric_state("idle")
                 self._sleep(delay_sec=run_interval)
             except (KeyboardInterrupt, SystemExit):
+                self.helper.metric_state("stopped")
                 self.helper.log_info("RiskIQ connector stop")
                 sys.exit(0)
             except Exception as e:
                 self.helper.log_error(str(e))
+                self.helper.metric_inc("error_count")
+                self.helper.metric_state("stopped")
                 sys.exit(0)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add the following metrics for riskiq connector:

Metric | Type | Description
-- | -- | --
bundle_send | Counter | The number of bundle that have been sent using the "send_bundle" function from pycti
record_send | Counter | The number of record (objects per bundle) send by the connector
run_count | Counter | The number of time the connector has run
error_count | Counter | The number of error that occurs in the connector
client_error_count | Counter | The number of error that occurs in the client when communicating with the remote data source
state | Enum | The state in which the connector is. One of `idle`, `running`, `stopped`


* Expose the metrics on an HTTP endpoint (so that they can be scraped by Prometheus)


### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

This PR needs the next version of pycti (5.0.3). 

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
