### PR TITLE
[virustotal] add prometheus metrics

### DIFF
--- a/internal-enrichment/virustotal/docker-compose.yml
+++ b/internal-enrichment/virustotal/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - CONNECTOR_AUTO=true # Enable/disable auto-enrichment of observables
       - CONNECTOR_CONFIDENCE_LEVEL=50 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_EXPOSE_METRICS=false
       - VIRUSTOTAL_TOKEN=ChangeMe
       - VIRUSTOTAL_MAX_TLP=TLP:AMBER
     restart: always

--- a/internal-enrichment/virustotal/src/config.yml.sample
+++ b/internal-enrichment/virustotal/src/config.yml.sample
@@ -10,6 +10,7 @@ connector:
   auto: true # Enable/disable auto-enrichment of observables
   confidence_level: 50 # From 0 (Unknown) to 100 (Fully trusted)
   log_level: 'info'
+  expose_metrics: false
 
 virustotal:
   token: 'ChangeMe'

--- a/internal-enrichment/virustotal/src/requirements.txt
+++ b/internal-enrichment/virustotal/src/requirements.txt
@@ -1,3 +1,4 @@
-pycti==5.0.2
+pycti==5.0.3
 stix2==2.1.0
 plyara~=2.1.1
+

--- a/internal-enrichment/virustotal/src/virustotal/virustotal.py
+++ b/internal-enrichment/virustotal/src/virustotal/virustotal.py
@@ -91,10 +91,14 @@ class VirusTotalConnector:
         )
 
     def _process_file(self, observable):
+        self.helper.metric_inc("run_count")
+        self.helper.metric_state("running")
+
         json_data = self.client.get_file_info(observable["observable_value"])
         if json_data is None:
             raise ValueError("An error has occurred")
         if "error" in json_data:
+            self.helper.metric_inc("client_error_count")
             if json_data["error"]["message"] == "Quota exceeded":
                 self.helper.log_info("Quota reached, waiting 1 hour.")
                 sleep(self._CONNECTOR_RUN_INTERVAL_SEC)
@@ -158,6 +162,8 @@ class VirusTotalConnector:
                 id=final_observable["id"],
                 external_reference_id=external_reference["id"],
             )
+            # One for the external reference plus the number of tags.
+            self.helper.metric_inc("record_send", 1 + len(attributes["tags"]))
 
             if "crowdsourced_yara_results" in attributes:
                 self.helper.log_info("[VirusTotal] adding yara results to file.")
@@ -184,8 +190,13 @@ class VirusTotalConnector:
                         toId=yara["id"],
                         relationship_type="related-to",
                     )
+                self.helper.metric_inc("record_send", len(yaras))
 
+            self.helper.metric_state("idle")
             return "File found on VirusTotal, knowledge attached."
+
+        self.helper.metric_state("idle")
+        return "File not found on VirusTotal."
 
     def _process_message(self, data):
         entity_id = data["entity_id"]
@@ -196,6 +207,8 @@ class VirusTotalConnector:
             if marking_definition["definition_type"] == "TLP":
                 tlp = marking_definition["definition"]
         if not OpenCTIConnectorHelper.check_max_tlp(tlp, self.max_tlp):
+            self.helper.metric_inc("error_count")
+            self.helper.metric_state("stopped")
             raise ValueError(
                 "Do not send any data, TLP of the observable is greater than MAX TLP"
             )
@@ -203,4 +216,6 @@ class VirusTotalConnector:
 
     def start(self):
         """Start the main loop."""
+        # Set default state as `idle`.
+        self.helper.metric_state("idle")
         self.helper.listen(self._process_message)

--- a/internal-enrichment/virustotal/src/virustotal/virustotal.py
+++ b/internal-enrichment/virustotal/src/virustotal/virustotal.py
@@ -96,11 +96,14 @@ class VirusTotalConnector:
 
         json_data = self.client.get_file_info(observable["observable_value"])
         if json_data is None:
-            raise ValueError("An error has occurred")
+            self.helper.metric_inc("client_error_count")
+            return "File not found on VirusTotal."
         if "error" in json_data:
             self.helper.metric_inc("client_error_count")
             if json_data["error"]["message"] == "Quota exceeded":
-                self.helper.log_info("Quota reached, waiting 1 hour.")
+                self.helper.log_info(
+                    f"Quota reached, waiting {self._CONNECTOR_RUN_INTERVAL_SEC} minutes."
+                )
                 sleep(self._CONNECTOR_RUN_INTERVAL_SEC)
             elif "not found" in json_data["error"]["message"]:
                 self.helper.log_info("File not found on VirusTotal.")


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add the following metrics for virustotal connector:


Metric | Type | Description
-- | -- | --
record_send | Counter | The number of record (objects per bundle) created by the connector using the GraphQL API
run_count | Counter | The number of time the connector has run
error_count | Counter | The number of error that occurs in the connector
client_error_count | Counter | The number of error that occurs in the client when communicating with the remote data source
state | Enum | The state in which the connector is. One of `idle`, `running`, `stopped`

* Improve the feedbacks when a file does not exist on VirusTotal.

### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

This PR needs the next version of pycti (5.0.3).
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
