### PR TITLE
[misp] add prometheus metrics

### DIFF
--- a/external-import/misp/docker-compose.yml
+++ b/external-import/misp/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_UPDATE_EXISTING_DATA=false
       - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_EXPOSE_METRICS=false
       - MISP_URL=http://localhost # Required
       - MISP_REFERENCE_URL= # Optional, will be used to create external reference to MISP event (default is "url")
       - MISP_KEY=ChangeMe # Required

--- a/external-import/misp/src/config.yml.sample
+++ b/external-import/misp/src/config.yml.sample
@@ -10,6 +10,7 @@ connector:
   confidence_level: 15 # 0 (Unknown) or from 1 to 100
   update_existing_data: False
   log_level: 'info'
+  expose_metrics: False
 
 misp:
   url: 'http://localhost' # Required

--- a/external-import/misp/src/misp.py
+++ b/external-import/misp/src/misp.py
@@ -1,10 +1,15 @@
-import re
-import os
-import yaml
-import time
-import json
-
 from datetime import datetime
+import json
+import os
+import re
+import time
+
+from pycti import (
+    OpenCTIConnectorHelper,
+    get_config_variable,
+    SimpleObservable,
+    OpenCTIStix2Utils,
+)
 from pymisp import ExpandedPyMISP
 from stix2 import (
     Bundle,
@@ -28,13 +33,7 @@ from stix2 import (
     ObservationExpression,
     Note,
 )
-
-from pycti import (
-    OpenCTIConnectorHelper,
-    get_config_variable,
-    SimpleObservable,
-    OpenCTIStix2Utils,
-)
+import yaml
 
 PATTERNTYPES = ["yara", "sigma", "pcre", "snort", "suricata"]
 OPENCTISTIX2 = {
@@ -180,6 +179,8 @@ class Misp:
 
     def run(self):
         while True:
+            self.helper.metric_inc("run_count")
+            self.helper.metric_state("running")
             timestamp = int(time.time())
             # Get the last_run datetime
             now = datetime.utcfromtimestamp(timestamp)
@@ -250,10 +251,12 @@ class Misp:
                     events = self.misp.search("events", **kwargs)
                 except Exception as e:
                     self.helper.log_error(str(e))
+                    self.helper.metric_inc("client_error_count")
                     try:
                         events = self.misp.search("events", **kwargs)
                     except Exception as e:
                         self.helper.log_error(str(e))
+                        self.helper.metric_inc("client_error_count")
 
                 self.helper.log_info("MISP returned " + str(len(events)) + " events.")
                 number_events = number_events + len(events)
@@ -272,6 +275,7 @@ class Misp:
             self.helper.log_info(message)
             self.helper.set_state({"last_run": timestamp})
             self.helper.api.work.to_processed(work_id, message)
+            self.helper.metric_state("idle")
             time.sleep(self.get_interval())
 
     def process_events(self, work_id, events):
@@ -656,6 +660,7 @@ class Misp:
             self.helper.send_stix2_bundle(
                 bundle, work_id=work_id, update=self.update_existing_data
             )
+            self.helper.metric_inc("record_send", len(bundle_objects))
 
     def _get_pdf_file(self, attribute):
         if not self.import_with_attachments:
@@ -810,6 +815,7 @@ class Misp:
                     )
                 except Exception as e:
                     self.helper.log_error(str(e))
+                    self.helper.metric_inc("error_count")
             observable = None
             if self.misp_create_observables and observable_type is not None:
                 try:
@@ -828,6 +834,7 @@ class Misp:
                     )
                 except Exception as e:
                     self.helper.log_error(str(e))
+                    self.helper.metric_inc("error_count")
             sightings = []
             identities = []
             if "Sighting" in attribute:

--- a/external-import/misp/src/requirements.txt
+++ b/external-import/misp/src/requirements.txt
@@ -1,4 +1,4 @@
-pycti==5.0.2
+pycti==5.0.3
 urllib3==1.26.5
 pymisp
 python-dateutil==2.8.1


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add the following metrics for misp connector:

Metric | Type | Description
-- | -- | --
bundle_send | Counter | The number of bundle that have been send using the "send_bundle" function from pycti
record_send | Counter | The number of record (objects per bundle) send by the connector
run_count | Counter | The number of time the connector has run
error_count | Counter | The number of error that occurs in the connector
client_error_count | Counter | The number of error that occurs in the client when communicating with the remote data source
state | Enum | The state in which the connector is. One of `idle`, `running`, `stopped`


* Expose the metrics on an HTTP endpoint (so that they can be scraped by Prometheus)

### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

This PR needs the next version of pycti (5.0.3).
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
