### PR TITLE
Bugfix: cyber-campaign-collection crashes when date fails parsing, infinite loop adding earlier items to queue forever

### DIFF
--- a/external-import/cyber-campaign-collection/src/cyber-campaign-collection.py
+++ b/external-import/cyber-campaign-collection/src/cyber-campaign-collection.py
@@ -129,7 +129,18 @@ class CyberMonitor:
                 year_contents = repo.get_contents(content_file.path)
                 for report_dir in year_contents:
                     # Sanitize
-                    report_date = parser.parse(report_dir.name[0:10].replace(".", "-"))
+                    report_date = report_dir.name[0:10].replace(".", "-")
+
+                    # Force report date to first month and/or first day if it is lacking
+                    # either field
+                    if report_date[5:7] == "00" or not report_date[5:7].isdigit():
+                        report_date = report_date[0:5] + "01" + report_date[7:]
+
+                    if report_date[8:10] == "00" or not report_date[8:10].isdigit():
+                        report_date = report_date[0:8] + "01"
+
+                    # Overwrite sanitized report_date with dateparser output from it
+                    report_date = parser.parse(report_date)
                     report_name = (
                         report_dir.name[11:].replace("_", " ").replace("-", " ")
                     )


### PR DESCRIPTION
### Proposed changes
When a date is extracted from the report filename, this attempts to determine if the month and day fields are sane numeric values. If not (such as '00' or 'XX'), the connector will now simply default to '01' for the malformed field.

### Related issues
The current code, when it encounters such a parsing failure, will throw an exception and exit, handling it semi-gracefully. However, the connector will not register where it left off, and it will start processing all of the successful reports from the first report again, adding all of the duplicate import work into the worker queue, in a permanent loop. I was able to test this successfully on all of the work items starting from year `2014` on up.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] Where necessary I refactored code to improve the overall quality