### PR TITLE
data.json.gz not found

### DIFF
--- a/external-import/cve/src/cve.py
+++ b/external-import/cve/src/cve.py
@@ -68,7 +68,7 @@ class Cve:
                 file.write(image)
             # Unzipping the file
             self.helper.log_info("Unzipping the file")
-            with gzip.open(os.path.dirname(os.path.abspath(__file__)) + "data.json.gz", "rb") as f_in:
+            with gzip.open(os.path.dirname(os.path.abspath(__file__)) + "/data.json.gz", "rb") as f_in:
                 with open("data.json", "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
             # Converting the file to stix2

--- a/external-import/cve/src/cve.py
+++ b/external-import/cve/src/cve.py
@@ -68,7 +68,7 @@ class Cve:
                 file.write(image)
             # Unzipping the file
             self.helper.log_info("Unzipping the file")
-            with gzip.open("data.json.gz", "rb") as f_in:
+            with gzip.open(os.path.dirname(os.path.abspath(__file__)) + "data.json.gz", "rb") as f_in:
                 with open("data.json", "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
             # Converting the file to stix2


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

This already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Set the static path when running the unzip command

### Related issues

* N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x ] I consider the submitted work as finished
- [x ] I tested the code for its functionality using different use cases
- [ x] I added/update the relevant documentation (either on github or on notion)
- [ x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

This should mitigate the failed to find data.json.gz issue I had experienced when trying to automate some connectors with various scripts and systemd

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
