### PR TITLE
[internal enrichment] Add Intezer Sandbox Connector

### DIFF
--- a/internal-enrichment/intezer-sandbox/Dockerfile
+++ b/internal-enrichment/intezer-sandbox/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9-alpine
+
+# Copy the worker
+COPY src /opt/opencti-connector-intezer-sandbox
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk --no-cache add git build-base libmagic libffi-dev && \
+    cd /opt/opencti-connector-intezer-sandbox && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh 
+ENTRYPOINT ["/entrypoint.sh"]

--- a/internal-enrichment/intezer-sandbox/docker-compose.yml
+++ b/internal-enrichment/intezer-sandbox/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  connector-intezer-sandbox:
+    image: opencti/connector-intezer-sandbox:1.0.0
+    environment:
+      - OPENCTI_URL=ChangeMe
+      - OPENCTI_TOKEN=ChangeMe
+      - CONNECTOR_ID=Intezer_Sandbox
+      - CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+      - "CONNECTOR_NAME=IntezerSandbox"
+      - CONNECTOR_SCOPE=Artifact
+      - CONNECTOR_AUTO=false # Enable/disable auto-enrichment of observables
+      - CONNECTOR_CONFIDENCE_LEVEL=50 # From 0 (Unknown) to 100 (Fully trusted)
+      - CONNECTOR_LOG_LEVEL=info
+      - INTEZER_SANDBOX_API_KEY=ChangeMe # See https://analyze.intezer.com/account-details
+      - INTEZER_SANDBOX_FAMILY_COLOR=#0059f7 # Label color for family
+      - INTEZER_SANDBOX_MALICIOUS_COLOR=#d90e18 # Label color for malicious verdict
+      - INTEZER_SANDBOX_TRUSTED_COLOR=#d90e18 # And so on...
+      - INTEZER_SANDBOX_UNKNOWN_COLOR=#ffff00
+      - INTEZER_SANDBOX_SUSPICIOUS_COLOR=#f79e00
+      - INTEZER_SANDBOX_MAX_TLP=TLP:AMBER
+    restart: always

--- a/internal-enrichment/intezer-sandbox/entrypoint.sh
+++ b/internal-enrichment/intezer-sandbox/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Go to the right directory
+cd /opt/opencti-connector-intezer-sandbox
+
+# Launch the worker
+python3 intezer_sandbox.py

--- a/internal-enrichment/intezer-sandbox/src/config.yml.sample
+++ b/internal-enrichment/intezer-sandbox/src/config.yml.sample
@@ -1,0 +1,21 @@
+opencti:
+  url: 'ChangeMe'
+  token: 'ChangeMe'
+
+connector:
+  id: 'Intezer_Sandbox'
+  type: 'INTERNAL_ENRICHMENT'
+  name: 'IntezerSandbox'
+  scope: 'Artifact'
+  auto: false # Enable/disable auto-enrichment of observables
+  confidence_level: 50 # From 0 (Unknown) to 100 (Fully trusted)
+  log_level: 'info'
+
+intezer_sandbox:
+  api_key: 'ChangeMe' # See https://analyze.intezer.com/account-details
+  family_color: '#0059f7' # Label color for malware family
+  malicious_color: '#d90e18' # Label color for malicious verdict
+  trusted_color: '#34a56f' # And so on...
+  unknown_color: '#ffff00'
+  suspicious_color: '#f79e00'
+  max_tlp: 'TLP:AMBER'

