### PR TITLE
Add a CRITs external-import connector

### DIFF
--- a/external-import/crits/.dockerignore
+++ b/external-import/crits/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/crits/Dockerfile
+++ b/external-import/crits/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-alpine
+
+# Copy the connector
+COPY src /opt/opencti-connector-crits
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev && \
+    cd /opt/opencti-connector-crits && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/crits/README.md
+++ b/external-import/crits/README.md
@@ -45,9 +45,34 @@ requests library to function.
 
 ### Behavior ###
 
-Below will be notes explaining how this connector goes about performing the data import
+This connector is intended to help migrate data from a CRITs CTI database into OpenCTI, on a regular basis. It
+is not designed to update CRITs with data from OpenCTI. The connector will, the first time it is run, import all
+of the compatible data in the target CRITs database. Then, on subsequent runs, it will only import when things
+have changed since the last run.
+
+Each run, the connector first starts by looking for new Events to import, and imports them with their first-degree
+object relationships as contents of the report. The connector will then look for CRITs objects that are related, and
+both contained in the same Event, and it will upload a STIX relationship capturing this relationship into the
+report as well. The campaign associated with the Event, either by a first-degree relationship, or use of the
+"campaign" field on the report, will also be uploaded as a content. The connector will ignore the "campaign" field
+on other non-Event object types. In its final phase, the connector will scan for all objects and relationships that
+aren't related to an Event, and will upload those without an analysis report relationship into OpenCTI.
+
+Campaigns will be auto-created (defaulting to use the IntrusionSet type, unless specified otherwise), and Organization
+entities for each encountered Source will also be auto-created. The source.*.instances.*.reference id's will
+all be imported as external references, with additional references created to point back at CRITs. Where they are
+identified as well-formed URLs, they'll be stored as such, otherwise they'll be imported as UIDs.
+
+There are a handful of datatypes that could not be imported, due to CRITs itself not exposing their contents via
+the (never completed) REST API:
+PCAP, Certificate, Screenshot
+
+Similarly, original raw email content isn't capable of being reconstructed from the CRITs API. However, the most
+significant metadata, headers, and portions of multipart contents are capable of being imported.
 
 ### Debugging ###
+
+The connector logs useful statistics and debbuging data to the console at run-time
 
 ### Additional information
 

--- a/external-import/crits/README.md
+++ b/external-import/crits/README.md
@@ -29,8 +29,9 @@ requests library to function.
 | `connector_type`                     | `CONNECTOR_TYPE`                    | Yes          | Must be `EXTERNAL_IMPORT` (this is the connector type).                                                                                                    |
 | `connector_name`                     | `CONNECTOR_NAME`                    | Yes          | The descriptive name for this connector                                                                                                                    |
 | `connector_scope`                    | `CONNECTOR_SCOPE`                   | Yes          | Supported scope: Default is 'crits'                                                                                                                        |
-| `connector_confidence_level`         | `CONNECTOR_CONFIDENCE_LEVEL`        | Yes          | The default confidence level for created entities (a number between 1 and 100).                                                                            |
+| `connector_confidence_level`         | `CONNECTOR_CONFIDENCE_LEVEL`        | No           | The default confidence level for created entities (a number between 1 and 100, default: 50).                                                               |
 | `connector_log_level`                | `CONNECTOR_LOG_LEVEL`               | Yes          | The log level for this connector, could be `debug`, `info`, `warn` or `error` (less verbose).                                                              |
+| `connector_update_existing_data`     | `CONNECTOR_UPDATE_EXISTING_DATA`    | No           | Connector will attempt to update existing data                                                                                                             |
 | `crits_url`                          | `CRITS_URL`                         | Yes          | The URL of the CRITs instance (leave off the trailing `/`)                                                                                                 |
 | `crits_reference_url`                | `CRITS_REFERENCE_URL`               | No           | The URL to embed as an "external reference" to link imported data to the external CRITs instance                                                           |
 | `crits_user`                         | `CRITS_USER`                        | Yes          | The login username for CRITs                                                                                                                               |
@@ -38,6 +39,9 @@ requests library to function.
 | `crits_event_type`                   | `CRITS_EVENT_TYPE`                  | Yes          | When importing CRITs Events as Analysis Reports, what Report Type to give them                                                                             |
 | `crits_interval`                     | `CRITS_INTERVAL`                    | Yes          | The interval to delay between updates, in minutes                                                                                                          |
 | `crits_import_campaign_as`           | `CRITS_IMPORT_CAMPAIGN_AS`          | No           | 'Campaign' or 'IntrusionSet': What STIX2.1 type to import Campaigns as. Default: IntrusionSet                                                              |
+| `crits_timestamp_field`              | `CRITS_TIMESTAMP_FIELD`             | No           | Which fieldin the CRITs objects to use for the timestamp (default: modified)                                                                               |
+| `crits_chunk_size`                   | `CRITS_CHUNK_SIZE`                  | No           | Ingests non-event-related observables in chunks of this size, helps with memory consumption. Adjust experimentally (default: 100)                          |
+| `crits_default_marking`              | `CRITS_DEFAULT_MARKING`             | No           | Marking definition to use, case insensitive, one of ["TLP:RED", "TLP:GREEN", "TLP:AMBER", "TLP:WHITE"] (default: TLP:GREEN)                                |
 
 ### Behavior ###
 

