### PR TITLE
[ExportReportPDF] Export Threat-Actor Entities

### DIFF
--- a/internal-enrichment/intezer-sandbox/src/intezer_api.py
+++ b/internal-enrichment/intezer-sandbox/src/intezer_api.py
@@ -36,8 +36,7 @@ class IntezerApi:
         file_obj = io.BytesIO(file_contents)
         files = {"file": ("file_name", file_obj)}
         response = self._session.post(f"{self.base_url}/analyze", files=files)
-        assert response.status_code == 201
-
+        response.raise_for_status()
         return response.json()["result_url"]
 
     def get_analysis_report(self, result_url):

--- a/internal-export-file/export-report-pdf/README.md
+++ b/internal-export-file/export-report-pdf/README.md
@@ -1,6 +1,6 @@
 # OpenCTI ExportReportPdf Connector
 
-OpenCTI ExportReportPdf connector allows an analyst to export all entities and observables for Report (Analysis) and Intrusion Set entities as a pdf file. This may be useful for sharing threat intelligence with an external entity in a nice, well-groomed format.
+OpenCTI ExportReportPdf connector allows exporting PDF based reports for the following entities: Report (Analysis), Intrusion Set, and Threat Actor. The PDF may be useful for sharing threat intelligence with an external entity in a nice, well-groomed format.
 
 
 #### Technical information

--- a/internal-export-file/export-report-pdf/docker-compose.yml
+++ b/internal-export-file/export-report-pdf/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   connector-export-report-pdf:
-    image: opencti/connector-export-report-pdf:5.3.16
+    image: opencti/connector-export-report-pdf:5.3.8
     environment:
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe

--- a/internal-export-file/export-report-pdf/docker-compose.yml
+++ b/internal-export-file/export-report-pdf/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   connector-export-report-pdf:
-    image: opencti/connector-export-report-pdf:5.3.8
+    image: opencti/connector-export-report-pdf:5.3.16
     environment:
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe

--- a/internal-export-file/export-report-pdf/src/export-report-pdf.py
+++ b/internal-export-file/export-report-pdf/src/export-report-pdf.py
@@ -4,7 +4,6 @@ import io
 import os
 import sys
 import time
-
 import cairosvg
 import yaml
 from jinja2 import Environment, FileSystemLoader
@@ -92,11 +91,9 @@ class ExportReportPdf:
 
     def _process_message(self, data):
         file_name = data["file_name"]
-        # TODO this can be implemented to filter every entity and observable
-        # max_marking = data["max_marking"]
         if "entity_type" not in data or "entity_id" not in data:
             raise ValueError(
-                'This Connector currently only handles direct export (single entity and no list) of the following entity types: "Report" and "Intrusion-Set'
+                'This Connector currently only handles direct export (single entity and no list) of the following entity types: "Report", "Intrusion-Set", and "Threat-Actor"'
             )
         entity_type = data["entity_type"]
         entity_id = data["entity_id"]
@@ -105,9 +102,11 @@ class ExportReportPdf:
             self._process_report(entity_id, file_name)
         elif entity_type == "Intrusion-Set":
             self._process_intrusion_set(entity_id, file_name)
+        elif entity_type == "Threat-Actor":
+            self._process_threat_actor(entity_id, file_name)
         else:
             raise ValueError(
-                f'This Connector currently only handles the entity types: "Report" and "Intrusion-Set", not "{entity_type}".'
+                f'This connector currently only handles the entity types: "Report", "Intrusion-Set", "Threat-Actor", not "{entity_type}".'
             )
 
         return "Export done"
@@ -210,8 +209,11 @@ class ExportReportPdf:
 
         # Upload the output pdf
         self.helper.log_info(f"Uploading: {file_name}")
-        self.helper.api.stix_domain_object.push_entity_export(
-            report_id, file_name, pdf_contents, "application/pdf"
+        self.helper.api.stix_domain_object.add_file(
+            id=report_id,
+            file_name=file_name,
+            data=pdf_contents,
+            mime_type="application/pdf",
         )
 
     def _process_intrusion_set(self, entity_id, file_name):
@@ -269,18 +271,18 @@ class ExportReportPdf:
             targeted_countries = []
             for relationship in context["entities"]["relationship"]:
                 if (
-                    relationship["relationship_type"] != "targets"
-                    and relationship["to"]["entity_type"] != "Country"
+                    relationship["entity_type"] == "targets"
+                    and relationship["relationship_type"] == "targets"
+                    and relationship["to"]["entity_type"] == "Country"
                 ):
-                    continue
+                    country_code = relationship["to"]["name"].lower()
+                    if not self._validate_country_code(country_code):
+                        self.helper.log_warning(
+                            f"{country_code} is not a supported country code, skipping..."
+                        )
+                        continue
 
-                country_name = relationship["to"]["name"]
-                country_code = self._get_country_code(country_name)
-                if not country_code:
-                    self.helper.log_error(f"{country_name} is not a supported country")
-                    continue
-
-                targeted_countries.append(country_code)
+                    targeted_countries.append(country_code)
 
             # Build targeted countries image
             if targeted_countries:
@@ -306,8 +308,108 @@ class ExportReportPdf:
 
         # Upload the output pdf
         self.helper.log_info(f"Uploading: {file_name}")
-        self.helper.api.stix_domain_object.push_entity_export(
-            entity_id, file_name, pdf_contents, "application/pdf"
+        self.helper.api.stix_domain_object.add_file(
+            id=entity_id,
+            file_name=file_name,
+            data=pdf_contents,
+            mime_type="application/pdf",
+        )
+
+    def _process_threat_actor(self, entity_id, file_name):
+        """
+        Process a Threat Actor entity and upload as pdf.
+        """
+
+        now_date = datetime.datetime.now().strftime("%b %d %Y")
+
+        # Store context for usage in html template
+        context = {
+            "entities": {},
+            "target_map_country": None,
+            "report_date": now_date,
+            "company_address_line_1": self.company_address_line_1,
+            "company_address_line_2": self.company_address_line_2,
+            "company_address_line_3": self.company_address_line_3,
+            "company_phone_number": self.company_phone_number,
+            "company_email": self.company_email,
+            "company_website": self.company_website,
+        }
+
+        # Get a bundle of all objects affiliated with the threat actor
+        bundle = self.helper.api.stix2.export_entity("Threat-Actor", entity_id, "full")
+
+        for bundle_obj in bundle["objects"]:
+            obj_id = bundle_obj["id"]
+            obj_entity_type = bundle_obj["type"]
+
+            reader_func = self._get_reader(obj_entity_type)
+            if reader_func is None:
+                self.helper.log_error(
+                    f'Could not find a function to read entity with type "{obj_entity_type}"'
+                )
+                continue
+
+            time.sleep(0.3)
+            entity_dict = reader_func(id=obj_id)
+
+            # Key names cannot have - in them for jinja2 templating
+            obj_entity_type = obj_entity_type.replace("-", "_")
+            if obj_entity_type not in context["entities"]:
+                context["entities"][obj_entity_type] = []
+
+            context["entities"][obj_entity_type].append(entity_dict)
+
+        # Generate the svg img contents for the targets map
+        if "relationship" in context["entities"]:
+
+            # Create world map
+            world_map = World()
+            world_map.title = "Targeted Countries"
+            targeted_countries = []
+            for relationship in context["entities"]["relationship"]:
+                if (
+                    relationship["entity_type"] == "targets"
+                    and relationship["relationship_type"] == "targets"
+                    and relationship["to"]["entity_type"] == "Country"
+                ):
+                    country_code = relationship["to"]["name"].lower()
+                    if not self._validate_country_code(country_code):
+                        self.helper.log_warning(
+                            f"{country_code} is not a supported country code, skipping..."
+                        )
+                        continue
+
+                    targeted_countries.append(country_code)
+
+            # Build targeted countries image
+            if targeted_countries:
+                world_map.add("Targeted Countries", targeted_countries)
+                # Convert the svg to base64 png
+                svg_bytes = world_map.render()
+                png_bytes = io.BytesIO()
+                cairosvg.svg2png(bytestring=svg_bytes, write_to=png_bytes)
+                base64_png = base64.b64encode(png_bytes.getvalue()).decode()
+                context["target_map_country"] = f"data:image/png;base64, {base64_png}"
+
+        # Render html with input variables
+        env = Environment(
+            loader=FileSystemLoader(self.current_dir), finalize=self._finalize
+        )
+        template = env.get_template("resources/threat-actor.html")
+        html_string = template.render(context)
+
+        # Generate pdf from html string
+        pdf_contents = HTML(
+            string=html_string, base_url=f"{self.current_dir}/resources"
+        ).write_pdf()
+
+        # Upload the output pdf
+        self.helper.log_info(f"Uploading: {file_name}")
+        self.helper.api.stix_domain_object.add_file(
+            id=entity_id,
+            file_name=file_name,
+            data=pdf_contents,
+            mime_type="application/pdf",
         )
 
     def _set_colors(self):
@@ -325,10 +427,13 @@ class ExportReportPdf:
                     with open(os.path.join(root, file_name), "w") as f:
                         f.write(new_css)
 
-    def _get_country_code(self, country_name):
-        for code, name in COUNTRIES.items():
-            if country_name.lower() in name.lower():
-                return code
+    def _validate_country_code(self, country_code):
+        """
+        Returns a boolean indicating whether or not the country code is valid.
+        """
+        if country_code in COUNTRIES:
+            return True
+        return False
 
     def _finalize(self, data):
         """

--- a/internal-export-file/export-report-pdf/src/export-report-pdf.py
+++ b/internal-export-file/export-report-pdf/src/export-report-pdf.py
@@ -274,7 +274,9 @@ class ExportReportPdf:
                 ):
                     country_code = relationship["to"]["name"].lower()
                     if not self._validate_country_code(country_code):
-                        self.helper.log_warning(f"{country_code} is not a supported country code, skipping...")
+                        self.helper.log_warning(
+                            f"{country_code} is not a supported country code, skipping..."
+                        )
                         continue
 
                     targeted_countries.append(country_code)
@@ -328,9 +330,7 @@ class ExportReportPdf:
         }
 
         # Get a bundle of all objects affiliated with the threat actor
-        bundle = self.helper.api.stix2.export_entity(
-            "Threat-Actor", entity_id, "full"
-        )
+        bundle = self.helper.api.stix2.export_entity("Threat-Actor", entity_id, "full")
 
         for bundle_obj in bundle["objects"]:
             obj_id = bundle_obj["id"]
@@ -368,7 +368,9 @@ class ExportReportPdf:
                 ):
                     country_code = relationship["to"]["name"].lower()
                     if not self._validate_country_code(country_code):
-                        self.helper.log_warning(f"{country_code} is not a supported country code, skipping...")
+                        self.helper.log_warning(
+                            f"{country_code} is not a supported country code, skipping..."
+                        )
                         continue
 
                     targeted_countries.append(country_code)

--- a/internal-export-file/export-report-pdf/src/export-report-pdf.py
+++ b/internal-export-file/export-report-pdf/src/export-report-pdf.py
@@ -209,11 +209,8 @@ class ExportReportPdf:
 
         # Upload the output pdf
         self.helper.log_info(f"Uploading: {file_name}")
-        self.helper.api.stix_domain_object.add_file(
-            id=report_id,
-            file_name=file_name,
-            data=pdf_contents,
-            mime_type="application/pdf",
+        self.helper.api.stix_domain_object.push_entity_export(
+            report_id, file_name, pdf_contents, "application/pdf"
         )
 
     def _process_intrusion_set(self, entity_id, file_name):
@@ -277,9 +274,7 @@ class ExportReportPdf:
                 ):
                     country_code = relationship["to"]["name"].lower()
                     if not self._validate_country_code(country_code):
-                        self.helper.log_warning(
-                            f"{country_code} is not a supported country code, skipping..."
-                        )
+                        self.helper.log_warning(f"{country_code} is not a supported country code, skipping...")
                         continue
 
                     targeted_countries.append(country_code)
@@ -308,11 +303,8 @@ class ExportReportPdf:
 
         # Upload the output pdf
         self.helper.log_info(f"Uploading: {file_name}")
-        self.helper.api.stix_domain_object.add_file(
-            id=entity_id,
-            file_name=file_name,
-            data=pdf_contents,
-            mime_type="application/pdf",
+        self.helper.api.stix_domain_object.push_entity_export(
+            entity_id, file_name, pdf_contents, "application/pdf"
         )
 
     def _process_threat_actor(self, entity_id, file_name):
@@ -336,7 +328,9 @@ class ExportReportPdf:
         }
 
         # Get a bundle of all objects affiliated with the threat actor
-        bundle = self.helper.api.stix2.export_entity("Threat-Actor", entity_id, "full")
+        bundle = self.helper.api.stix2.export_entity(
+            "Threat-Actor", entity_id, "full"
+        )
 
         for bundle_obj in bundle["objects"]:
             obj_id = bundle_obj["id"]
@@ -374,9 +368,7 @@ class ExportReportPdf:
                 ):
                     country_code = relationship["to"]["name"].lower()
                     if not self._validate_country_code(country_code):
-                        self.helper.log_warning(
-                            f"{country_code} is not a supported country code, skipping..."
-                        )
+                        self.helper.log_warning(f"{country_code} is not a supported country code, skipping...")
                         continue
 
                     targeted_countries.append(country_code)
@@ -405,11 +397,8 @@ class ExportReportPdf:
 
         # Upload the output pdf
         self.helper.log_info(f"Uploading: {file_name}")
-        self.helper.api.stix_domain_object.add_file(
-            id=entity_id,
-            file_name=file_name,
-            data=pdf_contents,
-            mime_type="application/pdf",
+        self.helper.api.stix_domain_object.push_entity_export(
+            entity_id, file_name, pdf_contents, "application/pdf"
         )
 
     def _set_colors(self):

--- a/internal-export-file/export-report-pdf/src/resources/threat-actor.css.template
+++ b/internal-export-file/export-report-pdf/src/resources/threat-actor.css.template
@@ -1,0 +1,297 @@
+@font-face {
+  font-family: Fira Sans;
+  font-weight: 400;
+  src: url(firasans-regular.otf);
+}
+@font-face {
+  font-family: Fira Sans;
+  font-style: italic;
+  font-weight: 400;
+  src: url(firasans-italic.otf);
+}
+@font-face {
+  font-family: Fira Sans;
+  font-weight: 300;
+  src: url(firasans-light.otf);
+}
+@font-face {
+  font-family: Fira Sans;
+  font-style: italic;
+  font-weight: 300;
+  src: url(firasans-lightitalic.otf);
+}
+@font-face {
+  font-family: Fira Sans;
+  font-weight: 700;
+  src: url(firasans-bold.otf);
+}
+
+@page {
+  @bottom-left {
+    background: <secondary_color>;
+    color: #fff;
+    content: counter(page);
+    height: 1cm;
+    text-align: center;
+    width: 1cm;
+  }
+  @bottom-center {
+    background: <secondary_color>;
+    content: '';
+    display: block;
+    height: .05cm;
+    width: 100%;
+  }
+  @bottom-right {
+    content: string(heading);
+    font-size: 12pt;
+    height: 1cm;
+    vertical-align: middle;
+    width: 100%;
+  }
+}
+
+@page :blank {
+  @bottom-left { background: none; content: '' }
+  @bottom-center { content: none }
+  @bottom-right { content: none }
+}
+@page no-chapter {
+  @bottom-left { background: none; content: none }
+  @bottom-center { content: none }
+  @bottom-right { content: none }
+}
+@page :first {
+  background: <secondary_color>;
+  margin: 0;
+}
+@page chapter {
+  background: <secondary_color>;
+  margin: 0;
+  @top-left { content: none }
+  @top-center { content: none }
+  @top-right { content: none }
+}
+
+html {
+  color: <secondary_color>;
+  font-family: Fira Sans;
+  font-size: 11pt;
+  font-weight: 300;
+  line-height: 1.5;
+}
+
+h1 {
+  color: <primary_color>;
+  font-size: 38pt;
+  margin: 4cm 0 0 2cm;
+  @page: no-chapter;
+  width: 100%;
+}
+h2, h3, h4 {
+  color: black;
+  font-weight: 400;
+}
+h2 {
+  break-before: always;
+  @page: no-chapter;
+  font-size: 28pt;
+  color: <primary_color>;
+  background: <secondary_color>;
+  margin: 0 -3cm 1cm;
+  padding: 1cm 1cm 1cm 3cm;
+  width: 21cm;
+  string-set: heading content();
+}
+
+h3 {
+  font-weight: 300;
+  font-size: 15pt;
+}
+h4 {
+  font-size: 13pt;
+}
+
+#cover {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 297mm;
+}
+
+#report-date {
+  color: #ffffff;
+  font-size: 12pt;
+  font-weight: 500;
+  margin-left: auto;
+  margin-right: 18px;
+  white-space: pre;
+}
+
+#report-heading {
+  color: <primary_color>;
+  font-size: 38pt;
+  font-weight: 700;
+  margin-left: 2cm;
+  overflow-wrap: break-word;
+  margin-top: 10cm;
+}
+
+#report-sub-heading {
+  color: #ffffff;
+  font-size: 38pt;
+  font-weight: 700;
+  margin-left: 2cm;
+  overflow-wrap: break-word;
+  margin-bottom: 10cm;
+}
+
+#cover #report-address {
+  background: <primary_color>;
+  padding: 2cm 0;
+  display: flex;
+  justify-content: center;
+  flex-direction: row;
+  margin-top: auto;
+}
+
+#cover address {
+  overflow-wrap: break-word;
+  white-space: pre;
+}
+
+
+#contents h2 {
+  font-size: 33pt;
+  font-weight: 400;
+  margin-bottom: 3cm;
+}
+#contents h3 {
+  font-weight: 500;
+  margin: 3em 0 1em;
+}
+
+#contents h3::before {
+  background: <primary_color>;
+  content: '';
+  display: block;
+  height: .08cm;
+  margin-bottom: .25cm;
+  width: 2cm;
+}
+
+#contents ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+#contents ul li {
+  border-top: .25pt solid #c1c1c1;
+  margin: .25cm 0;
+  padding-top: .25cm;
+}
+
+#contents ul li::before {
+  color: <primary_color>;
+  content: '• ';
+  font-size: 40pt;
+  line-height: 16pt;
+  vertical-align: bottom;
+}
+
+#contents ul li a {
+  color: inherit;
+  text-decoration-line: inherit;
+}
+
+#contents ul li a::before {
+  content: target-text(attr(href));
+}
+
+#contents ul li a::after {
+  color: <secondary_color>;
+  content: target-counter(attr(href), page);
+  float: right;
+}
+
+#columns section p {
+  text-align: left;
+}
+
+#columns h3 {
+  font-weight: 500;
+  margin: 3em 0 1em;
+}
+
+#columns h3::before {
+  background: <primary_color>;
+  content: '';
+  display: block;
+  height: .08cm;
+  margin-bottom: .25cm;
+  width: 2cm;
+}
+
+#columns ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+#columns ul li {
+  border-top: .25pt solid #c1c1c1;
+  margin: .25cm 0;
+  padding-top: .25cm;
+}
+
+#columns ul li::before {
+  color: <primary_color>;
+  content: '• ';
+  font-size: 40pt;
+  line-height: 16pt;
+  vertical-align: bottom;
+}
+
+#observables h3 {
+  background: <primary_color>;
+  margin: 0 -3cm 1cm;
+  padding: 1cm 1cm 1cm 3cm;
+  width: 21cm;
+}
+
+table {
+  margin: auto 0;
+  caption-side: top;
+  empty-cells: show;
+  table-layout: auto;
+  width: 100%;
+  margin-bottom: 1cm;
+}
+tr,
+td {
+  overflow-wrap: anywhere;
+}
+td {
+  padding: 15px;
+}
+th {
+  background-color: <secondary_color>;
+  color: <primary_color>;
+  text-align: left;
+  padding: 15px;
+}
+tr:nth-child(even) {
+  background-color: #f2f2f2;
+}
+
+pre {
+  font-family: Fira Sans;
+  white-space: pre-wrap;
+}
+
+#chapter {
+  align-items: center;
+  display: flex;
+  height: 297mm;
+  justify-content: center;
+  @page: chapter;
+}

--- a/internal-export-file/export-report-pdf/src/resources/threat-actor.html
+++ b/internal-export-file/export-report-pdf/src/resources/threat-actor.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8">
     <link href="intrusion-set.css" rel="stylesheet">
-    <title>{{ entities.intrusion_set.0.name }}_{{ report_date }}</title>
-    <meta name="description" content="{{ entities.intrusion_set.0.name }}_{{ report_date }}">
+    <title>{{ entities.threat_actor.0.name }}_{{ report_date }}</title>
+    <meta name="description" content="{{ entities.threat_actor.0.name }}_{{ report_date }}">
   </head>
 
   <body>
     <article id="cover">
       <div id="report-date">{{ report_date }}</div>
-      <div id="report-heading">Intrusion Set Report</div>
-      <div id="report-sub-heading">{{ entities.intrusion_set.0.name }}</div>
+      <div id="report-heading">Threat Actor Report</div>
+      <div id="report-sub-heading">{{ entities.threat_actor.0.name }}</div>
       <div id="report-address">
         <address style="margin-right: 1cm;">
           {{ company_address_line_1 }}
@@ -36,25 +36,25 @@
         <li><a href="#confidence-title"></a></li>
         <li><a href="#marking-definitions-title"></a></li>
         <li><a href="#labels-title"></a></li>
-        {% if entities.intrusion_set.0.aliases is not none %}
+        {% if entities.threat_actor.0.aliases is not none %}
         <li><a href="#aliases-title"></a></li>
         {% endif %}
         <li><a href="#first-seen-title"></a></li>
         <li><a href="#last-seen-title"></a></li>
         <li><a href="#originates-from-title"></a></li>
-        {% if entities.intrusion_set.0.resource_level is not none %}
+        {% if entities.threat_actor.0.resource_level is not none %}
         <li><a href="#resource-level-title"></a></li>
         {% endif %}
-        {% if entities.intrusion_set.0.goals is not none %}
+        {% if entities.threat_actor.0.goals is not none %}
         <li><a href="#goals-title"></a></li>
         {% endif %}
-        {% if entities.intrusion_set.0.primary_motivation is not none %}
+        {% if entities.threat_actor.0.primary_motivation is not none %}
         <li><a href="#primary-motivation-title"></a></li>
         {% endif %}
-        {% if entities.intrusion_set.0.secondary_motivations is not none %}
+        {% if entities.threat_actor.0.secondary_motivations is not none %}
         <li><a href="#secondary-motivations-title"></a></li>
         {% endif %}
-        {% if entities.intrusion_set.0.externalReferences %}
+        {% if entities.threat_actor.0.externalReferences %}
         <li><a href="#sources-title"></a></li>
         {% endif %}
       </ul>
@@ -98,7 +98,7 @@
           Author
         </h3>
         <p>
-          {{ entities.intrusion_set.0.createdBy.name }}
+          {{ entities.threat_actor.0.createdBy.name }}
         </p>
       </section>
       <section>
@@ -106,7 +106,7 @@
           Created At
         </h3>
         <p>
-          {{ entities.intrusion_set.0.created_at }}
+          {{ entities.threat_actor.0.created_at }}
         </p>
       </section>
       <section>
@@ -114,7 +114,7 @@
           Description
         </h3>
         <p>
-          {{ entities.intrusion_set.0.description }}
+          {{ entities.threat_actor.0.description }}
         </p>
       </section>
       <section>
@@ -122,7 +122,7 @@
           Confidence
         </h3>
         <p>
-          {{ entities.intrusion_set.0.confidence }} / 100
+          {{ entities.threat_actor.0.confidence }} / 100
           <br>
           <em>
             This value represents the confidence in the correctness of the data contained within this report.
@@ -134,7 +134,7 @@
           Marking Definitions
         </h3>
         <ul>
-        {% for marking_definiton in entities.intrusion_set.0.objectMarking %}
+        {% for marking_definiton in entities.threat_actor.0.objectMarking %}
         <li>{{ marking_definiton.definition }}</li>
         {% endfor %}
         </ul>
@@ -144,18 +144,18 @@
           Labels
         </h3>
         <ul>
-        {% for label in entities.intrusion_set.0.objectLabel %}
+        {% for label in entities.threat_actor.0.objectLabel %}
         <li>{{ label.value }}</li>
         {% endfor %}
         </ul>
       </section>
-      {% if entities.intrusion_set.0.aliases is not none %}
+      {% if entities.threat_actor.0.aliases is not none %}
       <section>
         <h3 id="aliases-title">
           Aliases
         </h3>
         <ul>
-        {% for alias in entities.intrusion_set.0.aliases %}
+        {% for alias in entities.threat_actor.0.aliases %}
           <li>{{ alias }}</li>
         {% endfor %}
         </ul>
@@ -166,7 +166,7 @@
           First Seen
         </h3>
         <p>
-          {{ entities.intrusion_set.0.first_seen }}
+          {{ entities.threat_actor.0.first_seen }}
         </p>
       </section>
       <section>
@@ -174,7 +174,7 @@
           Last Seen
         </h3>
         <p>
-          {{ entities.intrusion_set.0.last_seen }}
+          {{ entities.threat_actor.0.last_seen }}
         </p>
       </section>
       <section>
@@ -190,57 +190,57 @@
           {% endfor %}
         </ul>
       </section>
-      {% if entities.intrusion_set.0.resource_level is not none %}
+      {% if entities.threat_actor.0.resource_level is not none %}
       <section>
         <h3 id="resource-level-title">
           Resource Level
         </h3>
         <p>
-          {{ entities.intrusion_set.0.resource_level }}
+          {{ entities.threat_actor.0.resource_level }}
         </p>
       </section>
       {% endif %}
-      {% if entities.intrusion_set.0.goals is not none %}
+      {% if entities.threat_actor.0.goals is not none %}
       <section>
         <h3 id="goals-title">
           Goals
         </h3>
         <ul>
-          {% for goal in entities.intrusion_set.0.goals %}
+          {% for goal in entities.threat_actor.0.goals %}
           <li>{{ goal }}</li>
           {% endfor %}
         </ul>
       </section>
       {% endif %}
-      {% if entities.intrusion_set.0.primary_motivation is not none %}
+      {% if entities.threat_actor.0.primary_motivation is not none %}
       <section>
         <h3 id="primary-motivation-title">
           Primary Motivation
         </h3>
         <p>
-          {{ entities.intrusion_set.0.primary_motivation }}
+          {{ entities.threat_actor.0.primary_motivation }}
         </p>
       </section>
       {% endif %}
-      {% if entities.intrusion_set.0.secondary_motivations is not none %}
+      {% if entities.threat_actor.0.secondary_motivations is not none %}
       <section>
         <h3 id="secondary-motivations-title">
           Secondary Motivations
         </h3>
         <ul>
-          {% for secondary_motivation in entities.intrusion_set.0.secondary_motivations %}
+          {% for secondary_motivation in entities.threat_actor.0.secondary_motivations %}
             <li>{{ secondary_motivation }}</li>
           {% endfor %}
           </ul>
       </section>
       {% endif %}
-      {% if entities.intrusion_set.0.externalReferences %}
+      {% if entities.threat_actor.0.externalReferences %}
       <section>
         <h3 id="sources-title">
           Sources
         </h3>
         <ul>
-        {% for external_ref in entities.intrusion_set.0.externalReferences %}
+        {% for external_ref in entities.threat_actor.0.externalReferences %}
           <li><a href="{{ external_ref.url }}" target="_blank">{{ external_ref.url }}</a></li>
         {% endfor %}
         </ul>


### PR DESCRIPTION
### Proposed changes

* Handle the export of Threat Actor entities to PDF
* Fix issue where Intrusion Set entity reports missing Originates From, see changes to `internal-export-file/export-report-pdf/src/resources/intrusion-set.html`
* Fixed the intezer sandbox connector (minor change, can implement in another PR if needed)

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

These changes were made in order to allow exporting Threat Actors to PDF, as currently the connector only handles Intrusion Set and Report entities.
