### PR TITLE
[urlscan] Fix blob urls

### DIFF
--- a/external-import/urlscan/src/urlscan/connector.py
+++ b/external-import/urlscan/src/urlscan/connector.py
@@ -113,7 +113,15 @@ class UrlscanConnector:
             obs1 = self._create_url_observable(url, "Urlscan.io URL")
             bundle_objects.extend(filter(None, [*obs1]))
 
+            # This could potentially check for just "blob:"
+            if url.startswith("blob:http"):
+                url = url[5:]
+
             hostname = urlparse(url).hostname
+            if hostname is None:
+                log.warning("Could not parse url: %s", hostname)
+                continue
+
             if validators.domain(hostname):
                 obs2 = self._create_domain_observable(hostname, "Urlscan.io Domain")
                 bundle_objects.extend(filter(None, [*obs2]))


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* urls started coming in prefixed by `blob:`, breaks url parsing

### Related issues

* #960 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