--- a/external-import/crits/README.md
+++ b/external-import/crits/README.md
@@ -1,0 +1,48 @@
+# OpenCTI CRITs Connector
+
+This connector is intended to provide a mechanism for synchronizing data from a CRITs CTI database instance
+([https://crits.github.io](https://crits.github.io/)) into OpenCTI. The primary use case for this is to help
+ease the migration from CRITs (a largely unmaintained platform, as of 2022) to OpenCTI. Inspiration from the
+MISP connector, as well as some of the other connectors.
+
+The CRITs project has some documentation on their Authenticated API available here:
+* [https://github.com/crits/crits/wiki/Authenticated-API](https://github.com/crits/crits/wiki/Authenticated-API)
+
+## Installation
+
+Very few. The CRITs API calls will all be performed via the HTTP(S) REST API, which only needs the Python
+requests library to function.
+
+### Requirements
+
+- OpenCTI Platform >= 5.3.15
+- CRITs instance with API enabled
+- CRITs username and API key for user authenticating for the sync
+
+### Configuration
+
+| Parameter                            | Docker envvar                       | Mandatory    | Description                                                                                                                                                |
+| ------------------------------------ | ----------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `opencti_url`                        | `OPENCTI_URL`                       | Yes          | The URL of the OpenCTI platform.                                                                                                                           |
+| `opencti_token`                      | `OPENCTI_TOKEN`                     | Yes          | The default admin token configured in the OpenCTI platform parameters file.                                                                                |
+| `connector_id`                       | `CONNECTOR_ID`                      | Yes          | A valid arbitrary `UUIDv4` that must be unique for this connector.                                                                                         |
+| `connector_type`                     | `CONNECTOR_TYPE`                    | Yes          | Must be `EXTERNAL_IMPORT` (this is the connector type).                                                                                                    |
+| `connector_name`                     | `CONNECTOR_NAME`                    | Yes          | The descriptive name for this connector                                                                                                                    |
+| `connector_scope`                    | `CONNECTOR_SCOPE`                   | Yes          | Supported scope: Default is 'crits'                                                                                                                        |
+| `connector_confidence_level`         | `CONNECTOR_CONFIDENCE_LEVEL`        | Yes          | The default confidence level for created entities (a number between 1 and 100).                                                                            |
+| `connector_log_level`                | `CONNECTOR_LOG_LEVEL`               | Yes          | The log level for this connector, could be `debug`, `info`, `warn` or `error` (less verbose).                                                              |
+| `crits_url`                          | `CRITS_URL`                         | Yes          | The URL of the CRITs instance (leave off the trailing `/`)                                                                                                 |
+| `crits_reference_url`                | `CRITS_REFERENCE_URL`               | No           | The URL to embed as an "external reference" to link imported data to the external CRITs instance                                                           |
+| `crits_user`                         | `CRITS_USER`                        | Yes          | The login username for CRITs                                                                                                                               |
+| `crits_api_key`                      | `CRITS_API_KEY`                     | Yes          | The API Key used for authentication (not the user's password, but an API Key that's creatable/viewable in the user's profile in CRITs)                     |
+| `crits_event_type`                   | `CRITS_EVENT_TYPE`                  | Yes          | When importing CRITs Events as Analysis Reports, what Report Type to give them                                                                             |
+| `crits_interval`                     | `CRITS_INTERVAL`                    | Yes          | The interval to delay between updates, in minutes                                                                                                          |
+
+### Behavior ###
+
+Below will be notes explaining how this connector goes about performing the data import
+
+### Debugging ###
+
+### Additional information
+

--- a/external-import/crits/README.md
+++ b/external-import/crits/README.md
@@ -37,6 +37,7 @@ requests library to function.
 | `crits_api_key`                      | `CRITS_API_KEY`                     | Yes          | The API Key used for authentication (not the user's password, but an API Key that's creatable/viewable in the user's profile in CRITs)                     |
 | `crits_event_type`                   | `CRITS_EVENT_TYPE`                  | Yes          | When importing CRITs Events as Analysis Reports, what Report Type to give them                                                                             |
 | `crits_interval`                     | `CRITS_INTERVAL`                    | Yes          | The interval to delay between updates, in minutes                                                                                                          |
+| `crits_import_campaign_as`           | `CRITS_IMPORT_CAMPAIGN_AS`          | No           | 'Campaign' or 'IntrusionSet': What STIX2.1 type to import Campaigns as. Default: IntrusionSet                                                              |
 
 ### Behavior ###
 

--- a/external-import/crits/docker-compose.yml
+++ b/external-import/crits/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - CONNECTOR_TYPE=EXTERNAL_IMPORT
       - CONNECTOR_NAME=CRITs
       - CONNECTOR_SCOPE=crits
-      - CONNECTOR_CONFIDENCE_LEVEL=75
+      - CONNECTOR_CONFIDENCE_LEVEL=50
       - CONNECTOR_UPDATE_EXISTING_DATA=false
       - CONNECTOR_LOG_LEVEL=info
       - CRITS_URL=http://localhost
@@ -19,4 +19,7 @@ services:
       - CRITS_EVENT_TYPE=crits-event
       - CRITS_INTERVAL=60
       - CRITS_IMPORT_CAMPAIGN_AS=IntrusionSet
+      - CRITS_CHUNK_SIZE=100
+      - CRITS_TIMESTAMP_FIELD=modified
+      - CRITS_DEFAULT_MARKING=TLP:GREEN
     restart: always

--- a/external-import/crits/docker-compose.yml
+++ b/external-import/crits/docker-compose.yml
@@ -18,4 +18,5 @@ services:
       - CRITS_API_KEY=ChangeMe
       - CRITS_EVENT_TYPE=crits-event
       - CRITS_INTERVAL=60
+      - CRITS_IMPORT_CAMPAIGN_AS=IntrusionSet
     restart: always

--- a/external-import/crits/docker-compose.yml
+++ b/external-import/crits/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   connector-crits:
-    image: opencti/connector-crits:5.3.15
+    image: opencti/connector-crits:5.3.16
     environment:
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe

--- a/external-import/crits/docker-compose.yml
+++ b/external-import/crits/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  connector-crits:
+    image: opencti/connector-crits:5.3.15
+    environment:
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=ChangeMe
+      - CONNECTOR_ID=ChangeMe
+      - CONNECTOR_TYPE=EXTERNAL_IMPORT
+      - CONNECTOR_NAME=CRITs
+      - CONNECTOR_SCOPE=crits
+      - CONNECTOR_CONFIDENCE_LEVEL=75
+      - CONNECTOR_UPDATE_EXISTING_DATA=false
+      - CONNECTOR_LOG_LEVEL=info
+      - CRITS_URL=http://localhost
+      - CRITS_REFERENCE_URL= # Optional, used to create references to CRITs entities, defaults to URL
+      - CRITS_USER=ChangeMe
+      - CRITS_API_KEY=ChangeMe
+      - CRITS_EVENT_TYPE=crits-event
+      - CRITS_INTERVAL=60
+    restart: always

--- a/external-import/crits/entrypoint.sh
+++ b/external-import/crits/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Correct working directory
+cd /opt/opencti-connector-crits
+
+# Start the connector
+python3 crits.py

--- a/external-import/crits/src/config.yml.sample
+++ b/external-import/crits/src/config.yml.sample
@@ -1,0 +1,20 @@
+opencti:
+  url: 'http://localhost:8080'
+  token: 'ChangeMe'
+
+connector:
+  id: 'ChangeMe'
+  type: 'EXTERNAL_IMPORT'
+  name: 'CRITs'
+  scope: 'crits' # MIME type or SCO
+  confidence_level: 75 # From 0 (Unknown) to 100 (Fully trusted)
+  log_level: 'info'
+  update_existing_data: false
+
+crits:
+  url: 'http://localhost'
+  reference_url: ''
+  user: 'ChangeMe'
+  api_key: 'ChangeMe'
+  event_type: 'crits-event'
+  interval: 60

--- a/external-import/crits/src/config.yml.sample
+++ b/external-import/crits/src/config.yml.sample
@@ -18,3 +18,4 @@ crits:
   api_key: 'ChangeMe'
   event_type: 'crits-event'
   interval: 60
+  import_campaign_as: 'IntrusionSet'

--- a/external-import/crits/src/config.yml.sample
+++ b/external-import/crits/src/config.yml.sample
@@ -7,7 +7,7 @@ connector:
   type: 'EXTERNAL_IMPORT'
   name: 'CRITs'
   scope: 'crits' # MIME type or SCO
-  confidence_level: 75 # From 0 (Unknown) to 100 (Fully trusted)
+  confidence_level: 50 # From 0 (Unknown) to 100 (Fully trusted)
   log_level: 'info'
   update_existing_data: false
 
@@ -19,3 +19,6 @@ crits:
   event_type: 'crits-event'
   interval: 60
   import_campaign_as: 'IntrusionSet'
+  chunk_size: 100
+  timestamp_field: "modified"
+  default_marking: "TLP:GREEN"

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -49,16 +49,16 @@ class Text:
 
 # Large table to map CRITs Indicator types to corresponding STIXv2.1 ones
 INDICATOR_MAPPING = {
-    "IPv4 Address": "ipv4-addr",
-    "IPv4 Subnet": "ipv4-addr",
-    "Address - ipv4-addr": "ipv4-addr",
-    "IPv6 Address": "ipv6-addr",
-    "IPv6 Subnet": "ipv6-addr",
-    "Address - ipv6-addr": "ipv6-addr",
-    "IPv6 Subnet": "ipv6-addr",
-    "Domain": "domain-name",
-    "URI - Domain Name": "domain-name",
-    "URI - domain-name": "domain-name",
+    "IPv4 Address": "ipv4-addr:value",
+    "IPv4 Subnet": "ipv4-addr:value",
+    "Address - ipv4-addr": "ipv4-addr:value",
+    "IPv6 Address": "ipv6-addr:value",
+    "IPv6 Subnet": "ipv6-addr:value",
+    "Address - ipv6-addr": "ipv6-addr:value",
+    "IPv6 Subnet": "ipv6-addr:value",
+    "Domain": "domain-name:value",
+    "URI - Domain Name": "domain-name:value",
+    "URI - domain-name": "domain-name:value",
 }
 
 
@@ -371,10 +371,10 @@ class CRITsConnector:
             # observable.
             custom_properties["x_opencti_main_observable_type"] = INDICATOR_MAPPING[
                 crits_obj["type"]
-            ]
+            ].split(":")[0]
             custom_properties["x_opencti_detection"] = False
-            pattern = "[{t}:value = '{v}']".format(
-                t=custom_properties["x_opencti_main_observable_type"],
+            pattern = "[{t} = '{v}']".format(
+                t=INDICATOR_MAPPING[crits_obj["type"]],
                 v=crits_obj["value"],
             )
             return stix2.Indicator(

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -2,12 +2,279 @@ import os
 import sys
 import time
 import requests
+from math import ceil
+from datetime import datetime
+from dateutil.parser import parse as dtparse
 
 import yaml
-from pycti import OpenCTIConnectorHelper, get_config_variable
+from pycti import OpenCTIConnectorHelper, get_config_variable, Identity, Report
+import stix2
+import validators
 
 
 class CRITsConnector:
+    def collect_srcs_refs(self, crits_obj):
+        # Grab all the source.*.instances.*.references, and import them as a list
+        # of External references
+        ext_refs = []
+        srcs = []
+        for src in crits_obj["source"]:
+            sname = src["name"]
+            author = stix2.Identity(
+                id=Identity.generate_id(sname, "organization"),
+                name=sname,
+                identity_class="organization",
+            )
+            srcs.append(author)
+
+            for inst in src["instances"]:
+                ref_params = {
+                    "source_name": sname,
+                    "description": inst["method"],
+                }
+                if inst["reference"]:
+                    if validators.url(inst["reference"]):
+                        ref_params["url"] = inst["reference"]
+                        ref_params["external_id"] = ""
+                    else:
+                        ref_params["url"] = ""
+                        ref_params["external_id"] = inst["reference"]
+
+                    ext_refs.append(stix2.ExternalReference(**ref_params))
+
+        return srcs, ext_refs
+
+    def domain_to_stix(self, crits_obj, custom_properties):
+        custom_properties["description"] = crits_obj.get("description", "")
+
+        return stix2.DomainName(
+            value=crits_obj["domain"],
+            object_marking_refs=[self.default_marking],
+            custom_properties=custom_properties,
+        )
+
+    def ip_to_stix(self, crits_obj, custom_properties):
+        custom_properties["description"] = crits_obj.get("description", "")
+
+        # IP Address observables have 4 subtype possibilities. However,
+        # STIX 2.x maps "Address" and "Subnet" to the same data types, for
+        # each kind of IP (4 or 6)
+        if crits_obj["type"] in ["IPv4 Address", "IPv4 Subnet"]:
+            return stix2.IPv4Address(
+                value=crits_obj["ip"],
+                object_marking_refs=[self.default_marking],
+                custom_properties=custom_properties,
+            )
+        elif crits_obj["type"] in ["IPv6 Address", "IPv6 Subnet"]:
+            return stix2.IPv6Address(
+                value=crits_obj["ip"],
+                object_marking_refs=[self.default_marking],
+                custom_properties=custom_properties,
+            )
+
+        return None
+
+    def process_objects(self, collection, since):
+        http_response = self.make_api_get(
+            collection,
+            query="?c-{t}__gt={v}&limit={l}".format(
+                t=self.crits_timestamp_field, v=since.isoformat(), l=self.chunk_size
+            ),
+        )
+
+        # Will be used to loop through the pages in the results
+        while http_response.ok:
+            new_objects = []
+            content = http_response.json()
+
+            self.helper.log_info(
+                "{c}: total={t} page={n}/{m})".format(
+                    c=collection,
+                    t=content["meta"]["total_count"],
+                    n=int(content["meta"]["offset"] / content["meta"]["total_count"])
+                    + 1,
+                    m=ceil(content["meta"]["total_count"] / self.chunk_size),
+                )
+            )
+
+            # Walk through each of the entities and build a stix object
+            for crits_obj in content["objects"]:
+                # Grab the first Source name from this list, and import it as the author
+                srcs, ext_refs = self.collect_srcs_refs(crits_obj)
+                new_objects.extend(srcs)
+
+                new_obj = None
+                custom_properties = {
+                    "x_opencti_score": self.default_score,
+                    "created_by_ref": srcs[0]["id"],
+                    "external_references": ext_refs,
+                }
+                if collection == "ips":
+                    new_obj = self.ip_to_stix(
+                        crits_obj=crits_obj, custom_properties=custom_properties
+                    )
+                elif collection == "domains":
+                    new_obj = self.domain_to_stix(
+                        crits_obj=crits_obj, custom_properties=custom_properties
+                    )
+
+                if new_obj:
+                    new_objects.append(new_obj)
+
+            work_id = self.helper.api.work.initiate_work(
+                self.helper.connect_id,
+                "test CRITs upload",
+            )
+
+            bundle = stix2.Bundle(objects=new_objects, allow_custom=True).serialize()
+            self.helper.send_stix2_bundle(bundle, update=True, work_id=work_id)
+
+            # If this is the last page of the collection, then break
+            if (
+                content["meta"]["offset"] + len(content["objects"])
+                >= content["meta"]["total_count"] - 1
+            ):
+                break
+
+            # Otherwise, load next page
+            http_response = self.make_api_get(
+                collection,
+                query="?c-{t}__gt={v}&limit={l}&offset={o}".format(
+                    t=self.crits_timestamp_field,
+                    v=since.isoformat(),
+                    l=self.chunk_size,
+                    o=content["meta"]["offset"] + self.chunk_size,
+                ),
+            )
+
+        else:
+            self.helper.log_warn(
+                'Unable to access "{c}" collection, HTTP code: {r}'.format(
+                    c=collection,
+                    r=http_response.status_code,
+                )
+            )
+
+    def process_events(self, since):
+        http_response = self.make_api_get(
+            "events",
+            query="?c-{t}__gt={v}&limit={l}".format(
+                t=self.crits_timestamp_field, v=since.isoformat(), l=self.chunk_size
+            ),
+        )
+
+        # Will be used to loop through the pages in the results
+        while http_response.ok:
+            new_objects = []
+            content = http_response.json()
+
+            self.helper.log_info(
+                "events: total={t} page={n}/{m})".format(
+                    t=content["meta"]["total_count"],
+                    n=int(content["meta"]["offset"] / content["meta"]["total_count"])
+                    + 1,
+                    m=ceil(content["meta"]["total_count"] / self.chunk_size),
+                )
+            )
+
+            # Walk through each of the entities and build a stix object
+            for crits_obj in content["objects"]:
+                # Grab the first Source name from this list, and import it as the author
+
+                srcs, ext_refs = self.collect_srcs_refs(crits_obj)
+                new_objects.extend(srcs)
+
+                custom_properties = {"x_opencti_report_status": 2}
+
+                ts = dtparse(crits_obj["created"])
+
+                allowed_types = ["IP", "Domain"]
+                report_contents_crits = list(
+                    filter(
+                        lambda x: x["type"] in allowed_types, crits_obj["relationships"]
+                    )
+                )
+
+                contained_objects = []
+                for contained in report_contents_crits:
+                    contained_stix = None
+                    contained_custom_properties = {
+                        "x_opencti_score": self.default_score,
+                        "created_by_ref": srcs[0]["id"],
+                    }
+                    if contained["type"] == "IP":
+                        contained_tlo = self.make_api_getobj(
+                            collection="ips", objid=contained["value"]
+                        )
+                        if contained_tlo.ok:
+                            contained_stix = self.ip_to_stix(
+                                crits_obj=contained_tlo.json(),
+                                custom_properties=contained_custom_properties,
+                            )
+                    elif contained["type"] == "Domain":
+                        contained_tlo = self.make_api_getobj(
+                            collection="domains", objid=contained["value"]
+                        )
+                        if contained_tlo.ok:
+                            contained_stix = self.domain_to_stix(
+                                crits_obj=contained_tlo.json(),
+                                custom_properties=contained_custom_properties,
+                            )
+
+                    if contained_stix:
+                        new_objects.append(contained_stix)
+                        contained_objects.append(contained_stix["id"])
+
+                report_entity = stix2.Report(
+                    id=Report.generate_id(crits_obj["title"], ts),
+                    name=crits_obj["title"],
+                    description=crits_obj.get("description", ""),
+                    object_marking_refs=[self.default_marking],
+                    published=ts,
+                    created=ts,
+                    modified=dtparse(crits_obj["modified"]),
+                    report_types=[self.crits_event_type],
+                    created_by_ref=srcs[0]["id"],
+                    external_references=ext_refs,
+                    allow_custom=True,
+                    custom_properties=custom_properties,
+                    object_refs=contained_objects,
+                )
+                new_objects.append(report_entity)
+
+            work_id = self.helper.api.work.initiate_work(
+                self.helper.connect_id,
+                "test CRITs upload",
+            )
+
+            bundle = stix2.Bundle(objects=new_objects, allow_custom=True).serialize()
+            self.helper.send_stix2_bundle(bundle, update=True, work_id=work_id)
+
+            # If this is the last page of the collection, then break
+            if (
+                content["meta"]["offset"] + len(content["objects"])
+                >= content["meta"]["total_count"] - 1
+            ):
+                break
+
+            # Otherwise, load next page
+            http_response = self.make_api_get(
+                "ips",
+                query="?c-{t}__gt={v}&limit={l}&offset={o}".format(
+                    t=self.crits_timestamp_field,
+                    v=since.isoformat(),
+                    l=self.chunk_size,
+                    o=content["meta"]["offset"] + self.chunk_size,
+                ),
+            )
+
+        else:
+            self.helper.log_warn(
+                'Unable to access "ips" collection, HTTP code: {c}'.format(
+                    c=http_response.status_code
+                )
+            )
+
     def __init__(self):
         # Instantiate the connector helper from config
         config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
@@ -51,6 +318,10 @@ class CRITsConnector:
         self.crits_interval = get_config_variable(
             "CRITS_INTERVAL", ["crits", "interval"], config, True
         )
+        self.crits_timestamp_field = "modified"
+        self.chunk_size = 100
+        self.default_marking = stix2.TLP_GREEN
+        self.default_score = 75
 
         # Test connection to <crits_url>/api/v1/events/?limit=1, which should give a JSON result
         # if the authentication is working, whether or not there's any Events in the database.
@@ -68,6 +339,15 @@ class CRITsConnector:
         http_response = requests.get(
             "{base}/api/v1/{collection}/{query}".format(
                 base=self.crits_url, collection=collection, query=query
+            ),
+            params={"username": self.crits_user, "api_key": self.crits_api_key},
+        )
+        return http_response
+
+    def make_api_getobj(self, collection, objid):
+        http_response = requests.get(
+            "{base}/api/v1/{collection}/{objid}/".format(
+                base=self.crits_url, collection=collection, objid=objid
             ),
             params={"username": self.crits_user, "api_key": self.crits_api_key},
         )
@@ -114,6 +394,15 @@ class CRITsConnector:
             #       both elements? Neither?
             #    2) Upload the relationships - walk through containing reports, if needed
             #
+            tmp_earliest = datetime(2010, 1, 1)
+
+            # First collect entities and observables and other objects that can be contained within reports
+            for collection in ["ips", "domains"]:
+                self.process_objects(collection=collection, since=tmp_earliest)
+
+            # Next, collect reports
+            self.process_events(since=tmp_earliest)
+
             time.sleep(60 * self.crits_interval)
 
 

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -584,7 +584,7 @@ class CRITsConnector:
             )
 
         else:
-            self.helper.log_warn(
+            self.helper.log_warning(
                 'Unable to access "{c}" collection, HTTP code: {r}'.format(
                     c=collection,
                     r=http_response.status_code,
@@ -1030,7 +1030,7 @@ class CRITsConnector:
             )
 
         else:
-            self.helper.log_warn(
+            self.helper.log_warning(
                 'Unable to access "events" collection, HTTP code: {c}'.format(
                     c=http_response.status_code
                 )
@@ -1136,7 +1136,7 @@ class CRITsConnector:
         elif config_marking == "tlp:red":
             self.default_marking = stix2.TLP_RED
         else:
-            self.helper.log_warn(
+            self.helper.log_warning(
                 "Unrecognized marking definition {m}, defaulting to TLP:GREEN".format(
                     m=config_marking
                 )

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -59,6 +59,12 @@ INDICATOR_MAPPING = {
     "Domain": "domain-name:value",
     "URI - Domain Name": "domain-name:value",
     "URI - domain-name": "domain-name:value",
+    "MD5": "file:hashes.'MD5'",
+    "SHA1": "file:hashes.'SHA-1'",
+    "SHA256": "file:hashes.'SHA-256'",
+    "SSDEEP": "file:hashes.'SSDEEP'",
+    "URI": "url:value",
+    "User Agent": "network-traffic:extensions.'http-request-ext'.request_header.'User-Agent'",
 }
 
 

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -127,7 +127,9 @@ class CRITsConnector:
             )
 
             bundle = stix2.Bundle(objects=new_objects, allow_custom=True).serialize()
-            self.helper.send_stix2_bundle(bundle, update=True, work_id=work_id)
+            self.helper.send_stix2_bundle(
+                bundle, update=self.update_existing_data, work_id=work_id
+            )
 
             # If this is the last page of the collection, then break
             if (
@@ -248,7 +250,9 @@ class CRITsConnector:
             )
 
             bundle = stix2.Bundle(objects=new_objects, allow_custom=True).serialize()
-            self.helper.send_stix2_bundle(bundle, update=True, work_id=work_id)
+            self.helper.send_stix2_bundle(
+                bundle, update=self.update_existing_data, work_id=work_id
+            )
 
             # If this is the last page of the collection, then break
             if (
@@ -317,6 +321,13 @@ class CRITsConnector:
         )
         self.crits_interval = get_config_variable(
             "CRITS_INTERVAL", ["crits", "interval"], config, True
+        )
+        self.update_existing_data = get_config_variable(
+            "CONNECTOR_UPDATE_EXISTING_DATA",
+            ["connector", "update_existing_data"],
+            config,
+            isNumber=False,
+            default=True,
         )
         self.crits_timestamp_field = "modified"
         self.chunk_size = 100

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -1123,7 +1123,7 @@ class CRITsConnector:
             ["crits", "default_marking"],
             config,
             isNumber=False,
-            default="TLP:GREEM",
+            default="TLP:GREEN",
         ).lower()
 
         # Only change to new marking definition if it matches the naming convention

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -75,6 +75,7 @@ class CRITsConnector:
                     id=Identity.generate_id(sname, "organization"),
                     name=sname,
                     identity_class="organization",
+                    object_marking_refs=[self.default_marking],
                 )
                 srcs.append(author)
 
@@ -607,6 +608,7 @@ class CRITsConnector:
                 description=relation["to"]["rel_reason"],
                 source_ref=crits_stix_mapping[relation["from"]],
                 target_ref=crits_stix_mapping[relation["to"]["value"]],
+                object_marking_refs=[self.default_marking],
                 allow_custom=True,
             )
             new_objects.append(new_rel)
@@ -974,6 +976,7 @@ class CRITsConnector:
                         description=relation["to"]["rel_reason"],
                         source_ref=crits_stix_mapping[relation["from"]],
                         target_ref=crits_stix_mapping[relation["to"]["value"]],
+                        object_marking_refs=[self.default_marking],
                         allow_custom=True,
                     )
                     new_objects.append(new_rel)

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -97,7 +97,7 @@ class CRITsConnector:
         if "created_by_ref" in custom_properties.keys():
             dynamic_params["created_by_ref"] = custom_properties["created_by_ref"]
 
-        cve = crits_obj["cve"]
+        # cve = crits_obj["cve"]
 
         return stix2.Malware(
             id=Malware.generate_id(name=crits_obj["name"]),

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -503,14 +503,15 @@ class CRITsConnector:
                 if new_obj:
                     new_objects.append(new_obj)
 
-            work_id = self.helper.api.work.initiate_work(
-                self.helper.connect_id,
-                "test CRITs upload",
-            )
+            if not self.work_id:
+                self.work_id = self.helper.api.work.initiate_work(
+                    self.helper.connect_id,
+                    "test CRITs upload",
+                )
 
             bundle = stix2.Bundle(objects=new_objects, allow_custom=True).serialize()
             self.helper.send_stix2_bundle(
-                bundle, update=self.update_existing_data, work_id=work_id
+                bundle, update=self.update_existing_data, work_id=self.work_id
             )
 
             # If this is the last page of the collection, then break
@@ -755,14 +756,15 @@ class CRITsConnector:
                 )
                 new_objects.append(report_entity)
 
-            work_id = self.helper.api.work.initiate_work(
-                self.helper.connect_id,
-                "test CRITs upload",
-            )
+            if not self.work_id:
+                self.work_id = self.helper.api.work.initiate_work(
+                    self.helper.connect_id,
+                    "test CRITs upload",
+                )
 
             bundle = stix2.Bundle(objects=new_objects, allow_custom=True).serialize()
             self.helper.send_stix2_bundle(
-                bundle, update=self.update_existing_data, work_id=work_id
+                bundle, update=self.update_existing_data, work_id=self.work_id
             )
 
             # If this is the last page of the collection, then break
@@ -799,6 +801,7 @@ class CRITsConnector:
             else {}
         )
         self.helper = OpenCTIConnectorHelper(config)
+        self.work_id = None
         self.crits_url = get_config_variable(
             "CRITS_URL",
             ["crits", "url"],
@@ -944,6 +947,9 @@ class CRITsConnector:
                 "targets",
             ]:
                 self.process_objects(collection=collection, since=tmp_earliest)
+
+            # Clear out the completed work id (if any)
+            self.work_id = None
 
             time.sleep(60 * self.crits_interval)
 

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -1246,6 +1246,10 @@ class CRITsConnector:
             # Clear out the completed work id (if any)
             self.work_id = None
 
+            if self.helper.connect_run_and_terminate:
+                self.helper.log_info("Connector stop")
+                sys.exit(0)
+
             time.sleep(60 * self.crits_interval)
 
 

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -1101,14 +1101,14 @@ class CRITsConnector:
             isNumber=False,
             default="modified",
         )
-        self.crits_chunk_size = get_config_variable(
+        self.chunk_size = get_config_variable(
             "CRITS_CHUNK_SIZE",
             ["crits", "chunk_size"],
             config,
             isNumber=True,
             default=100,
         )
-        self.crits_default_score = get_config_variable(
+        self.default_score = get_config_variable(
             "CONNECTOR_CONFIDENCE_LEVEL",
             ["connector", "confidence_level"],
             config,

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -1228,7 +1228,11 @@ class CRITsConnector:
             if last_state and "last_run" in last_state:
                 tmp_earliest = dtparse(last_state["last_run"]).astimezone(pytz.utc)
 
-            self.helper.log_info("Running CRITs connector, last run: {t}".format(t=tmp_earliest.isoformat()))
+            self.helper.log_info(
+                "Running CRITs connector, last run: {t}".format(
+                    t=tmp_earliest.isoformat()
+                )
+            )
 
             # First, collect up reports, which will initially populate using the Report-centric object model
             self.process_events(since=tmp_earliest)

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -1,0 +1,127 @@
+import os
+import sys
+import time
+import requests
+
+import yaml
+from pycti import OpenCTIConnectorHelper, get_config_variable
+
+
+class CRITsConnector:
+    def __init__(self):
+        # Instantiate the connector helper from config
+        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
+        config = (
+            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
+            if os.path.isfile(config_file_path)
+            else {}
+        )
+        self.helper = OpenCTIConnectorHelper(config)
+        self.crits_url = get_config_variable(
+            "CRITS_URL",
+            ["crits", "url"],
+            config,
+        )
+
+        # If the admin left the trailing '/' on the CRITS_URL, then strip it from the end of
+        # the URL, for consistency later on
+        if self.crits_url[-1] == "/":
+            self.crits_url = self.crits_url[0:-1]
+
+        self.crits_reference_url = get_config_variable(
+            "CRITS_REFERENCE_URL",
+            ["crits", "reference_url"],
+            config,
+            False,
+            self.crits_url,
+        )
+        self.crits_user = get_config_variable(
+            "CRITS_USER",
+            ["crits", "user"],
+            config,
+        )
+        self.crits_api_key = get_config_variable(
+            "CRITS_API_KEY",
+            ["crits", "api_key"],
+            config,
+        )
+        self.crits_event_type = get_config_variable(
+            "CRITS_EVENT_TYPE", ["crits", "event_type"], config, False, "crits-event"
+        )
+        self.crits_interval = get_config_variable(
+            "CRITS_INTERVAL", ["crits", "interval"], config, True
+        )
+
+        # Test connection to <crits_url>/api/v1/events/?limit=1, which should give a JSON result
+        # if the authentication is working, whether or not there's any Events in the database.
+        # 401 Unauthorized will be the result code, if the authentication doesn't work
+        http_response = self.make_api_get(collection="events", query="?limit=1")
+        http_response.raise_for_status()
+        self.helper.log_info(
+            "Success authenticating to CRITs {url}".format(url=self.crits_url)
+        )
+
+    def make_api_get(self, collection, query=""):
+        if query and query[0] != "?":
+            query = "?{q}".format(q=query)
+
+        http_response = requests.get(
+            "{base}/api/v1/{collection}/{query}".format(
+                base=self.crits_url, collection=collection, query=query
+            ),
+            params={"username": self.crits_user, "api_key": self.crits_api_key},
+        )
+        return http_response
+
+    def run(self):
+        while True:
+            #
+            # Some key considerations to keep in mind:
+            # - CRITs allows storage of various entities without requiring they be part of a "Event"
+            # - Event is a TLO that we'll consider analogous to "Analysis report" in OpenCTI
+            # - CRITs tracks relationships between all entities the same, using a specific taxonomy that's built in for reltype,
+            #   but using exclusively the BSON ObjectId associated to the relationships
+            # - CRITs doesn't strictly adhere to STIX, and where it tries to, it's STIX 1.x
+            # - CRITs doesn't offer API listing of "Sources", so these must be organically collected during the processing
+            #   of entitites
+            # - CRITs "Campaign" links to entities is handled as a unique relationship that uses the text of the campaign
+            #   name, rather than its entity id, in a custom purpose-specific field. Interestingly enough, the generic
+            #   relationships can also link to a campaign, so there's two relational mechanisms to keep in mind for this
+            # - CRITs "Campaign" covers both "Intrusion Set" and "Campaign" in OpenCTI taxonomy
+            # - CRITs doesn't associate TLO or Campaign relationships with Events or other sourcing info
+            # - CRITs doesn't require that "external references" necessitate any corresponding Event objects
+            # - CRITs allows other TLOs to share external references with Events, but leaves it to analysts to relate them. This
+            #   should probably be used to help clean up dirty related data on import (maybe as a togglable)
+            # - CRITs has TLOs that map to some "Observation" types, as well as some Entity types, in OpenCTI.
+            #   Furthermore, there are sub-types of Indicator that map to even more Observations for which there's no TLO.
+            #   There likely will need to be some mechanism similar to how MISP ingest works to optionally create
+            #   "indicators" or "observables" or "both", for any of the sub-types of "Indicator" TLOs
+            # - ... TO BE CONTINUED
+            #
+            # Ingest plan (likely) will consist of the following phases:
+            #
+            # A) Walk through each of CRITs "Top Level Objects" (TLOs) that map 1-to-1 to an OpenCTI Object type, except for
+            #    Events
+            #    1) Format into a STIX2 bundle, and have it ingested
+            #    2) CRITs API uses pagination, so perform this work 100 at a time to reduce memory usage
+            #    3) Import these bundles into OpenCTI
+            #
+            # B) Walk through all CRITs Events, and import them with "contains" relationships to the other TLOs that they relate to
+            #    ... Do 1-3 from above
+            #
+            # C) Go back through and mine relationships out of the dataset, and populate those over into OpenCTI
+            #    1) CRITs relationships aren't tied to source reporting. Do I store the relation in all reports containing
+            #       both elements? Neither?
+            #    2) Upload the relationships - walk through containing reports, if needed
+            #
+            time.sleep(60 * self.crits_interval)
+
+
+if __name__ == "__main__":
+    try:
+        connector = CRITsConnector()
+        connector.run()
+    except Exception as e:
+        print(e)
+        time.sleep(10)
+        sys.exit(0)

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -65,6 +65,7 @@ class CRITsConnector:
         return stix2.ThreatActor(
             id=ThreatActor.generate_id(name=crits_obj["name"]),
             name=crits_obj["name"],
+            labels=crits_obj.get("bucket_list", []),
             object_marking_refs=[self.default_marking],
             custom_properties=custom_properties,
             **dynamic_params,
@@ -81,6 +82,7 @@ class CRITsConnector:
         return stix2.Malware(
             id=Malware.generate_id(name=crits_obj["name"]),
             name=crits_obj["name"],
+            labels=crits_obj.get("bucket_list", []),
             object_marking_refs=[self.default_marking],
             custom_properties=custom_properties,
             is_family=True,
@@ -100,6 +102,7 @@ class CRITsConnector:
         return stix2.Malware(
             id=Malware.generate_id(name=crits_obj["name"]),
             name=crits_obj["name"],
+            labels=crits_obj.get("bucket_list", []),
             object_marking_refs=[self.default_marking],
             custom_properties=custom_properties,
             is_family=True,
@@ -119,6 +122,7 @@ class CRITsConnector:
             return stix2.Campaign(
                 id=Campaign.generate_id(name=crits_obj["name"]),
                 name=crits_obj["name"],
+                labels=crits_obj.get("bucket_list", []),
                 object_marking_refs=[self.default_marking],
                 custom_properties=custom_properties,
                 **dynamic_params,
@@ -127,6 +131,7 @@ class CRITsConnector:
         return stix2.IntrusionSet(
             id=IntrusionSet.generate_id(name=crits_obj["name"]),
             name=crits_obj["name"],
+            labels=crits_obj.get("bucket_list", []),
             object_marking_refs=[self.default_marking],
             custom_properties=custom_properties,
             **dynamic_params,
@@ -134,6 +139,7 @@ class CRITsConnector:
 
     def domain_to_stix(self, crits_obj, custom_properties):
         custom_properties["description"] = crits_obj.get("description", "")
+        custom_properties["labels"] = crits_obj.get("bucket_list", [])
 
         return stix2.DomainName(
             value=crits_obj["domain"],
@@ -143,6 +149,7 @@ class CRITsConnector:
 
     def ip_to_stix(self, crits_obj, custom_properties):
         custom_properties["description"] = crits_obj.get("description", "")
+        custom_properties["labels"] = crits_obj.get("bucket_list", [])
 
         # IP Address observables have 4 subtype possibilities. However,
         # STIX 2.x maps "Address" and "Subnet" to the same data types, for
@@ -402,6 +409,7 @@ class CRITsConnector:
                     name=crits_obj["title"],
                     description=crits_obj.get("description", ""),
                     object_marking_refs=[self.default_marking],
+                    labels=crits_obj.get("bucket_list", []),
                     published=ts,
                     created=ts,
                     modified=dtparse(crits_obj["modified"]),

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -804,7 +804,7 @@ class CRITsConnector:
 
         else:
             self.helper.log_warn(
-                'Unable to access "ips" collection, HTTP code: {c}'.format(
+                'Unable to access "events" collection, HTTP code: {c}'.format(
                     c=http_response.status_code
                 )
             )

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -18,6 +18,7 @@ from pycti import (
     ThreatActor,
     Malware,
     Indicator,
+    StixCoreRelationship,
 )
 import stix2
 import validators
@@ -618,6 +619,8 @@ class CRITsConnector:
                 )
 
                 contained_objects = []
+                contained_rels = []
+                crits_stix_mapping = {}
                 for contained in report_contents_crits:
                     contained_stix = None
                     contained_custom_properties = {
@@ -629,110 +632,206 @@ class CRITsConnector:
                             collection="ips", objid=contained["value"]
                         )
                         if contained_tlo.ok:
+                            crits_obj = contained_tlo.json()
                             contained_stix = self.ip_to_stix(
-                                crits_obj=contained_tlo.json(),
+                                crits_obj=crits_obj,
                                 custom_properties=contained_custom_properties,
+                            )
+                            crits_stix_mapping[crits_obj["_id"]] = contained_stix["id"]
+                            contained_rels.extend(
+                                [
+                                    {"from": crits_obj["_id"], "to": rel}
+                                    for rel in crits_obj["relationships"]
+                                ]
                             )
                     elif contained["type"] == "Domain":
                         contained_tlo = self.make_api_getobj(
                             collection="domains", objid=contained["value"]
                         )
                         if contained_tlo.ok:
+                            crits_obj = contained_tlo.json()
                             contained_stix = self.domain_to_stix(
-                                crits_obj=contained_tlo.json(),
+                                crits_obj=crits_obj,
                                 custom_properties=contained_custom_properties,
+                            )
+                            crits_stix_mapping[crits_obj["_id"]] = contained_stix["id"]
+                            contained_rels.extend(
+                                [
+                                    {"from": crits_obj["_id"], "to": rel}
+                                    for rel in crits_obj["relationships"]
+                                ]
                             )
                     elif contained["type"] == "RawData":
                         contained_tlo = self.make_api_getobj(
                             collection="raw_data", objid=contained["value"]
                         )
                         if contained_tlo.ok:
+                            crits_obj = contained_tlo.json()
                             contained_stix = self.rawdata_to_text(
-                                crits_obj=contained_tlo.json(),
+                                crits_obj=crits_obj,
                                 custom_properties=contained_custom_properties,
+                            )
+                            crits_stix_mapping[crits_obj["_id"]] = contained_stix["id"]
+                            contained_rels.extend(
+                                [
+                                    {"from": crits_obj["_id"], "to": rel}
+                                    for rel in crits_obj["relationships"]
+                                ]
                             )
                     elif contained["type"] == "Sample":
                         contained_tlo = self.make_api_getobj(
                             collection="samples", objid=contained["value"]
                         )
                         if contained_tlo.ok:
+                            crits_obj = contained_tlo.json()
                             contained_stix, artifact_id = self.sample_to_stix(
-                                crits_obj=contained_tlo.json(),
+                                crits_obj=crits_obj,
                                 custom_properties=contained_custom_properties,
                             )
                             if artifact_id:
                                 contained_objects.append(artifact_id)
+                            crits_stix_mapping[crits_obj["_id"]] = contained_stix["id"]
+                            contained_rels.extend(
+                                [
+                                    {"from": crits_obj["_id"], "to": rel}
+                                    for rel in crits_obj["relationships"]
+                                ]
+                            )
                     elif contained["type"] == "Campaign":
                         contained_tlo = self.make_api_getobj(
                             collection="campaigns", objid=contained["value"]
                         )
                         if contained_tlo.ok:
+                            crits_obj = contained_tlo.json()
                             contained_stix = self.campaign_to_stix(
-                                crits_obj=contained_tlo.json(),
+                                crits_obj=crits_obj,
                                 custom_properties=contained_custom_properties,
+                            )
+                            crits_stix_mapping[crits_obj["_id"]] = contained_stix["id"]
+                            contained_rels.extend(
+                                [
+                                    {"from": crits_obj["_id"], "to": rel}
+                                    for rel in crits_obj["relationships"]
+                                ]
                             )
                     elif contained["type"] == "Actor":
                         contained_tlo = self.make_api_getobj(
                             collection="actors", objid=contained["value"]
                         )
                         if contained_tlo.ok:
+                            crits_obj = contained_tlo.json()
                             contained_stix = self.actor_to_stix(
-                                crits_obj=contained_tlo.json(),
+                                crits_obj=crits_obj,
                                 custom_properties=contained_custom_properties,
+                            )
+                            crits_stix_mapping[crits_obj["_id"]] = contained_stix["id"]
+                            contained_rels.extend(
+                                [
+                                    {"from": crits_obj["_id"], "to": rel}
+                                    for rel in crits_obj["relationships"]
+                                ]
                             )
                     elif contained["type"] == "Backdoor":
                         contained_tlo = self.make_api_getobj(
                             collection="backdoors", objid=contained["value"]
                         )
                         if contained_tlo.ok:
+                            crits_obj = contained_tlo.json()
                             contained_stix = self.backdoor_to_stix(
-                                crits_obj=contained_tlo.json(),
+                                crits_obj=crits_obj,
                                 custom_properties=contained_custom_properties,
+                            )
+                            crits_stix_mapping[crits_obj["_id"]] = contained_stix["id"]
+                            contained_rels.extend(
+                                [
+                                    {"from": crits_obj["_id"], "to": rel}
+                                    for rel in crits_obj["relationships"]
+                                ]
                             )
                     elif contained["type"] == "Exploit":
                         contained_tlo = self.make_api_getobj(
                             collection="exploits", objid=contained["value"]
                         )
                         if contained_tlo.ok:
+                            crits_obj = contained_tlo.json()
                             contained_stix = self.exploit_to_stix(
-                                crits_obj=contained_tlo.json(),
+                                crits_obj=crits_obj,
                                 custom_properties=contained_custom_properties,
+                            )
+                            crits_stix_mapping[crits_obj["_id"]] = contained_stix["id"]
+                            contained_rels.extend(
+                                [
+                                    {"from": crits_obj["_id"], "to": rel}
+                                    for rel in crits_obj["relationships"]
+                                ]
                             )
                     elif contained["type"] == "Indicator":
                         contained_tlo = self.make_api_getobj(
                             collection="indicators", objid=contained["value"]
                         )
                         if contained_tlo.ok:
+                            crits_obj = contained_tlo.json()
                             contained_stix = self.indicator_to_stix(
-                                crits_obj=contained_tlo.json(),
+                                crits_obj=crits_obj,
                                 custom_properties=contained_custom_properties,
+                            )
+                            crits_stix_mapping[crits_obj["_id"]] = contained_stix["id"]
+                            contained_rels.extend(
+                                [
+                                    {"from": crits_obj["_id"], "to": rel}
+                                    for rel in crits_obj["relationships"]
+                                ]
                             )
                     elif contained["type"] == "Signature":
                         contained_tlo = self.make_api_getobj(
                             collection="signatures", objid=contained["value"]
                         )
                         if contained_tlo.ok:
+                            crits_obj = contained_tlo.json()
                             contained_stix = self.signature_to_stix(
-                                crits_obj=contained_tlo.json(),
+                                crits_obj=crits_obj,
                                 custom_properties=contained_custom_properties,
+                            )
+                            crits_stix_mapping[crits_obj["_id"]] = contained_stix["id"]
+                            contained_rels.extend(
+                                [
+                                    {"from": crits_obj["_id"], "to": rel}
+                                    for rel in crits_obj["relationships"]
+                                ]
                             )
                     elif contained["type"] == "Email":
                         contained_tlo = self.make_api_getobj(
                             collection="emails", objid=contained["value"]
                         )
                         if contained_tlo.ok:
+                            crits_obj = contained_tlo.json()
                             contained_stix = self.email_to_stix(
-                                crits_obj=contained_tlo.json(),
+                                crits_obj=crits_obj,
                                 custom_properties=contained_custom_properties,
+                            )
+                            crits_stix_mapping[crits_obj["_id"]] = contained_stix["id"]
+                            contained_rels.extend(
+                                [
+                                    {"from": crits_obj["_id"], "to": rel}
+                                    for rel in crits_obj["relationships"]
+                                ]
                             )
                     elif contained["type"] == "Target":
                         contained_tlo = self.make_api_getobj(
                             collection="targets", objid=contained["value"]
                         )
                         if contained_tlo.ok:
+                            crits_obj = contained_tlo.json()
                             contained_stix = self.target_to_stix(
-                                crits_obj=contained_tlo.json(),
+                                crits_obj=crits_obj,
                                 custom_properties=contained_custom_properties,
+                            )
+                            crits_stix_mapping[crits_obj["_id"]] = contained_stix["id"]
+                            contained_rels.extend(
+                                [
+                                    {"from": crits_obj["_id"], "to": rel}
+                                    for rel in crits_obj["relationships"]
+                                ]
                             )
 
                     if contained_stix:
@@ -761,6 +860,28 @@ class CRITsConnector:
                             )
                             new_objects.append(new_obj)
                             contained_objects.append(new_obj["id"])
+
+                # Create and store all relationships that capture BOTH entities within this same report
+                for relation in filter(
+                    lambda x: x["from"] in crits_stix_mapping
+                    and x["to"]["value"] in crits_stix_mapping,
+                    contained_rels,
+                ):
+                    new_rel = stix2.Relationship(
+                        id=StixCoreRelationship.generate_id(
+                            "related-to",
+                            relation["from"],
+                            relation["to"]["value"],
+                        ),
+                        relationship_type="related-to",
+                        created_by_ref=srcs[0]["id"],
+                        description=relation["to"]["rel_reason"],
+                        source_ref=crits_stix_mapping[relation["from"]],
+                        target_ref=crits_stix_mapping[relation["to"]["value"]],
+                        allow_custom=True,
+                    )
+                    new_objects.append(new_rel)
+                    contained_objects.append(new_rel["id"])
 
                 report_entity = stix2.Report(
                     id=Report.generate_id(crits_obj["title"], ts),

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -341,7 +341,7 @@ class CRITsConnector:
                 artifact["mime_type"] = crits_obj["mimetype"]
 
             r = self.helper.api.stix_cyber_observable.upload_artifact(**artifact)
-            dynamic_params["content_ref"] = r["standard_id"]
+            dynamic_params["contains_refs"] = [r["standard_id"]]
 
         return stix2.File(
             hashes=hashes,

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -407,12 +407,12 @@ class CRITsConnector:
             #
             tmp_earliest = datetime(2010, 1, 1)
 
-            # First collect entities and observables and other objects that can be contained within reports
+            # First, collect up reports, which will initially populate using the Report-centric object model
+            self.process_events(since=tmp_earliest)
+
+            # Second, collect entities and observables and other objects that can be created without relating to Reports/Events
             for collection in ["ips", "domains"]:
                 self.process_objects(collection=collection, since=tmp_earliest)
-
-            # Next, collect reports
-            self.process_events(since=tmp_earliest)
 
             time.sleep(60 * self.crits_interval)
 

--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -454,6 +454,10 @@ class CRITsConnector:
             new_objects = []
             content = http_response.json()
 
+            # If no work, then just return
+            if content["meta"]["total_count"] == 0:
+                return
+
             self.helper.log_info(
                 "{c}: total={t} page={n}/{m})".format(
                     c=collection,
@@ -637,6 +641,10 @@ class CRITsConnector:
         while http_response.ok:
             new_objects = []
             content = http_response.json()
+
+            # If no work, then just return
+            if content["meta"]["total_count"] == 0:
+                return
 
             self.helper.log_info(
                 "events: total={t} page={n}/{m})".format(

--- a/external-import/crits/src/requirements.txt
+++ b/external-import/crits/src/requirements.txt
@@ -1,0 +1,2 @@
+pycti==5.3.15
+requests

--- a/external-import/crits/src/requirements.txt
+++ b/external-import/crits/src/requirements.txt
@@ -1,2 +1,4 @@
 pycti==5.3.15
 requests
+python-dateutil
+validators


### PR DESCRIPTION
This is intended to be a connector that will fetch data from an external CRITs (https://crits.github.io) instance, and import it into OpenCTI. Similar to the existing `external-import/misp` connector. **This is a work in progress**.

### Proposed changes

* Add a new `external-import` connector named `crits` which will import data from a CRITs instance (https://crits.github.io)

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This is a work in progress, but I wanted to publish a PR on the feature branch early in the development process so that discussion could happen here, as well as awareness. I've used the CRITs platform for over 10 years, and while it was a great platform at the time, its front-end is largely based upon an outdated approach to web application development, it is not compatible with Python 3, where it uses STIX it uses STIX 1.x, and it is no longer actively maintained by the contributors. For these reasons, its prudent to provide a mechanism to migrate data from it to another modern platform that's actively maintained.