### PR TITLE
VirusTotal fixes

### DIFF
--- a/internal-enrichment/virustotal/src/main.py
+++ b/internal-enrichment/virustotal/src/main.py
@@ -1,8 +1,16 @@
 # -*- coding: utf-8 -*-
 """VirusTotal connector main file."""
 
+import sys
+import time
+
 from virustotal import VirusTotalConnector
 
 if __name__ == "__main__":
-    connector = VirusTotalConnector()
-    connector.start()
+    try:
+        connector = VirusTotalConnector()
+        connector.start()
+    except Exception as e:
+        print(e)
+        time.sleep(10)
+        sys.exit(0)


### PR DESCRIPTION
### Proposed changes

* Add delay if connector fails to start because it can't make a connection to the OpenCTI platform (following the template's example)
* When VirusTotal connector had auto-enrichment enabled, if a large artifact file was uploaded, it took a few seconds to finish uploading to OpenCTI and propagate through the system. The VT connector would fail with a list index exception when looking for the "importFiles" list. Adding a small delay and updating the observable variable allows for that propagation time to complete before moving on with the process.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
  - Tested with multiple file sizes
  - Tested with bringing services up slowly
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
