### PR TITLE
[import-document] Adding support for markdown documents. Fixes #669

### DIFF
--- a/internal-import-file/import-document/README.md
+++ b/internal-import-file/import-document/README.md
@@ -25,7 +25,7 @@ OpenCTI data is coming from *import* connectors.
 | `connector_name`                     | `CONNECTOR_NAME`                    | Yes          | Option `ImportReport`                                                                                                                          |
 | `connector_only_contextual`          | `CONNCETOR_ONLY_CONTEXTUAL`         | Yes          | `true` Only extract data related to an entity (a report, a threat actor, etc.)                                                                             |
 | `connector_auto`                     | `CONNCETOR_AUTO`                    | Yes          | `false` Enable/disable auto import of report file                                                                                                          |
-| `connector_scope`                    | `CONNECTOR_SCOPE`                   | Yes          | Supported file types: `'application/pdf','text/plain','text/html', 'text/csv`                                                                                                     |
+| `connector_scope`                    | `CONNECTOR_SCOPE`                   | Yes          | Supported file types: `'application/pdf','text/plain','text/html', 'text/csv,'text/markdown'`                                                                                                     |
 | `connector_confidence_level`         | `CONNECTOR_CONFIDENCE_LEVEL`        | Yes          | The default confidence level for created sightings (a number between 1 and 4).                                                                             |
 | `connector_log_level`                | `CONNECTOR_LOG_LEVEL`               | Yes          | The log level for this connector, could be `debug`, `info`, `warn` or `error` (less verbose).                                                              |
 | `import_document_create_indicator`   | `IMPORT_DOCUMENT_CREATE_INDICATOR`    | Yes          | Create an indicator for each extracted observable                                                                                                         |
@@ -65,6 +65,7 @@ DEBUG:root:Text: 'executed with arp.exe and cmd.exe to run it' -> extracts {'cmd
 - Text file
 - HTML file
 - CSV file
+- MD file
 
 **Extractable Entities/Stix Domain Objects**
 

--- a/internal-import-file/import-document/docker-compose.yml
+++ b/internal-import-file/import-document/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - CONNECTOR_TYPE=INTERNAL_IMPORT_FILE
       - CONNECTOR_NAME=ImportDocument
       - CONNECTOR_VALIDATE_BEFORE_IMPORT=true # Validate any bundle before import
-      - CONNECTOR_SCOPE=application/pdf,text/plain,text/html,text/csv
+      - CONNECTOR_SCOPE=application/pdf,text/plain,text/html,text/csv,text/markdown
       - CONNECTOR_AUTO=true # Enable/disable auto-import of file
       - CONNECTOR_ONLY_CONTEXTUAL=true # Only extract data related to an entity (a report, a threat actor, etc.)
       - CONNECTOR_CONFIDENCE_LEVEL=100 # From 0 (Unknown) to 100 (Fully trusted)

--- a/internal-import-file/import-document/src/config.yml.sample
+++ b/internal-import-file/import-document/src/config.yml.sample
@@ -7,7 +7,7 @@ connector:
   type: 'INTERNAL_IMPORT_FILE'
   name: 'ImportDocument'
   validate_before_import: true # Validate any bundle before import
-  scope: 'application/pdf,text/plain,text/html,text/csv'
+  scope: 'application/pdf,text/plain,text/html,text/csv,text/markdown'
   auto: true # Enable/disable auto-import of file
   only_contextual: false # Only extract data related to an entity (a report, a threat actor, etc.)
   confidence_level: 100 # From 0 (Unknown) to 100 (Fully trusted)

--- a/internal-import-file/import-document/src/reportimporter/constants.py
+++ b/internal-import-file/import-document/src/reportimporter/constants.py
@@ -2,6 +2,7 @@ MIME_PDF = "application/pdf"
 MIME_TXT = "text/plain"
 MIME_HTML = "text/html"
 MIME_CSV = "text/csv"
+MIME_MD = "text/markdown"
 
 RESULT_FORMAT_TYPE = "type"
 RESULT_FORMAT_CATEGORY = "category"

--- a/internal-import-file/import-document/src/reportimporter/report_parser.py
+++ b/internal-import-file/import-document/src/reportimporter/report_parser.py
@@ -19,6 +19,7 @@ from reportimporter.constants import (
     MIME_TXT,
     MIME_HTML,
     MIME_CSV,
+    MIME_MD,
     OBSERVABLE_DETECTION_CUSTOM_REGEX,
     OBSERVABLE_DETECTION_LIBRARY,
 )
@@ -51,6 +52,7 @@ class ReportParser(object):
             MIME_TXT: self._parse_text,
             MIME_HTML: self._parse_html,
             MIME_CSV: self._parse_text,
+            MIME_MD: self._parse_text,
         }
 
         self.library_lookup = library_mapping()


### PR DESCRIPTION
### Proposed changes

* Adding markdown document support for the parser. Using the text parser for markdown documents.

### Related issues

* #669

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
