### PR TITLE
[splunk] Use JWT for Splunk auth, sanitize kvstore keys, ignore some entity types

### DIFF
--- a/stream/splunk/README.md
+++ b/stream/splunk/README.md
@@ -26,4 +26,5 @@ This connector allows organizations to feed a **Splunk** KV Store using OpenCTI 
 | `splunk_owner`                       | `SPLUNK_OWNER`                      | Yes          | The Splunk KV store owners as array (same order as URLs)                                      |
 | `splunk_ssl_verify`                  | `SPLUNK_SSL_VERIFY`                 | Yes          | Enable the SSL certificate check for all instances (default: `true`)                          |
 | `splunk_app`                         | `SPLUNK_APP`                        | Yes          | The app of the KV Store for all instances.                                                    |
-| `splunk_kv_store_name`               | `SPLUNK_KV_STORE_NAME`              | Yes          | The name of the KV Store for all instances.                                                                    |
+| `splunk_kv_store_name`               | `SPLUNK_KV_STORE_NAME`              | Yes          | The name of the KV Store for all instances.                                                   |
+| `splunk_ignore_types`                | `SPLUNK_IGNORE_TYPES`               | Yes          | The list of entity types to ignore.                                                           |

--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -91,6 +91,13 @@ class SplunkConnector:
         payload=None,
         is_json=False,
     ):
+        if (
+            "type" in payload
+            and payload["type"] in self.splunk_ignore_types
+        ):
+            self.helper.log_info("Ignoring " + payload["id"])
+            return
+            
         self.helper.log_info(
             "Query "
             + method

--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -91,21 +91,12 @@ class SplunkConnector:
         payload=None,
         is_json=False,
     ):
-        if (
-            "type" in payload
-            and payload["type"] in self.splunk_ignore_types
-        ):
+        if "type" in payload and payload["type"] in self.splunk_ignore_types:
             self.helper.log_info("Ignoring " + payload["id"])
             return
