### PR TITLE
Add 3 default MISP feeds: CIRCL, ThreatFox, Botvrij

### DIFF
--- a/external-import/misp-feed/src/config.botvrij.yml.sample
+++ b/external-import/misp-feed/src/config.botvrij.yml.sample
@@ -1,0 +1,27 @@
+opencti:
+  url: 'http://localhost:8080'
+  token: 'ChangeMe'
+
+connector:
+  id: 'ChangeMe'
+  type: 'EXTERNAL_IMPORT'
+  name: 'MISP Feed (Botvrij)'
+  scope: 'misp-feed-botvrij'
+  confidence_level: 80 # From 0 (Unknown) to 100 (Fully trusted)
+  update_existing_data: false
+  run_and_terminate: false
+  log_level: 'info'
+
+misp_feed:
+  url: 'https://www.botvrij.eu/data/feed-osint/'
+  ssl_verify: true
+  create_reports: true # Required, create report for MISP event
+  report_type: 'misp-event' # Report typpe to use for event
+  import_from_date: '2010-01-01' # Required, import all event from this date
+  create_indicators: true # Required, create indicators from attributes
+  create_observables: true # Required, create observables from attributes
+  create_object_observables: true # Required, create text observables for MISP objects
+  import_to_ids_no_score: 40 # Optional, use as a score for the indicator/observable if the attribute to_ids is no
+  import_unsupported_observables_as_text: false # Optional, import unsupported observable as x_opencti_text
+  import_with_attachments: true # Optional, try to import a PDF file from the attachment attribute
+  interval: 60 # Required, in minutes

--- a/external-import/misp-feed/src/config.circl.yml.sample
+++ b/external-import/misp-feed/src/config.circl.yml.sample
@@ -1,0 +1,27 @@
+opencti:
+  url: 'http://localhost:8080'
+  token: 'ChangeMe'
+
+connector:
+  id: 'ChangeMe'
+  type: 'EXTERNAL_IMPORT'
+  name: 'MISP Feed (CIRCL)'
+  scope: 'misp-feed-circl'
+  confidence_level: 80 # From 0 (Unknown) to 100 (Fully trusted)
+  update_existing_data: false
+  run_and_terminate: false
+  log_level: 'info'
+
+misp_feed:
+  url: 'https://www.circl.lu/doc/misp/feed-osint/'
+  ssl_verify: true
+  create_reports: true # Required, create report for MISP event
+  report_type: 'misp-event' # Report typpe to use for event
+  import_from_date: '2010-01-01' # Required, import all event from this date
+  create_indicators: true # Required, create indicators from attributes
+  create_observables: true # Required, create observables from attributes
+  create_object_observables: true # Required, create text observables for MISP objects
+  import_to_ids_no_score: 40 # Optional, use as a score for the indicator/observable if the attribute to_ids is no
+  import_unsupported_observables_as_text: false # Optional, import unsupported observable as x_opencti_text
+  import_with_attachments: true # Optional, try to import a PDF file from the attachment attribute
+  interval: 60 # Required, in minutes

--- a/external-import/misp-feed/src/config.threatfox.yml.sample
+++ b/external-import/misp-feed/src/config.threatfox.yml.sample
@@ -1,0 +1,27 @@
+opencti:
+  url: 'http://localhost:8080'
+  token: 'ChangeMe'
+
+connector:
+  id: 'ChangeMe'
+  type: 'EXTERNAL_IMPORT'
+  name: 'MISP Feed (ThreatFox)'
+  scope: 'misp-feed-threatfox'
+  confidence_level: 80 # From 0 (Unknown) to 100 (Fully trusted)
+  update_existing_data: false
+  run_and_terminate: false
+  log_level: 'info'
+
+misp_feed:
+  url: 'https://threatfox.abuse.ch/downloads/misp/'
+  ssl_verify: true
+  create_reports: true # Required, create report for MISP event
+  report_type: 'misp-event' # Report typpe to use for event
+  import_from_date: '2010-01-01' # Required, import all event from this date
+  create_indicators: true # Required, create indicators from attributes
+  create_observables: true # Required, create observables from attributes
+  create_object_observables: true # Required, create text observables for MISP objects
+  import_to_ids_no_score: 40 # Optional, use as a score for the indicator/observable if the attribute to_ids is no
+  import_unsupported_observables_as_text: false # Optional, import unsupported observable as x_opencti_text
+  import_with_attachments: true # Optional, try to import a PDF file from the attachment attribute
+  interval: 60 # Required, in minutes


### PR DESCRIPTION
### Proposed changes

***Update***: Added 3 sample `config.yml` files. The platform admin can decide how they'd like to deploy the local copies of `misp-feed` to consume whatever feeds that they want to consume.

<strike>Modify `external-import/misp-feed/src/misp-feed.py` so that it will read the `config.yml` from the current working directory, rather than trying to find the one that is located in the same folder as the `misp-feed.py` script.

Add three subdirectories to the misp-feed `src/` folder that contain config templates for the following MISP-format feeds:
* https://www.circl.lu/doc/misp/feed-osint
* https://www.botvrij.eu/data/feed-osint
* https://threatfox.abuse.ch/downloads/misp/

A proposal for the use would be to (more or less) run each like this:
```sh
cd connectors/external-import/misp-feed/src/circl
python3 ../misp-feed.py
```
```sh
cd connectors/external-import/misp-feed/src/botvrij
python3 ../misp-feed.py
```
```sh
cd connectors/external-import/misp-feed/src/threatfox
python3 ../misp-feed.py
```

In my environment, I have written 3 `systemd` services that execute each feed derivative like above from within each of the working directories, but likely some further modification would need to be made to the `docker-compose` code to run all three of these in a single docker, or multiple docker, instances (depending upon what the preference is for the team) to support the containerized approach.

The hope here is that providing these as part of the codebase will make it a lot easier & quicker for new users to install a system that starts populating itself with well-known OSINT datasets out there.

Another key piece here was that I wanted there to remain a single `misp-feed.py` script that all MISP feeds would use, rather than having to make copies of it into new connector folders for each feed, and then re-copy it every time fixes are released from the project.</strike>

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases

<!-- For completed items, change [ ] to [x]. -->