### PR TITLE
Add a space separator between the extracted texts

### DIFF
--- a/internal-import-file/import-document/src/reportimporter/report_parser.py
+++ b/internal-import-file/import-document/src/reportimporter/report_parser.py
@@ -126,7 +126,7 @@ class ReportParser(object):
     def _parse_html(self, file_data: IO) -> Dict[str, Dict]:
         parse_info = {}
         soup = BeautifulSoup(file_data, "html.parser")
-        buf = io.StringIO(soup.get_text())
+        buf = io.StringIO(soup.get_text(separator=" "))
         for text in buf.readlines():
             parse_info.update(self._parse(text))
         return parse_info


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Add a separating space between the extracted texts.

### Related issues


- Importing the following report https://thedfirreport.com/2022/09/26/bumblebee-round-two/ 
- it detects non existent objects like `case.info` or `affiliates.in`
![image](https://user-images.githubusercontent.com/31675/198126295-05ab9594-28b2-4522-be6e-53d82f013665.png)

![image](https://user-images.githubusercontent.com/31675/198126507-bcd68181-032a-40e0-85e4-d3c407f19706.png)

![image](https://user-images.githubusercontent.com/31675/198126618-553dc31e-c82f-4240-bd2e-92ea5f6b3bed.png)


Adding a space separator should fix this issue:
```
>>> html = """<p>Reviewing the <a href="https://www.inversecos.com/2021/02/forensic-analysis-of-anydesk-logs.html" target="_blank" rel="noopener">ad_svc.trace logs</a> from Anydesk located in %programdata%\AnyDesk reveal the logins originating from 108.177.235.25. This was again the same IP observered in the prior <a href="https://thedfirreport.com/2022/08/08/bumblebee-roasts-its-way-to-domain-admin/" target="_blank" rel="noopener">Bumblebee case</a>.</p><pre>info REDACTED 19:07:21.173 gsvc 1160 408 24 anynet.any_socket - Logged in from 108.177.235.25:49672 on relay dafa4c5b.<br>info REDACTED 19:27:45.255 gsvc 1160 408 41 anynet.any_socket - Logged in from 108.177.235.25:49672 on relay dafa4c5b.</pre>"""
>>> from bs4 import BeautifulSoup
>>> bs = BeautifulSoup(html)
>>> print(bs.get_text())
Reviewing the ad_svc.trace logs from Anydesk located in %programdata%\AnyDesk reveal the logins originating from 108.177.235.25. This was again the same IP observered in the prior Bumblebee case.info REDACTED 19:07:21.173 gsvc 1160 408 24 anynet.any_socket - Logged in from 108.177.235.25:49672 on relay dafa4c5b.info REDACTED 19:27:45.255 gsvc 1160 408 41 anynet.any_socket - Logged in from 108.177.235.25:49672 on relay dafa4c5b.
>>> print(bs.get_text(separator=" "))
Reviewing the  ad_svc.trace logs  from Anydesk located in %programdata%\AnyDesk reveal the logins originating from 108.177.235.25. This was again the same IP observered in the prior  Bumblebee case . info REDACTED 19:07:21.173 gsvc 1160 408 24 anynet.any_socket - Logged in from 108.177.235.25:49672 on relay dafa4c5b. info REDACTED 19:27:45.255 gsvc 1160 408 41 anynet.any_socket - Logged in from 108.177.235.25:49672 on relay dafa4c5b.
````

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases  :sweat_smile:
- [ ] I added/update the relevant documentation (either on github or on notion) :
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
