### PR TITLE
[domaintools] add enrichment connector

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -845,6 +845,10 @@ jobs:
           name: Build Docker image opencti/connector-cape-sandbox
           command: docker build -t opencti/connector-cape-sandbox:rolling .
       - run:
+          working_directory: ~/opencti/internal-enrichment/domaintools
+          name: Build Docker image opencti/connector-domaintools
+          command: docker build -t opencti/connector-domaintools:rolling .
+      - run:
           working_directory: ~/opencti/internal-enrichment/intezer-sandbox
           name: Build Docker image opencti/connector-intezer-sandbox
           command: docker build -t opencti/connector-intezer-sandbox:rolling .
@@ -978,6 +982,7 @@ jobs:
             docker push opencti/connector-restore-files:rolling
             docker push opencti/connector-virustotal-livehunt-notifications:rolling
             docker push opencti/connector-cape-sandbox:rolling
+            docker push opencti/connector-domaintools:rolling
             docker push opencti/connector-intezer-sandbox:rolling
             docker push opencti/connector-hatching-triage-sandbox:rolling
             docker push opencti/connector-unpac-me:rolling

--- a/internal-enrichment/domaintools/.dockerignore
+++ b/internal-enrichment/domaintools/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/internal-enrichment/domaintools/.gitignore
+++ b/internal-enrichment/domaintools/.gitignore
@@ -1,0 +1,4 @@
+config.yml
+__pycache__
+logs
+*.gql

