### PR TITLE
[internal enrichment] Add CAPEv2 Sandbox Connector

### DIFF
--- a/internal-enrichment/cape-sandbox/.dockerignore
+++ b/internal-enrichment/cape-sandbox/.dockerignore
@@ -1,0 +1,4 @@
+src/config.yml
+src/__pycache__
+src/logs
+src/*.gql

--- a/internal-enrichment/cape-sandbox/.gitignore
+++ b/internal-enrichment/cape-sandbox/.gitignore
@@ -1,0 +1,4 @@
+config.yml
+__pycache__
+logs
+*.gql

--- a/internal-enrichment/cape-sandbox/Dockerfile
+++ b/internal-enrichment/cape-sandbox/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9-alpine
+
+# Copy the worker
+COPY src /opt/opencti-connector-cape-sandbox
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk --no-cache add git build-base libmagic libffi-dev && \
+    cd /opt/opencti-connector-cape-sandbox && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh 
+ENTRYPOINT ["/entrypoint.sh"]

--- a/internal-enrichment/cape-sandbox/docker-compose.yml
+++ b/internal-enrichment/cape-sandbox/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+services:
+  connector-cape-sandbox:
+    image: opencti/connector-cape-sandbox:1.0.0
+    environment:
+      - OPENCTI_URL=ChangeMe
+      - OPENCTI_TOKEN=ChangeMe
+      - CONNECTOR_ID=CAPEv2_Sandbox
+      - CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+      - "CONNECTOR_NAME=CAPEv2 Sandbox"
+      - CONNECTOR_SCOPE=StixFile,Artifact
+      - CONNECTOR_AUTO=false # Enable/disable auto-enrichment of observables
+      - CONNECTOR_CONFIDENCE_LEVEL=50 # From 0 (Unknown) to 100 (Fully trusted)
+      - CONNECTOR_LOG_LEVEL=info
+      - CAPE_SANDBOX_URL=ChangeMe # Base URL
+      - CAPE_SANDBOX_TOKEN=ChangeMe # Change if using auth
+      - CAPE_SANDBOX_ROUTE=tor # Network routing, other examples include: none, internet, vpn0
+      - CAPE_SANDBOX_TIMEOUT=300 # Maximum amount of seconds to run the analysis for
+      - CAPE_SANDBOX_ENFORCE_TIMEOUT=false # Enforce analysis to run for the full timeout period
+      - CAPE_SANDBOX_PRIORITY=1 # Set priority for submitted samples, 1-3, where 3 is highest priority
+      - CAPE_SANDBOX_OPTIONS=procmemdump=1,import_reconstruction=1 # List of options to be passed to the analysis package
+      - CAPE_SANDBOX_LESS_NOISE=true # Only upload Artifacts associated with Yara rule matches
+      - CAPE_SANDBOX_COOLDOWN_TIME=20 # Set the amount of seconds to wait between retries of the API
+      - CAPE_SANDBOX_MAX_RETRIES=10 # Set the amount of maximum retries for the API before failing
+      - CAPE_SANDBOX_MAX_TLP=TLP:AMBER
+    restart: always

--- a/internal-enrichment/cape-sandbox/entrypoint.sh
+++ b/internal-enrichment/cape-sandbox/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Go to the right directory
+cd /opt/opencti-connector-cape-sandbox
+
+# Launch the worker
+python3 cape-sandbox.py

--- a/internal-enrichment/cape-sandbox/src/cape-sandbox.py
+++ b/internal-enrichment/cape-sandbox/src/cape-sandbox.py
@@ -1,0 +1,696 @@
+# coding: utf-8
+
+import os
+import yaml
+import requests
+import time
+import io
+import json
+import re
+import pyzipper
+import magic
+from retrying import retry
+
+from stix2 import Bundle, AttackPattern, Relationship, TLP_WHITE, Note
+from pycti import (
+    OpenCTIConnectorHelper,
+    OpenCTIStix2Utils,
+    get_config_variable,
+    SimpleObservable,
+)
+
+
+class CapeSandboxConnector:
+    _cooldown_time = None
+    _max_retries = None
+
+    def __init__(self):
+        # Instantiate the connector helper from config
+        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
+        config = (
+            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
+            if os.path.isfile(config_file_path)
+            else {}
+        )
+        self.helper = OpenCTIConnectorHelper(config)
+
+        self.identity = self.helper.api.identity.create(
+            type="Organization",
+            name="CAPEv2 Sandbox",
+            description="CAPEv2 Sandbox.",
+        )["standard_id"]
+
+        self.octi_api_url = get_config_variable(
+            "OPENCTI_URL", ["opencti", "url"], config
+        )
+        self.cape_url = get_config_variable(
+            "CAPE_SANDBOX_URL", ["cape_sandbox", "url"], config
+        )
+        self.cape_api_url = f"{self.cape_url}/apiv2"
+        self.token = get_config_variable(
+            "CAPE_SANDBOX_TOKEN", ["cape_sandbox", "token"], config
+        )
+        self.max_tlp = get_config_variable(
+            "CAPE_SANDBOX_MAX_TLP", ["cape_sandbox", "max_tlp"], config
+        )
+        self.less_noise = get_config_variable(
+            "CAPE_SANDBOX_LESS_NOISE", ["cape_sandbox", "less_noise"], config
+        )
+        self._cooldown_time = 1000 * get_config_variable(
+            "CAPE_SANDBOX_COOLDOWN_TIME", ["cape_sandbox", "cooldown_time"], config
+        )
+        self._max_retries = get_config_variable(
+            "CAPE_SANDBOX_MAX_RETRIES", ["cape_sandbox", "max_retries"], config
+        )
+
+        self.headers = {"Authorization": f"Token {self.token}"}
+
+        # Analysis options
+
+        self.route = get_config_variable(
+            "CAPE_SANDBOX_ROUTE", ["cape_sandbox", "route"], config
+        )
+
+        self.options = get_config_variable(
+            "CAPE_SANDBOX_OPTIONS", ["cape_sandbox", "options"], config
+        )
+
+        self.timeout = get_config_variable(
+            "CAPE_SANDBOX_TIMEOUT", ["cape_sandbox", "timeout"], config
+        )
+
+        self.enforce_timeout = get_config_variable(
+            "CAPE_SANDBOX_ENFORCE_TIMEOUT", ["cape_sandbox", "enforce_timeout"], config
+        )
+
+        self.priority = get_config_variable(
+            "CAPE_SANDBOX_PRIORITY", ["cape_sandbox", "priority"], config
+        )
+
+    def _send_knowledge(self, observable, report):
+        bundle_objects = []
+        final_observable = observable
+
+        target = report["target"]["file"]
+        task_id = report["info"]["id"]
+
+        final_observable = self.helper.api.stix_cyber_observable.update_field(
+            id=final_observable["id"],
+            input={"key": "hashes.MD5", "value": target["md5"]},
+        )
+        final_observable = self.helper.api.stix_cyber_observable.update_field(
+            id=final_observable["id"],
+            input={"key": "hashes.SHA-1", "value": target["sha1"]},
+        )
+        final_observable = self.helper.api.stix_cyber_observable.update_field(
+            id=final_observable["id"],
+            input={
+                "key": "hashes.SHA-256",
+                "value": target["sha256"],
+            },
+        )
+
+        self.helper.api.stix_cyber_observable.update_field(
+            id=final_observable["id"],
+            input={
+                "key": "x_opencti_score",
+                "value": str(int(report["malscore"] * 10)),
+            },
+        )
+
+        # Create external references
+        # Analysis URL
+        external_reference = self.helper.api.external_reference.create(
+            source_name="CAPEv2 Sandbox Analysis",
+            url=f"{self.cape_url}/analysis/{task_id}/",
+            description="CAPEv2 Sandbox Analysis",
+        )
+        self.helper.api.stix_cyber_observable.add_external_reference(
+            id=final_observable["id"],
+            external_reference_id=external_reference["id"],
+        )
+        # JSON report
+        external_reference = self.helper.api.external_reference.create(
+            source_name="CAPEv2 Sandbox JSON Report",
+            url=f"{self.cape_url}/filereport/{task_id}/json/",
+            description="CAPEv2 Sandbox JSON Report",
+        )
+        self.helper.api.stix_cyber_observable.add_external_reference(
+            id=final_observable["id"],
+            external_reference_id=external_reference["id"],
+        )
+        # HTML Report
+        external_reference = self.helper.api.external_reference.create(
+            source_name="CAPEv2 Sandbox HTML Report",
+            url=f"{self.cape_url}/filereport/{task_id}/html/",
+            description="CAPEv2 Sandbox HTML Report",
+        )
+        self.helper.api.stix_cyber_observable.add_external_reference(
+            id=final_observable["id"],
+            external_reference_id=external_reference["id"],
+        )
+
+        # Create label if family was detected
+        if "detections" in report and report["detections"]:
+            label = self.helper.api.label.create(
+                value=report["detections"], color="#0059f7"
+            )
+            self.helper.api.stix_cyber_observable.add_label(
+                id=final_observable["id"], label_id=label["id"]
+            )
+
+        # Create a Note containing the TrID results
+        trid_json = json.dumps(report["trid"], indent=2)
+        note = Note(
+            abstract="TrID Analysis",
+            content=f"```\n{trid_json}\n```",
+            created_by_ref=self.identity,
+            object_refs=[final_observable["standard_id"]],
+        )
+        bundle_objects.append(note)
+
+        # Attach the TTPs
+        for tactic_dict in report["ttps"]:
+
+            attack_id = tactic_dict["ttp"]
+            signature = tactic_dict["signature"]
+
+            attack_pattern = AttackPattern(
+                id=OpenCTIStix2Utils.generate_random_stix_id("attack-pattern"),
+                created_by_ref=self.identity,
+                name=signature,
+                custom_properties={
+                    "x_mitre_id": attack_id,
+                },
+                object_marking_refs=[TLP_WHITE],
+            )
+
+            relationship = Relationship(
+                id=OpenCTIStix2Utils.generate_random_stix_id("relationship"),
+                relationship_type="uses",
+                created_by_ref=self.identity,
+                source_ref=final_observable["standard_id"],
+                target_ref=attack_pattern.id,
+                object_marking_refs=[TLP_WHITE],
+            )
+            bundle_objects.append(attack_pattern)
+            bundle_objects.append(relationship)
+
+        # Handle procdumps and attach any Flare CAPA TTPs
+        if "procdump" in report and report["procdump"]:
+
+            # Download the zip archive of procdump files
+            zip_contents = self.get_procdump_zip(task_id)
+            zip_obj = io.BytesIO(zip_contents)
+
+            # Extract with "infected" password
+            zip_file = pyzipper.AESZipFile(zip_obj)
+            zip_file.setpassword(b"infected")
+
+            # Process each entry in the procdump key
+            for procdump_dict in report["procdump"]:
+
+                # If less noise was specified
+                if self.less_noise:
+                    # and no Yara matches, skip this procdump
+                    if not procdump_dict["cape_yara"] or not procdump_dict["yara"]:
+                        continue
+
+                sha256 = procdump_dict["sha256"]
+                cape_type = procdump_dict["cape_type"]
+                module_path = procdump_dict["module_path"]
+                procdump_contents = zip_file.read(sha256)
+                mime_type = magic.from_buffer(procdump_contents, mime=True)
+
+                kwargs = {
+                    "file_name": module_path,
+                    "data": procdump_contents,
+                    "mime_type": mime_type,
+                    "x_opencti_description": cape_type,
+                }
+                response = self.helper.api.stix_cyber_observable.upload_artifact(
+                    **kwargs
+                )
+                self.helper.log_info(
+                    f'Uploaded procdump with sha256 "{sha256}" and type "{cape_type}".'
+                )
+
+                # Build labels
+                yara_rules = []
+                cape_yara_rules = []
+                yara_rules.extend(
+                    [yara_dict["name"] for yara_dict in procdump_dict["yara"]]
+                )
+                cape_yara_rules.extend(
+                    [yara_dict["name"] for yara_dict in procdump_dict["cape_yara"]]
+                )
+                cape_yara_rules.extend(
+                    [
+                        yara_dict["meta"]["cape_type"]
+                        for yara_dict in procdump_dict["cape_yara"]
+                    ]
+                )
+
+                # Create and apply yara rule based labels
+                for yara_rule in yara_rules:
+                    label = self.helper.api.label.create(
+                        value=yara_rule, color="#0059f7"
+                    )
+                    self.helper.api.stix_cyber_observable.add_label(
+                        id=response["id"], label_id=label["id"]
+                    )
+
+                # Create and apply cape yara rule based labels
+                for cape_yara_rule in cape_yara_rules:
+                    label = self.helper.api.label.create(
+                        value=cape_yara_rule, color="#ff8178"
+                    )
+                    self.helper.api.stix_cyber_observable.add_label(
+                        id=response["id"], label_id=label["id"]
+                    )
+
+                # Create label for cape_type
+                label = self.helper.api.label.create(value=cape_type, color="#0059f7")
+                self.helper.api.stix_cyber_observable.add_label(
+                    id=response["id"], label_id=label["id"]
+                )
+
+                # Create relationship between uploaded procdump Artifact and original
+                relationship = Relationship(
+                    id=OpenCTIStix2Utils.generate_random_stix_id("relationship"),
+                    relationship_type="related-to",
+                    created_by_ref=self.identity,
+                    source_ref=response["standard_id"],
+                    target_ref=final_observable["standard_id"],
+                )
+                bundle_objects.append(relationship)
+
+                # Handle Flare CAPA TTPs
+                if "flare_capa" in procdump_dict and procdump_dict["flare_capa"]:
+                    attck_dict = procdump_dict["flare_capa"]["ATTCK"]
+                    for tactic in attck_dict:
+                        tp_list = attck_dict[tactic]
+                        for tp in tp_list:
+                            attack_pattern = AttackPattern(
+                                id=OpenCTIStix2Utils.generate_random_stix_id(
+                                    "attack-pattern"
+                                ),
+                                created_by_ref=self.identity,
+                                name=tactic,
+                                custom_properties={
+                                    "x_mitre_id": tp,
+                                },
+                                object_marking_refs=[TLP_WHITE],
+                            )
+
+                            relationship = Relationship(
+                                id=OpenCTIStix2Utils.generate_random_stix_id(
+                                    "relationship"
+                                ),
+                                relationship_type="uses",
+                                created_by_ref=self.identity,
+                                source_ref=response["standard_id"],
+                                target_ref=attack_pattern.id,
+                                object_marking_refs=[TLP_WHITE],
+                            )
+                            bundle_objects.append(attack_pattern)
+                            bundle_objects.append(relationship)
+
+                else:
+                    self.helper.log_info(
+                        f"Could not find flare_capa key or was empty in procdump {sha256}."
+                    )
+
+            # Close the zip file
+            zip_file.close()
+
+        else:
+            self.helper.log_info(
+                "Skipping processing process dumps, procdump key is empty or not exists."
+            )
+
+        # Attach CnC addresses if any configs were found
+        if "CAPE" in report and report["CAPE"]["configs"]:
+            configs_list = report["CAPE"]["configs"]
+            for config_dict in configs_list:
+                for detection_name in config_dict:
+                    # Create a Note containing the config
+                    note = Note(
+                        abstract=f"{detection_name} Config",
+                        content=f"```\n{json.dumps(config_dict, indent=2)}\n```",
+                        created_by_ref=self.identity,
+                        object_refs=[final_observable["standard_id"]],
+                    )
+                    bundle_objects.append(note)
+
+                    if not "address" in config_dict[detection_name]:
+                        self.helper.log_info(
+                            f'Could not find an "address" key in {detection_name} config.'
+                        )
+                        continue
+
+                    address_list = config_dict[detection_name]["address"]
+                    for address in address_list:
+                        parsed = address.rsplit(":", 1)[0]
+                        if self.is_ipv4_address(address):
+                            host_stix = SimpleObservable(
+                                id=OpenCTIStix2Utils.generate_random_stix_id(
+                                    "x-opencti-simple-observable"
+                                ),
+                                labels=[detection_name, "c2 server"],
+                                key="IPv4-Addr.value",
+                                value=parsed,
+                                created_by_ref=self.identity,
+                            )
+                            relationship = Relationship(
+                                id=OpenCTIStix2Utils.generate_random_stix_id(
+                                    "relationship"
+                                ),
+                                relationship_type="communicates-with",
+                                created_by_ref=self.identity,
+                                source_ref=final_observable["standard_id"],
+                                target_ref=host_stix.id,
+                            )
+                            bundle_objects.append(host_stix)
+                            bundle_objects.append(relationship)
+                        else:
+                            domain_stix = SimpleObservable(
+                                id=OpenCTIStix2Utils.generate_random_stix_id(
+                                    "x-opencti-simple-observable"
+                                ),
+                                labels=[detection_name, "c2 server"],
+                                key="Url.value",
+                                value=address,
+                                created_by_ref=self.identity,
+                                object_marking_refs=[TLP_WHITE],
+                            )
+                            relationship = Relationship(
+                                id=OpenCTIStix2Utils.generate_random_stix_id(
+                                    "relationship"
+                                ),
+                                relationship_type="communicates-with",
+                                created_by_ref=self.identity,
+                                source_ref=final_observable["standard_id"],
+                                target_ref=domain_stix.id,
+                            )
+                            bundle_objects.append(domain_stix)
+                            bundle_objects.append(relationship)
+
+        # Attach the domains
+        for domain_dict in report["network"]["domains"]:
+            domain_stix = SimpleObservable(
+                id=OpenCTIStix2Utils.generate_random_stix_id(
+                    "x-opencti-simple-observable"
+                ),
+                key="Domain-Name.value",
+                value=domain_dict["domain"],
+                created_by_ref=self.identity,
+                object_marking_refs=[TLP_WHITE],
+            )
+            relationship = Relationship(
+                id=OpenCTIStix2Utils.generate_random_stix_id("relationship"),
+                relationship_type="communicates-with",
+                created_by_ref=self.identity,
+                source_ref=final_observable["standard_id"],
+                target_ref=domain_stix.id,
+            )
+            bundle_objects.append(domain_stix)
+            bundle_objects.append(relationship)
+
+        # Attach the IP addresses
+        for host_dict in report["network"]["hosts"]:
+            host = host_dict["ip"]
+            host_stix = SimpleObservable(
+                id=OpenCTIStix2Utils.generate_random_stix_id(
+                    "x-opencti-simple-observable"
+                ),
+                key="IPv4-Addr.value",
+                value=host,
+                created_by_ref=self.identity,
+            )
+            relationship = Relationship(
+                id=OpenCTIStix2Utils.generate_random_stix_id("relationship"),
+                relationship_type="communicates-with",
+                created_by_ref=self.identity,
+                source_ref=final_observable["standard_id"],
+                target_ref=host_stix.id,
+            )
+            bundle_objects.append(host_stix)
+            bundle_objects.append(relationship)
+
+        # Handle CAPE payloads and attach Flare CAPA TTPs if any
+        if (
+            "CAPE" in report
+            and "payloads" in report["CAPE"]
+            and report["CAPE"]["payloads"]
+        ):
+
+            # Download the zip archive of payloads
+            zip_contents = self.get_payloads_zip(task_id)
+            zip_obj = io.BytesIO(zip_contents)
+
+            # Extract with "infected" password
+            zip_file = pyzipper.AESZipFile(zip_obj)
+            zip_file.setpassword(b"infected")
+
+            # Process each payload
+            for payload_dict in report["CAPE"]["payloads"]:
+
+                module_path = payload_dict["module_path"]
+                sha256 = payload_dict["sha256"]
+                cape_type = payload_dict["cape_type"]
+                payload_contents = zip_file.read(sha256)
+                mime_type = magic.from_buffer(payload_contents, mime=True)
+
+                kwargs = {
+                    "file_name": module_path,
+                    "data": payload_contents,
+                    "mime_type": mime_type,
+                    "x_opencti_description": cape_type,
+                }
+                response = self.helper.api.stix_cyber_observable.upload_artifact(
+                    **kwargs
+                )
+                self.helper.log_info(
+                    f'Uploaded CAPE payload with sha256 "{sha256}" and type "{cape_type}".'
+                )
+
+                # Create and apply label
+                label = self.helper.api.label.create(value=cape_type, color="#ff8178")
+                self.helper.api.stix_cyber_observable.add_label(
+                    id=response["id"], label_id=label["id"]
+                )
+
+                # Create relationship between uploaded payload Artifact and original
+                relationship = Relationship(
+                    id=OpenCTIStix2Utils.generate_random_stix_id("relationship"),
+                    relationship_type="related-to",
+                    created_by_ref=self.identity,
+                    source_ref=response["standard_id"],
+                    target_ref=final_observable["standard_id"],
+                )
+                bundle_objects.append(relationship)
+
+                # Handle Flare CAPA TTPs if any
+                if "flare_capa" in payload_dict and payload_dict["flare_capa"]:
+                    attck_dict = payload_dict["flare_capa"]["ATTCK"]
+                    for tactic in attck_dict:
+                        for tp in attck_dict[tactic]:
+                            attack_pattern = AttackPattern(
+                                id=OpenCTIStix2Utils.generate_random_stix_id(
+                                    "attack-pattern"
+                                ),
+                                created_by_ref=self.identity,
+                                name=tactic,
+                                custom_properties={
+                                    "x_mitre_id": tp,
+                                },
+                                object_marking_refs=[TLP_WHITE],
+                            )
+
+                            relationship = Relationship(
+                                id=OpenCTIStix2Utils.generate_random_stix_id(
+                                    "relationship"
+                                ),
+                                relationship_type="uses",
+                                created_by_ref=self.identity,
+                                source_ref=response["standard_id"],
+                                target_ref=attack_pattern.id,
+                                object_marking_refs=[TLP_WHITE],
+                            )
+                            bundle_objects.append(attack_pattern)
+                            bundle_objects.append(relationship)
+                else:
+                    self.helper.log_info(
+                        f"Could not find flare_capa key or was empty in CAPE payload {sha256}."
+                    )
+
+            # Close the zip file
+            zip_file.close()
+
+        else:
+            self.helper.log_info(
+                "Skipping processing CAPE payloads, payloads key is empty or not exists."
+            )
+
+        # Serialize and send all bundles
+        if bundle_objects:
+            bundle = Bundle(objects=bundle_objects).serialize()
+            bundles_sent = self.helper.send_stix2_bundle(bundle)
+            return f"Sent {len(bundles_sent)} stix bundle(s) for worker import"
+        else:
+            return "Nothing to attach"
+
+    def _trigger_sandbox(self, observable):
+        self.helper.log_info("Triggering the sandbox...")
+
+        if not observable["importFiles"]:
+            raise ValueError(f"No files found for {observable['observable_value']}")
+
+        # Build the URI to download the file
+        file_name = observable["importFiles"][0]["name"]
+        file_id = observable["importFiles"][0]["id"]
+        file_uri = f"{self.octi_api_url}/storage/get/{file_id}"
+        file_content = self.helper.api.fetch_opencti_file(file_uri, True)
+
+        # Create file object
+        file_obj = io.BytesIO(file_content)
+
+        # Upload file for analysis
+        files = {"file": (file_name, file_obj)}
+        analysis_options = {
+            "options": self.options,
+            "route": self.route,
+            "priority": self.priority,
+            "timeout": self.timeout,
+            "enforce_timeout": self.enforce_timeout,
+        }
+
+        response_dict = self.create_file(files=files, analysis_options=analysis_options)
+
+        task_id = response_dict["data"]["task_ids"][0]
+        self.helper.log_info(f"Analysis {task_id} has started...")
+        time.sleep(20)
+
+        # Wait until analysis is finished
+        status = None
+        while True:
+
+            # Get the task's status
+            response_dict = self.get_status(task_id)
+            status = response_dict["data"]
+            error = response_dict["error"]
+
+            if status == "reported":
+                break
+            elif error:
+                raise ValueError(f'Analysis {task_id} failed with status "{status}".')
+
+            self.helper.log_info(f'Analysis {task_id} has status "{status}"...')
+            time.sleep(20)
+
+        # Analysis is finished, process the report
+        response_dict = self.get_report(task_id)
+
+        self.helper.log_info(f"Analysis {task_id} finished, processing report...")
+        return self._send_knowledge(observable, response_dict)
+
+    def _process_observable(self, observable):
+        self.helper.log_info(
+            "Processing the observable " + observable["observable_value"]
+        )
+        # If File or Artifact
+        if observable["entity_type"] in ["StixFile", "Artifact"]:
+            return self._trigger_sandbox(observable)
+        else:
+            raise ValueError(
+                f"Failed to process observable, {observable['entity_type']} is not a supported entity type."
+            )
+
+    def _process_message(self, data):
+        entity_id = data["entity_id"]
+        observable = self.helper.api.stix_cyber_observable.read(id=entity_id)
+        if observable is None:
+            raise ValueError(
+                "Observable not found "
+                "(may be linked to data seggregation, check your group and permissions)"
+            )
+        # Extract TLP
+        tlp = "TLP:WHITE"
+        for marking_definition in observable["objectMarking"]:
+            if marking_definition["definition_type"] == "TLP":
+                tlp = marking_definition["definition"]
+        if not OpenCTIConnectorHelper.check_max_tlp(tlp, self.max_tlp):
+            raise ValueError(
+                "Do not send any data, TLP of the observable is greater than MAX TLP"
+            )
+        return self._process_observable(observable)
+
+    # API helper methods with retry wrapping
+    @retry(wait_fixed=_cooldown_time, stop_max_attempt_number=_max_retries)
+    def get_procdump_zip(self, task_id):
+        response = requests.get(
+            f"{self.cape_api_url}/tasks/get/procdumpfiles/{task_id}/",
+            headers=self.headers,
+        )
+        response.raise_for_status()
+        response_contents = response.content
+        return response_contents
+
+    @retry(wait_fixed=_cooldown_time, stop_max_attempt_number=_max_retries)
+    def get_payloads_zip(self, task_id):
+        response = requests.get(
+            f"{self.cape_api_url}/tasks/get/payloadfiles/{task_id}/",
+            headers=self.headers,
+        )
+        response.raise_for_status()
+        response_contents = response.content
+        return response_contents
+
+    @retry(wait_fixed=_cooldown_time, stop_max_attempt_number=_max_retries)
+    def get_report(self, task_id):
+        response = requests.get(
+            f"{self.cape_api_url}/tasks/get/report/{task_id}/", headers=self.headers
+        )
+        response.raise_for_status()
+        response_dict = response.json()
+        return response_dict
+
+    @retry(wait_fixed=_cooldown_time, stop_max_attempt_number=_max_retries)
+    def get_status(self, task_id):
+        response = requests.get(
+            f"{self.cape_api_url}/tasks/status/{task_id}/", headers=self.headers
+        )
+        response.raise_for_status()
+        response_dict = response.json()
+        return response_dict
+
+    @retry(wait_fixed=_cooldown_time, stop_max_attempt_number=_max_retries)
+    def create_file(self, files, analysis_options):
+        response = requests.post(
+            f"{self.cape_api_url}/tasks/create/file/",
+            headers=self.headers,
+            files=files,
+            data=analysis_options,
+        )
+        response.raise_for_status()
+        response_dict = response.json()
+        return response_dict
+
+    # Start the main loop
+    def start(self):
+        self.helper.listen(self._process_message)
+
+    def is_ipv4_address(self, ip):
+        m = re.match(r"^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$", ip)
+        return bool(m) and all(map(lambda n: 0 <= int(n) <= 255, m.groups()))
+
+
+if __name__ == "__main__":
+    try:
+        cape_sandbox = CapeSandboxConnector()
+        cape_sandbox.start()
+    except Exception as e:
+        print(e)
+        time.sleep(10)
+        exit(0)

--- a/internal-enrichment/cape-sandbox/src/cape-sandbox.py
+++ b/internal-enrichment/cape-sandbox/src/cape-sandbox.py
@@ -9,6 +9,7 @@ import json
 import re
 import pyzipper
 import magic
+from urllib.parse import urlparse
 from retrying import retry
 
 from stix2 import Bundle, AttackPattern, Relationship, TLP_WHITE, Note
@@ -352,7 +353,7 @@ class CapeSandboxConnector:
                     address_list = config_dict[detection_name]["address"]
                     for address in address_list:
                         parsed = address.rsplit(":", 1)[0]
-                        if self._is_ipv4_address(address):
+                        if self._is_ipv4_address(parsed):
                             host_stix = SimpleObservable(
                                 id=OpenCTIStix2Utils.generate_random_stix_id(
                                     "x-opencti-simple-observable"
@@ -374,13 +375,14 @@ class CapeSandboxConnector:
                             bundle_objects.append(host_stix)
                             bundle_objects.append(relationship)
                         else:
+                            domain = urlparse(address).hostname
                             domain_stix = SimpleObservable(
                                 id=OpenCTIStix2Utils.generate_random_stix_id(
                                     "x-opencti-simple-observable"
                                 ),
                                 labels=[detection_name, "c2 server"],
-                                key="Url.value",
-                                value=address,
+                                key="Domain-Name.value",
+                                value=domain,
                                 created_by_ref=self.identity,
                                 object_marking_refs=[TLP_WHITE],
                             )

--- a/internal-enrichment/cape-sandbox/src/cape-sandbox.py
+++ b/internal-enrichment/cape-sandbox/src/cape-sandbox.py
@@ -566,7 +566,9 @@ class CapeSandboxConnector:
             "enforce_timeout": self.enforce_timeout,
         }
 
-        response_dict = self._create_file(files=files, analysis_options=analysis_options)
+        response_dict = self._create_file(
+            files=files, analysis_options=analysis_options
+        )
 
         task_id = response_dict["data"]["task_ids"][0]
         self.helper.log_info(f"Analysis {task_id} has started...")
@@ -680,7 +682,6 @@ class CapeSandboxConnector:
     def _is_ipv4_address(self, ip):
         m = re.match(r"^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$", ip)
         return bool(m) and all(map(lambda n: 0 <= int(n) <= 255, m.groups()))
-
 
     # Start the main loop
     def start(self):

--- a/internal-enrichment/cape-sandbox/src/config.yml.sample
+++ b/internal-enrichment/cape-sandbox/src/config.yml.sample
@@ -1,0 +1,48 @@
+# Pre-requisites:
+
+# 1. Enable procdumps and CAPE payloads API
+#    See: [procdumpfiles] and [payloadfiles] in CAPEv2/conf/api.conf
+
+# 2. Increase API rate limits in conf/api.conf for the following:
+#    [procdumpfiles]
+#    [payloadfiles]
+#    [taskstatus]
+#    [taskreport]
+#    Note: Alternatively if you don't wish to increase these limits,
+#          you can adjust the values for cape_sandbox:cooldown_time
+#          and cape_sandbox:max_retries to suit your needs.
+
+# 3: (Optional) Enable authentication
+#    See: https://capev2.readthedocs.io/en/latest/usage/api.html?highlight=auth#rest-api-v2
+#    Update CAPEv2/conf/api.conf:token_auth_enabled = yes
+#    and set auth_only for [procdumpfiles] and [payloadfiles]
+#    and restart cape services
+#    Afterwards change the value for cape_sandbox:token
+#    Note: If you run into SQL table errors after enabling auth, try running:
+#          sudo python3 /opt/CAPEv2/web/manage.py migrate
+
+opencti:
+  url: 'ChangeMe'
+  token: 'ChangeMe'
+
+connector:
+  id: 'CAPEv2_Sandbox'
+  type: 'INTERNAL_ENRICHMENT'
+  name: 'CAPEv2 Sandbox'
+  scope: 'StixFile,Artifact'
+  auto: false # Enable/disable auto-enrichment of observables
+  confidence_level: 50 # From 0 (Unknown) to 100 (Fully trusted)
+  log_level: 'info'
+
+cape_sandbox:
+  url: 'ChangeMe' # Base URL
+  token: 'ChangeMe' # Change if using auth
+  route: 'tor' # Network routing, other examples include: none, internet, vpn0
+  timeout: 300 # Maximum amount of seconds to run the analysis for
+  enforce_timeout: false # Enforce analysis to run for the full timeout period
+  priority: 1 # Set priority for submitted samples, 1-3, where 3 is highest priority
+  options: 'procmemdump=1,import_reconstruction=1,fake-rdtsc=1' # List of options to be passed to the analysis package
+  less_noise: true # Only upload Artifacts associated with Yara rule matches
+  cooldown_time: 20 # Set the amount of seconds to wait between retries of the API
+  max_retries: 10 # Set the amount of maximum retries for the API before failing
+  max_tlp: 'TLP:AMBER'

--- a/internal-enrichment/cape-sandbox/src/requirements.txt
+++ b/internal-enrichment/cape-sandbox/src/requirements.txt
@@ -1,0 +1,3 @@
+pycti==5.0.3
+pyzipper==0.3.5
+retrying==1.3.3


### PR DESCRIPTION
### Proposed changes

* Add internal enrichment CAPEv2 Sandbox connector

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] Where necessary I refactored code to improve the overall quality
- [ ]  Not sure how to update documentation on Notion...

### Further comments

This Connector was developed to aid analysts in the research of Artifacts. As an Internal Enrichment based Connector, an analyst can refresh the knowledge on a particular Artifact and all associated hosts, domains will be attached as relationships to the original artifact. For any identified malware configurations, they will be attached to the original artifact as a Note. The same goes for trID results. All TTPs and FLARE Capa TTPs will also be associated with the original artifact as Attack Patterns with associated TTP #. All CAPE payloads and process dumps will be uploaded As Artifacts associated to the original artifact and include: unpacked shellcode, injected shellcode, unpacked payloads, etc. All uploaded Artifacts are labeled appropriately.

Previews:

![Preview1](https://i.imgur.com/mA7Tvcm.png)
![Preview2](https://i.imgur.com/knbNPut.png)