### PR TITLE
Fix X509 Subject and Issuer in Shodan enrichment

### DIFF
--- a/internal-enrichment/shodan/src/shodanImport.py
+++ b/internal-enrichment/shodan/src/shodanImport.py
@@ -91,15 +91,15 @@ class ShodanConnector:
                     observableData={
                         "type": "x509-certificate",
                         "issuer": ", ".join(
-                            (
-                                f"{k}={v}"
-                                for k, v in sslObject["cert"]["issuer"].items()
-                            )
+                            (f"{k}={v}" for k, v in sslObject["cert"]["issuer"].items())
                         ),
                         "validity_not_before": issued.isoformat().split(".")[0] + "Z",
                         "validity_not_after": expires.isoformat().split(".")[0] + "Z",
                         "subject": ", ".join(
-                            (f"{k}={v}" for k, v in sslObject["cert"]["subject"].items())
+                            (
+                                f"{k}={v}"
+                                for k, v in sslObject["cert"]["subject"].items()
+                            )
                         ),
                         "serial_number": ":".join(
                             [

--- a/internal-enrichment/shodan/src/shodanImport.py
+++ b/internal-enrichment/shodan/src/shodanImport.py
@@ -93,13 +93,13 @@ class ShodanConnector:
                         "issuer": ", ".join(
                             (
                                 f"{k}={v}"
-                                for k, v in sslObject["cert"]["subject"].items()
+                                for k, v in sslObject["cert"]["issuer"].items()
                             )
                         ),
                         "validity_not_before": issued.isoformat().split(".")[0] + "Z",
                         "validity_not_after": expires.isoformat().split(".")[0] + "Z",
                         "subject": ", ".join(
-                            (f"{k}={v}" for k, v in sslObject["cert"]["issuer"].items())
+                            (f"{k}={v}" for k, v in sslObject["cert"]["subject"].items())
                         ),
                         "serial_number": ":".join(
                             [


### PR DESCRIPTION
### Proposed changes

* Switch Subject and Issuer when creating new X.509 certificate Observables, which were accidentally backwards

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

N/A
