### PR TITLE
[cisa-known-exploited-vulnerabilities] Fix unknown IDs (#843)

### DIFF
--- a/external-import/cisa-known-exploited-vulnerabilities/src/main.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/main.py
@@ -174,6 +174,7 @@ class Cisa:
                 object_marking_refs=[f"{marking_id}"],
             )
             stix_objects.append(stix_vuln)
+            vuln_id = stix_vuln["id"]
         else:
             created_by = cti_vuln["createdBy"]["standard_id"]
             vuln_created = cti_vuln["created"]
@@ -206,6 +207,7 @@ class Cisa:
                 object_marking_refs=[f"{marking_id}"],
             )
             stix_objects.append(stix_org)
+            org_id = stix_org["id"]
         else:
             self.helper.log_info(f"{vendor_name} was found in the CTI Service")
             vendor_id = cti_vendor["standard_id"]


### PR DESCRIPTION
### Proposed changes

* Ensure vuln_id and org_id are assigned when a new vulnerability and infrastructure object are created by the connector.


### Related issues

* #843 

### Checklist


- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


### Further comments