--- a/internal-enrichment/intezer-sandbox/src/intezer_api.py
+++ b/internal-enrichment/intezer-sandbox/src/intezer_api.py
@@ -1,0 +1,65 @@
+import requests
+import io
+
+
+class IntezerApi:
+    """
+    A simple wrapper for the Intezer API v2.
+    """
+
+    def __init__(self, api_key):
+
+        self.base_url = "https://analyze.intezer.com/api/v2-0"
+
+        access_token = self._get_access_token(api_key)
+        self._session = requests.session()
+        self._session.headers["Authorization"] = f"Bearer {access_token}"
+
+    def _get_access_token(self, api_key):
+        response = requests.post(
+            f"{self.base_url}/get-access-token", json={"api_key": api_key}
+        )
+        response.raise_for_status()
+        return response.json()["result"]
+
+    def upload_file(self, file_name, file_contents):
+        """
+        Upload a file for analysis.
+
+        file_name: a str representing the name of the file
+        file_contents: a bytes object containing the contents of the file
+
+        returns: a str containing the URL for querying the analysis' status
+        """
+
+        file_obj = io.BytesIO(file_contents)
+        files = {"file": ("file_name", file_obj)}
+        response = self._session.post(f"{self.base_url}/analyze", files=files)
+        assert response.status_code == 201
+
+        return response.json()["result_url"]
+
+    def get_analysis_report(self, result_url):
+        """
+        Get an analysis' report. For use after obtaining result url by upload_file method.
+
+        returns: a dict in the form:
+                {
+                    'result': {'analysis_id': 'f010f718-8cea-4f00-9113-a3f6e346a164',
+                            'analysis_time': 'Tue, 13 Nov 2018 09:10:42 GMT',
+                            'analysis_url': 'https://analyze.intezer.com/analyses/f010f718-8cea-4f00-9113-a3f6e346a164',
+                            'family_name': 'Cedar',
+                            'is_private': True,
+                            'sha256': 'e5b68ab68b12c3eaff612ada09eb2d4c403f923cdec8a5c8fe253c6773208baf',
+                            'sub_verdict': 'malicious',
+                            'verdict': 'malicious'
+                    },
+                    'result_url': '/analyses/f010f718-8cea-4f00-9113-a3f6e346a164',
+                    'status': 'succeeded'
+                }
+        """
+
+        response = self._session.get(f"{self.base_url}{result_url}")
+        response.raise_for_status()
+        report_dict = response.json()
+        return report_dict

