### PR TITLE
[external-import] Add MalwareBazaar Recent Additions Connector

### DIFF
--- a/external-import/malwarebazaar-recent-additions/.dockerignore
+++ b/external-import/malwarebazaar-recent-additions/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/malwarebazaar-recent-additions/Dockerfile
+++ b/external-import/malwarebazaar-recent-additions/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9-alpine
+
+# Copy the connector
+COPY src /opt/opencti-connector-malwarebazaar-recent-additions
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk --no-cache add git build-base libmagic libffi-dev && \
+    cd /opt/opencti-connector-malwarebazaar-recent-additions && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/malwarebazaar-recent-additions/docker-compose.yml
+++ b/external-import/malwarebazaar-recent-additions/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  connector-malware-bazaar-recent-additions:
+    image: opencti/connector-malwarebazaar-recent-additions:5.1.1
+    environment:
+      - OPENCTI_URL=http://opencti:8080
+      - OPENCTI_TOKEN=ChangeMe
+      - CONNECTOR_ID=MalwareBazaar_Recent_Additions
+      - CONNECTOR_TYPE=EXTERNAL_IMPORT
+      - "CONNECTOR_NAME=MalwareBazaar Recent Additions"
+      - CONNECTOR_CONFIDENCE_LEVEL=50 # From 0 (Unknown) to 100 (Fully trusted)
+      - CONNECTOR_UPDATE_EXISTING_DATA=true
+      - CONNECTOR_LOG_LEVEL=info
+      - MALWAREBAZAAR_RECENT_ADDITIONS_API_URL=https://mb-api.abuse.ch/api/v1/
+      - MALWAREBAZAAR_RECENT_ADDITIONS_COOLDOWN_SECONDS=300 # Time to wait in seconds between subsequent requests
+      - MALWAREBAZAAR_RECENT_ADDITIONS_INCLUDE_TAGS=exe,dll,docm,docx,doc,xls,xlsx,xlsm,js # (Optional) Only download files if any tag matches. (Comma separated)
+      - MALWAREBAZAAR_RECENT_ADDITIONS_INCLUDE_REPORTERS= # (Optional) Only download files uploaded by these reporters. (Comma separated)
+      - MALWAREBAZAAR_RECENT_ADDITIONS_LABELS=malware-bazar # (Optional) Labels to apply to uploaded Artifacts. (Comma separated)
+      - MALWAREBAZAAR_RECENT_ADDITIONS_LABELS_COLOR=#54483b # Color to use for labels
+    restart: always

--- a/external-import/malwarebazaar-recent-additions/docker-compose.yml
+++ b/external-import/malwarebazaar-recent-additions/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   connector-malware-bazaar-recent-additions:
-    image: opencti/connector-malwarebazaar-recent-additions:5.1.1
+    image: opencti/connector-malwarebazaar-recent-additions:5.1.2
     environment:
       - OPENCTI_URL=http://opencti:8080
       - OPENCTI_TOKEN=ChangeMe

--- a/external-import/malwarebazaar-recent-additions/entrypoint.sh
+++ b/external-import/malwarebazaar-recent-additions/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Correct working directory
+cd /opt/opencti-connector-malwarebazaar-recent-additions
+
+# Start the connector
+python3 malwarebazaar-recent-additions.py

--- a/external-import/malwarebazaar-recent-additions/src/config.yml.sample
+++ b/external-import/malwarebazaar-recent-additions/src/config.yml.sample
@@ -1,0 +1,21 @@
+opencti:
+  url: 'ChangeMe'
+  token: 'ChangeMe'
+
+connector:
+  id: 'malwarebazaar_recent_additions'
+  type: 'EXTERNAL_IMPORT'
+  name: 'MalwareBazaar Recent Additions'
+  scope: 'malwarebazaar_recent_additions'
+  confidence_level: 40 # From 0 (Unknown) to 100 (Fully trusted)
+  create_indicator: False
+  update_existing_data: True
+  log_level: 'info'
+
+malwarebazaar_recent_additions:
+  api_url: 'https://mb-api.abuse.ch/api/v1/'
+  cooldown_seconds: 300 # Time to wait in seconds between subsequent requests
+  include_tags: 'exe,dll,docm,docx,doc,xls,xlsx,xlsm,js' # (Optional) Only download files if any tag matches. (Comma separated)
+  include_reporters: '' # (Optional) Only download files uploaded by these reporters. (Comma separated)
+  labels: 'malware-bazaar' # (Optional) Labels to apply to uploaded Artifacts. (Comma separated)
+  labels_color: '#54483b' # Color to use for all labels

