### PR TITLE
[connector] add missing dockerignore files

### DIFF
--- a/external-import/alienvault/.dockerignore
+++ b/external-import/alienvault/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/amitt/.dockerignore
+++ b/external-import/amitt/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/crowdstrike/.dockerignore
+++ b/external-import/crowdstrike/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/cryptolaemus/.dockerignore
+++ b/external-import/cryptolaemus/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/cuckoo/.dockerignore
+++ b/external-import/cuckoo/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/cve/.dockerignore
+++ b/external-import/cve/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/cyber-threat-coalition/.dockerignore
+++ b/external-import/cyber-threat-coalition/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/cybercrime-tracker/.dockerignore
+++ b/external-import/cybercrime-tracker/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/fireeye/.dockerignore
+++ b/external-import/fireeye/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/lastinfosec/.dockerignore
+++ b/external-import/lastinfosec/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/malpedia/.dockerignore
+++ b/external-import/malpedia/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/misp/.dockerignore
+++ b/external-import/misp/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/mitre/.dockerignore
+++ b/external-import/mitre/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/opencti/.dockerignore
+++ b/external-import/opencti/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/riskiq/.dockerignore
+++ b/external-import/riskiq/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/sekoia/.dockerignore
+++ b/external-import/sekoia/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/taxii2/.dockerignore
+++ b/external-import/taxii2/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/thehive/.dockerignore
+++ b/external-import/thehive/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/threatmatch/.dockerignore
+++ b/external-import/threatmatch/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/urlhaus/.dockerignore
+++ b/external-import/urlhaus/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/valhalla/.dockerignore
+++ b/external-import/valhalla/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/vxvault/.dockerignore
+++ b/external-import/vxvault/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/internal-enrichment/lastinfosec/.dockerignore
+++ b/internal-enrichment/lastinfosec/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/internal-import-file/import-report/.dockerignore
+++ b/internal-import-file/import-report/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/template/.dockerignore
+++ b/template/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__


### PR DESCRIPTION
Only a few connectors have a `.dockerignore` file. There should be a `.dockerignore` file for every connector, especially to avoid having the cache folder and the `config.yml` file inside the docker image. 

Having the `config.yml` file inside the images can lead to some nasty bugs. For example having a variable set in the `config.yml` file and not set (overriden) in the docker-compose file can make us think that the variable is not set even if it is because of the `config.yml` file. 

### Proposed changes

* Add a `.dockerignore` file for every connector.

### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
