### PR TITLE
[misp-feed] Cannot parse feed of the Flashpoint API

### DIFF
--- a/external-import/misp-feed/src/misp-feed.py
+++ b/external-import/misp-feed/src/misp-feed.py
@@ -1426,6 +1426,14 @@ class MispFeed:
             self._retrieve_data(self.misp_feed_url + "/" + event_id + ".json")
         )
 
+        # Check the event is a list or not
+        ## It may be an illegal case if the length is not 1
+        if isinstance(event, list):
+            if len(event) == 1:
+                event = event[0]
+            else:
+                raise ValueError(f"The list of {event_id=} is too long.")
+
         ### Default variables
         added_markings = []
         added_entities = []


### PR DESCRIPTION
## Description
[Flashpoint](https://flashpoint.io/) provides their CTIs as MISP-Feed and we want to include them.
But the structure of the json file for each event (introduced as `<event_id>.json` )  is DictArray such as `[ {"Event": ...} ]`  and we caught below shortened traceback with additional survey.

```
  File "/path/to/misp-feed.py", line xxx, in <module>
    id=Identity.generate_id(event["Event"]["Orgc"]["name"], "organization"),
TypeError: list indices must be integers or slices, not str
```

The location of above exception is https://github.com/OpenCTI-Platform/connectors/blob/master/external-import/misp-feed/src/misp-feed.py#L1441

## Proposed changes
1. Check if the json of each event is list or not
2. Get one row if it is a list and the length is 1
3. Raise exception if it is a list and the length is not 1
    - this means the each json file should include one Event

## Environment

1. OS: Alpine Linux v3.16 (Official Docker image)
3. OpenCTI version: 5.3.13
5. OpenCTI client: python

## Reproducible Steps
Sorry, but I don't know the similar service.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
