### PR TITLE
[riskiq] fix importation when `publishedDate` is not provided

### DIFF
--- a/external-import/riskiq/src/riskiq/article_importer.py
+++ b/external-import/riskiq/src/riskiq/article_importer.py
@@ -222,8 +222,14 @@ class ArticleImporter:
     def run(self, work_id: str, state: Mapping[str, Any]) -> Mapping[str, Any]:
         """Run the importation of the article."""
         self.work_id = work_id
-        published = parser.parse(self.article["publishedDate"])
         created = parser.parse(self.article["createdDate"])
+        # RisIQ API does not always provide the `publishedDate`.
+        # If it does not exist, take the value of the `createdDate` instead.
+        published = (
+            parser.parse(self.article["publishedDate"])
+            if self.article["publishedDate"] is not None
+            else created
+        )
 
         indicators = itertools.chain(
             *[


### PR DESCRIPTION
The field `publishedDate` returned by RiskIQ API is null, making it impossible to use it for the published date of the report. If the `publishedDate` is null, use the `createdDate` instead.

Fixes #606

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Use the `createdDate` as published date if the `publishedDate` is null. 


### Related issues

* #606 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