--- a/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
+++ b/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
@@ -4,7 +4,6 @@ import time
 import io
 import magic
 import pyzipper
-import json
 import requests
 from pycti import (
     OpenCTIConnectorHelper,

--- a/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
+++ b/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
@@ -56,7 +56,7 @@ class MalwareBazaarRecentAdditions:
             config,
         )
         if self.include_tags:
-            self.include_tags = self.include_tags.split(',')
+            self.include_tags = self.include_tags.split(",")
 
         self.include_reporters = get_config_variable(
             "MALWAREBAZAAR_RECENT_ADDITIONS_INCLUDE_REPORTERS",
@@ -64,7 +64,7 @@ class MalwareBazaarRecentAdditions:
             config,
         )
         if self.include_reporters:
-            self.include_reporters = self.include_reporters.split(',')
+            self.include_reporters = self.include_reporters.split(",")
 
         labels = get_config_variable(
             "MALWAREBAZAAR_RECENT_ADDITIONS_LABELS",
@@ -88,21 +88,25 @@ class MalwareBazaarRecentAdditions:
                 recent_additions_list = self.get_recent_additions()
                 for recent_additions_dict in recent_additions_list:
 
-                    self.helper.log_info(f'Processing: {recent_additions_dict}')
-                    sha256 = recent_additions_dict['sha256_hash']
-                    reporter = recent_additions_dict['reporter']
-                    file_name = recent_additions_dict['file_name']
-                    tags = recent_additions_dict['tags']
+                    self.helper.log_info(f"Processing: {recent_additions_dict}")
+                    sha256 = recent_additions_dict["sha256_hash"]
+                    reporter = recent_additions_dict["reporter"]
+                    file_name = recent_additions_dict["file_name"]
+                    tags = recent_additions_dict["tags"]
 
                     # If the artifact has an excluded tag, skip processing
                     if self.include_reporters:
                         if not reporter in self.include_reporters:
-                            self.helper.log_info(f'Skipping {sha256} as it was from a reporter not in the included list: {reporter}')
+                            self.helper.log_info(
+                                f"Skipping {sha256} as it was from a reporter not in the included list: {reporter}"
+                            )
                             continue
 
                     if self.include_tags:
                         if not any(x in tags for x in self.include_tags):
-                            self.helper.log_info(f'Skipping {sha256} as it did not contain a tag in the included list.')
+                            self.helper.log_info(
+                                f"Skipping {sha256} as it did not contain a tag in the included list."
+                            )
                             continue
 
                     # If the artifact already exists in OpenCTI skip it
@@ -119,7 +123,7 @@ class MalwareBazaarRecentAdditions:
                     response = self.upload_artifact_opencti(
                         file_name,
                         file_contents,
-                        f"Uploaded to MalwareBazaar by Twitter user: {reporter}."
+                        f"Uploaded to MalwareBazaar by Twitter user: {reporter}.",
                     )
 
                     # Create external reference to MalwareBazaar report
@@ -149,7 +153,9 @@ class MalwareBazaarRecentAdditions:
                             id=response["id"], label_id=label["id"]
                         )
 
-                self.helper.log_info(f"Re-checking for new additions in {self.cooldown_seconds} seconds...")
+                self.helper.log_info(
+                    f"Re-checking for new additions in {self.cooldown_seconds} seconds..."
+                )
                 time.sleep(self.cooldown_seconds)
 
             except (KeyboardInterrupt, SystemExit):
@@ -170,13 +176,13 @@ class MalwareBazaarRecentAdditions:
                  60 minutes to MalwareBazaar.
         """
 
-        data = {'query': 'get_recent', 'selector': 'time'}
+        data = {"query": "get_recent", "selector": "time"}
         resp = requests.post(self.api_url, data=data)
 
         # Handle the response data
-        
+
         recent_additions_list = resp.json()
-        return recent_additions_list['data']
+        return recent_additions_list["data"]
 
     def download_unzip(self, sha256):
         """
