### PR TITLE
[ironnet] Fix IP indicator config option

### DIFF
--- a/external-import/ironnet/src/ironnet/config.py
+++ b/external-import/ironnet/src/ironnet/config.py
@@ -76,8 +76,8 @@ class IronNetConfig(BaseSettings):
         default=True,
     )
     create_ip_indicators: bool = Field(
-        description="Create indicators from observables",
-        env="IRONNET_CREATE_INDICATORS",
+        description="Create IP indicators from observables",
+        env="IRONNET_CREATE_IP_INDICATORS",
         default=False,
     )
     ip_indicator_valid_until: timedelta = Field(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* The create_ip_indicators config option was half-broken, it was duplicating the IRONNET_CREATE_INDICATORS env var.

### Related issues

* n/a

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
