### PR TITLE
Update docker-compose.yml

### DIFF
--- a/external-import/cisa-known-exploited-vulnerabilities/docker-compose.yml
+++ b/external-import/cisa-known-exploited-vulnerabilities/docker-compose.yml
@@ -14,5 +14,5 @@ services:
       - CONNECTOR_RUN_AND_TERMINATE=false
       - CONNECTOR_LOG_LEVEL=info
       - CISA_CATALOG_URL=https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
-      - MITRE_INTERVAL=2 # In days, must be strictly greater than 1
+      - CISA_INTERVAL=2 # In days, must be strictly greater than 1
     restart: always


### PR DESCRIPTION
Per the src code, the interval time should be CISA_INTERVAL and not MITRE_INTERVAL.


### Proposed changes

* Change MITRE_INTERVAL to CISA_INTERVAL in docker compose YML file. 

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/721




### Further comments
Small change proposal as this was causing an error on the docker compose side for MITRE_INTERVAL on the CISA connector which should be CISA_INTERVAL
