### PR TITLE
[mitre] add prometheus metrics

### DIFF
--- a/external-import/mitre/docker-compose.yml
+++ b/external-import/mitre/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_UPDATE_EXISTING_DATA=true
       - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_EXPOSE_METRICS=false
       - MITRE_ENTERPRISE_FILE_URL=https://raw.githubusercontent.com/mitre/cti/master/enterprise-attack/enterprise-attack.json
       - MITRE_PRE_ATTACK_FILE_URL=https://raw.githubusercontent.com/mitre/cti/master/pre-attack/pre-attack.json
       - MITRE_MOBILE_ATTACK_FILE_URL=https://raw.githubusercontent.com/mitre/cti/master/mobile-attack/mobile-attack.json

--- a/external-import/mitre/src/config.yml.sample
+++ b/external-import/mitre/src/config.yml.sample
@@ -10,6 +10,7 @@ connector:
   confidence_level: 15 # From 0 (Unknown) to 100 (Fully trusted)
   update_existing_data: True
   log_level: 'info'
+  expose_metrics: False
 
 mitre:
   enterprise_file_url: 'https://raw.githubusercontent.com/mitre/cti/master/enterprise-attack/enterprise-attack.json'

--- a/external-import/mitre/src/mitre.py
+++ b/external-import/mitre/src/mitre.py
@@ -1,12 +1,14 @@
-import os
-import yaml
-import time
-import urllib.request
-import certifi
-import ssl
-
 from datetime import datetime
+import os
+import ssl
+import time
+import urllib
+from typing import Optional
+import sys
+
+import certifi
 from pycti import OpenCTIConnectorHelper, get_config_variable
+import yaml
 
 
 class Mitre:
@@ -44,8 +46,37 @@ class Mitre:
     def get_interval(self):
         return int(self.mitre_interval) * 60 * 60 * 24
 
-    def next_run(self, seconds):
-        return
+    def retrieve_data(self, url: str) -> Optional[str]:
+        """
+        Retrieve data from the given url.
+
+        Parameters
+        ----------
+        url : str
+            Url to retrieve.
+
+        Returns
+        -------
+        str
+            A string with the content or None in case of failure.
+        """
+        try:
+            return (
+                urllib.request.urlopen(
+                    url,
+                    context=ssl.create_default_context(cafile=certifi.where()),
+                )
+                .read()
+                .decode("utf-8")
+            )
+        except (
+            urllib.error.URLError,
+            urllib.error.HTTPError,
+            urllib.error.ContentTooShortError,
+        ) as urllib_error:
+            self.helper.log_error(f"Error retrieving url {url}: {urllib_error}")
+            self.helper.metric_inc("error_client_count")
+        return None
 
     def run(self):
         self.helper.log_info("Fetching MITRE datasets...")
@@ -71,87 +102,32 @@ class Mitre:
                     > ((int(self.mitre_interval) - 1) * 60 * 60 * 24)
                 ):
                     self.helper.log_info("Connector will run!")
+                    self.helper.metric_inc("run_count")
+                    self.helper.metric_state("running")
+
                     now = datetime.utcfromtimestamp(timestamp)
                     friendly_name = "MITRE run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
                     work_id = self.helper.api.work.initiate_work(
                         self.helper.connect_id, friendly_name
                     )