--- a/internal-enrichment/domaintools/Dockerfile
+++ b/internal-enrichment/domaintools/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-alpine
+
+# Copy the worker
+COPY src /opt/opencti-connector-domaintools
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk --no-cache add git build-base libmagic libffi-dev && \
+    cd /opt/opencti-connector-domaintools && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/internal-enrichment/domaintools/README.md
+++ b/internal-enrichment/domaintools/README.md
@@ -1,0 +1,14 @@
+# OpenCTI DomainTools Connector
+
+The OpenCTI DomainTools connector can be used to import knowledge from the [DomainTools API](https://www.domaintools.com/). This connector uses the [Domain Tools Official Python API](https://github.com/DomainTools/python_api).
+
+The connector enrich the domain and ip with other domains, ips, email addresses and autonomous systems. 
+
+## Configuration
+
+The connector can be configured with the following variables: 
+
+| Config Parameter          | Docker env var                        | Default    | Description                                                      |
+|---------------------------|---------------------------------------|------------|------------------------------------------------------------------|
+| `api_username`            | `DOMAINTOOLS_API_USERNAME`            | `ChangeMe` | The username required for the authentication on DomainTools API. |
+| `api_key`                 | `DOMAINTOOLS_API_KEY`                 | `ChangeMe` | The password required for the authentication on DomainTools API. |

--- a/internal-enrichment/domaintools/docker-compose.yml
+++ b/internal-enrichment/domaintools/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  connector-domaintools:
+    image: opencti/connector-domaintools:5.4.1
+    environment:
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=ChangeMe
+      - CONNECTOR_ID=ChangeMe
+      - CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+      - CONNECTOR_NAME=DomainTools
+      - CONNECTOR_SCOPE=Domain-Name,Ipv4-Addr
+      - CONNECTOR_AUTO=false # Enable/disable auto-enrichment of observables
+      - CONNECTOR_CONFIDENCE_LEVEL=80 # From 0 (Unknown) to 100 (Fully trusted)
+      - CONNECTOR_LOG_LEVEL=info
+      - DOMAINTOOLS_API_USERNAME=ChangeMe
+      - DOMAINTOOLS_API_KEY=ChangeMe
+    restart: always

--- a/internal-enrichment/domaintools/entrypoint.sh
+++ b/internal-enrichment/domaintools/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Go to the right directory
+cd /opt/opencti-connector-domaintools
+
+# Launch the worker
+python3 main.py

--- a/internal-enrichment/domaintools/src/config.yml.sample
+++ b/internal-enrichment/domaintools/src/config.yml.sample
@@ -1,0 +1,16 @@
+opencti:
+  url: 'http://localhost:8080'
+  token: 'ChangeMe'
+
+connector:
+  id: 'ChangeMe'
+  type: 'INTERNAL_ENRICHMENT'
+  name: 'DomainTools'
+  scope: 'Domain-Name,Ipv4-Addr'
+  auto: false # Enable/disable auto-enrichment of observables
+  confidence_level: 80 # From 0 (Unknown) to 100 (Fully trusted)
+  log_level: 'info'
+
+domaintools:
+  api_username: 'ChangeMe'
+  api_key: 'ChangeMe'

--- a/internal-enrichment/domaintools/src/connector/__init__.py
+++ b/internal-enrichment/domaintools/src/connector/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""DomainTools connector module."""
+
+from .core import DomainToolsConnector
+
+__all__ = ["DomainToolsConnector"]

--- a/internal-enrichment/domaintools/src/connector/builder.py
+++ b/internal-enrichment/domaintools/src/connector/builder.py
@@ -1,0 +1,446 @@
+# -*- coding: utf-8 -*-
+"""Builder for DomainTools."""
+
+from datetime import datetime
+from typing import Optional, Union
+
+import validators
+from pycti import OpenCTIConnectorHelper, StixCoreRelationship
+from stix2 import (
+    TLP_AMBER,
+    AutonomousSystem,
+    Bundle,
+    DomainName,
+    EmailAddress,
+    Identity,
+    IPv4Address,
+    Relationship,
+)
+
+from .constants import EntityType
+
+
+class DtBuilder:
+    """
+    DomainTools builder.
+    Create the STIX objects and relationships.
+    """
+
+    def __init__(
+        self,
+        helper: OpenCTIConnectorHelper,
+        author: Identity,
+    ):
+        """Initialize DtBuilder."""
+        self.helper = helper
+        self.author = author
+
+        # Use custom properties to set the author and the confidence level of the object.
+        self.custom_props = {
+            "x_opencti_created_by_ref": author["id"],
+        }
+
+        self.bundle: list[
+            Union[AutonomousSystem, DomainName, EmailAddress, IPv4Address, Relationship]
+        ] = []
+
+    def reset_score(self):
+        """Reset the score used."""
+        if "x_opencti_score" in self.custom_props:
+            self.custom_props.pop("x_opencti_score")
+
+    def set_score(self, score: int):
+        """
+        Set the score for the observable.
+
+        Parameters
+        ----------
+        score : int
+            Score to use as `x_opencti_score`
+        """
+        self.custom_props["x_opencti_score"] = score
+
+    def create_autonomous_system(self, number: int) -> Optional[str]:
+        """
+        Create an autonomous_system object with the author and custom properties.
+
+        Parameters
+        ----------
+        number : int
+            Number of the autonomous system to create.
+
+        Returns
+        -------
+        str
+            Id of the inserted autonomous system or None.
+        """
+        auto_system = AutonomousSystem(
+            type="autonomous-system",
+            number=number,
+            object_marking_refs=TLP_AMBER,
+            custom_properties=self.custom_props,
+        )
+
+        self.bundle.append(auto_system)
+        return auto_system.id
+
+    def create_belongs_to(
+        self,
+        source_id: str,
+        target_id: str,
+        start_date: datetime,
+        end_date: datetime,
+        description: Optional[str] = None,
+    ) -> Relationship:
+        """
+        Create the `belongs-to` relationship between the source and the target.
+        The relation is added to the bundle.
+
+        Parameters
+        ----------
+        source_id : str
+            Id of the source, must be the id of a `domain-name`.
+        target_id : str
+            Id of the target, must be the id of a `domain-name` or an `ipv4-addr`.
+        start_date : datetime
+            Starting date for the relationship.
+        end_date : datetime
+            Ending date for the relationship.
+        description : str, optional
+            Description of the relationship (e.g. the type (name-server, redirect, etc.).
+
+        Returns
+        -------
+        Relationship
+            Created relationship.
+        """
+        rel = self.create_relationship(
+            "belongs-to", source_id, target_id, start_date, end_date, description
+        )
+
+        self.bundle.append(rel)
+        return rel
+
+    def create_domain(self, domain: str) -> Optional[str]:
+        """
+        Create a domain object with the author and custom properties.
+
+        Parameters
+        ----------
+        domain : str
+            Domain to create.
+
+        Returns
+        -------
+        str
+            Id of the inserted domain or None if the domain is invalid.
+        """
+        if not validators.domain(domain):
+            self.helper.log_warning(
+                f"[DomainTools] domain {domain} is not correctly "
+                "formatted. Skipping."
+            )
+            return None
+        domain_obj = DomainName(
+            type="domain-name",
+            value=domain,
+            object_marking_refs=TLP_AMBER,
+            custom_properties=self.custom_props,
+        )
+
+        self.bundle.append(domain_obj)
+        return domain_obj.id
+
+    def create_email(self, email: str) -> Optional[str]:
+        """
+        Create an email object with the author and custom properties.
+
+        Parameters
+        ----------
+        email : str
+            Email to create.
+
+        Returns
+        -------
+        str
+            Id of the inserted email or None if the domain is invalid.
+        """
+        if not validators.email(email):
+            self.helper.log_warning(
+                f"[DomainTools] email {email} is " "not correctly formatted. Skipping."
+            )
+            return None
+        email_obj = EmailAddress(
+            type="email-addr",
+            value=email,
+            object_marking_refs=TLP_AMBER,
+            custom_properties=self.custom_props,
+        )
+
+        self.bundle.append(email_obj)
+        return email_obj.id
+
+    def create_ipv4(self, ip: str) -> Optional[str]:
+        """
+        Create an ip object with the author and custom properties.
+
+        Parameters
+        ----------
+        ip : str
+            Ip to create.
+
+        Returns
+        -------
+        str
+            Id of the inserted ip or None if the ip is invalid.
+        """
+        if not validators.ipv4(ip):
+            self.helper.log_warning(
+                f"[DomainTools] ip {ip} is not correctly " "formatted. Skipping."
+            )
+            return None
+        ip_obj = IPv4Address(
+            type="ipv4-addr",
+            value=ip,
+            object_marking_refs=TLP_AMBER,
+            custom_properties=self.custom_props,
+        )
+
+        self.bundle.append(ip_obj)
+        return ip_obj.id
+
+    def create_related_to(
+        self,
+        source_id: str,
+        target_id: str,
+        start_date: datetime,
+        end_date: datetime,
+        description: Optional[str] = None,
+    ) -> Relationship:
+        """
+        Create the `related-to` relationship between the source and the target.
+        The relation is added to the bundle.
+
+        Parameters
+        ----------
+        source_id : str
+            Id of the source.
+        target_id : str
+            Id of the target.
+        start_date : datetime
+            Starting date for the relationship.
+        end_date : datetime
+            Ending date for the relationship.
+        description : str
+            Description of the relationship.
+
+        Returns
+        -------
+        Relationship
+            Created relationship.
+        """
+        rel = self.create_relationship(
+            "related-to", source_id, target_id, start_date, end_date, description
+        )
+
+        self.bundle.append(rel)
+        return rel
+
+    def create_relationship(
+        self,
+        relationship_type: str,
+        source_id: str,
+        target_id: str,
+        start_date: datetime,
+        end_date: datetime,
+        description: Optional[str] = None,
+    ) -> Relationship:
+        """
+        Create a relationship between the source and the target.
+
+        Author and confidence level is added from class value.
+
+        Parameters
+        ----------
+        relationship_type : str
+            Type of the relationship (e.g. `related-to`, `belongs-to`, `resolves-to`).
+        source_id : str
+            Id of the source.
+        target_id : str
+            Id of the target.
+        start_date : datetime
+            Starting date for the relationship.
+        end_date : datetime
+            Ending date for the relationship.
+        description : str, optional
+            Description of the relationship (e.g. the type (name-server, redirect, etc.).
+
+        Returns
+        -------
+        Relationship
+            Created relationship.
+        """
+        kwargs = {
+            "created_by_ref": self.author,
+            "confidence": self.helper.connect_confidence_level,
+        }
+        if description is not None:
+            kwargs["description"] = description
+        if start_date != "" and end_date != "":
+            kwargs |= {"start_time": start_date, "stop_time": end_date}
+        return Relationship(
+            id=StixCoreRelationship.generate_id(
+                relationship_type, source_id, target_id, start_date, end_date
+            ),
+            relationship_type=relationship_type,
+            source_ref=source_id,
+            target_ref=target_id,
+            **kwargs,
+        )
+
+    def create_resolves_to(
+        self,
+        source_id: str,
+        target_id: str,
+        start_date: datetime,
+        end_date: datetime,
+        description: Optional[str] = None,
+    ) -> Relationship:
+        """
+        Create the `resolves-to` relationship between the source and the target.
+        The relation is added to the bundle.
+
+        Parameters
+        ----------
+        source_id : str
+            Id of the source, must be the id of a `domain-name`.
+        target_id : str
+            Id of the target, must be the id of a `domain-name` or an `ipv4-addr`.
+        start_date : datetime
+            Starting date for the relationship.
+        end_date : datetime
+            Ending date for the relationship.
+        description : str, optional
+            Description of the relationship (e.g. the type (name-server, redirect, etc.).
+
+        Returns
+        -------
+        Relationship
+            Created relationship.
+        """
+        rel = self.create_relationship(
+            "resolves-to", source_id, target_id, start_date, end_date, description
+        )
+
+        self.bundle.append(rel)
+        return rel
+
+    def link_domain_related_to_email(
+        self,
+        source: str,
+        target: str,
+        start_date: datetime,
+        end_date: datetime,
+        description: str,
+    ):
+        """
+        Create the `related-to` relationship between the `domain-name` and the `email-addr`.
+        The created objects are saved into the `bundle` object of the class.
+
+        Parameters
+        ----------
+        source : str
+            Value of the source (domain-name) of the relationship.
+        target : str
+            Value of the target (email-addr) of the relationship.
+        start_date : datetime
+            Starting date for the relationship.
+        end_date : datetime
+            Ending date for the relationship.
+        description : str
+            Description of the relationship.
+        """
+        email_id = self.create_email(target)
+        if email_id is not None:
+            self.create_related_to(source, email_id, start_date, end_date, description)
+
+    def link_domain_resolves_to(
+        self,
+        source_id: str,
+        target: str,
+        target_type: EntityType,
+        start_date: datetime,
+        end_date: datetime,
+        description: Optional[str] = None,
+    ) -> Optional[str]:
+        """
+        Create the `resolves-to` relationship between the `domain-name` and the target.
+        The target can either be a `domain-name` or an `ipv4-addr`
+        The created objects are saved into the `bundle` object of the class.
+
+        Parameters
+        ----------
+        source_id : str
+            Id of the source (`domain-name` object)
+        target : str
+            Value of the target of the relationship.
+        target_type : str
+            Type of the target. The type of the target is created based on this field.
+        start_date : datetime
+            Starting date for the relationship.
+        end_date : datetime
+            Ending date for the relationship.
+        description : str, optional
+            Description of the relationship (e.g. the type (name-server, redirect, etc).
+
+        Returns
+        -------
+        str, optional
+            Target id inserted. This will allow re-using it for other insertions.
+        """
+        target_obj = (
+            self.create_domain(target)
+            if target_type == EntityType.DOMAIN_NAME
+            else self.create_ipv4(target)
+        )
+        if target_obj is not None:
+            self.create_resolves_to(
+                source_id, target_obj, start_date, end_date, description
+            )
+            return target_obj
+        return None
+
+    def link_ip_belongs_to_asn(
+        self, source: str, target: int, start_date: datetime, end_date: datetime
+    ):
+        """
+        Create the `belongs-to` relationship between the `ipv4-addr` and the `autonomous-system`.
+        The created objects are saved into the `bundle` object of the class.
+
+        Parameters
+        ----------
+        source : str
+            Value of the source (ip) of the relationship.
+        target : int
+            Value of the target (autonomous-system) of the relationship.
+        start_date : datetime
+            Starting date for the relationship.
+        end_date : datetime
+            Ending date for the relationship.
+        """
+        auto_system = self.create_autonomous_system(target)
+
+        if auto_system is not None:
+            self.create_belongs_to(source, auto_system, start_date, end_date)
+
+    def send_bundle(self) -> None:
+        """
+        Create and send the bundle containing the author and the enrichment entities.
+
+        Note: `allow_custom` must be set to True in order to specify the author of an object.
+        """
+        self.helper.send_stix2_bundle(
+            Bundle(objects=[self.author] + self.bundle, allow_custom=True).serialize(),
+            allow_custom=True,
+            update=True,
+        )

--- a/internal-enrichment/domaintools/src/connector/constants.py
+++ b/internal-enrichment/domaintools/src/connector/constants.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Constants for DomainTools."""
+
+from enum import Enum
+
+
+class EntityType(Enum):
+    """Enumeration of possible entities."""
+
+    AUTONOMOUS_SYSTEM = "Autonomous-System"
+    DOMAIN_NAME = "Domain-Name"
+    EMAIL_ADDRESS = "Email-Addr"
+    IPV4 = "IPv4-Addr"
+
+
+DOMAIN_FIELDS = {
+    "mx": "mx-server",
+    "name_server": "name-server",
+}
+
+IP_FIELDS = {"A": "domain-ip"}
+
+EMAIL_FIELDS = {
+    "email": "email",
+    "soa_email": "DNS/SOA",
+    "ssl_email": "SSL",
+    "additional_whois_email": "whois",
+    "admin_contact": "email-admin",
+    "billing_contact": "email-billing",
+    "registrant_contact": "email-registrant",
+    "technical_contact": "email-technical",
+}
+
+DEFAULT_RISK_SCORE = 100

--- a/internal-enrichment/domaintools/src/connector/core.py
+++ b/internal-enrichment/domaintools/src/connector/core.py
@@ -1,0 +1,241 @@
+# -*- coding: utf-8 -*-
+"""DomainTools enrichment module."""
+
+from datetime import datetime
+from pathlib import Path
+
+import domaintools
+import validators
+import yaml
+from pycti import OpenCTIConnectorHelper, get_config_variable
+from stix2 import Identity
+
+from .builder import DtBuilder
+from .constants import DEFAULT_RISK_SCORE, DOMAIN_FIELDS, EMAIL_FIELDS, EntityType
+
+
+class DomainToolsConnector:
+    """DomainTools connector."""
+
+    _DEFAULT_AUTHOR = "DomainTools"
+    _CONNECTOR_RUN_INTERVAL_SEC = 60 * 60
+
+    def __init__(self):
+        # Instantiate the connector helper from config
+        config_file_path = Path(__file__).parent.parent.resolve() / "config.yml"
+
+        config = (
+            yaml.load(open(config_file_path, encoding="utf-8"), Loader=yaml.FullLoader)
+            if config_file_path.is_file()
+            else {}
+        )
+        self.helper = OpenCTIConnectorHelper(config)
+
+        # DomainTools
+        api_username = get_config_variable(
+            "DOMAINTOOLS_API_USERNAME",
+            ["domaintools", "api_username"],
+            config,
+        )
+        api_key = get_config_variable(
+            "DOMAINTOOLS_API_KEY",
+            ["domaintools", "api_key"],
+            config,
+        )
+        self.api = domaintools.API(api_username, api_key)
+
+        self.author = Identity(
+            name=self._DEFAULT_AUTHOR,
+            identity_class="organization",
+            description=" DomainTools is a leading provider of Whois and other DNS"
+            " profile data for threat intelligence enrichment."
+            " It is a part of the Datacenter Group (DCL Group SA)."
+            " DomainTools data helps security analysts investigate malicious"
+            " activity on their networks.",
+            confidence=self.helper.connect_confidence_level,
+        )
+
+    def _enrich_domaintools(self, builder: DtBuilder, observable: dict) -> str:
+        """
+        Enrich observable using DomainTools API.
+
+        The source of the relationship is always the domain-name.
+        When enriching an ipv4-addr, multiple entries will be returned.
+        Each entry is added as an enrichment with the domain-name as source.
+
+        Parameters
+        ----------
+        builder : DtBuilder
+            Builder to enrich the observable and create the bundle.
+        observable : dict
+            Observable received from OpenCTI.
+
+        Returns
+        -------
+        str
+            String informing the state of the enrichment.
+        """
+        self.helper.log_info("Starting enrichment using DomainTools API.")
+        self.helper.log_info(f"Type of the observable: {observable['entity_type']}")
+        if observable["entity_type"] == "Domain-Name":
+            results = (
+                self.api.iris_investigate(observable["observable_value"])
+                .response()
+                .get("results", ())
+            )
+        elif observable["entity_type"] == "IPv4-Addr":
+            results = (
+                self.api.iris_investigate(ip=observable["observable_value"])
+                .response()
+                .get("results", ())
+            )
+        else:
+            self.helper.log_error(
+                f"Entity type of the observable: {observable['entity_type']} not supported."
+            )
+            raise ValueError(
+                f"Entity type of the observable: {observable['entity_type']} not supported."
+            )
+
+        for entry in results:
+            self.helper.log_info(f"Starting enrichment of domain {entry['domain']}")
+            # Retrieve common properties for all relationships.
+            builder.reset_score()
+            score = entry.get("domain_risk", {}).get("risk_score", DEFAULT_RISK_SCORE)
+            builder.set_score(score)
+            # Get the creation date / expiration date for the validity.
+            creation_date = entry.get("create_date", {}).get("value", "")
+            expiration_date = entry.get("expiration_date", {}).get("value", "")
+            if creation_date != "" and expiration_date != "":
+                creation_date = datetime.strptime(creation_date, "%Y-%m-%d")
+            if expiration_date != "":
+                expiration_date = datetime.strptime(expiration_date, "%Y-%m-%d")
+
+            if creation_date >= expiration_date:
+                self.helper.log_warning(
+                    f"Expiration date {expiration_date} not after creation date {creation_date}, not using dates."
+                )
+                creation_date = ""
+                expiration_date = ""
+
+            # In case of IP enrichment, create the domain as it might not exist.
+            domain_source_id = (
+                builder.create_domain(entry["domain"])
+                if observable["entity_type"] == "IPv4-Addr"
+                else observable["standard_id"]
+            )
+
+            # Get ip
+            for ip in entry.get("ip", ()):
+                if "address" in ip:
+                    ip_id = builder.link_domain_resolves_to(
+                        domain_source_id,
+                        ip["address"]["value"],
+                        EntityType.IPV4,
+                        creation_date,
+                        expiration_date,
+                        "domain-ip",
+                    )
+                    if ip_id is not None:
+                        for asn in ip.get("asn", ()):
+                            builder.link_ip_belongs_to_asn(
+                                ip_id,
+                                asn["value"],
+                                creation_date,
+                                expiration_date,
+                            )
+
+            # Get domains (name-server / mx)
+            for category, description in DOMAIN_FIELDS.items():
+                for values in entry.get(category, ()):
+                    if (domain := values["domain"]["value"]) != entry["domain"]:
+                        if not validators.domain(domain):
+                            self.helper.log_warning(
+                                f"[DomainTools] domain {domain} is not correctly "
+                                "formatted. Skipping."
+                            )
+                            continue
+                        new_domain_id = builder.link_domain_resolves_to(
+                            domain_source_id,
+                            domain,
+                            EntityType.DOMAIN_NAME,
+                            creation_date,
+                            expiration_date,
+                            description,
+                        )
+                        # Add the related ips of the name server to the newly created domain.
+                        if new_domain_id is not None:
+                            for ip in values.get("ip", ()):
+                                builder.link_domain_resolves_to(
+                                    new_domain_id,
+                                    ip["value"],
+                                    EntityType.IPV4,
+                                    creation_date,
+                                    expiration_date,
+                                    f"{description}-ip",
+                                )
+
+            # Emails
+            for category, description in EMAIL_FIELDS.items():
+                emails = (
+                    entry.get(category, ())
+                    if "contact" not in category
+                    else entry.get(category, {}).get("email", ())
+                )
+                for email in emails:
+                    builder.link_domain_related_to_email(
+                        domain_source_id,
+                        email["value"],
+                        creation_date,
+                        expiration_date,
+                        description,
+                    )
+
+            # Domains of emails
+            for domain in entry.get("email_domain", ()):
+                if domain["value"] != entry["domain"]:
+                    builder.link_domain_resolves_to(
+                        domain_source_id,
+                        domain["value"],
+                        EntityType.DOMAIN_NAME,
+                        creation_date,
+                        expiration_date,
+                        "email_domain",
+                    )
+
+            # Redirects (red)
+            if (red := entry.get("redirect_domain", {}).get("value", "")) not in (
+                domain_source_id,
+                "",
+            ):
+                builder.link_domain_resolves_to(
+                    domain_source_id,
+                    red,
+                    EntityType.DOMAIN_NAME,
+                    creation_date,
+                    expiration_date,
+                    "redirect",
+                )
+
+        if len(builder.bundle) > 1:
+            builder.send_bundle()
+            self.helper.log_info(
+                f"[DomainTools] inserted {len(builder.bundle)} entries."
+            )
+            return f"Observable found on DomainTools, {len(builder.bundle)} knowledge attached."
+        return "Observable not found on DomainTools."
+
+    def _process_file(self, observable):
+        builder = DtBuilder(self.helper, self.author)
+
+        # Enrichment using DomainTools API.
+        return self._enrich_domaintools(builder, observable)
+
+    def _process_message(self, data):
+        entity_id = data["entity_id"]
+        observable = self.helper.api.stix_cyber_observable.read(id=entity_id)
+        return self._process_file(observable)
+
+    def start(self):
+        """Start the main loop."""
+        self.helper.listen(self._process_message)

--- a/internal-enrichment/domaintools/src/main.py
+++ b/internal-enrichment/domaintools/src/main.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""DomainTools connector main file."""
+
+from connector import DomainToolsConnector
+
+if __name__ == "__main__":
+    connector = DomainToolsConnector()
+    connector.start()

--- a/internal-enrichment/domaintools/src/requirements.txt
+++ b/internal-enrichment/domaintools/src/requirements.txt
@@ -1,0 +1,3 @@
+pycti==5.4.1
+domaintools-api==1.0.1
+validators~=0.20.0


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

Add DomainTools as a new enrichment connector. The connector can be triggered on `domain-name` and `ipv4-addr`. 

Depending on the information retrieved, the following observable types might be created: 
  - `domain-name` 
  - `ipv4-addr`
  - `email-addr`
  - `autonomous-system`

### Proposed changes

* Add a new enrichment connector: domaintools

### Related issues

* #910 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
