### PR TITLE
[cape-sandbox] add static extraction config option

### DIFF
--- a/internal-enrichment/cape-sandbox/docker-compose.yml
+++ b/internal-enrichment/cape-sandbox/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   connector-cape-sandbox:
-    image: opencti/connector-cape-sandbox:1.0.0
+    image: opencti/connector-cape-sandbox:1.0.1
     environment:
       - OPENCTI_URL=ChangeMe
       - OPENCTI_TOKEN=ChangeMe

--- a/internal-enrichment/cape-sandbox/docker-compose.yml
+++ b/internal-enrichment/cape-sandbox/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - CAPE_SANDBOX_TIMEOUT=300 # Maximum amount of seconds to run the analysis for
       - CAPE_SANDBOX_ENFORCE_TIMEOUT=false # Enforce analysis to run for the full timeout period
       - CAPE_SANDBOX_PRIORITY=1 # Set priority for submitted samples, 1-3, where 3 is highest priority
+      - CAPE_SANDBOX_TRY_EXTRACT=true # Try and extract configs statically without a VM first
       - CAPE_SANDBOX_OPTIONS=procmemdump=1,import_reconstruction=1 # List of options to be passed to the analysis package
       - CAPE_SANDBOX_LESS_NOISE=true # Only upload Artifacts associated with Yara rule matches
       - CAPE_SANDBOX_COOLDOWN_TIME=20 # Set the amount of seconds to wait between retries of the API

--- a/internal-enrichment/cape-sandbox/src/cape-sandbox.py
+++ b/internal-enrichment/cape-sandbox/src/cape-sandbox.py
@@ -671,7 +671,8 @@ class CapeSandboxConnector:
     @retry(wait_fixed=_cooldown_time, stop_max_attempt_number=_max_retries)
     def _get_status(self, task_id):
         response = requests.get(
-            f"{self.cape_api_url}/tasks/status/{task_id}/?format=json", headers=self.headers
+            f"{self.cape_api_url}/tasks/status/{task_id}/?format=json",
+            headers=self.headers,
         )
         response.raise_for_status()
         response_dict = response.json()

--- a/internal-enrichment/cape-sandbox/src/cape-sandbox.py
+++ b/internal-enrichment/cape-sandbox/src/cape-sandbox.py
@@ -689,17 +689,6 @@ class CapeSandboxConnector:
         response_dict = response.json()
         return response_dict
 
-    @retry(wait_fixed=_cooldown_time, stop_max_attempt_number=2)
-    def _create_static(self, files):
-        response = requests.post(
-            f"{self.cape_api_url}/tasks/create/static/",
-            headers=self.headers,
-            files=files
-        )
-        response.raise_for_status()
-        response_dict = response.json()
-        return response_dict
-
     def _is_ipv4_address(self, ip):
         m = re.match(r"^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$", ip)
         return bool(m) and all(map(lambda n: 0 <= int(n) <= 255, m.groups()))

--- a/internal-enrichment/cape-sandbox/src/config.yml.sample
+++ b/internal-enrichment/cape-sandbox/src/config.yml.sample
@@ -41,6 +41,7 @@ cape_sandbox:
   timeout: 300 # Maximum amount of seconds to run the analysis for
   enforce_timeout: false # Enforce analysis to run for the full timeout period
   priority: 1 # Set priority for submitted samples, 1-3, where 3 is highest priority
+  try_extract: true # Try and extract configs statically without a VM first
   options: 'procmemdump=1,import_reconstruction=1,fake-rdtsc=1' # List of options to be passed to the analysis package
   less_noise: true # Only upload Artifacts associated with Yara rule matches
   cooldown_time: 20 # Set the amount of seconds to wait between retries of the API


### PR DESCRIPTION
### Proposed changes

* Minor bug fixes
* Add static extraction

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

These changes were made to improve the processing time it takes to extract malware configurations from samples that are already unpacked. By enabling the config option "try_extract" first CAPE will attempt to extract the configuration without sending the file to a VM.
