### PR TITLE
[cape-sandbox] Fix re-trying upon API failure

### DIFF
--- a/internal-enrichment/cape-sandbox/src/requirements.txt
+++ b/internal-enrichment/cape-sandbox/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.0.3
 pyzipper==0.3.5
-retrying==1.3.3


### PR DESCRIPTION
### Proposed changes

* Fix re-trying upon API failure

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

It occurred to me recently that there was a bug where the CAPEv2 API will throttle. These changes fix the re-trying capabilities.
