### PR TITLE
Adding variable Start Date for NVD CVE Feeds

### DIFF
--- a/external-import/cve/docker-compose.yml
+++ b/external-import/cve/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - CONNECTOR_LOG_LEVEL=info
       - CVE_IMPORT_HISTORY=true # Import history at the first run (after only recent), reset the connector state if you want to re-import
       - CVE_NVD_DATA_FEED=https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-recent.json.gz
+      - CVE_HISTORY_START_DATE=2002
       - CVE_HISTORY_DATA_FEED=https://nvd.nist.gov/feeds/json/cve/1.1/
       - CVE_INTERVAL=7 # In days, must be strictly greater than 1
     restart: always

--- a/external-import/cve/src/config.yml.sample
+++ b/external-import/cve/src/config.yml.sample
@@ -14,6 +14,7 @@ connector:
 
 cve:
   nvd_data_feed: 'https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-recent.json.gz'
+  history_start_date: 2002
   history_data_feed: 'https://nvd.nist.gov/feeds/json/cve/1.1/'
   import_history: True # Import history at the first run (after only recent), reset the connector state if you want to re-import
   interval: 7 # In days, must be strictly greater than 1

--- a/external-import/cve/src/cve.py
+++ b/external-import/cve/src/cve.py
@@ -32,7 +32,10 @@ class Cve:
             "CVE_NVD_DATA_FEED", ["cve", "nvd_data_feed"], config
         )
         self.cve_history_data_feed = get_config_variable(
-            "CVE_HISTORY_DATA_FEED", ["cve", "history_data_feed"], config
+            "CVE_HISTORY_DATA_FEED", ["cve", "history_data_feed"], config,
+        )
+        self.cve_history_start_date = get_config_variable(
+            "CVE_HISTORY_START_DATE", ["cve", "history_start_date"], config, True
         )
         self.cve_interval = get_config_variable(
             "CVE_INTERVAL", ["cve", "interval"], config, True
@@ -119,7 +122,7 @@ class Cve:
                 # If import history and never run
                 if last_run is None and self.cve_import_history:
                     now = datetime.now()
-                    years = list(range(2002, now.year + 1))
+                    years = list(range(self.cve_history_start_date, now.year + 1))
                     for year in years:
                         self.convert_and_send(
                             f"{self.cve_history_data_feed}nvdcve-1.1-{year}.json.gz",


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Implement a variable CVE historical start date to avoid ingesting CVE data from previous years that are not relevant
*

### Related issues

* N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ x ] I consider the submitted work as finished
- [ x ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

No further comments, the change is minor.
