### PR TITLE
[external-import] Add URLHaus Recent Payloads Connector

### DIFF
--- a/external-import/urlhaus-recent-payloads/.dockerignore
+++ b/external-import/urlhaus-recent-payloads/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/urlhaus-recent-payloads/Dockerfile
+++ b/external-import/urlhaus-recent-payloads/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9-alpine
+
+# Copy the connector
+COPY src /opt/opencti-connector-urlhaus-recent-payloads
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk --no-cache add git build-base libmagic libffi-dev && \
+    cd /opt/opencti-connector-urlhaus-recent-payloads && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/urlhaus-recent-payloads/docker-compose.yml
+++ b/external-import/urlhaus-recent-payloads/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+services:
+  connector-urlhaus-recent-payloads:
+    image: opencti/connector-urlhaus-recent-payloads:5.1.2
+    environment:
+      - OPENCTI_URL=http://opencti:8080
+      - OPENCTI_TOKEN=ChangeMe
+      - CONNECTOR_ID=URLHaus_Recent_Payloads
+      - CONNECTOR_TYPE=EXTERNAL_IMPORT
+      - "CONNECTOR_NAME=URLHaus Recent Payloads"
+      - CONNECTOR_CONFIDENCE_LEVEL=50 # From 0 (Unknown) to 100 (Fully trusted)
+      - CONNECTOR_UPDATE_EXISTING_DATA=true
+      - CONNECTOR_LOG_LEVEL=info
+      - URLHAUS_RECENT_PAYLOADS_API_URL=https://urlhaus-api.abuse.ch/v1/
+      - URLHAUS_RECENT_PAYLOADS_COOLDOWN_SECONDS=300 # Time to wait in seconds between subsequent requests
+      - URLHAUS_RECENT_PAYLOADS_INCLUDE_FILETYPES=exe,dll,docm,docx,doc,xls,xlsx,xlsm,js,xll # (Optional) Only download files if any tag matches. (Comma separated)
+      - URLHAUS_RECENT_PAYLOADS_INCLUDE_SIGNATURES= # (Optional) Only download files uploaded by these reporters. (Comma separated)
+      - URLHAUS_RECENT_PAYLOADS_SKIP_UNKNOWN_FILETYPES=true # Skip files with an unknown file type
+      - URLHAUS_RECENT_PAYLOADS_SKIP_NULL_SIGNATURE=true # Skip files that didn't match known Yara signatures
+      - URLHAUS_RECENT_PAYLOADS_LABELS=urlhaus # (Optional) Labels to apply to uploaded Artifacts. (Comma separated)
+      - URLHAUS_RECENT_PAYLOADS_LABELS_COLOR=#54483b
+      - URLHAUS_RECENT_PAYLOADS_SIGNATURE_LABEL_COLOR=#0059f7 # Color for signature match label
+      - URLHAUS_RECENT_PAYLOADS_FILETYPE_LABEL_COLOR=#54483b # Color to use for filetype label
+    restart: always

--- a/external-import/urlhaus-recent-payloads/entrypoint.sh
+++ b/external-import/urlhaus-recent-payloads/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Correct working directory
+cd /opt/opencti-connector-urlhaus-recent-payloads
+
+# Start the connector
+python3 urlhaus-recent-payloads.py

--- a/external-import/urlhaus-recent-payloads/src/config.yml.sample
+++ b/external-import/urlhaus-recent-payloads/src/config.yml.sample
@@ -1,0 +1,25 @@
+opencti:
+  url: 'ChangeMe'
+  token: 'ChangeMe'
+
+connector:
+  id: 'urlhaus_recent_payloads'
+  type: 'EXTERNAL_IMPORT'
+  name: 'MalwareBazaar Recent Additions'
+  scope: 'urlhaus_recent_payloads'
+  confidence_level: 40 # From 0 (Unknown) to 100 (Fully trusted)
+  create_indicator: False
+  update_existing_data: True
+  log_level: 'info'
+
+urlhaus_recent_payloads:
+  api_url: 'https://urlhaus-api.abuse.ch/v1/'
+  cooldown_seconds: 300 # Time to wait in seconds between subsequent requests
+  include_filetypes: 'exe,zip,dll,docm,docx,doc,xls,xlsx,xlsm,js,xll' # (Optional) Only download files if file type matches. (Comma separated)
+  include_signatures: '' # (Optional) Only download files if match these signatures. (Comma separated)
+  skip_unknown_filetypes: True # Skip files with an unknown file type
+  skip_null_signature: True # Skip files that didn't match known Yara signatures
+  labels: 'urlhaus' # (Optional) Labels to apply to uploaded Artifacts. (Comma separated)
+  labels_color: '#54483b' # Color for labels specified above
+  signature_label_color: '#0059f7' # Color for signature match label
+  filetype_label_color: '#54483b' # Color to use for filetype label

