### PR TITLE
[thehive_connector] Add hostname observable in thehive connector

### DIFF
--- a/external-import/thehive/src/thehive.py
+++ b/external-import/thehive/src/thehive.py
@@ -33,6 +33,7 @@ OBSERVABLES_MAPPING = {
     "file_sha256": "File.hashes.SHA-256",
     "filename": "File.name",
     "fqdn": "X-OpenCTI-Hostname.value",
+    "hostname": "X-OpenCTI-Hostname.value",
     "hash": None,
     "ip": "IPv4-Addr.value",
     "mail": "Email-Message.body",


### PR DESCRIPTION
Right now thehive come with hostname observable, because of that the thehive connector is crashing and cannot import cases with hostname type as observable.
connector-thehive_1                          | INFO:root:Connector last_case_date: 2022-03-15 07:30:59
connector-thehive_1                          | INFO:root:Get cases since last run (2022-03-15 07:30:59)
connector-thehive_1                          | INFO:root:Initiate work for f27f6437-d79e-444c-a20f-11af49e91902
connector-thehive_1                          | ERROR:root:'hostname'
connector-thehive_1                          | INFO:root:Connector successfully run, storing last_run as 1647329519
connector-thehive_1                          | INFO:root:Reporting work update_received opencti-work--5f5465af-f9aa-45a0-8fdc-e51eedbcfb9e

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add hostname field in OBSERVABLES_MAPPING


### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
