### PR TITLE
Fix wrong return misp connector

### DIFF
--- a/external-import/misp/src/misp.py
+++ b/external-import/misp/src/misp.py
@@ -867,7 +867,7 @@ class Misp:
             self.helper.send_stix2_bundle(
                 bundle, work_id=work_id, update=self.update_existing_data
             )
-            return last_event_timestamp
+        return last_event_timestamp
 
     def _get_pdf_file(self, attribute):
         if not self.import_with_attachments:


### PR DESCRIPTION
Just a quick fix even though as a high impact.
Connectors code really need some love, functions with 400 lines of code... 