-            
+
         self.helper.log_info(
-            "Query "
-            + method
-            + " on "
-            + uri
-            + " (url="
-            + splunk_url
-            + ")"
+            "Query " + method + " on " + uri + " (url=" + splunk_url + ")"
         )
         url = (
             splunk_url
@@ -134,7 +125,9 @@ class SplunkConnector:
                     payload["mapped_values"] = []
                     for value in parsed["parsed_stix"]:
                         formatted_value = {}
-                        formatted_value[sanitize_key(value["attribute"])] = value["value"]
+                        formatted_value[sanitize_key(value["attribute"])] = value[
+                            "value"
+                        ]
                         payload["mapped_values"].append(formatted_value)
             except:
                 try:
@@ -150,9 +143,7 @@ class SplunkConnector:
         if method == "get":
             r = requests.get(
                 url,
-                headers={
-                    "Authorization": "Bearer " + splunk_token
-                },
+                headers={"Authorization": "Bearer " + splunk_token},
                 params=payload,
                 verify=self.splunk_ssl_verify,
             )
@@ -162,7 +153,7 @@ class SplunkConnector:
                     url,
                     headers={
                         "Authorization": "Bearer " + splunk_token,
-                        "content-type": "application/json"
+                        "content-type": "application/json",
                     },
                     json=payload,
                     verify=self.splunk_ssl_verify,
@@ -170,18 +161,14 @@ class SplunkConnector:
             else:
                 r = requests.post(
                     url,
-                    headers={
-                        "Authorization": "Bearer " + splunk_token
-                    },
+                    headers={"Authorization": "Bearer " + splunk_token},
                     data=payload,
                     verify=self.splunk_ssl_verify,
                 )
         elif method == "delete":
             r = requests.delete(
                 url,
-                headers={
-                    "Authorization": "Bearer " + splunk_token
-                },
+                headers={"Authorization": "Bearer " + splunk_token},
                 verify=self.splunk_ssl_verify,
             )
         else:
@@ -211,10 +198,7 @@ class SplunkConnector:
 
     def _distribute_works(self, method, uri, data, is_json=False):
         for x, url in enumerate(self.splunk_url):
-            if (
-                len(self.splunk_token) - 1 < x
-                or len(self.splunk_owner) - 1 < x
-            ):
+            if len(self.splunk_token) - 1 < x or len(self.splunk_owner) - 1 < x:
                 raise ValueError(
                     "Token or owner do not have the same number of items as URLs"
                 )

--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -29,11 +29,8 @@ class SplunkConnector:
         self.splunk_url = get_config_variable(
             "SPLUNK_URL", ["splunk", "url"], config
         ).split(",")
-        self.splunk_login = get_config_variable(
-            "SPLUNK_LOGIN", ["splunk", "login"], config
-        ).split(",")
-        self.splunk_password = get_config_variable(
-            "SPLUNK_PASSWORD", ["splunk", "password"], config
+        self.splunk_token = get_config_variable(
+            "SPLUNK_TOKEN", ["splunk", "token"], config
         ).split(",")
         self.splunk_owner = get_config_variable(
             "SPLUNK_OWNER", ["splunk", "owner"], config
@@ -71,8 +68,7 @@ class SplunkConnector:
     def _query(
         self,
         splunk_url,
-        splunk_login,
-        splunk_password,
+        splunk_token,
         splunk_owner,
         method,
         uri,
@@ -86,8 +82,6 @@ class SplunkConnector:
             + uri
             + " (url="
             + splunk_url
-            + ", login="
-            + splunk_login
             + ")"
         )
         url = (
@@ -133,31 +127,38 @@ class SplunkConnector:
         if method == "get":
             r = requests.get(
                 url,
-                auth=(splunk_login, splunk_password),
+                headers={
+                    "Authorization": "Bearer " + splunk_token
+                },
                 params=payload,
                 verify=self.splunk_ssl_verify,
             )
         elif method == "post":
             if is_json:
-                headers = {"content-type": "application/json"}
                 r = requests.post(
                     url,
-                    auth=(splunk_login, splunk_password),
-                    headers=headers,
+                    headers={
+                        "Authorization": "Bearer " + splunk_token,
+                        "content-type": "application/json"
+                    },
                     json=payload,
                     verify=self.splunk_ssl_verify,
                 )
             else:
                 r = requests.post(
                     url,
-                    auth=(splunk_login, splunk_password),
+                    headers={
+                        "Authorization": "Bearer " + splunk_token
+                    },
                     data=payload,
                     verify=self.splunk_ssl_verify,
                 )
         elif method == "delete":
             r = requests.delete(
                 url,
-                auth=(splunk_login, splunk_password),
+                headers={
+                    "Authorization": "Bearer " + splunk_token
+                },
                 verify=self.splunk_ssl_verify,
             )
         else:
@@ -176,8 +177,7 @@ class SplunkConnector:
             item = q.get()
             self._query(
                 item["splunk_url"],
-                item["splunk_login"],
-                item["splunk_password"],
+                item["splunk_token"],
                 item["splunk_owner"],
                 item["method"],
                 item["uri"],
@@ -189,17 +189,15 @@ class SplunkConnector:
     def _distribute_works(self, method, uri, data, is_json=False):
         for x, url in enumerate(self.splunk_url):
             if (
-                len(self.splunk_login) - 1 < x
-                or len(self.splunk_password) - 1 < x
+                len(self.splunk_token) - 1 < x
                 or len(self.splunk_owner) - 1 < x
             ):
                 raise ValueError(
-                    "Login, password or owner do not have the same number of items as URLs"
+                    "Token or owner do not have the same number of items as URLs"
                 )
             item = {
                 "splunk_url": url,
-                "splunk_login": self.splunk_login[x],
-                "splunk_password": self.splunk_password[x],
+                "splunk_token": self.splunk_token[x],
                 "splunk_owner": self.splunk_owner[x],
                 "method": method,
                 "uri": uri,

--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -15,6 +15,22 @@ from stix_shifter.stix_translation import stix_translation
 q = queue.Queue()
 
 
+def sanitize_key(key):
+    """Sanitize key name for Splunk usage
+
+    Splunk KV store keys cannot contain ".". Also, keys containing
+    unusual characters like "'" make their usage less convenient
+    when writing SPL queries.
+
+    Args:
+        key (str): value to sanitize
+
+    Returns:
+        str: sanitized result
+    """
+    return key.replace(".", ":").replace("'", "")
+
+
 class SplunkConnector:
     def __init__(self):
         # Initialize parameters and OpenCTI helper
@@ -111,12 +127,12 @@ class SplunkConnector:
                     payload["mapped_values"] = []
                     for value in parsed["parsed_stix"]:
                         formatted_value = {}
-                        formatted_value[value["attribute"]] = value["value"]
+                        formatted_value[sanitize_key(value["attribute"])] = value["value"]
                         payload["mapped_values"].append(formatted_value)
             except:
                 try:
                     splitted = payload["pattern"].split(" = ")
-                    key = splitted[0].replace("[", "")
+                    key = sanitize_key(splitted[0].replace("[", ""))
                     value = splitted[1].replace("'", "").replace("]", "")
                     formatted_value = {}
                     formatted_value[key] = value


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Using token (JWT) for Splunk authentication: this is a more standard way to authenticate to Splunk API and it avoids using raw credentials without adding complexity in the code. 
* Sanitize KV store keys: the connector cannot process indicators like `[file:hashes.'SHA-256' = 'xyz']` because KV store keys cannot contain `.`. Also, unusual characters like `'` make usage of these keys less convenient when writing Splunk queries. I proposed in this PR to replace `.` by `:` and to remove single quotes.
* Ignore some entity types: the `splunk_ignore_types` var was already defined but not used. I just added a simple condition ignoring types provided in this var. 

### Related issues

I didn't create any issue related to these changes.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