@@ -185,7 +191,7 @@ class MalwareBazaarRecentAdditions:
         sha256: a str representing the sample's sha256.
         returns: a bytes object containing the contents of the file
         """
-        data = {'query': 'get_file', 'sha256_hash': sha256}
+        data = {"query": "get_file", "sha256_hash": sha256}
         resp = requests.post(self.api_url, data=data)
         zip_contents = resp.content
         zip_obj = io.BytesIO(zip_contents)

--- a/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
+++ b/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
@@ -1,0 +1,243 @@
+import os
+import yaml
+import time
+import io
+import magic
+import pyzipper
+import json
+import requests
+from pycti import (
+    OpenCTIConnectorHelper,
+    get_config_variable,
+)
+
+
+class MalwareBazaarRecentAdditions:
+    """
+    Process recent additions to Malware Bazaar
+    """
+
+    def __init__(self):
+        # Instantiate the connector helper from config
+        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
+        config = (
+            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
+            if os.path.isfile(config_file_path)
+            else {}
+        )
+        self.helper = OpenCTIConnectorHelper(config)
+        self.identity = self.helper.api.identity.create(
+            type="Organization",
+            name="MalwareBazaar",
+            description="For more info, see https://bazaar.abuse.ch/about/",
+        )
+
+        self.api_url = get_config_variable(
+            "MALWAREBAZAAR_RECENT_ADDITIONS_API_URL",
+            ["malwarebazaar_recent_additions", "api_url"],
+            config,
+        )
+
+        self.cooldown_seconds = get_config_variable(
+            "MALWAREBAZAAR_RECENT_ADDITIONS_COOLDOWN_SECONDS",
+            ["malwarebazaar_recent_additions", "cooldown_seconds"],
+            config,
+        )
+
+        self.labels_color = get_config_variable(
+            "MALWAREBAZAAR_RECENT_ADDITIONS_LABELS_COLOR",
+            ["malwarebazaar_recent_additions", "labels_color"],
+            config,
+        )
+
+        self.include_tags = get_config_variable(
+            "MALWAREBAZAAR_RECENT_ADDITIONS_INCLUDE_TAGS",
+            ["malwarebazaar_recent_additions", "include_tags"],
+            config,
+        )
+        if self.include_tags:
+            self.include_tags = self.include_tags.split(',')
+
+        self.include_reporters = get_config_variable(
+            "MALWAREBAZAAR_RECENT_ADDITIONS_INCLUDE_REPORTERS",
+            ["malwarebazaar_recent_additions", "include_reporters"],
+            config,
+        )
+        if self.include_reporters:
+            self.include_reporters = self.include_reporters.split(',')
+
+        labels = get_config_variable(
+            "MALWAREBAZAAR_RECENT_ADDITIONS_LABELS",
+            ["malwarebazaar_recent_additions", "labels"],
+            config,
+        ).split(",")
+
+        # Create default labels
+        self.label_ids = []
+        for label in labels:
+            created_label = self.helper.api.label.create(
+                value=label, color=self.labels_color
+            )
+            self.label_ids.append(created_label["id"])
+
+    def run(self):
+        self.helper.log_info("Starting MalwareBazaar Recent Additions Connector")
+        while True:
+            try:
+
+                recent_additions_list = self.get_recent_additions()
+                for recent_additions_dict in recent_additions_list:
+
+                    self.helper.log_info(f'Processing: {recent_additions_dict}')
+                    sha256 = recent_additions_dict['sha256_hash']
+                    reporter = recent_additions_dict['reporter']
+                    file_name = recent_additions_dict['file_name']
+                    tags = recent_additions_dict['tags']
+
+                    # If the artifact has an excluded tag, skip processing
+                    if self.include_reporters:
+                        if not reporter in self.include_reporters:
+                            self.helper.log_info(f'Skipping {sha256} as it was from a reporter not in the included list: {reporter}')
+                            continue
+
+                    if self.include_tags:
+                        if not any(x in tags for x in self.include_tags):
+                            self.helper.log_info(f'Skipping {sha256} as it did not contain a tag in the included list.')
+                            continue
+
+                    # If the artifact already exists in OpenCTI skip it
+                    if self.artifact_exists_opencti(sha256):
+                        self.helper.log_info(
+                            f'Skipping Artifact with "{sha256}" as it already exists in OpenCTI.'
+                        )
+                        continue
+
+                    # Download the artifact and unzip with default "infected" password
+                    file_contents = self.download_unzip(sha256)
+
+                    # Upload the artifact to OpenCTI
+                    response = self.upload_artifact_opencti(
+                        file_name,
+                        file_contents,
+                        f"Uploaded to MalwareBazaar by Twitter user: {reporter}."
+                    )
+
+                    # Create external reference to MalwareBazaar report
+                    external_reference = self.helper.api.external_reference.create(
+                        source_name="MalwareBazaar Recent Additions",
+                        url=f"https://bazaar.abuse.ch/sample/{sha256}/",
+                        description="MalwareBazaar Recent Additions",
+                    )
+                    self.helper.api.stix_cyber_observable.add_external_reference(
+                        id=response["id"],
+                        external_reference_id=external_reference["id"],
+                    )
+
+                    # Attach all default labels if any
+                    for label_id in self.label_ids:
+                        self.helper.api.stix_cyber_observable.add_label(
+                            id=response["id"], label_id=label_id
+                        )
+
+                    # Attach all tags as labels if any
+                    for tag in tags:
+                        label = self.helper.api.label.create(
+                            value=tag,
+                            color=self.labels_color,
+                        )
+                        self.helper.api.stix_cyber_observable.add_label(
+                            id=response["id"], label_id=label["id"]
+                        )
+
+                self.helper.log_info(f"Re-checking for new additions in {self.cooldown_seconds} seconds...")
+                time.sleep(self.cooldown_seconds)
+
+            except (KeyboardInterrupt, SystemExit):
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            except Exception as e:
+                self.helper.log_error(str(e))
+                time.sleep(self.cooldown_seconds)
+
+    def get_recent_additions(self):
+        """
+        Get recent additions to MalwareBazaar.
+
+        See https://bazaar.abuse.ch/api/#latest_additions
+
+        returns: a dict containing the recent additions in the last
+                 60 minutes to MalwareBazaar.
+        """
+
+        data = {'query': 'get_recent', 'selector': 'time'}
+        resp = requests.post(self.api_url, data=data)
+
+        # Handle the response data
+        
+        recent_additions_list = resp.json()
+        return recent_additions_list['data']
+
+    def download_unzip(self, sha256):
+        """
+        Download and unzip a sample from MalwareBazaar.
+
+        sha256: a str representing the sample's sha256.
+        returns: a bytes object containing the contents of the file
+        """
+        data = {'query': 'get_file', 'sha256_hash': sha256}
+        resp = requests.post(self.api_url, data=data)
+        zip_contents = resp.content
+        zip_obj = io.BytesIO(zip_contents)
+        zip_file = pyzipper.AESZipFile(zip_obj)
+        zip_file.setpassword(b"infected")
+        file_name = zip_file.namelist()[0]
+        return zip_file.read(file_name)
+
+    def artifact_exists_opencti(self, sha256):
+        """
+        Determine whether or not an Artifact already exists in OpenCTI.
+
+        sha256: a str representing the sha256 of the artifact's file contents
+        returns: a bool indicidating the aforementioned
+        """
+
+        response = self.helper.api.stix_cyber_observable.read(
+            filters=[{"key": "hashes_SHA256", "values": [sha256]}]
+        )
+
+        if response:
+            return True
+        return False
+
+    def upload_artifact_opencti(self, file_name, file_contents, description):
+        """
+        Upload a file to OpenCTI.
+
+        file_name: a str representing the name of the file
+        file_contents: a bytes object representing the file contents
+        description: a str representing the description for the upload
+
+        returns: response of upload
+        """
+
+        mime_type = magic.from_buffer(file_contents, mime=True)
+
+        kwargs = {
+            "file_name": file_name,
+            "data": file_contents,
+            "mime_type": mime_type,
+            "x_opencti_description": description,
+        }
+
+        return self.helper.api.stix_cyber_observable.upload_artifact(**kwargs)
+
+
+if __name__ == "__main__":
+    try:
+        malwarebazaar_recent_additions = MalwareBazaarRecentAdditions()
+        malwarebazaar_recent_additions.run()
+    except Exception as e:
+        print(e)
+        time.sleep(10)
+        exit(0)

--- a/external-import/malwarebazaar-recent-additions/src/requirements.txt
+++ b/external-import/malwarebazaar-recent-additions/src/requirements.txt
@@ -1,0 +1,3 @@
+pycti==5.1.2
+pyzipper==0.3.5
+requests==2.26.0

--- a/external-import/malwarebazaar-recent-additions/src/requirements.txt
+++ b/external-import/malwarebazaar-recent-additions/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.1.2
 pyzipper==0.3.5
-requests==2.26.0


### PR DESCRIPTION
### Proposed changes

* [external-import] Add MalwareBazaar Recent Additions Connector

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This Connector was created to allow pro-active threat research of samples available in MalwareBazaar. Samples are uploaded to MalwareBazaar by IT-security researchers and include file types such as: doc, docm, docx, exe, dll, etc. This Connector will periodically poll the recent additions API of MalwareBazaar and download any not-yet uploaded samples and upload them into OpenCTI with associated tags as labels.