### PR TITLE
[malpedia] add prometheus metrics

### DIFF
--- a/external-import/malpedia/docker-compose.yml
+++ b/external-import/malpedia/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=30 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_UPDATE_EXISTING_DATA=false
       - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_EXPOSE_METRICS=false
       - MALPEDIA_AUTH_KEY= # Empty key only fetches TLP:WHITE information
       - MALPEDIA_INTERVAL_SEC=86400 # Run once every day
       - MALPEDIA_IMPORT_INTRUSION_SETS=false

--- a/external-import/malpedia/src/config.yml.sample
+++ b/external-import/malpedia/src/config.yml.sample
@@ -10,6 +10,7 @@ connector:
   confidence_level: 30 # From 0 (Unknown) to 100 (Fully trusted)
   update_existing_data: false
   log_level: 'info'
+  expose_metrics: false
 
 malpedia:
   auth_key: ''

--- a/external-import/malpedia/src/malpedia/client.py
+++ b/external-import/malpedia/src/malpedia/client.py
@@ -1,22 +1,24 @@
 # -*- coding: utf-8 -*-
 """OpenCTI Malpedia client module."""
 import logging
-import requests
-
 from urllib.parse import urljoin
-from typing import Any
+from typing import Any, Optional
+
+import requests
 
 logger = logging.getLogger(__name__)
 
 
 class MalpediaClient:
+    """Malpedia client."""
 
     _DEFAULT_API_URL = "https://malpedia.caad.fkie.fraunhofer.de/api/"
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str, metrics: Optional[dict[str, Any]] = None) -> None:
         """Initialize Malpedia api client."""
         self.api_url = self._DEFAULT_API_URL
         self.api_key = api_key
+        self.metrics = metrics
 
         if self.api_key == "" or self.api_key is None:
             self.unauthenticated = True
@@ -38,6 +40,8 @@ class MalpediaClient:
                 data = r.json()
         except requests.exceptions.RequestException as e:
             logger.error(f"error in malpedia query: {e}")
+            if self.metrics is not None:
+                self.metrics["client_error_count"].inc()
             return None
         return data
 
@@ -45,6 +49,7 @@ class MalpediaClient:
         response_json = self.query("check/apikey")
         if "Valid token" in response_json["detail"]:
             return True
+        return False
 
     def current_version(self) -> int:
         response_json = self.query("get/version")

--- a/external-import/malpedia/src/malpedia/models.py
+++ b/external-import/malpedia/src/malpedia/models.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """OpenCTI Malpedia connector models."""
 
-import re
-import dateutil.parser as dp
 from datetime import datetime, date
+import re
 from typing import Optional, List
 
+import dateutil.parser as dp
 from pydantic import BaseModel
 
 
@@ -39,8 +39,7 @@ class Family(BaseModel):
         """Malpedia names list."""
         if self.common_name == "":
             return self.malpedia_name
-        else:
-            return self.common_name
+        return self.common_name
 
 
 class YaraRule(BaseModel):
@@ -56,11 +55,10 @@ class YaraRule(BaseModel):
         extract = re.search(r"([0-9]{4}\-[0-9]{2}\-[0-9]{2})", self.raw_rule)
         if extract is None:
             return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+00:00")
-        else:
-            try:
-                return dp.isoparse(extract.group(1)).strftime("%Y-%m-%dT%H:%M:%S+00:00")
-            except Exception:
-                return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        try:
+            return dp.isoparse(extract.group(1)).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        except Exception:
+            return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+00:00")
 
 
 class Sample(BaseModel):

--- a/external-import/malpedia/src/requirements.txt
+++ b/external-import/malpedia/src/requirements.txt
@@ -1,2 +1,2 @@
-pycti==5.0.2
+pycti==5.0.3
 pydantic==1.8.2


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add the following metrics for malpedia connector:

Metric | Type | Description
-- | -- | --
record_send | Counter | The number of record (objects per bundle) created by the connector using the GraphQL API
run_count | Counter | The number of time the connector has run
error_count | Counter | The number of error that occurs in the connector
client_error_count | Counter | The number of error that occurs in the client when communicating with the remote data source
state | Enum | The state in which the connector is. One of `idle`, `running`, `stopped`


* Expose the metrics on an HTTP endpoint (so that they can be scraped by Prometheus)

### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This PR needs the next version of pycti (5.0.3).