### PR TITLE
Added report description attribute finder in MISP connector

### DIFF
--- a/external-import/misp/README.md
+++ b/external-import/misp/README.md
@@ -28,6 +28,7 @@ If you are using it independently, remember that the connector will try to conne
 | `misp_key`                               | `MISP_KEY`                        | Yes          | The MISP instance key.                                                                               |
 | `misp_ssl_verify`                        | `MISP_SSL_VERIFY`                 | Yes          | A boolean (`True` or `False`), check if the SSL certificate is valid when using `https`.             |
 | `misp_datetime_attribute`                | `MISP_DATETIME_ATTRIBUTE`         | Yes          | The attribute to be used in filter to query new MISP events.                                         |
+| `misp_report_description_attribute_filter`                | `MISP_REPORT_DESCRIPTION_ATTRIBUTE_FILTER`         | No          |  Filter to be used to find the attribute with report description (example: "type=comment,category=Internal reference").                                         |
 | `misp_create_reports`                    | `MISP_CREATE_REPORTS`             | Yes          | A boolean (`True` or `False`), create reports for each imported MISP event.                          |
 | `misp_create_object_observables`         | `MISP_CREATE_OBJECT_OBSERVABLES`         | Yes          | A boolean (`True` or `False`), create a text observable for each imported MISP object.               |
 | `misp_create_observables`                | `MISP_CREATE_OBSERVABLES`         | Yes          | A boolean (`True` or `False`), create an observable for each imported MISP attribute.                |

--- a/external-import/misp/docker-compose.yml
+++ b/external-import/misp/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - MISP_KEY=ChangeMe # Required
       - MISP_SSL_VERIFY=false # Required
       - MISP_DATETIME_ATTRIBUTE=timestamp # Required, filter to be used in query for new MISP events
+      - MISP_REPORT_DESCRIPTION_ATTRIBUTE_FILTER= # Optional, filter to be used to find the attribute with report description (example: "type=comment,category=Internal reference")
       - MISP_CREATE_REPORTS=true # Required, create report for MISP event
       - MISP_CREATE_INDICATORS=true # Required, create indicators from attributes
       - MISP_CREATE_OBSERVABLES=true # Required, create observables from attributes

--- a/external-import/misp/src/config.yml.sample
+++ b/external-import/misp/src/config.yml.sample
@@ -21,6 +21,7 @@ misp:
   create_indicators: true # Required, create indicators for attributes
   create_observables: true # Required, create observables for attributes
   create_object_observables: true # Required, create text observables for MISP objects
+  report_description_attribute_filter: '' # Optional, example: "type=comment,category=Internal reference"
   report_type: 'misp-event' # Optional, report_class if creating report for event
   report_status: 'New' # New, In progress, Analyzed and Closed
   import_from_date: '2010-01-01' # Optional, import all event from this date


### PR DESCRIPTION
This new config option will allow a user to set a attribute filter in order for the MISP connector find the right value to use as Report description.