### PR TITLE
[shodan] remove indicator, enrich as a note

### DIFF
--- a/internal-enrichment/shodan-internetdb/README.md
+++ b/internal-enrichment/shodan-internetdb/README.md
@@ -17,7 +17,6 @@ There are a number of configuration options, which are set either in `docker-com
 
 | Docker Env variable      | config variable   | Default | Description                                      |
 |--------------------------|-------------------|---------|--------------------------------------------------|
-| SHODAN_CREATE_INDICATORS | create_indicators | true    | Create indicators for any observables created    |
 | SHODAN_MAX_TLP           | max_tlp           | white   | The max TLP allowed to be sent to the Shodan API |
 | SHODAN_SSL_VERIFY        | ssl_verify        | true    | Verify SSL connections to the API endpoint       |
 

--- a/internal-enrichment/shodan-internetdb/docker-compose.yml
+++ b/internal-enrichment/shodan-internetdb/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=75
       - CONNECTOR_AUTO=true
       - CONNECTOR_LOG_LEVEL=info
-      - SHODAN_CREATE_INDICATORS=true
       - SHODAN_MAX_TLP=white
       - SHODAN_SSL_VERIFY=true
     restart: always

--- a/internal-enrichment/shodan-internetdb/src/config.yml.sample
+++ b/internal-enrichment/shodan-internetdb/src/config.yml.sample
@@ -15,6 +15,5 @@ connector:
   confidence_level: 75
 
 shodan:
-  create_indicators: true
   max_tlp: "white"
   ssl_verify: true

--- a/internal-enrichment/shodan-internetdb/src/shodan_internetdb/config.py
+++ b/internal-enrichment/shodan-internetdb/src/shodan_internetdb/config.py
@@ -33,13 +33,8 @@ class ShodanConfig(BaseSettings):
         env="SHODAN_SSL_VERIFY",
         default=True,
     )
-    create_indicators: bool = Field(
-        description="Create indicators from observables",
-        env="SHODAN_CREATE_INDICATORS",
-        default=True,
-    )
 
-    @validator("ssl_verify", "create_indicators", pre=True)
+    @validator("ssl_verify", pre=True)
     def _bool_validator(cls, value: str) -> bool:
         """Convert a truthy/falsy value to a bool"""
 


### PR DESCRIPTION
### Proposed changes

* Remove SHODAN_CREATE_INDICATOR, nothing about the shodan enrichment specifies maliciousness, an indicator should not be created by this.
* Add the enrichment as a note, instead of description hacking. Updating a description, even with appending the enrichment was a messy proposition to begin with. 

### Related issues

* None

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Searching works relatively well, you'd just need to pivot from the note back to the observable if that's what was in the results.

Abstract:
```
Shodan InternetDB Enrichment of 8.8.8.8
```

Content:
```
Shodan InternetDB:
------------------
Hostnames: 
- dns.google
------------------
Software: n/a
------------------
Vulnerabilities: n/a
------------------
Ports: 
- 53
- 443
------------------
```
