### PR TITLE
[export-report-pdf] Fix_missing_Error_loading_shared_library_pango-1.0-0

### DIFF
--- a/internal-export-file/export-report-pdf/Dockerfile
+++ b/internal-export-file/export-report-pdf/Dockerfile
@@ -7,12 +7,12 @@ COPY src /opt/opencti-connector-export-report-pdf
 # hadolint ignore=DL3003
 RUN apk --no-cache add git build-base libmagic libffi-dev zlib-dev tiff-dev jpeg-dev openjpeg-dev zlib-dev \
     freetype-dev lcms2-dev libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev libimagequant-dev \
-    libxcb-dev libpng-dev pango weasyprint && \
+    libxcb-dev libpng-dev cairo-dev pango weasyprint && \
     cd /opt/opencti-connector-export-report-pdf && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
 # Expose and entrypoint
 COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh 
+RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Adding cairo-dev apk in Dockerfile

### Related issues

* export report in pdf is broken
* connector logs shows root cause is absence of pango-1.0-0 library

Observed error:

    docker-compose -f docker-compose.yml logs -f connector-export-report-pdf
    Attaching to docker_connector-export-report-pdf_1
    connector-export-report-pdf_1  | Traceback (most recent call last):
    connector-export-report-pdf_1  |   File "/opt/opencti-connector-export-report-pdf/export-report-pdf.py", line 6, in <module>
    connector-export-report-pdf_1  |     from weasyprint import HTML
    connector-export-report-pdf_1  |   File "/usr/local/lib/python3.9/site-packages/weasyprint/__init__.py", line 322, in <module>
    connector-export-report-pdf_1  |     from .css import preprocess_stylesheet  # noqa isort:skip
    connector-export-report-pdf_1  |   File "/usr/local/lib/python3.9/site-packages/weasyprint/css/__init__.py", line 27, in <module>
    connector-export-report-pdf_1  |     from . import computed_values, counters, media_queries
    connector-export-report-pdf_1  |   File "/usr/local/lib/python3.9/site-packages/weasyprint/css/computed_values.py", line 16, in <module>
    connector-export-report-pdf_1  |     from ..text.ffi import ffi, pango, units_to_double
    connector-export-report-pdf_1  |   File "/usr/local/lib/python3.9/site-packages/weasyprint/text/ffi.py", line 383, in <module>
    connector-export-report-pdf_1  |     pango = _dlopen(
    connector-export-report-pdf_1  |   File "/usr/local/lib/python3.9/site-packages/weasyprint/text/ffi.py", line 377, in _dlopen
    connector-export-report-pdf_1  |     return ffi.dlopen(names[0])  # pragma: no cover
    connector-export-report-pdf_1  |   File "/usr/local/lib/python3.9/site-packages/cffi/api.py", line 150, in dlopen
    connector-export-report-pdf_1  |     lib, function_cache = _make_ffi_library(self, name, flags)
    connector-export-report-pdf_1  |   File "/usr/local/lib/python3.9/site-packages/cffi/api.py", line 832, in _make_ffi_library
    connector-export-report-pdf_1  |     backendlib = _load_backend_lib(backend, libname, flags)
    connector-export-report-pdf_1  |   File "/usr/local/lib/python3.9/site-packages/cffi/api.py", line 827, in _load_backend_lib
    connector-export-report-pdf_1  |     raise OSError(msg)
    connector-export-report-pdf_1  | OSError: cannot load library 'pango-1.0-0': Error loading shared library pango-1.0-0: No such file or directory.  Additionally, ctypes.util.find_library() did not manage to locate a library called 'pango-1.0-0'

After adding cairo-dev apk into Dockerfile, we observe

- no more errors in connector logs
- pdf report is successfully exported

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