--- a/internal-enrichment/intezer-sandbox/src/intezer_sandbox.py
+++ b/internal-enrichment/intezer-sandbox/src/intezer_sandbox.py
@@ -1,0 +1,199 @@
+# coding: utf-8
+
+import os
+import yaml
+import time
+from intezer_api import IntezerApi
+from pycti import (
+    OpenCTIConnectorHelper,
+    get_config_variable,
+)
+
+
+class IntezerSandboxConnector:
+    def __init__(self):
+        # Instantiate the connector helper from config
+        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
+        config = (
+            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
+            if os.path.isfile(config_file_path)
+            else {}
+        )
+        self.helper = OpenCTIConnectorHelper(config)
+
+        self.identity = self.helper.api.identity.create(
+            type="Organization",
+            name="Intezer Sandbox",
+            description="Intezer Sandbox",
+        )["standard_id"]
+
+        self.octi_api_url = get_config_variable(
+            "OPENCTI_URL", ["opencti", "url"], config
+        )
+
+        # Get api key from config, use to instantiate the client
+        api_key = get_config_variable(
+            "INTEZER_SANDBOX_API_KEY",
+            ["intezer_sandbox", "api_key"],
+            config,
+        )
+        self.intezer_client = IntezerApi(api_key=api_key)
+
+        # Other config settings
+        self.family_color = get_config_variable(
+            "INTEZER_SANDBOX_FAMILY_COLOR",
+            ["intezer_sandbox", "family_color"],
+            config,
+        )
+        self.malicious_color = get_config_variable(
+            "INTEZER_SANDBOX_MALICIOUS_COLOR",
+            ["intezer_sandbox", "malicious_color"],
+            config,
+        )
+        self.trusted_color = get_config_variable(
+            "INTEZER_SANDBOX_TRUSTED_COLOR",
+            ["intezer_sandbox", "trusted_color"],
+            config,
+        )
+        self.unknown_color = get_config_variable(
+            "INTEZER_SANDBOX_UNKNOWN_COLOR",
+            ["intezer_sandbox", "unknown_color"],
+            config,
+        )
+        self.suspicious_color = get_config_variable(
+            "INTEZER_SANDBOX_SUSPICIOUS_COLOR",
+            ["intezer_sandbox", "suspicious_color"],
+            config,
+        )
+        self.max_tlp = get_config_variable(
+            "INTEZER_SANDBOX_MAX_TLP",
+            ["intezer_sandbox", "max_tlp"],
+            config,
+        )
+
+    def _process_report(self, observable, report):
+
+        self.helper.log_info(report)
+
+        # Create external reference
+        analysis_url = report["result"]["analysis_url"]
+        external_reference = self.helper.api.external_reference.create(
+            source_name="Intezer Sandbox Results",
+            url=analysis_url,
+            description="Intezer Sandbox Results",
+        )
+        self.helper.api.stix_cyber_observable.add_external_reference(
+            id=observable["id"],
+            external_reference_id=external_reference["id"],
+        )
+
+        # Attach family name as label if present
+        if "family_name" in report["result"] and report["result"]["family_name"]:
+
+            family_label = self.helper.api.label.create(
+                value=report["result"]["family_name"], color=self.family_color
+            )
+            self.helper.api.stix_cyber_observable.add_label(
+                id=observable["id"], label_id=family_label["id"]
+            )
+
+        # Attach verdict as label with color
+        color = self.malicious_color
+        verdict = report["result"]["verdict"]
+        if verdict == "suspicious":
+            color = self.suspicious_color
+        elif verdict == "unknown":
+            color = self.unknown_color
+        elif verdict == "trusted":
+            color = self.trusted_color
+
+        verdict_label = self.helper.api.label.create(value=verdict, color=color)
+        self.helper.api.stix_cyber_observable.add_label(
+            id=observable["id"], label_id=verdict_label["id"]
+        )
+
+        return "Nothing to attach"
+
+    def _process_file(self, observable):
+
+        if not observable["importFiles"]:
+            raise ValueError(f"No files found for {observable['observable_value']}")
+
+        # Build the URI to download the file
+        file_name = observable["importFiles"][0]["name"]
+        file_id = observable["importFiles"][0]["id"]
+        file_uri = f"{self.octi_api_url}/storage/get/{file_id}"
+        file_contents = self.helper.api.fetch_opencti_file(file_uri, True)
+
+        # Submit sample for analysis
+        result_url = self.intezer_client.upload_file(
+            file_name=file_name, file_contents=file_contents
+        )
+
+        # Wait for the analysis to finish
+        status = None
+        report = None
+        while True:
+
+            report = self.intezer_client.get_analysis_report(result_url)
+            status = report["status"]
+
+            if status == "succeeded":
+                break
+            elif status == "error" or status == "failed" or status == "expired":
+                raise ValueError(
+                    f"Intezer Sandbox failed to analyze {file_name}, status: {status}."
+                )
+
+            self.helper.log_info(f"Analysis for {file_name} has status {status}...")
+            time.sleep(20)
+
+        self.helper.log_info("Analysis succeeded, processing results...")
+
+        return self._process_report(observable, report)
+
+    def _process_observable(self, observable):
+        self.helper.log_info(
+            "Processing the observable " + observable["observable_value"]
+        )
+
+        # If File, Artifact
+        if observable["entity_type"] == "Artifact":
+            return self._process_file(observable)
+        else:
+            raise ValueError(
+                f"Failed to process observable, {observable['entity_type']} is not a supported entity type."
+            )
+
+    def _process_message(self, data):
+        entity_id = data["entity_id"]
+        observable = self.helper.api.stix_cyber_observable.read(id=entity_id)
+        if observable is None:
+            raise ValueError(
+                "Observable not found "
+                "(may be linked to data seggregation, check your group and permissions)"
+            )
+        # Extract TLP
+        tlp = "TLP:WHITE"
+        for marking_definition in observable["objectMarking"]:
+            if marking_definition["definition_type"] == "TLP":
+                tlp = marking_definition["definition"]
+        if not OpenCTIConnectorHelper.check_max_tlp(tlp, self.max_tlp):
+            raise ValueError(
+                "Do not send any data, TLP of the observable is greater than MAX TLP"
+            )
+        return self._process_observable(observable)
+
+    # Start the main loop
+    def start(self):
+        self.helper.listen(self._process_message)
+
+
+if __name__ == "__main__":
+    try:
+        intezer_sandbox = IntezerSandboxConnector()
+        intezer_sandbox.start()
+    except Exception as e:
+        print(e)
+        time.sleep(10)
+        exit(0)

--- a/internal-enrichment/intezer-sandbox/src/requirements.txt
+++ b/internal-enrichment/intezer-sandbox/src/requirements.txt
@@ -1,0 +1,2 @@
+pycti==5.0.3
+requests==2.26.0


### PR DESCRIPTION
### Proposed changes

* Add Intezer Sandbox Connector

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This Connector has been written to improve the efforts of analysts while analyzing Artifacts. An analyst can send an Artifact for analysis by Intezer Sandbox and retrieve the results as an external reference to the Artifact, in addition to labels being applied to the Artifact such as: verdict (malicious, suspicious, trusted, unknown) and malware family (if any).
