### PR TITLE
[shodan-internetdb] Fix for TLPv2 (CLEAR vs. WHITE)

### DIFF
--- a/internal-enrichment/shodan-internetdb/src/shodan_internetdb/connector.py
+++ b/internal-enrichment/shodan-internetdb/src/shodan_internetdb/connector.py
@@ -74,6 +74,9 @@ class ShodanInternetDBConnector:
 
         for tlp in tlps:
             max_tlp_name = self._config.shodan.max_tlp.name
+            if max_tlp_name == 'TLP:WHITE':
+                max_tlp_name = 'TLP:CLEAR'
+
             if not OpenCTIConnectorHelper.check_max_tlp(tlp, max_tlp_name):
                 log.debug("Skipping observable, TLP is greater than the MAX TLP")
                 return "Skipping observable (TLP)"


### PR DESCRIPTION
### Proposed changes

The connector still needs 'TLP:WHITE' in the configuration, as that's
what the service still uses upstream, but this also makes the connector
throw an error at runtime on 5.3.9. This fixes it by translating
TLP:WHITE to TLP:CLEAR right before validating the marking defs in
OpenCTI at line 77 in the current code.

The overall change is very small.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
