### PR TITLE
Adding valid state and initial start time to Splunk Stream connector

### DIFF
--- a/stream/splunk/README.md
+++ b/stream/splunk/README.md
@@ -27,3 +27,4 @@ This connector allows organizations to feed a **Splunk** KV Store using OpenCTI 
 | `splunk_ssl_verify`                  | `SPLUNK_SSL_VERIFY`                 | Yes          | Enable the SSL certificate check for all instances (default: `true`)                          |
 | `splunk_app`                         | `SPLUNK_APP`                        | Yes          | The app of the KV Store for all instances.                                                    |
 | `splunk_kv_store_name`               | `SPLUNK_KV_STORE_NAME`              | Yes          | The name of the KV Store for all instances.                                                                    |
+| `splunk_start_timestamp`               | `SPLUNK_START_TIMESTAMP`              | No          | To pull from specific time or comment the line out to pull from the initial time the instance was built. Time format 2020-12-31T00:00:00 or Epoch 1607731200 .                |

--- a/stream/splunk/docker-compose.yml
+++ b/stream/splunk/docker-compose.yml
@@ -21,4 +21,5 @@ services:
       - SPLUNK_SSL_VERIFY=true
       - SPLUNK_APP=search
       - SPLUNK_KV_STORE_NAME=opencti
+      # - SPLUNK_START_TIMESTAMP=2020-05-01T00:00:00 #Comment this line for first time pull. Time format 2020-12-31T00:00:00 or Epoch 1607731200 
     restart: always


### PR DESCRIPTION
### Proposed changes

*Adding initial start time feature, users that have already pushed data won't have to start over.
*Adding valid state initialization, for the connector to recover and continue sending data in case the container crashes. 


### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

