### PR TITLE
[Splunk Streamer] fixing error message to display object of the messa…

### DIFF
--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -213,7 +213,7 @@ class SplunkConnector:
         try:
             data = json.loads(msg.data)["data"]
         except:
-            raise ValueError("Cannot process the message: " + msg)
+            raise ValueError("Cannot process the message: " + str(msg))
         # Handle creation
         if data["type"] in self.splunk_ignore_types:
             self.helper.log_info(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Fixing simple error message on the Splunk Streamer to display the msg object.

### Related issues


* #947 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
