### PR TITLE
[external-import] Break loop if run and terminate is enabled

### DIFF
--- a/external-import/alienvault/src/alienvault/builder.py
+++ b/external-import/alienvault/src/alienvault/builder.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from typing import Callable, List, Mapping, NamedTuple, Optional, Set
 
 import stix2
+from stix2.v21 import _DomainObject, _Observable  # type: ignore
+
 from alienvault.models import Pulse, PulseIndicator
 from alienvault.utils import (
     OBSERVATION_FACTORY_CRYPTOCURRENCY_WALLET,
@@ -41,7 +43,6 @@ from alienvault.utils import (
     create_vulnerability_external_reference,
     get_tlp_string_marking_definition,
 )
-from stix2.v21 import _DomainObject, _Observable  # type: ignore
 
 log = logging.getLogger(__name__)
 

--- a/external-import/alienvault/src/alienvault/client.py
+++ b/external-import/alienvault/src/alienvault/client.py
@@ -4,9 +4,10 @@
 from datetime import datetime
 from typing import List
 
-from alienvault.models import Pulse
 from OTXv2 import OTXv2  # type: ignore
 from pydantic import parse_obj_as
+
+from alienvault.models import Pulse
 
 
 class AlienVaultClient:

--- a/external-import/alienvault/src/alienvault/core.py
+++ b/external-import/alienvault/src/alienvault/core.py
@@ -263,10 +263,15 @@ class AlienVault:
                         "Connector will not run, next run in: {0} seconds", next_run
                     )
 
-                self._sleep(delay_sec=run_interval)
             except (KeyboardInterrupt, SystemExit):
                 self._info("Connector stop")
                 exit(0)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            self._sleep(delay_sec=run_interval)
 
     @classmethod
     def _sleep(cls, delay_sec: Optional[int] = None) -> None:

--- a/external-import/alienvault/src/alienvault/core.py
+++ b/external-import/alienvault/src/alienvault/core.py
@@ -3,11 +3,17 @@
 
 import datetime
 import os
+import sys
 import time
 from typing import Any, Dict, List, Mapping, Optional
 
 import stix2
 import yaml
+from pycti.connector.opencti_connector_helper import (  # type: ignore
+    OpenCTIConnectorHelper,
+    get_config_variable,
+)
+
 from alienvault.client import AlienVaultClient
 from alienvault.importer import PulseImporter, PulseImporterConfig
 from alienvault.utils import (
@@ -16,10 +22,6 @@ from alienvault.utils import (
     get_tlp_string_marking_definition,
 )
 from alienvault.utils.constants import DEFAULT_TLP_MARKING_DEFINITION
-from pycti.connector.opencti_connector_helper import (  # type: ignore
-    OpenCTIConnectorHelper,
-    get_config_variable,
-)
 
 
 class AlienVault:
@@ -265,11 +267,11 @@ class AlienVault:
 
             except (KeyboardInterrupt, SystemExit):
                 self._info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             self._sleep(delay_sec=run_interval)
 

--- a/external-import/alienvault/src/alienvault/importer.py
+++ b/external-import/alienvault/src/alienvault/importer.py
@@ -6,14 +6,15 @@ from datetime import datetime
 from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Set
 
 import stix2
-from alienvault.builder import PulseBundleBuilder, PulseBundleBuilderConfig
-from alienvault.client import AlienVaultClient
-from alienvault.models import Pulse
-from alienvault.utils import iso_datetime_str_to_datetime
 from pycti.connector.opencti_connector_helper import (
     OpenCTIConnectorHelper,
 )  # type: ignore
 from stix2.exceptions import STIXError  # type: ignore
+
+from alienvault.builder import PulseBundleBuilder, PulseBundleBuilderConfig
+from alienvault.client import AlienVaultClient
+from alienvault.models import Pulse
+from alienvault.utils import iso_datetime_str_to_datetime
 
 
 class PulseImporterConfig(NamedTuple):

--- a/external-import/amitt/src/amitt.py
+++ b/external-import/amitt/src/amitt.py
@@ -116,7 +116,6 @@ class Amitt:
                         + str(round(self.get_interval() / 60 / 60 / 24, 2))
                         + " days"
                     )
-                    time.sleep(60)
                 else:
                     new_interval = self.get_interval() - (timestamp - last_run)
                     self.helper.log_info(
@@ -124,13 +123,19 @@ class Amitt:
                         + str(round(new_interval / 60 / 60 / 24, 2))
                         + " days"
                     )
-                    time.sleep(60)
+
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 exit(0)
+
             except Exception as e:
                 self.helper.log_error(str(e))
-                time.sleep(60)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            time.sleep(60)
 
 
 if __name__ == "__main__":

--- a/external-import/amitt/src/amitt.py
+++ b/external-import/amitt/src/amitt.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import urllib.request
 from datetime import datetime
@@ -126,14 +127,14 @@ class Amitt:
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             except Exception as e:
                 self.helper.log_error(str(e))
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(60)
 
@@ -145,4 +146,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/cape/src/main.py
+++ b/external-import/cape/src/main.py
@@ -179,6 +179,10 @@ class capeConnector:
                 f"Run Complete. Sleeping until next run in " f"{self.interval} Minutes"
             )
 
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
             time.sleep(self.get_interval())
 
 

--- a/external-import/cape/src/main.py
+++ b/external-import/cape/src/main.py
@@ -1,11 +1,13 @@
 import os
+import sys
 import time
 from datetime import datetime
 
 import yaml
+from pycti import OpenCTIConnectorHelper, get_config_variable
+
 from cape.cape import cuckoo, cuckooReport
 from cape.telemetry import openCTIInterface
-from pycti import OpenCTIConnectorHelper, get_config_variable
 
 
 class capeConnector:
@@ -181,7 +183,7 @@ class capeConnector:
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(self.get_interval())
 

--- a/external-import/cisa-known-exploited-vulnerabilities/src/cisa.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/cisa.py
@@ -148,9 +148,11 @@ class Cisa:
                     + str(round(new_interval / 60 / 60 / 24, 2))
                     + " days"
                 )
+
         except (KeyboardInterrupt, SystemExit):
             self.helper.log_info("Connector stop")
             sys.exit(0)
+
         except Exception as e:
             self.helper.log_error(str(e))
 

