### PR TITLE
[misp] fix NoneType on observable

### DIFF
--- a/external-import/misp/src/misp.py
+++ b/external-import/misp/src/misp.py
@@ -361,11 +361,11 @@ class Misp:
                 try:
                     events = self.misp.search("events", **kwargs)
                 except Exception as e:
-                    self.helper.log_error(str(e))
+                    self.helper.log_error(f"Error fetching misp event: {e}")
                     try:
                         events = self.misp.search("events", **kwargs)
                     except Exception as e:
-                        self.helper.log_error(str(e))
+                        self.helper.log_error(f"Error fetching misp event again: {e}")
 
                 self.helper.log_info("MISP returned " + str(len(events)) + " events.")
                 number_events = number_events + len(events)
@@ -1014,7 +1014,7 @@ class Misp:
                         },
                     )
                 except Exception as e:
-                    self.helper.log_error(str(e))
+                    self.helper.log_error(f"Error processing indicator {name}: {e}")
             observable = None
             if self.misp_create_observables and observable_type is not None:
                 try:
@@ -1145,7 +1145,9 @@ class Misp:
                             custom_properties=custom_properties,
                         )
                 except Exception as e:
-                    self.helper.log_error(str(e))
+                    self.helper.log_error(
+                        f"Error creating observable type {observable_type} with value {observable_value}: {e}"
+                    )
             sightings = []
             identities = []
             if "Sighting" in attribute:
@@ -1224,7 +1226,9 @@ class Misp:
                 relationships.append(
                     stix2.Relationship(
                         id=StixCoreRelationship.generate_id(
-                            "related-to", object_observable.id, observable.id
+                            "related-to",
+                            object_observable.id,
+                            observable.id if observable is not None else indicator.id,
                         ),
                         relationship_type="related-to",
                         created_by_ref=author["id"],


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

Since version 5.3.5, the creation of the relationship id uses a value that can be `None`. 

Example of error (row number might not match): 

```
Traceback (most recent call last):
{{ File "/opt/opencti-connector-misp/misp.py", line 2038, in <module>}}
{{ mispConnector.run()}}
{{ File "/opt/opencti-connector-misp/misp.py", line 380, in run}}
{{ event_timestamp = self.process_events(work_id, events)}}
{{ File "/opt/opencti-connector-misp/misp.py", line 632, in process_events}}
{{ indicator = self.process_attribute(}}
{{ File "/opt/opencti-connector-misp/misp.py", line 1235, in process_attribute}}
{{ "related-to", object_observable.id, observable.id}}
AttributeError: 'NoneType' object has no attribute 'id'
Killed 
```

### Proposed changes

* Fix the creation of the id to avoid crashing the connector
* ~~Few changes regarding pylint warnings~~

### Related issues

* N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
