### PR TITLE
[VXVault] - Fix #973 and #974 - connector imports garbage data

### DIFF
--- a/external-import/vxvault/src/vxvault.py
+++ b/external-import/vxvault/src/vxvault.py
@@ -1,13 +1,14 @@
 import os
+import re
 import ssl
 import sys
 import time
 import urllib.request
-import re
 from datetime import datetime
 
 import certifi
 import yaml
+
 from pycti import OpenCTIConnectorHelper, get_config_variable
 from stix2 import TLP_WHITE, URL, Bundle, ExternalReference
 
@@ -74,7 +75,7 @@ class VXVault:
                 # If the last_run is more than interval-1 day
                 if last_run is None or (
                     (timestamp - last_run)
-                    > ((int(self.vxvault_interval) - 1) * 60 * 60 * 24)
+                    < ((int(self.vxvault_interval) - 1) * 60 * 60 * 24)
                 ):
                     self.helper.log_info("Connector will run!")
                     now = datetime.utcfromtimestamp(timestamp)

--- a/external-import/vxvault/src/vxvault.py
+++ b/external-import/vxvault/src/vxvault.py
@@ -3,6 +3,7 @@ import ssl
 import sys
 import time
 import urllib.request
+import re
 from datetime import datetime
 
 import certifi
@@ -100,6 +101,13 @@ class VXVault:
                             for line in fp:
                                 count += 1
                                 if count <= 3:
+                                    continue
+                                line=line.strip()
+                                matchHtmlTag = re.search(r'^<\/?\w+>', line)
+                                if matchHtmlTag:
+                                    continue
+                                matchBlankLine = re.search(r'^\s*$', line)
+                                if matchBlankLine:
                                     continue
                                 external_reference = ExternalReference(
                                     source_name="VX Vault",

--- a/external-import/vxvault/src/vxvault.py
+++ b/external-import/vxvault/src/vxvault.py
@@ -75,7 +75,7 @@ class VXVault:
                 # If the last_run is more than interval-1 day
                 if last_run is None or (
                     (timestamp - last_run)
-                    < ((int(self.vxvault_interval) - 1) * 60 * 60 * 24)
+                    > ((int(self.vxvault_interval) - 1) * 60 * 60 * 24)
                 ):
                     self.helper.log_info("Connector will run!")
                     now = datetime.utcfromtimestamp(timestamp)


### PR DESCRIPTION
Fixing #973 and #974 - connector imports garbage data and leaves trailing `\n` characters in the name and value field of indicators and observables.

I propose a simple fix for both issues, keeping changes to a minimum. The author of the source data has adjusted the format of the data slightly (https://twitter.com/GraemeMeyer/status/1613900217434230788?s=20), and this PR accounts for that.

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Strip (trim) all values before import to remove leading and trailing whitespace characters
* Check against accidentally importing HTML tags and blank/whitespace events as indicators/observables

### Related issues

* #973 
* #974 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [N/A] I added/update the relevant documentation (either on github or on notion)
- [N/A ] Where necessary I refactored code to improve the overall quality

### Further comments
This is my first PR for the project, so I'm unaware if the version number of the connector should be updated, or if there are any other prerequisites for making such a fix/change, but I wanted to get the PR up there for the developers to see and consider.