--- a/external-import/crowdstrike/src/crowdstrike/core.py
+++ b/external-import/crowdstrike/src/crowdstrike/core.py
@@ -2,11 +2,16 @@
 """OpenCTI CrowdStrike connector core module."""
 
 import os
+import sys
 import time
 from typing import Any, Dict, List, Mapping, Optional
 
 import stix2
 import yaml
+from crowdstrike_client.client import CrowdStrikeClient
+from pycti import OpenCTIConnectorHelper  # type: ignore
+from pycti.connector.opencti_connector_helper import get_config_variable  # type: ignore
+
 from crowdstrike.actor.importer import ActorImporter
 from crowdstrike.importer import BaseImporter
 from crowdstrike.indicator.importer import IndicatorImporter, IndicatorImporterConfig
@@ -20,9 +25,6 @@ from crowdstrike.utils import (
     timestamp_to_datetime,
 )
 from crowdstrike.utils.constants import DEFAULT_TLP_MARKING_DEFINITION
-from crowdstrike_client.client import CrowdStrikeClient
-from pycti import OpenCTIConnectorHelper  # type: ignore
-from pycti.connector.opencti_connector_helper import get_config_variable  # type: ignore
 
 
 class CrowdStrike:
@@ -383,20 +385,20 @@ class CrowdStrike:
 
                 if self.helper.connect_run_and_terminate:
                     self.helper.log_info("Connector stop")
-                    exit(0)
+                    sys.exit(0)
 
                 self._sleep(delay_sec=run_interval)
 
             except (KeyboardInterrupt, SystemExit):
                 self._info("CrowdStrike connector stopping...")
-                exit(0)
+                sys.exit(0)
 
             except Exception as e:  # noqa: B902
                 self._error("CrowdStrike connector internal error: {0}", str(e))
 
                 if self.helper.connect_run_and_terminate:
                     self.helper.log_info("Connector stop")
-                    exit(0)
+                    sys.exit(0)
 
                 self._sleep()
 

--- a/external-import/crowdstrike/src/crowdstrike/core.py
+++ b/external-import/crowdstrike/src/crowdstrike/core.py
@@ -381,12 +381,23 @@ class CrowdStrike:
                         "Connector will not run, next run in: {0} seconds", next_run
                     )
 
+                if self.helper.connect_run_and_terminate:
+                    self.helper.log_info("Connector stop")
+                    exit(0)
+
                 self._sleep(delay_sec=run_interval)
+
             except (KeyboardInterrupt, SystemExit):
                 self._info("CrowdStrike connector stopping...")
                 exit(0)
+
             except Exception as e:  # noqa: B902
                 self._error("CrowdStrike connector internal error: {0}", str(e))
+
+                if self.helper.connect_run_and_terminate:
+                    self.helper.log_info("Connector stop")
+                    exit(0)
+
                 self._sleep()
 
     def _initiate_work(self, timestamp: int) -> str:

--- a/external-import/cryptolaemus/src/cryptolaemus.py
+++ b/external-import/cryptolaemus/src/cryptolaemus.py
@@ -234,7 +234,6 @@ class Cryptolaemus:
                         + str(round(self.get_interval() / 60 / 60 / 24, 2))
                         + " days"
                     )
-                    time.sleep(60)
                 else:
                     new_interval = self.get_interval() - (timestamp - last_run)
                     self.helper.log_info(
@@ -242,13 +241,19 @@ class Cryptolaemus:
                         + str(round(new_interval / 60 / 60 / 24, 2))
                         + " days"
                     )
-                    time.sleep(60)
+
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 exit(0)
+
             except Exception as e:
                 self.helper.log_error(str(e))
-                time.sleep(60)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            time.sleep(60)
 
 
 if __name__ == "__main__":

--- a/external-import/cryptolaemus/src/cryptolaemus.py
+++ b/external-import/cryptolaemus/src/cryptolaemus.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 from datetime import datetime
 
@@ -244,14 +245,14 @@ class Cryptolaemus:
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             except Exception as e:
                 self.helper.log_error(str(e))
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(60)
 
@@ -263,4 +264,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/cuckoo/src/main.py
+++ b/external-import/cuckoo/src/main.py
@@ -1,11 +1,13 @@
 import os
+import sys
 import time
 from datetime import datetime
 
 import yaml
+from pycti import OpenCTIConnectorHelper, get_config_variable
+
 from cuckoo.cuckoo import cuckoo
 from cuckoo.telemetry import openCTIInterface
-from pycti import OpenCTIConnectorHelper, get_config_variable
 
 
 class cuckooConnector:
@@ -183,7 +185,7 @@ class cuckooConnector:
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(self.get_interval())
 

--- a/external-import/cuckoo/src/main.py
+++ b/external-import/cuckoo/src/main.py
@@ -181,6 +181,10 @@ class cuckooConnector:
                 f"Run Complete. Sleeping until next run in " f"{self.interval} Minutes"
             )
 
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
             time.sleep(self.get_interval())
 
 

--- a/external-import/cve/src/cve.py
+++ b/external-import/cve/src/cve.py
@@ -4,14 +4,16 @@ import gzip
 import os
 import shutil
 import ssl
+import sys
 import time
 import urllib.request
 from datetime import datetime
 
 import certifi
 import yaml
-from cvetostix2 import convert
 from pycti import OpenCTIConnectorHelper, get_config_variable
+
+from cvetostix2 import convert
 
 
 class Cve:
@@ -153,7 +155,7 @@ class Cve:
 
         except (KeyboardInterrupt, SystemExit):
             self.helper.log_info("Connector stop")
-            exit(0)
+            sys.exit(0)
 
         except Exception as e:
             self.helper.log_error(str(e))
@@ -176,4 +178,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/cve/src/cve.py
+++ b/external-import/cve/src/cve.py
@@ -150,9 +150,11 @@ class Cve:
                     + str(round(new_interval / 60 / 60 / 24, 2))
                     + " days"
                 )
+
         except (KeyboardInterrupt, SystemExit):
             self.helper.log_info("Connector stop")
             exit(0)
+
         except Exception as e:
             self.helper.log_error(str(e))
 

--- a/external-import/cybercrime-tracker/src/cybercrime-tracker.py
+++ b/external-import/cybercrime-tracker/src/cybercrime-tracker.py
@@ -366,7 +366,6 @@ class Cybercrimetracker:
                             str(round(self.interval, 2))
                         )
                     )
-                    time.sleep(60)
                 else:
                     new_interval = self.interval - (timestamp - last_run)
                     self.helper.log_info(
@@ -375,14 +374,19 @@ class Cybercrimetracker:
                             str(round(new_interval, 2))
                         )
                     )
-                    time.sleep(60)
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 exit(0)
+
             except Exception as e:
                 self.helper.log_error(str(e))
-                time.sleep(60)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            time.sleep(60)
 
 
 if __name__ == "__main__":

--- a/external-import/cybercrime-tracker/src/cybercrime-tracker.py
+++ b/external-import/cybercrime-tracker/src/cybercrime-tracker.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import sys
 import time
 from urllib.parse import quote, urlparse
 
@@ -377,14 +378,14 @@ class Cybercrimetracker:
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             except Exception as e:
                 self.helper.log_error(str(e))
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(60)
 
@@ -396,4 +397,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/intel471/src/intel471/connector.py
+++ b/external-import/intel471/src/intel471/connector.py
@@ -6,15 +6,15 @@ import yaml
 from apscheduler.jobstores.memory import MemoryJobStore
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.schedulers.base import BaseScheduler
+from pycti import OpenCTIConnectorHelper, get_config_variable
 from yaml.parser import ParserError
 
-from pycti import OpenCTIConnectorHelper, get_config_variable
+from . import HelperRequest
 from .streams.common import Intel471Stream
+from .streams.cves import Intel471CVEsStream
 from .streams.indicators import Intel471IndicatorsStream
 from .streams.iocs import Intel471IOCsStream
-from .streams.cves import Intel471CVEsStream
 from .streams.yara import Intel471YARAStream
-from . import HelperRequest
 
 
 class Intel471Connector:

--- a/external-import/intel471/src/intel471/mappers/__init__.py
+++ b/external-import/intel471/src/intel471/mappers/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from .common import StixMapper
 from .cves import CveMapper
-from .iocs import IOCMapper
 from .indicators import IndicatorsMapper
+from .iocs import IOCMapper
 from .yara import YaraMapper

--- a/external-import/intel471/src/intel471/mappers/common.py
+++ b/external-import/intel471/src/intel471/mappers/common.py
@@ -8,16 +8,16 @@ from typing import Union
 
 import titan_client
 from stix2 import (
-    Relationship,
+    URL,
+    Bundle,
+    DomainName,
     EmailAddress,
     File,
-    ThreatActor,
-    IPv4Address,
-    URL,
-    Location,
-    DomainName,
-    Bundle,
     Identity,
+    IPv4Address,
+    Location,
+    Relationship,
+    ThreatActor,
 )
 from stix2.base import _DomainObject, _Observable
 from stix2.canonicalization.Canonicalize import canonicalize

--- a/external-import/intel471/src/intel471/mappers/cves.py
+++ b/external-import/intel471/src/intel471/mappers/cves.py
@@ -1,7 +1,7 @@
 import yaml
-from stix2 import Bundle, Vulnerability, ExternalReference, TLP_AMBER
+from stix2 import TLP_AMBER, Bundle, ExternalReference, Vulnerability
 
-from .common import BaseMapper, StixMapper, generate_id, author_identity
+from .common import BaseMapper, StixMapper, author_identity, generate_id
 
 
 @StixMapper.register("cves", lambda x: "cveReportsTotalCount" in x)

--- a/external-import/intel471/src/intel471/mappers/indicators.py
+++ b/external-import/intel471/src/intel471/mappers/indicators.py
@@ -2,11 +2,11 @@ import datetime
 
 import yaml
 from pytz import UTC
-from stix2 import Indicator, Bundle, Relationship, KillChainPhase, TLP_AMBER
+from stix2 import TLP_AMBER, Bundle, Indicator, KillChainPhase, Relationship
 
-from .common import StixMapper, BaseMapper, generate_id, author_identity, MappingConfig
-from .patterning import create_url_pattern, create_ipv4_pattern, create_file_pattern
-from .observables import create_url, create_ipv4, create_file
+from .common import BaseMapper, MappingConfig, StixMapper, author_identity, generate_id
+from .observables import create_file, create_ipv4, create_url
+from .patterning import create_file_pattern, create_ipv4_pattern, create_url_pattern
 from .sdo import create_malware
 
 

--- a/external-import/intel471/src/intel471/mappers/iocs.py
+++ b/external-import/intel471/src/intel471/mappers/iocs.py
@@ -3,12 +3,12 @@ import logging
 from typing import Union
 
 from pytz import UTC
-from stix2 import Bundle, Indicator, Report, TLP_AMBER, DomainName, URL, Relationship
+from stix2 import TLP_AMBER, URL, Bundle, DomainName, Indicator, Relationship, Report
 
-from .patterning import create_domain_pattern, create_url_pattern
+from .common import BaseMapper, MappingConfig, StixMapper, author_identity, generate_id
 from .observables import create_domain, create_url
+from .patterning import create_domain_pattern, create_url_pattern
 from .reports import ReportMapper
-from .common import StixMapper, BaseMapper, generate_id, author_identity, MappingConfig
 
 log = logging.getLogger(__name__)
 

--- a/external-import/intel471/src/intel471/mappers/observables.py
+++ b/external-import/intel471/src/intel471/mappers/observables.py
@@ -1,4 +1,4 @@
-from stix2 import URL, TLP_AMBER, IPv4Address, File, DomainName
+from stix2 import TLP_AMBER, URL, DomainName, File, IPv4Address
 
 
 def create_url(value: str) -> URL:

--- a/external-import/intel471/src/intel471/mappers/reports.py
+++ b/external-import/intel471/src/intel471/mappers/reports.py
@@ -5,9 +5,9 @@ from typing import List
 
 import titan_client
 from pytz import UTC
-from stix2 import Bundle, Report, ExternalReference, TLP_AMBER
+from stix2 import TLP_AMBER, Bundle, ExternalReference, Report
 
-from .common import StixMapper, BaseMapper, generate_id, author_identity
+from .common import BaseMapper, StixMapper, author_identity, generate_id
 
 log = logging.getLogger(__name__)
 

--- a/external-import/intel471/src/intel471/mappers/sdo.py
+++ b/external-import/intel471/src/intel471/mappers/sdo.py
@@ -1,5 +1,6 @@
-from stix2 import Malware, TLP_AMBER
-from .common import generate_id, author_identity
+from stix2 import TLP_AMBER, Malware
+
+from .common import author_identity, generate_id
 
 
 def create_malware(value: str) -> Malware:

--- a/external-import/intel471/src/intel471/mappers/yara.py
+++ b/external-import/intel471/src/intel471/mappers/yara.py
@@ -2,8 +2,9 @@ import datetime
 
 import yaml
 from pytz import UTC
-from stix2 import Indicator, Bundle, Relationship, TLP_AMBER
-from .common import StixMapper, BaseMapper, generate_id, author_identity
+from stix2 import TLP_AMBER, Bundle, Indicator, Relationship
+
+from .common import BaseMapper, StixMapper, author_identity, generate_id
 from .sdo import create_malware
 
 

--- a/external-import/intel471/src/intel471/streams/common.py
+++ b/external-import/intel471/src/intel471/streams/common.py
@@ -3,15 +3,15 @@ import time
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from queue import Queue
-from typing import Iterator, Union, Any
-
-from stix2 import Bundle
+from typing import Any, Iterator, Union
 
 import titan_client
 from pycti import OpenCTIConnectorHelper
-from ..mappers.exceptions import EmptyBundle
+from stix2 import Bundle
+
 from .. import HelperRequest
 from ..mappers import StixMapper
+from ..mappers.exceptions import EmptyBundle
 
 
 class Intel471Stream(ABC):

--- a/external-import/intel471/src/intel471/streams/indicators.py
+++ b/external-import/intel471/src/intel471/streams/indicators.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from .common import Intel471Stream
 

--- a/external-import/intel471/src/intel471/streams/iocs.py
+++ b/external-import/intel471/src/intel471/streams/iocs.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from .common import Intel471Stream
 

--- a/external-import/intel471/src/main.py
+++ b/external-import/intel471/src/main.py
@@ -1,6 +1,5 @@
 from intel471.connector import Intel471Connector
 
-
 if __name__ == "__main__":
     connector = Intel471Connector()
     connector.run()

--- a/external-import/intel471/tests/test_stix_mappers.py
+++ b/external-import/intel471/tests/test_stix_mappers.py
@@ -1,11 +1,11 @@
 import json
 
 import pytest
-from mock.mock import patch, MagicMock
 import titan_client
-
 from mappers import StixMapper
-from .conftest import get_fixture, strip_random_values, get_rest_client_get_side_effect
+from mock.mock import MagicMock, patch
+
+from .conftest import get_fixture, get_rest_client_get_side_effect, strip_random_values
 
 
 @patch("titan_client.rest.RESTClientObject")

--- a/external-import/kaspersky/src/kaspersky/connector.py
+++ b/external-import/kaspersky/src/kaspersky/connector.py
@@ -415,12 +415,23 @@ class KasperskyConnector:
                         "Connector will not run, next run in: {0} seconds", next_run
                     )
 
+                if self.helper.connect_run_and_terminate:
+                    self.helper.log_info("Connector stop")
+                    exit(0)
+
                 self._sleep(delay_sec=run_interval)
+
             except (KeyboardInterrupt, SystemExit):
                 self._info("Kaspersky connector stop")
                 exit(0)
+
             except Exception as e:  # noqa: B902
                 self._error("Kaspersky connector internal error: {0}", str(e))
+
+                if self.helper.connect_run_and_terminate:
+                    self.helper.log_info("Connector stop")
+                    exit(0)
+
                 self._sleep()
 
     def _initiate_work(self, timestamp: int) -> str:

--- a/external-import/kaspersky/src/kaspersky/connector.py
+++ b/external-import/kaspersky/src/kaspersky/connector.py
@@ -1,10 +1,14 @@
 """Kaspersky connector module."""
 
 import os
+import sys
 import time
 from typing import Any, Dict, List, Mapping, Optional
 
 import yaml
+from pycti import OpenCTIConnectorHelper, get_config_variable  # type: ignore
+from stix2 import Identity, MarkingDefinition  # type: ignore
+
 from kaspersky.client import KasperskyClient
 from kaspersky.master_ioc.importer import MasterIOCImporter
 from kaspersky.master_yara.importer import MasterYaraImporter
@@ -16,8 +20,6 @@ from kaspersky.utils import (
     get_tlp_string_marking_definition,
     timestamp_to_datetime,
 )
-from pycti import OpenCTIConnectorHelper, get_config_variable  # type: ignore
-from stix2 import Identity, MarkingDefinition  # type: ignore
 
 
 class KasperskyConnector:
@@ -417,20 +419,20 @@ class KasperskyConnector:
 
                 if self.helper.connect_run_and_terminate:
                     self.helper.log_info("Connector stop")
-                    exit(0)
+                    sys.exit(0)
 
                 self._sleep(delay_sec=run_interval)
 
             except (KeyboardInterrupt, SystemExit):
                 self._info("Kaspersky connector stop")
-                exit(0)
+                sys.exit(0)
 
             except Exception as e:  # noqa: B902
                 self._error("Kaspersky connector internal error: {0}", str(e))
 
                 if self.helper.connect_run_and_terminate:
                     self.helper.log_info("Connector stop")
-                    exit(0)
+                    sys.exit(0)
 
                 self._sleep()
 

--- a/external-import/lastinfosec/src/lastinfosec.py
+++ b/external-import/lastinfosec/src/lastinfosec.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+import sys
 import time
 
 import requests
@@ -114,10 +115,10 @@ class LastInfoSec:
             else:
                 self.helper.log_info("CTI Feed not configured")
                 time.sleep(60)
-                exit(0)
+                sys.exit(0)
         except (KeyboardInterrupt, SystemExit):
             self.helper.log_info("Connector stop")
-            exit(0)
+            sys.exit(0)
         except Exception as e:
             self.helper.log_error("run:" + str(e))
             time.sleep(60)
@@ -179,4 +180,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(100)
-        exit(0)
+        sys.exit(0)

--- a/external-import/malpedia/src/malpedia/core.py
+++ b/external-import/malpedia/src/malpedia/core.py
@@ -2,6 +2,7 @@
 """OpenCTI Malpedia connector core module."""
 
 import os
+import sys
 import time
 from datetime import datetime
 from typing import Any, Dict, Mapping, Optional
@@ -175,15 +176,15 @@ class Malpedia:
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("connector stop")
-                exit(0)
+                sys.exit(0)
 
             except Exception as e:
                 self.helper.log_error(str(e))
-                exit(0)
+                sys.exit(0)
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(60)
 

--- a/external-import/malpedia/src/malpedia/core.py
+++ b/external-import/malpedia/src/malpedia/core.py
@@ -173,13 +173,19 @@ class Malpedia:
                         f"connector will not run, next run in: {new_interval} seconds"
                     )
 
-                time.sleep(60)
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("connector stop")
                 exit(0)
+
             except Exception as e:
                 self.helper.log_error(str(e))
                 exit(0)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            time.sleep(60)
 
     def _run_knowledge_importer(
         self, current_state: Mapping[str, Any]

--- a/external-import/maltiverse/src/main.py
+++ b/external-import/maltiverse/src/main.py
@@ -55,28 +55,30 @@ class MaltiverseConnector:
                     last_run = None
                     self.helper.log_info("Connector has never run")
                 # If the last_run is more than interval-1 day
-                if last_run is None or (
-                    (timestamp - last_run)
-                    > (self.get_interval())
-                ):
+                if last_run is None or ((timestamp - last_run) > (self.get_interval())):
                     timestamp = int(time.time())
                     now = datetime.utcfromtimestamp(timestamp)
-                    friendly_name = "Connector run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
+                    friendly_name = "Connector run @ " + now.strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
                     work_id = self.helper.api.work.initiate_work(
                         self.helper.connect_id, friendly_name
                     )
 
-                    cli = taxiicli.Server('https://api.maltiverse.com/taxii2/',
-                                          user=self.user,
-                                          password=self.passwd)
+                    cli = taxiicli.Server(
+                        "https://api.maltiverse.com/taxii2/",
+                        user=self.user,
+                        password=self.passwd,
+                    )
 
-                    collections = [col for col in cli.default.collections if col.id in self.feeds]
+                    collections = [
+                        col for col in cli.default.collections if col.id in self.feeds
+                    ]
 
                     for col in collections:
                         try:
                             self.helper.send_stix2_bundle(
-                                json.dumps(col.get_objects()),
-                                update=True
+                                json.dumps(col.get_objects()), update=True
                             )
                         except Exception as e:
                             self.helper.log_error("error sending collection: " + str(e))

--- a/external-import/maltiverse/src/main.py
+++ b/external-import/maltiverse/src/main.py
@@ -1,10 +1,11 @@
+import json
 import os
+import sys
 import time
 from datetime import datetime
-import json
 
-import yaml
 import taxii2client.v21 as taxiicli
+import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
 
 
@@ -105,6 +106,7 @@ class MaltiverseConnector:
             except Exception as e:
                 print(e)
 
+
 if __name__ == "__main__":
     try:
         connector = MaltiverseConnector()
@@ -112,4 +114,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
+++ b/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
@@ -1,5 +1,6 @@
 import io
 import os
+import sys
 import time
 
 import magic
@@ -163,14 +164,14 @@ class MalwareBazaarRecentAdditions:
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             except Exception as e:
                 self.helper.log_error(str(e))
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(self.cooldown_seconds)
 
@@ -254,4 +255,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
+++ b/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
@@ -160,7 +160,6 @@ class MalwareBazaarRecentAdditions:
                 self.helper.log_info(
                     f"Re-checking for new additions in {self.cooldown_seconds} seconds..."
                 )
-                time.sleep(self.cooldown_seconds)
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
@@ -168,7 +167,12 @@ class MalwareBazaarRecentAdditions:
 
             except Exception as e:
                 self.helper.log_error(str(e))
-                time.sleep(self.cooldown_seconds)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            time.sleep(self.cooldown_seconds)
 
     def get_recent_additions(self):
         """

--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -586,19 +586,19 @@ class Mandiant:
 
                 if self.helper.connect_run_and_terminate:
                     self.helper.log_info("Connector stop")
-                    exit(0)
+                    sys.exit(0)
 
                 time.sleep(self.get_interval())
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             except Exception as e:
                 self.helper.log_error(str(e))
 
                 if self.helper.connect_run_and_terminate:
                     self.helper.log_info("Connector stop")
-                    exit(0)
+                    sys.exit(0)
 
                 time.sleep(60)
 

--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -583,12 +583,23 @@ class Mandiant:
                 message = "End of synchronization"
                 self.helper.api.work.to_processed(work_id, message)
                 self.helper.log_info(message)
+
+                if self.helper.connect_run_and_terminate:
+                    self.helper.log_info("Connector stop")
+                    exit(0)
+
                 time.sleep(self.get_interval())
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 exit(0)
+
             except Exception as e:
                 self.helper.log_error(str(e))
+
+                if self.helper.connect_run_and_terminate:
+                    self.helper.log_info("Connector stop")
+                    exit(0)
+
                 time.sleep(60)
 
 

--- a/external-import/misp/src/misp.py
+++ b/external-import/misp/src/misp.py
@@ -398,6 +398,11 @@ class Misp:
                 }
             )
             self.helper.api.work.to_processed(work_id, message)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
             time.sleep(self.get_interval())
 
     def process_events(self, work_id, events) -> int:

--- a/external-import/misp/src/misp.py
+++ b/external-import/misp/src/misp.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import sys
 import time
 from datetime import datetime
 
@@ -401,7 +402,7 @@ class Misp:
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(self.get_interval())
 

--- a/external-import/obstracts/src/taxii2.py
+++ b/external-import/obstracts/src/taxii2.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 import time
 from datetime import datetime, timedelta
 
@@ -142,7 +143,7 @@ class Taxii2Connector:
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(self.get_interval())
 

--- a/external-import/obstracts/src/taxii2.py
+++ b/external-import/obstracts/src/taxii2.py
@@ -139,6 +139,11 @@ class Taxii2Connector:
                 f"Run Complete. Sleeping until next run in " f"{self.interval} hours"
             )
             self.helper.set_state({"last_run": timestamp})
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
             time.sleep(self.get_interval())
 
     def poll_all_roots(self, coll_title):

--- a/external-import/opencti/src/opencti.py
+++ b/external-import/opencti/src/opencti.py
@@ -1,13 +1,14 @@
-import os
-import time
-import ssl
 import json
+import os
+import ssl
+import sys
+import time
 import urllib.request
 from datetime import datetime
 from typing import Optional
 
-import yaml
 import certifi
+import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
 
 
@@ -147,7 +148,7 @@ class OpenCTI:
                 )
         except (KeyboardInterrupt, SystemExit):
             self.helper.log_info("Connector stop")
-            exit(0)
+            sys.exit(0)
         except Exception as e:
             self.helper.log_error(str(e))
 
@@ -181,4 +182,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/riskiq/src/riskiq/riskiq.py
+++ b/external-import/riskiq/src/riskiq/riskiq.py
@@ -187,10 +187,16 @@ class RiskIQConnector:
                         f"[RiskIQ] Connector will not run, next run in {run_interval} seconds"
                     )
 
-                self._sleep(delay_sec=run_interval)
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("RiskIQ connector stop")
                 sys.exit(0)
+
             except Exception as e:
                 self.helper.log_error(str(e))
                 sys.exit(0)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            self._sleep(delay_sec=run_interval)

--- a/external-import/riskiq/src/riskiq/riskiq.py
+++ b/external-import/riskiq/src/riskiq/riskiq.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """RiskIQ external-import module."""
+
 import datetime
 import sys
 import time
@@ -197,6 +198,6 @@ class RiskIQConnector:
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             self._sleep(delay_sec=run_interval)

--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -87,6 +87,10 @@ class Sekoia(object):
                 message = f"Connector encountered an error, cursor updated to {cursor}"
                 self.helper.api.work.to_processed(work_id, message)
 
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
             time.sleep(60)
 
     @staticmethod

--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+import sys
 import time
 from datetime import datetime, timedelta
 from posixpath import join as urljoin
@@ -77,7 +78,7 @@ class Sekoia(object):
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 self.helper.api.work.to_processed(work_id, "Connector is stopping")
-                exit(0)
+                sys.exit(0)
             except Exception as ex:
                 # In case of error try to get the last updated cursor
                 # since `_run` updates it after every successful request
@@ -89,7 +90,7 @@ class Sekoia(object):
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(60)
 
@@ -415,4 +416,4 @@ if __name__ == "__main__":
         sekoiaConnector.run()
     except Exception:
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/sentinelone-threats/src/sentinelone_threats.py
+++ b/external-import/sentinelone-threats/src/sentinelone_threats.py
@@ -1,9 +1,11 @@
 import os
+import sys
 import time
 
 import magic
 import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
+
 from s1api import SentinelOneApi
 
 
@@ -232,14 +234,14 @@ class SentinelOneThreats:
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             except Exception as e:
                 self.helper.log_error(str(e))
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(self.cooldown_seconds)
 
@@ -289,4 +291,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/sentinelone-threats/src/sentinelone_threats.py
+++ b/external-import/sentinelone-threats/src/sentinelone_threats.py
@@ -229,7 +229,6 @@ class SentinelOneThreats:
                 self.helper.log_info(
                     f"Re-checking for new threats in {self.cooldown_seconds} seconds..."
                 )
-                time.sleep(self.cooldown_seconds)
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
@@ -237,7 +236,12 @@ class SentinelOneThreats:
 
             except Exception as e:
                 self.helper.log_error(str(e))
-                time.sleep(self.cooldown_seconds)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            time.sleep(self.cooldown_seconds)
 
     def artifact_exists_opencti(self, sha1):
         """

--- a/external-import/siemrules/src/taxii2.py
+++ b/external-import/siemrules/src/taxii2.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 import time
 from datetime import datetime, timedelta
 
@@ -142,7 +143,7 @@ class Taxii2Connector:
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(self.get_interval())
 

--- a/external-import/siemrules/src/taxii2.py
+++ b/external-import/siemrules/src/taxii2.py
@@ -139,6 +139,11 @@ class Taxii2Connector:
                 f"Run Complete. Sleeping until next run in " f"{self.interval} hours"
             )
             self.helper.set_state({"last_run": timestamp})
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
             time.sleep(self.get_interval())
 
     def poll_all_roots(self, coll_title):

--- a/external-import/socprime/src/socprime/core.py
+++ b/external-import/socprime/src/socprime/core.py
@@ -1,25 +1,28 @@
-import os
-import yaml
-import time
 import datetime
-from typing import Any, Dict, List, Optional, Mapping, Union
+import os
+import sys
+import time
+from typing import Any, Dict, List, Mapping, Optional, Union
+
+import pycti
+import yaml
 from pycti.connector.opencti_connector_helper import (
     OpenCTIConnectorHelper,
     get_config_variable,
 )
 from stix2 import (
-    Bundle,
-    Indicator,
-    Identity,
-    Tool,
-    Relationship,
-    Malware,
     AttackPattern,
+    Bundle,
+    Identity,
+    Indicator,
+    Malware,
+    Relationship,
     ThreatActor,
+    Tool,
 )
-from socprime.tdm_api_client import ApiClient
+
 from socprime.mitre_attack import MitreAttack
-import pycti
+from socprime.tdm_api_client import ApiClient
 
 
 class SocprimeConnector:
@@ -419,10 +422,10 @@ class SocprimeConnector:
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             self._sleep(delay_sec=run_interval)

--- a/external-import/socprime/src/socprime/core.py
+++ b/external-import/socprime/src/socprime/core.py
@@ -417,7 +417,12 @@ class SocprimeConnector:
                         f"Connector will not run, next run in: {next_run} seconds"
                     )
 
-                self._sleep(delay_sec=run_interval)
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 exit(0)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            self._sleep(delay_sec=run_interval)

--- a/external-import/stixify/src/taxii2.py
+++ b/external-import/stixify/src/taxii2.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 import time
 from datetime import datetime, timedelta
 
@@ -142,7 +143,7 @@ class Taxii2Connector:
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(self.get_interval())
 

--- a/external-import/stixify/src/taxii2.py
+++ b/external-import/stixify/src/taxii2.py
@@ -139,6 +139,11 @@ class Taxii2Connector:
                 f"Run Complete. Sleeping until next run in " f"{self.interval} hours"
             )
             self.helper.set_state({"last_run": timestamp})
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
             time.sleep(self.get_interval())
 
     def poll_all_roots(self, coll_title):

--- a/external-import/taxii2/src/taxii2.py
+++ b/external-import/taxii2/src/taxii2.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 import time
 from datetime import datetime, timedelta
 
@@ -142,7 +143,7 @@ class Taxii2Connector:
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(self.get_interval())
 

--- a/external-import/taxii2/src/taxii2.py
+++ b/external-import/taxii2/src/taxii2.py
@@ -139,6 +139,11 @@ class Taxii2Connector:
                 f"Run Complete. Sleeping until next run in " f"{self.interval} hours"
             )
             self.helper.set_state({"last_run": timestamp})
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
             time.sleep(self.get_interval())
 
     def poll_all_roots(self, coll_title):

