### PR TITLE
[hatching triage sandbox] Resolve "stix2.exceptions.InvalidValueError: Invalid value for Relationship 'target_ref'"

### DIFF
--- a/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
+++ b/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
@@ -175,6 +175,7 @@ class HatchingTriageSandboxConnector:
                     else:
                         parsed = c2
                         relationship_type = "related-to"
+
                     host_stix = SimpleObservable(
                         id=OpenCTIStix2Utils.generate_random_stix_id(
                             "x-opencti-simple-observable"
@@ -202,6 +203,7 @@ class HatchingTriageSandboxConnector:
                     protocol = cred_dict.get("protocol")
 
                     if host:
+                        # Add Host Observable
                         host_stix = SimpleObservable(
                             id=OpenCTIStix2Utils.generate_random_stix_id(
                                 "x-opencti-simple-observable"
@@ -225,12 +227,10 @@ class HatchingTriageSandboxConnector:
                         bundle_objects.append(host_stix)
                         bundle_objects.append(relationship)
 
-                    if protocol == "smtp":
+                    if protocol == "smtp" and username:
                         # Add Email Address Observable
-                        host_stix = SimpleObservable(
-                            id=OpenCTIStix2Utils.generate_random_stix_id(
-                                "x-opencti-simple-observable"
-                            ),
+                        email_stix = SimpleObservable(
+                            id=OpenCTIStix2Utils.generate_random_stix_id("x-opencti-simple-observable"),
                             labels=[config_rule, "credentials"],
                             key="Email-Addr.value",
                             value=username,
@@ -238,16 +238,15 @@ class HatchingTriageSandboxConnector:
                         )
 
                         relationship = Relationship(
-                            id=OpenCTIStix2Utils.generate_random_stix_id(
-                                "relationship"
-                            ),
+                            id=OpenCTIStix2Utils.generate_random_stix_id("relationship"),
                             relationship_type="related-to",
                             created_by_ref=self.identity,
                             source_ref=observable["standard_id"],
-                            target_ref=host_stix.id,
+                            target_ref=email_stix.id,
+                            allow_custom=True,
                         )
 
-                        bundle_objects.append(host_stix)
+                        bundle_objects.append(email_stix)
                         bundle_objects.append(relationship)
 
                 # Download task file, wait for it to become available

--- a/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
+++ b/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
@@ -232,7 +232,9 @@ class HatchingTriageSandboxConnector:
                     if protocol == "smtp" and username:
                         # Add Email Address Observable
                         email_stix = SimpleObservable(
-                            id=OpenCTIStix2Utils.generate_random_stix_id("x-opencti-simple-observable"),
+                            id=OpenCTIStix2Utils.generate_random_stix_id(
+                                "x-opencti-simple-observable"
+                            ),
                             labels=[config_rule, "credentials"],
                             key="Email-Addr.value",
                             value=username,
@@ -240,7 +242,9 @@ class HatchingTriageSandboxConnector:
                         )
 
                         relationship = Relationship(
-                            id=OpenCTIStix2Utils.generate_random_stix_id("relationship"),
+                            id=OpenCTIStix2Utils.generate_random_stix_id(
+                                "relationship"
+                            ),
                             relationship_type="related-to",
                             created_by_ref=self.identity,
                             source_ref=observable["standard_id"],

--- a/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
+++ b/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
@@ -191,6 +191,7 @@ class HatchingTriageSandboxConnector:
                         created_by_ref=self.identity,
                         source_ref=observable["standard_id"],
                         target_ref=host_stix.id,
+                        allow_custom=True,
                     )
                     bundle_objects.append(host_stix)
                     bundle_objects.append(relationship)
@@ -222,6 +223,7 @@ class HatchingTriageSandboxConnector:
                             created_by_ref=self.identity,
                             source_ref=observable["standard_id"],
                             target_ref=host_stix.id,
+                            allow_custom=True,
                         )
 
                         bundle_objects.append(host_stix)
@@ -293,6 +295,7 @@ class HatchingTriageSandboxConnector:
                     created_by_ref=self.identity,
                     source_ref=response["standard_id"],
                     target_ref=observable["standard_id"],
+                    allow_custom=True,
                 )
                 bundle_objects.append(relationship)
 
@@ -332,6 +335,7 @@ class HatchingTriageSandboxConnector:
                         created_by_ref=self.identity,
                         source_ref=observable["standard_id"],
                         target_ref=url_stix.id,
+                        allow_custom=True,
                     )
                     bundle_objects.append(url_stix)
                     bundle_objects.append(relationship)
@@ -363,6 +367,7 @@ class HatchingTriageSandboxConnector:
                 created_by_ref=self.identity,
                 source_ref=observable["standard_id"],
                 target_ref=domain_stix.id,
+                allow_custom=True,
             )
             bundle_objects.append(domain_stix)
             bundle_objects.append(relationship)
@@ -395,6 +400,7 @@ class HatchingTriageSandboxConnector:
                 created_by_ref=self.identity,
                 source_ref=observable["standard_id"],
                 target_ref=host_stix.id,
+                allow_custom=True,
             )
             bundle_objects.append(host_stix)
             bundle_objects.append(relationship)
@@ -429,6 +435,7 @@ class HatchingTriageSandboxConnector:
                         source_ref=observable["standard_id"],
                         target_ref=attack_pattern.id,
                         object_marking_refs=[TLP_WHITE],
+                        allow_custom=True,
                     )
                     bundle_objects.append(attack_pattern)
                     bundle_objects.append(relationship)

--- a/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
+++ b/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
@@ -325,7 +325,7 @@ class HatchingTriageSandboxConnector:
                         ),
                         labels=[dropper_type],
                         key="Url.value",
-                        value=url,
+                        value=url.rstrip(),
                         created_by_ref=self.identity,
                         object_marking_refs=[TLP_WHITE],
                     )


### PR DESCRIPTION
### Proposed changes

* Resolve bug where AgentTesla samples aren't processed correctly, exception: 
```
* raise InvalidValueError(
stix2.exceptions.InvalidValueError: Invalid value for Relationship 'target_ref': reference to custom object type: x-opencti-simple-observable
```

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality