### PR TITLE
Add capability to choose to add MISP tags as labels

### DIFF
--- a/external-import/misp/README.md
+++ b/external-import/misp/README.md
@@ -33,6 +33,7 @@ If you are using it independently, remember that the connector will try to conne
 | `misp_create_object_observables`         | `MISP_CREATE_OBJECT_OBSERVABLES`         | Yes          | A boolean (`True` or `False`), create a text observable for each imported MISP object.               |
 | `misp_create_observables`                | `MISP_CREATE_OBSERVABLES`         | Yes          | A boolean (`True` or `False`), create an observable for each imported MISP attribute.                |
 | `misp_create_indicators`                 | `MISP_CREATE_INDICATORS`          | Yes          | A boolean (`True` or `False`), create an indicator for each imported MISP attribute.                 |
+| `misp_create_tags_as_labels`             | `MISP_CREATE_TAGS_AS_LABELS`          | No          | A boolean (`True` or `False`), create tags as labels.                 |
 | `misp_report_class`                      | `MISP_REPORT_CLASS`               | No           | If `create_reports` is `True`, specify the `report_class` (category), default is `MISP Event`        |
 | `misp_import_from_date`                  | `MISP_IMPORT_FROM_DATE`           | No           | A date formatted `YYYY-MM-DD`, only import events created after this date.                           |
 | `misp_import_tags`                       | `MISP_IMPORT_TAGS`                | No           | A list of tags separated with `,`, only import events with these tags.                               |

--- a/external-import/misp/docker-compose.yml
+++ b/external-import/misp/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - MISP_CREATE_INDICATORS=true # Required, create indicators from attributes
       - MISP_CREATE_OBSERVABLES=true # Required, create observables from attributes
       - MISP_CREATE_OBJECT_OBSERVABLES=true # Required, create text observables for MISP objects
+      - MISP_CREATE_TAGS_AS_LABELS=true # Optional, create tags as labels
       - MISP_REPORT_TYPE=misp-event # Optional, report_class if creating report for event
       - MISP_IMPORT_FROM_DATE=2000-01-01 # Required, import all event from this date
       - MISP_IMPORT_TAGS=opencti:import,type:osint # Optional, list of tags used for import events

--- a/external-import/misp/src/config.yml.sample
+++ b/external-import/misp/src/config.yml.sample
@@ -22,6 +22,7 @@ misp:
   create_observables: true # Required, create observables for attributes
   create_object_observables: true # Required, create text observables for MISP objects
   report_description_attribute_filter: '' # Optional, example: "type=comment,category=Internal reference"
+  create_tags_as_labels: true # Optional, create tags as labels
   report_type: 'misp-event' # Optional, report_class if creating report for event
   report_status: 'New' # New, In progress, Analyzed and Closed
   import_from_date: '2010-01-01' # Optional, import all event from this date

--- a/external-import/misp/src/misp.py
+++ b/external-import/misp/src/misp.py
@@ -205,6 +205,9 @@ class Misp:
             False,
             False,
         )
+        self.misp_create_tags_as_labels = get_config_variable(
+            "MISP_CREATE_TAGS_AS_LABELS", ["misp", "create_tags_as_labels"], config, default=True
+        )
         self.misp_report_type = get_config_variable(
             "MISP_REPORT_TYPE", ["misp", "report_type"], config, False, "misp-event"
         )
@@ -1995,6 +1998,10 @@ class Misp:
 
     def resolve_tags(self, tags):
         opencti_tags = []
+
+        if not self.misp_create_tags_as_labels:
+            return opencti_tags
+
         for tag in tags:
             if (
                 tag["name"] != "tlp:white"


### PR DESCRIPTION
Added capability to choose to add MISP tags as labels. Some MISP events from certain sources provide tags that are not relevant, therefore, with this option, a user can choose if want those tags to be added as labels (like is already doing by default) or not.