--- a/external-import/thehive/src/thehive.py
+++ b/external-import/thehive/src/thehive.py
@@ -538,13 +538,17 @@ class TheHive:
                 else:
                     current_state["last_case_date"] = timestamp
                 self.helper.set_state(current_state)
-                time.sleep(60)
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 exit(0)
             except Exception as e:
                 self.helper.log_error(str(e))
-                time.sleep(60)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            time.sleep(60)
 
 
 if __name__ == "__main__":

--- a/external-import/thehive/src/thehive.py
+++ b/external-import/thehive/src/thehive.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 from datetime import datetime
 
@@ -540,13 +541,13 @@ class TheHive:
                 self.helper.set_state(current_state)
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
             except Exception as e:
                 self.helper.log_error(str(e))
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(60)
 
@@ -558,4 +559,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/threatmatch/src/threatmatch.py
+++ b/external-import/threatmatch/src/threatmatch.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import time
 from datetime import datetime
 
@@ -226,14 +227,14 @@ class ThreatMatch:
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             except Exception as e:
                 self.helper.log_error(str(e))
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(60)
 
@@ -245,4 +246,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/threatmatch/src/threatmatch.py
+++ b/external-import/threatmatch/src/threatmatch.py
@@ -216,7 +216,6 @@ class ThreatMatch:
                         + str(round(self.get_interval() / 60, 2))
                         + " minutes"
                     )
-                    time.sleep(60)
                 else:
                     new_interval = self.get_interval() - (timestamp - last_run)
                     self.helper.log_info(
@@ -224,13 +223,19 @@ class ThreatMatch:
                         + str(round(new_interval / 60 / 60 / 24, 2))
                         + " days"
                     )
-                    time.sleep(60)
+
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 exit(0)
+
             except Exception as e:
                 self.helper.log_error(str(e))
-                time.sleep(60)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            time.sleep(60)
 
 
 if __name__ == "__main__":

--- a/external-import/urlhaus-recent-payloads/src/urlhaus-recent-payloads.py
+++ b/external-import/urlhaus-recent-payloads/src/urlhaus-recent-payloads.py
@@ -210,7 +210,6 @@ class URLHausRecentPayloads:
                 self.helper.log_info(
                     f"Re-checking for new payloads in {self.cooldown_seconds} seconds..."
                 )
-                time.sleep(self.cooldown_seconds)
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
@@ -218,7 +217,12 @@ class URLHausRecentPayloads:
 
             except Exception as e:
                 self.helper.log_error(str(e))
-                time.sleep(self.cooldown_seconds)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            time.sleep(self.cooldown_seconds)
 
     def get_recent_payloads(self):
         """

--- a/external-import/urlhaus-recent-payloads/src/urlhaus-recent-payloads.py
+++ b/external-import/urlhaus-recent-payloads/src/urlhaus-recent-payloads.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import sys
 import time
 
 import magic
@@ -213,14 +214,14 @@ class URLHausRecentPayloads:
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             except Exception as e:
                 self.helper.log_error(str(e))
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(self.cooldown_seconds)
 
@@ -297,4 +298,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/urlhaus/src/urlhaus.py
+++ b/external-import/urlhaus/src/urlhaus.py
@@ -156,7 +156,6 @@ class URLhaus:
                         + str(round(self.get_interval() / 60 / 60 / 24, 2))
                         + " days"
                     )
-                    time.sleep(60)
                 else:
                     new_interval = self.get_interval() - (timestamp - last_run)
                     self.helper.log_info(
@@ -164,13 +163,18 @@ class URLhaus:
                         + str(round(new_interval / 60 / 60 / 24, 2))
                         + " days"
                     )
-                    time.sleep(60)
+
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 exit(0)
             except Exception as e:
                 self.helper.log_error(str(e))
-                time.sleep(60)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            time.sleep(60)
 
 
 if __name__ == "__main__":

--- a/external-import/urlhaus/src/urlhaus.py
+++ b/external-import/urlhaus/src/urlhaus.py
@@ -1,6 +1,7 @@
 import csv
 import os
 import ssl
+import sys
 import time
 import urllib.request
 from datetime import datetime
@@ -166,13 +167,13 @@ class URLhaus:
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
             except Exception as e:
                 self.helper.log_error(str(e))
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(60)
 
@@ -184,4 +185,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/valhalla/src/valhalla/core.py
+++ b/external-import/valhalla/src/valhalla/core.py
@@ -2,6 +2,7 @@
 """OpenCTI valhalla connector core module."""
 
 import os
+import sys
 import time
 from datetime import datetime
 from typing import Any, Dict, Mapping, Optional
@@ -129,14 +130,14 @@ class Valhalla:
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("connector stop")
-                exit(0)
+                sys.exit(0)
             except Exception as e:
                 self.helper.log_error(str(e))
-                exit(0)
+                sys.exit(0)
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             # After a successful run pause at least 60sec
             time.sleep(60)

--- a/external-import/valhalla/src/valhalla/core.py
+++ b/external-import/valhalla/src/valhalla/core.py
@@ -127,14 +127,19 @@ class Valhalla:
                         f"connector will not run, next run in: {new_interval} seconds"
                     )
 
-                # After a successful run pause at least 60sec
-                time.sleep(60)
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("connector stop")
                 exit(0)
             except Exception as e:
                 self.helper.log_error(str(e))
                 exit(0)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            # After a successful run pause at least 60sec
+            time.sleep(60)
 
     def _get_interval(self) -> int:
         return int(self.INTERVAL_SEC)

--- a/external-import/virustotal-livehunt-notifications/src/virustotal-livehunt-notifications.py
+++ b/external-import/virustotal-livehunt-notifications/src/virustotal-livehunt-notifications.py
@@ -252,15 +252,18 @@ class VirustotalLivehuntNotifications:
 
                 self.helper.log_info("No new Livehunt Notifications found...")
 
-                time.sleep(self.cooldown_seconds)
-
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 exit(0)
 
             except Exception as e:
                 self.helper.log_error(str(e))
-                time.sleep(self.cooldown_seconds)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            time.sleep(self.cooldown_seconds)
 
     def delete_livehunt_notification(self, notification_id):
         """