-                    try:
-                        enterprise_data = (
-                            urllib.request.urlopen(
-                                self.mitre_enterprise_file_url,
-                                context=ssl.create_default_context(
-                                    cafile=certifi.where()
-                                ),
-                            )
-                            .read()
-                            .decode("utf-8")
-                        )
-                        self.helper.send_stix2_bundle(
-                            enterprise_data,
-                            entities_types=self.helper.connect_scope,
-                            update=self.update_existing_data,
-                            work_id=work_id,
-                        )
-                    except Exception as e:
-                        self.helper.log_error(str(e))
-                    try:
-                        pre_attack_data = (
-                            urllib.request.urlopen(
-                                self.mitre_pre_attack_file_url,
-                                context=ssl.create_default_context(
-                                    cafile=certifi.where()
-                                ),
-                            )
-                            .read()
-                            .decode("utf-8")
-                        )
-                        self.helper.send_stix2_bundle(
-                            pre_attack_data,
-                            entities_types=self.helper.connect_scope,
-                            update=self.update_existing_data,
-                            work_id=work_id,
-                        )
-                    except Exception as e:
-                        self.helper.log_error(str(e))
-                    try:
-                        mobile_attack_data = (
-                            urllib.request.urlopen(
-                                self.mitre_mobile_attack_file_url,
-                                context=ssl.create_default_context(
-                                    cafile=certifi.where()
-                                ),
-                            )
-                            .read()
-                            .decode("utf-8")
-                        )
-                        self.helper.send_stix2_bundle(
-                            mobile_attack_data,
-                            entities_types=self.helper.connect_scope,
-                            update=self.update_existing_data,
-                            work_id=work_id,
-                        )
-                    except Exception as e:
-                        self.helper.log_error(str(e))
-                    try:
-                        ics_attack_data = (
-                            urllib.request.urlopen(
-                                self.mitre_ics_attack_file_url,
-                                context=ssl.create_default_context(
-                                    cafile=certifi.where()
-                                ),
-                            )
-                            .read()
-                            .decode("utf-8")
-                        )
-                        self.helper.send_stix2_bundle(
-                            ics_attack_data,
-                            entities_types=self.helper.connect_scope,
-                            update=self.update_existing_data,
-                            work_id=work_id,
-                        )
-                    except Exception as e:
-                        self.helper.log_error(str(e))
+                    # Mitre enterprise file url
+                    enterprise_data = self.retrieve_data(self.mitre_enterprise_file_url)
+                    self.send_bundle(work_id, enterprise_data)
+
+                    # Mitre pre attack file url
+                    pre_attack_data = self.retrieve_data(self.mitre_pre_attack_file_url)
+                    self.send_bundle(work_id, pre_attack_data)
+
+                    # Mitre mobile attack file url
+                    mobile_attack_data = self.retrieve_data(
+                        self.mitre_mobile_attack_file_url
+                    )
+                    self.send_bundle(work_id, mobile_attack_data)
+
+                    # Mitre ics attack file url
+                    ics_attack_data = self.retrieve_data(self.mitre_ics_attack_file_url)
+                    self.send_bundle(work_id, ics_attack_data)
+
                     # Store the current timestamp as a last run
                     message = "Connector successfully run, storing last_run as " + str(
                         timestamp
@@ -164,7 +140,6 @@ class Mitre:
                         + str(round(self.get_interval() / 60 / 60 / 24, 2))
                         + " days"
                     )
-                    time.sleep(60)
                 else:
                     new_interval = self.get_interval() - (timestamp - last_run)
                     self.helper.log_info(
@@ -172,13 +147,29 @@ class Mitre:
                         + str(round(new_interval / 60 / 60 / 24, 2))
                         + " days"
                     )
-                    time.sleep(60)
+                # Set the state as `idle` before sleeping.
+                self.helper.metric_state("idle")
+                time.sleep(60)
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                self.helper.metric_state("stopped")
+                sys.exit(0)
             except Exception as e:
                 self.helper.log_error(str(e))
                 time.sleep(60)
+
+    def send_bundle(self, work_id: str, serialized_bundle: str) -> None:
+        try:
+            self.helper.send_stix2_bundle(
+                serialized_bundle,
+                entities_types=self.helper.connect_scope,
+                update=self.update_existing_data,
+                work_id=work_id,
+            )
+        except Exception as e:
+            self.helper.log_error(f"Error while sending bundle: {e}")
+            if self.helper.metrics is not None:
+                self.helper.metric_inc("error_count")
 
 
 if __name__ == "__main__":
@@ -188,4 +179,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/mitre/src/requirements.txt
+++ b/external-import/mitre/src/requirements.txt
@@ -1,3 +1,3 @@
-pycti==5.0.2
+pycti==5.0.3
 urllib3==1.26.5
 certifi==2020.12.5


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add the following metrics for mitre connector:


Metric | Type | Description
-- | -- | --
bundle_send | Counter | The number of bundle that have been send using the "send_bundle" function from pycti
run_count | Counter | The number of time the connector has run
error_count | Counter | The number of error that occurs in the connector
client_error_count | Counter | The number of error that occurs in the client when communicating with the remote data source
state | Enum | The state in which the connector is. One of `idle`, `running`, `stopped`


* Expose the metrics on an HTTP endpoint (so that they can be scraped by Prometheus)


### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

This PR needs the next version of pycti (5.0.3).
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
