### PR TITLE
replaces name for value and resolves 694

### DIFF
--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -361,8 +361,8 @@ class Mandiant:
                             pattern=pattern,
                             pattern_type="stix",
                             allow_custom=True,
-                            name=self._redacted_as_none("name", indicator)
-                            if self._redacted_as_none("name", indicator) is not None
+                            name=self._redacted_as_none("value", indicator)
+                            if self._redacted_as_none("value", indicator) is not None
                             else pattern,
                             description=self._redacted_as_none(
                                 "description", indicator


### PR DESCRIPTION
### Proposed changes

* replace name for value when importing indicators using the /v4/indicators endpoint for the Mandiant connector

### Related issues

* #694 