### PR TITLE
[kaspersky] switch some logs to debug to reduce verbosity

### DIFF
--- a/external-import/kaspersky/src/kaspersky/client.py
+++ b/external-import/kaspersky/src/kaspersky/client.py
@@ -237,7 +237,7 @@ class KasperskyClient:
         :return: a publication
         :rtype: Publication
         """
-        log.info(
+        log.debug(
             "Getting publication details for ID '%s' include '%s' info with language '%s'.",  # noqa: E501
             publication_id,
             include_info,

--- a/external-import/kaspersky/src/kaspersky/importer.py
+++ b/external-import/kaspersky/src/kaspersky/importer.py
@@ -61,6 +61,10 @@ class BaseImporter(ABC):
         fmt_msg = msg.format(*args)
         self.helper.log_info(fmt_msg)
 
+    def _debug(self, msg: str, *args: Any) -> None:
+        fmt_msg = msg.format(*args)
+        self.helper.log_debug(fmt_msg)
+
     def _error(self, msg: str, *args: Any) -> None:
         fmt_msg = msg.format(*args)
         self.helper.log_error(fmt_msg)

--- a/external-import/kaspersky/src/kaspersky/utils/yara.py
+++ b/external-import/kaspersky/src/kaspersky/utils/yara.py
@@ -135,7 +135,7 @@ class YaraRuleUpdater:
                 self._error("Rule '{0}' ({1}) not updated", new_rule_name, indicator_id)
             return updated
         else:
-            self._info("Not updating rule '{0}' ({1})", new_rule_name, indicator_id)
+            self._debug("Not updating rule '{0}' ({1})", new_rule_name, indicator_id)
             return False
 
     def _needs_updating(self, current_rule: YaraRule, new_rule: YaraRule) -> bool:
@@ -147,7 +147,7 @@ class YaraRuleUpdater:
             )
             return False
 
-        self._info(
+        self._debug(
             "Current rule last modified '{0}', new rule last modified '{1}'",
             current_rule.last_modified,
             new_rule.last_modified,
@@ -177,6 +177,10 @@ class YaraRuleUpdater:
     def _info(self, msg: str, *args: Any) -> None:
         fmt_msg = msg.format(*args)
         self.helper.log_info(fmt_msg)
+
+    def _debug(self, msg: str, *args: Any) -> None:
+        fmt_msg = msg.format(*args)
+        self.helper.log_debug(fmt_msg)
 
     def _error(self, msg: str, *args: Any) -> None:
         fmt_msg = msg.format(*args)
@@ -281,11 +285,11 @@ def _parse_yara_rule(yara_rule: str) -> Optional[Mapping[str, Any]]:
 
     report = _get_report(yara_rule)
     if report is None:
-        log.info("No report for rule: %s", name)
+        log.debug("No report for rule: %s", name)
 
     last_modified = _get_last_modified(yara_rule)
     if last_modified is None:
-        log.info("No last modified for rule: %s", name)
+        log.debug("No last modified for rule: %s", name)
 
     return {
         "name": name,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

The Kaspersky connector has a lot of logs as `info`, making it really verbose. 

### Proposed changes

* Switch some of the `info` logs as `debug` to avoid generating that much logs in production. 

### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [] I added/update the relevant documentation (either on github or on notion)
- [] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
