### PR TITLE
[kaspersky] add prometheus metrics

### DIFF
--- a/external-import/kaspersky/docker-compose.yml
+++ b/external-import/kaspersky/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_UPDATE_EXISTING_DATA=false
       - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_EXPOSE_METRICS=false
       - KASPERSKY_BASE_URL=https://tip.kaspersky.com
       - KASPERSKY_USER=ChangeMe
       - KASPERSKY_PASSWORD=ChangeMe

--- a/external-import/kaspersky/src/config.yml.sample
+++ b/external-import/kaspersky/src/config.yml.sample
@@ -10,6 +10,7 @@ connector:
   confidence_level: 15  # From 0 (Unknown) to 100 (Fully trusted)
   update_existing_data: false
   log_level: 'info'
+  expose_metrics: false
 
 kaspersky:
   base_url: 'https://tip.kaspersky.com'

--- a/external-import/kaspersky/src/kaspersky/client.py
+++ b/external-import/kaspersky/src/kaspersky/client.py
@@ -21,8 +21,6 @@ log = logging.getLogger(__name__)
 class KasperskyClientException(Exception):
     """Kaspersky client exception."""
 
-    pass
-
 
 class KasperskyClient:
     """Kaspersky client."""
@@ -57,10 +55,16 @@ class KasperskyClient:
     _PUBLICATIONS_FIELD_PUBLICATIONS = "publications"
 
     def __init__(
-        self, base_url: str, user: str, password: str, certificate_path: str
+        self,
+        base_url: str,
+        user: str,
+        password: str,
+        certificate_path: str,
+        metrics: Optional[dict[str, Any]] = None,
     ) -> None:
         """Initialize Kaspersky client."""
         self.base_url = base_url if not base_url.endswith("/") else base_url[:-1]
+        self.metrics = metrics
 
         self.session = requests.Session()
         self.session.auth = (user, password)
@@ -108,8 +112,11 @@ class KasperskyClient:
                 self._duration_ms(start_time_ms),
             )
 
-    @staticmethod
-    def _raise_client_exception(message: str, log_stacktrace: bool = False) -> NoReturn:
+    def _raise_client_exception(
+        self, message: str, log_stacktrace: bool = False
+    ) -> NoReturn:
+        if self.metrics is not None:
+            self.metrics["client_error_count"].inc()
         if log_stacktrace:
             log.exception(message)
         else:

--- a/external-import/kaspersky/src/kaspersky/importer.py
+++ b/external-import/kaspersky/src/kaspersky/importer.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 from typing import Any, Mapping, Optional
 
 from pycti import OpenCTIConnectorHelper  # type: ignore
-
 from stix2 import Bundle, Identity, MarkingDefinition  # type: ignore
 
 from kaspersky.client import KasperskyClient
@@ -72,6 +71,7 @@ class BaseImporter(ABC):
         return self.helper.connect_confidence_level
 
     def _send_bundle(self, bundle: Bundle) -> None:
+        self.helper.metric_inc("record_send", len(bundle.objects))
         serialized_bundle = bundle.serialize()
         self.helper.send_stix2_bundle(
             serialized_bundle, work_id=self.work_id, update=self.update_existing_data

--- a/external-import/kaspersky/src/kaspersky/master_ioc/importer.py
+++ b/external-import/kaspersky/src/kaspersky/master_ioc/importer.py
@@ -253,6 +253,7 @@ class MasterIOCImporter(BaseImporter):
         try:
             return bundle_builder.build()
         except STIXError as e:
+            self.helper.metric_inc("error_count")
             self._error(
                 "Failed to build indicator group bundle for '{0}': {1}",
                 indicator_group[0],

--- a/external-import/kaspersky/src/kaspersky/master_yara/importer.py
+++ b/external-import/kaspersky/src/kaspersky/master_yara/importer.py
@@ -191,6 +191,7 @@ class MasterYaraImporter(BaseImporter):
         try:
             return bundle_builder.build()
         except STIXError as e:
+            self.helper.metric_inc("error_count")
             self._error(
                 "Failed to build YARA rule bundle for '{0}': {1}",
                 yara_rule_group[0],

--- a/external-import/kaspersky/src/kaspersky/publication/builder.py
+++ b/external-import/kaspersky/src/kaspersky/publication/builder.py
@@ -147,7 +147,7 @@ class PublicationBundleBuilder:
         )
 
         # TODO: Ignore reports without any references or not?
-        # Hack, the report must have at least on object reference.
+        # Hack, the report must have at least one object reference.
         if not object_refs:
             dummy_object = self._create_dummy_object()
 

--- a/external-import/kaspersky/src/kaspersky/publication/importer.py
+++ b/external-import/kaspersky/src/kaspersky/publication/importer.py
@@ -218,6 +218,7 @@ class PublicationImporter(BaseImporter):
         try:
             return bundle_builder.build()
         except STIXError as e:
+            self.helper.metric_inc("error_count")
             self._error(
                 "Failed to build publication bundle for '{0}' ({1}): {2}",
                 publication.name,

--- a/external-import/kaspersky/src/requirements.txt
+++ b/external-import/kaspersky/src/requirements.txt
@@ -1,3 +1,3 @@
-pycti==5.0.2
+pycti==5.0.3
 pydantic==1.8.2
 lxml==4.6.3


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add the following metrics for kaspersky connector:

Metric | Type | Description
-- | -- | --
bundle_send | Counter | The number of bundle that have been sent using the "send_bundle" function from pycti
record_send | Counter | The number of record (objects per bundle) send by the connector
run_count | Counter | The number of time the connector has run
error_count | Counter | The number of error that occurs in the connector
client_error_count | Counter | The number of error that occurs in the client when communicating with the remote data source
state | Enum | The state in which the connector is. One of `idle`, `running`, `stopped`


* Expose the metrics on an HTTP endpoint (so that they can be scraped by Prometheus)


### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

This PR needs the next version of pycti (5.0.3).
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