--- a/external-import/virustotal-livehunt-notifications/src/virustotal-livehunt-notifications.py
+++ b/external-import/virustotal-livehunt-notifications/src/virustotal-livehunt-notifications.py
@@ -1,5 +1,6 @@
 import io
 import os
+import sys
 import time
 from datetime import datetime
 
@@ -254,14 +255,14 @@ class VirustotalLivehuntNotifications:
 
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             except Exception as e:
                 self.helper.log_error(str(e))
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(self.cooldown_seconds)
 
@@ -322,4 +323,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/vulmatch/src/taxii2.py
+++ b/external-import/vulmatch/src/taxii2.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 import time
 from datetime import datetime, timedelta
 
@@ -142,7 +143,7 @@ class Taxii2Connector:
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(self.get_interval())
 

--- a/external-import/vulmatch/src/taxii2.py
+++ b/external-import/vulmatch/src/taxii2.py
@@ -139,6 +139,11 @@ class Taxii2Connector:
                 f"Run Complete. Sleeping until next run in " f"{self.interval} hours"
             )
             self.helper.set_state({"last_run": timestamp})
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
             time.sleep(self.get_interval())
 
     def poll_all_roots(self, coll_title):

--- a/external-import/vxvault/src/vxvault.py
+++ b/external-import/vxvault/src/vxvault.py
@@ -1,5 +1,6 @@
 import os
 import ssl
+import sys
 import time
 import urllib.request
 from datetime import datetime
@@ -154,13 +155,13 @@ class VXVault:
                     )
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
             except Exception as e:
                 self.helper.log_error(str(e))
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
-                exit(0)
+                sys.exit(0)
 
             time.sleep(60)
 
@@ -172,4 +173,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/external-import/vxvault/src/vxvault.py
+++ b/external-import/vxvault/src/vxvault.py
@@ -145,7 +145,6 @@ class VXVault:
                         + str(round(self.get_interval() / 60 / 60 / 24, 2))
                         + " days"
                     )
-                    time.sleep(60)
                 else:
                     new_interval = self.get_interval() - (timestamp - last_run)
                     self.helper.log_info(
@@ -153,13 +152,17 @@ class VXVault:
                         + str(round(new_interval / 60 / 60 / 24, 2))
                         + " days"
                     )
-                    time.sleep(60)
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 exit(0)
             except Exception as e:
                 self.helper.log_error(str(e))
-                time.sleep(60)
+
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                exit(0)
+
+            time.sleep(60)
 
 
 if __name__ == "__main__":

--- a/internal-enrichment/cape-sandbox/src/cape-sandbox.py
+++ b/internal-enrichment/cape-sandbox/src/cape-sandbox.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import re
+import sys
 import time
 from urllib.parse import urlparse
 
@@ -737,4 +738,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
+++ b/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
@@ -5,6 +5,7 @@ import ipaddress
 import json
 import os
 import re
+import sys
 import time
 from hashlib import sha256
 
@@ -581,4 +582,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/internal-enrichment/hybrid-analysis-sandbox/src/hybrid-analysis-sandbox.py
+++ b/internal-enrichment/hybrid-analysis-sandbox/src/hybrid-analysis-sandbox.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 import os
+import sys
 import time
 
 import requests
@@ -396,4 +397,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/internal-enrichment/intezer-sandbox/src/intezer_sandbox.py
+++ b/internal-enrichment/intezer-sandbox/src/intezer_sandbox.py
@@ -1,11 +1,13 @@
 # coding: utf-8
 
 import os
+import sys
 import time
 
 import yaml
-from intezer_api import IntezerApi
 from pycti import OpenCTIConnectorHelper, get_config_variable
+
+from intezer_api import IntezerApi
 
 
 class IntezerSandboxConnector:
@@ -194,4 +196,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/internal-enrichment/lastinfosec/src/lastinfosec.py
+++ b/internal-enrichment/lastinfosec/src/lastinfosec.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 import time
 
 import requests
@@ -94,4 +95,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/internal-enrichment/unpac-me/src/unpac_me.py
+++ b/internal-enrichment/unpac-me/src/unpac_me.py
@@ -1,12 +1,14 @@
 # coding: utf-8
 
 import os
+import sys
 import time
 
 import magic
 import stix2
 import yaml
 from pycti import OpenCTIConnectorHelper, StixCoreRelationship, get_config_variable
+
 from unpac_me_api_client import UnpacMeApi, UnpacMeStatus
 
 
@@ -239,4 +241,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/internal-enrichment/virustotal-downloader/src/virustotal-downloader.py
+++ b/internal-enrichment/virustotal-downloader/src/virustotal-downloader.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 import os
+import sys
 import time
 import urllib.request
 
@@ -125,4 +126,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -2,6 +2,7 @@ import csv
 import io
 import json
 import os
+import sys
 import time
 
 import yaml
@@ -263,4 +264,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/internal-export-file/export-file-stix/src/export-file-stix.py
+++ b/internal-export-file/export-file-stix/src/export-file-stix.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import time
 
 import yaml
@@ -95,4 +96,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import time
 
 import yaml
@@ -109,4 +110,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/internal-export-file/export-report-pdf/src/export-report-pdf.py
+++ b/internal-export-file/export-report-pdf/src/export-report-pdf.py
@@ -2,6 +2,7 @@ import base64
 import datetime
 import io
 import os
+import sys
 import time
 
 import cairosvg
@@ -392,4 +393,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/internal-import-file/import-file-stix/src/import-file-stix.py
+++ b/internal-import-file/import-file-stix/src/import-file-stix.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 from typing import Dict, List
 
@@ -92,4 +93,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)

--- a/template/src/main.py
+++ b/template/src/main.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 
 import yaml
@@ -33,4 +34,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(e)
         time.sleep(10)
-        exit(0)
+        sys.exit(0)


### PR DESCRIPTION
### Proposed changes

* Connectors should obey the `CONNECTOR_RUN_AND_TERMINATE` option if possible. Run once, then die without looping infinitely. 
* At some point I'll have to rework the listener queue to enable this for the internal connector types, I'd like them to die if the queue is empty. Spin up a task every N minutes, check for messages, die once complete. 

### Related issues

* None

### Checklist

- [x] I consider the submitted work as finished
- ❌  ~~I tested the code for its functionality using different use cases~~
  - Half of these require creds to test, however the changes are small and the config option is guaranteed to exist in the helper.
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

- 👍 
