### PR TITLE
IVRE: prevent false positives in TOR certificates detection

### DIFF
--- a/internal-enrichment/ivre/src/ivre_connector.py
+++ b/internal-enrichment/ivre/src/ivre_connector.py
@@ -231,7 +231,7 @@ class IvreConnector:
             update=True,
         )["id"]
         self.link_cyber(obs_id, cert_id, firstseen, lastseen)
-        if all(
+        if not cert.get("self_signed") and all(
             TOR_CERT_SUBJECT.search(cert.get(f"{fld}_text", ""))
             for fld in ["issuer", "subject"]
         ):


### PR DESCRIPTION
### Proposed changes

* TOR certificates are not self signed. This simple heuristic prevents some false positives.

### Related issues

* This heuristic is also used in ivre/ivre#1240

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

That's a tiny-yet-important change, as most false positives get catched by this simple heuristic.