--- a/external-import/urlhaus-recent-payloads/src/requirements.txt
+++ b/external-import/urlhaus-recent-payloads/src/requirements.txt
@@ -1,2 +1,1 @@
 pycti==5.1.2
-pyzipper==0.3.5

--- a/external-import/urlhaus-recent-payloads/src/requirements.txt
+++ b/external-import/urlhaus-recent-payloads/src/requirements.txt
@@ -1,0 +1,2 @@
+pycti==5.1.2
+pyzipper==0.3.5

--- a/external-import/urlhaus-recent-payloads/src/urlhaus-recent-payloads.py
+++ b/external-import/urlhaus-recent-payloads/src/urlhaus-recent-payloads.py
@@ -1,9 +1,7 @@
 import os
 import yaml
 import time
-import io
 import magic
-import pyzipper
 import requests
 import datetime
 from pycti import (
@@ -113,7 +111,9 @@ class URLHausRecentPayloads:
                 last_first_seen_datetime = None
                 if current_state is not None and "last_first_seen" in current_state:
                     last_first_seen = current_state["last_first_seen"]
-                    last_first_seen_datetime = datetime.datetime.strptime(last_first_seen, '%Y-%m-%d %H:%M:%S')
+                    last_first_seen_datetime = datetime.datetime.strptime(
+                        last_first_seen, "%Y-%m-%d %H:%M:%S"
+                    )
                     self.helper.log_info(
                         f"Connector last processed a file that was first seen at: {last_first_seen}"
                     )
@@ -130,14 +130,16 @@ class URLHausRecentPayloads:
                     download_url = recent_payload_dict["urlhaus_download"]
 
                     if last_first_seen_datetime is not None:
-                        new_first_seen_datetime = datetime.datetime.strptime(first_seen, '%Y-%m-%d %H:%M:%S')
+                        new_first_seen_datetime = datetime.datetime.strptime(
+                            first_seen, "%Y-%m-%d %H:%M:%S"
+                        )
                         if new_first_seen_datetime < last_first_seen_datetime:
                             self.helper.log_info(
                                 f"Skipping {sha256} seen at {first_seen} as it is older than {last_first_seen}."
                             )
                             continue
 
-                    if self.skip_unknown_filetypes and file_type == 'unknown':
+                    if self.skip_unknown_filetypes and file_type == "unknown":
                         self.helper.log_info(
                             f"Skipping {sha256} as it was an unknown file type."
                         )
@@ -190,8 +192,7 @@ class URLHausRecentPayloads:
 
                     # Attach file type as label
                     label = self.helper.api.label.create(
-                        value=file_type,
-                        color=self.filetype_label_color
+                        value=file_type, color=self.filetype_label_color
                     )
                     self.helper.api.stix_cyber_observable.add_label(
                         id=response["id"], label_id=label["id"]
@@ -229,7 +230,7 @@ class URLHausRecentPayloads:
                  payloads collected by URLHaus.
         """
 
-        url = self.api_url + 'payloads/recent/'
+        url = self.api_url + "payloads/recent/"
         resp = requests.get(url)
 
         # Handle the response data

--- a/external-import/urlhaus-recent-payloads/src/urlhaus-recent-payloads.py
+++ b/external-import/urlhaus-recent-payloads/src/urlhaus-recent-payloads.py
@@ -1,0 +1,297 @@
+import os
+import yaml
+import time
+import io
+import magic
+import pyzipper
+import requests
+import datetime
+from pycti import (
+    OpenCTIConnectorHelper,
+    get_config_variable,
+)
+
+
+class URLHausRecentPayloads:
+    """
+    Process recent payloads in URLHaus
+    """
+
+    def __init__(self):
+        # Instantiate the connector helper from config
+        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
+        config = (
+            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
+            if os.path.isfile(config_file_path)
+            else {}
+        )
+        self.helper = OpenCTIConnectorHelper(config)
+        self.identity = self.helper.api.identity.create(
+            type="Organization",
+            name="URLHaus",
+            description="For more info, see https://urlhaus-api.abuse.ch/",
+        )
+
+        self.api_url = get_config_variable(
+            "URLHAUS_RECENT_PAYLOADS_API_URL",
+            ["urlhaus_recent_payloads", "api_url"],
+            config,
+        )
+
+        self.cooldown_seconds = get_config_variable(
+            "URLHAUS_RECENT_PAYLOADS_COOLDOWN_SECONDS",
+            ["urlhaus_recent_payloads", "cooldown_seconds"],
+            config,
+        )
+
+        self.signature_label_color = get_config_variable(
+            "URLHAUS_RECENT_PAYLOADS_SIGNATURE_LABEL_COLOR",
+            ["urlhaus_recent_payloads", "signature_label_color"],
+            config,
+        )
+
+        self.filetype_label_color = get_config_variable(
+            "URLHAUS_RECENT_PAYLOADS_FILETYPE_LABEL_COLOR",
+            ["urlhaus_recent_payloads", "filetype_label_color"],
+            config,
+        )
+
+        self.include_filetypes = get_config_variable(
+            "URLHAUS_RECENT_PAYLOADS_INCLUDE_FILETYPES",
+            ["urlhaus_recent_payloads", "include_filetypes"],
+            config,
+        )
+        if self.include_filetypes:
+            self.include_filetypes = self.include_filetypes.split(",")
+
+        self.include_signatures = get_config_variable(
+            "URLHAUS_RECENT_PAYLOADS_INCLUDE_SIGNATURES",
+            ["urlhaus_recent_payloads", "include_signatures"],
+            config,
+        )
+        if self.include_signatures:
+            self.include_signatures = self.include_signatures.split(",")
+
+        self.skip_unknown_filetypes = get_config_variable(
+            "URLHAUS_RECENT_PAYLOADS_SKIP_UNKNOWN_FILETYPES",
+            ["urlhaus_recent_payloads", "skip_unknown_filetypes"],
+            config,
+        )
+
+        self.skip_null_signature = get_config_variable(
+            "URLHAUS_RECENT_PAYLOADS_SKIP_NULL_SIGNATURE",
+            ["urlhaus_recent_payloads", "skip_null_signature"],
+            config,
+        )
+
+        labels = get_config_variable(
+            "URLHAUS_RECENT_PAYLOADS_LABELS",
+            ["urlhaus_recent_payloads", "labels"],
+            config,
+        ).split(",")
+
+        self.labels_color = get_config_variable(
+            "URLHAUS_RECENT_PAYLOADS_LABELS_COLOR",
+            ["urlhaus_recent_payloads", "labels_color"],
+            config,
+        )
+
+        # Create default labels
+        self.label_ids = []
+        for label in labels:
+            created_label = self.helper.api.label.create(
+                value=label, color=self.labels_color
+            )
+            self.label_ids.append(created_label["id"])
+
+    def run(self):
+        self.helper.log_info("Starting URLHaus Recent Payloads Connector")
+        while True:
+            try:
+
+                current_state = self.helper.get_state()
+                last_first_seen_datetime = None
+                if current_state is not None and "last_first_seen" in current_state:
+                    last_first_seen = current_state["last_first_seen"]
+                    last_first_seen_datetime = datetime.datetime.strptime(last_first_seen, '%Y-%m-%d %H:%M:%S')
+                    self.helper.log_info(
+                        f"Connector last processed a file that was first seen at: {last_first_seen}"
+                    )
+                else:
+                    self.helper.log_info("Connector has never run")
+
+                recent_payloads_list = self.get_recent_payloads()
+                for recent_payload_dict in recent_payloads_list:
+                    self.helper.log_debug(f"Processing: {recent_payload_dict}")
+                    sha256 = recent_payload_dict["sha256_hash"]
+                    first_seen = recent_payload_dict["firstseen"]
+                    file_type = recent_payload_dict["file_type"]
+                    signature = recent_payload_dict["signature"]
+                    download_url = recent_payload_dict["urlhaus_download"]
+
+                    if last_first_seen_datetime is not None:
+                        new_first_seen_datetime = datetime.datetime.strptime(first_seen, '%Y-%m-%d %H:%M:%S')
+                        if new_first_seen_datetime < last_first_seen_datetime:
+                            self.helper.log_info(
+                                f"Skipping {sha256} seen at {first_seen} as it is older than {last_first_seen}."
+                            )
+                            continue
+
+                    if self.skip_unknown_filetypes and file_type == 'unknown':
+                        self.helper.log_info(
+                            f"Skipping {sha256} as it was an unknown file type."
+                        )
+                        continue
+
+                    if self.skip_null_signature and not signature:
+                        self.helper.log_info(
+                            f"Skipping {sha256} as signature was null."
+                        )
+                        continue
+
+                    # If the artifact doesn't have an included file type, skip processing
+                    if self.include_filetypes:
+                        if not file_type in self.include_filetypes:
+                            self.helper.log_info(
+                                f"Skipping {sha256} as it did not match a file type in the included list: {file_type}"
+                            )
+                            continue
+
+                    # If the artifact doesn't have an included signature, skip processing
+                    if self.include_signatures:
+                        if not signature in self.include_signatures:
+                            self.helper.log_info(
+                                f"Skipping {sha256} as it did not match a signature in the included list: {signature}"
+                            )
+                            continue
+
+                    # If the artifact already exists in OpenCTI skip it
+                    if self.artifact_exists_opencti(sha256):
+                        self.helper.log_info(
+                            f'Skipping Artifact with "{sha256}" as it already exists in OpenCTI.'
+                        )
+                        continue
+
+                    # Download the payload
+                    file_contents = self.download_payload(file_type, download_url)
+
+                    # Upload the artifact to OpenCTI
+                    response = self.upload_artifact_opencti(
+                        sha256,
+                        file_contents,
+                        f"URLHaus recent payload seen at {first_seen}.",
+                    )
+
+                    # Attach all default labels if any
+                    for label_id in self.label_ids:
+                        self.helper.api.stix_cyber_observable.add_label(
+                            id=response["id"], label_id=label_id
+                        )
+
+                    # Attach file type as label
+                    label = self.helper.api.label.create(
+                        value=file_type,
+                        color=self.filetype_label_color
+                    )
+                    self.helper.api.stix_cyber_observable.add_label(
+                        id=response["id"], label_id=label["id"]
+                    )
+
+                    # Attach signature as label
+                    label = self.helper.api.label.create(
+                        value=signature,
+                        color=self.signature_label_color,
+                    )
+                    self.helper.api.stix_cyber_observable.add_label(
+                        id=response["id"], label_id=label["id"]
+                    )
+
+                    self.helper.set_state({"last_first_seen": first_seen})
+
+                self.helper.log_info(
+                    f"Re-checking for new payloads in {self.cooldown_seconds} seconds..."
+                )
+                time.sleep(self.cooldown_seconds)
+
+            except (KeyboardInterrupt, SystemExit):
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            except Exception as e:
+                self.helper.log_error(str(e))
+                time.sleep(self.cooldown_seconds)
+
+    def get_recent_payloads(self):
+        """
+        Get recent payloads from URLHaus.
+
+        returns: a list containing the last 1000 recent
+                 payloads collected by URLHaus.
+        """
+
+        url = self.api_url + 'payloads/recent/'
+        resp = requests.get(url)
+
+        # Handle the response data
+
+        recent_payloads_list = resp.json()
+        return recent_payloads_list["payloads"]
+
+    def download_payload(self, file_type, download_url):
+        """
+        Download and unzip if a sample is a zip from URLHaus.
+
+        download_url: a str representing the sample's download url
+        returns: a bytes object containing the contents of the file
+        """
+
+        resp = requests.get(download_url)
+        return resp.content
+
+    def artifact_exists_opencti(self, sha256):
+        """
+        Determine whether or not an Artifact already exists in OpenCTI.
+
+        sha256: a str representing the sha256 of the artifact's file contents
+        returns: a bool indicidating the aforementioned
+        """
+
+        response = self.helper.api.stix_cyber_observable.read(
+            filters=[{"key": "hashes_SHA256", "values": [sha256]}]
+        )
+
+        if response:
+            return True
+        return False
+
+    def upload_artifact_opencti(self, file_name, file_contents, description):
+        """
+        Upload a file to OpenCTI.
+
+        file_name: a str representing the name of the file
+        file_contents: a bytes object representing the file contents
+        description: a str representing the description for the upload
+
+        returns: response of upload
+        """
+
+        mime_type = magic.from_buffer(file_contents, mime=True)
+
+        kwargs = {
+            "file_name": file_name,
+            "data": file_contents,
+            "mime_type": mime_type,
+            "x_opencti_description": description,
+        }
+
+        return self.helper.api.stix_cyber_observable.upload_artifact(**kwargs)
+
+
+if __name__ == "__main__":
+    try:
+        urlhaus_recent_payloads = URLHausRecentPayloads()
+        urlhaus_recent_payloads.run()
+    except Exception as e:
+        print(e)
+        time.sleep(10)
+        exit(0)


### PR DESCRIPTION
### Proposed changes

* [external import] Add URLHaus Recent Payloads Connector

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This Connector was created to enable pro-active threat research of samples available in URLHaus. Samples are uploaded to URLHaus by IT-security researchers and include file types such as: doc, docm, docx, exe, dll, etc. This Connector will periodically poll the recent payloads API of URLHaus and download any not-yet uploaded samples and upload them into OpenCTI with associated signature and filetype as labels.