### PR TITLE
[misp] fixes bug with no external_id in AttackPattern

### DIFF
--- a/external-import/misp/src/misp.py
+++ b/external-import/misp/src/misp.py
@@ -1318,7 +1318,8 @@ class Misp:
                     if name not in added_names:
                         x_mitre_id = None
                         if "external_id" in galaxy_entity["meta"]:
-                            x_mitre_id = galaxy_entity["meta"]["external_id"][0]
+                            if len(galaxy_entity["meta"]["external_id"]) > 0:
+                                x_mitre_id = galaxy_entity["meta"]["external_id"][0]
                         elements["attack_patterns"].append(
                             AttackPattern(
                                 name=name,

--- a/external-import/misp/src/misp.py
+++ b/external-import/misp/src/misp.py
@@ -1316,6 +1316,9 @@ class Misp:
                     else:
                         aliases = [name]
                     if name not in added_names:
+                        x_mitre_id = None
+                        if "external_id" in galaxy_entity["meta"]:
+                            x_mitre_id = galaxy_entity["meta"]["external_id"][0]
                         elements["attack_patterns"].append(
                             AttackPattern(
                                 name=name,
@@ -1323,9 +1326,7 @@ class Misp:
                                 created_by_ref=author,
                                 object_marking_refs=markings,
                                 custom_properties={
-                                    "x_mitre_id": galaxy_entity["meta"]["external_id"][
-                                        0
-                                    ],
+                                    "x_mitre_id": x_mitre_id,
                                     "x_opencti_aliases": aliases,
                                 },
                                 allow_custom=True,


### PR DESCRIPTION
### Proposed changes

* Fixes MISP connector bug by setting `x_mitre_id` to `None` if it is not returned by misp

### Related issues

* #626


### Checklist

- [X] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality


### Further comments

This sets `x_mitre_id` to `None` if it is not returned by misp, right now it crashes 