### PR TITLE
[VirusTotal] Connector async and added url upload

### DIFF
--- a/internal-enrichment/virustotal/docker-compose.yml
+++ b/internal-enrichment/virustotal/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   connector-virustotal:
     image: opencti/connector-virustotal:5.5.2
@@ -18,10 +18,6 @@ services:
       # File/Artifact specific config settings
       - VIRUSTOTAL_FILE_CREATE_NOTE_FULL_REPORT=true # Whether or not to include the full report as a Note
       - VIRUSTOTAL_FILE_UPLOAD_UNSEEN_ARTIFACTS=false # Whether to upload artifacts (smaller than 32MB) that VirusTotal has no record of
-      ##### WAIT_FOR_ARTIFACT_ANALYSIS_COMPLETION DETAILS ##### VirusTotal (VT) analysis of a new file can take tens of minutes to process dependent on size and priority in the VT analysis queue. Since this connector is a blocking process, it will attempt to wait a maximum of 25 minutes for analysis of the artifact to finish before enriching it with VT data. This delay will push all other calls being sent to VT into this connector's queue until the analysis is complete. If your VT connector is set to automatic enrichment above (CONNECTOR_AUTO=true) and you expect it to be making requests to the VT API frequently, it is suggested you:
-      # 1) Disable the delaying block by changing the below VIRUSTOTAL_FILE_WAIT_FOR_ARTIFACT_ANALYSIS_COMPLETION to false. This will upload the artifact but will very likely require manually rerunning enrichment at a later time since the artifact is not analyzed immediately.
-      # 2) Change the number of replicas of this connector in the docker-compose yaml file (deploy->replicas) so that as one VT connector waits for analysis to finish, another one can concurrently fetch results from the VT API.
-      - VIRUSTOTAL_FILE_WAIT_FOR_ARTIFACT_ANALYSIS_COMPLETION=true # If upload unseen artifacts is enabled, have the connector wait for analysis completion and enrichment (within 25 minute timeout)
       - VIRUSTOTAL_FILE_INDICATOR_CREATE_POSITIVES=10 # Create an indicator for File/Artifact based observables once this positive theshold is reached. Note: specify 0 to disable indicator creation
       - VIRUSTOTAL_FILE_INDICATOR_VALID_MINUTES=2880 # How long the indicator is valid for in minutes
       - VIRUSTOTAL_FILE_INDICATOR_DETECT=true # Whether or not to set detection for the indicator to true
@@ -34,6 +30,7 @@ services:
       - VIRUSTOTAL_DOMAIN_INDICATOR_VALID_MINUTES=2880 # How long the indicator is valid for in minutes
       - VIRUSTOTAL_DOMAIN_INDICATOR_DETECT=true # Whether or not to set detection for the indicator to true
       # URL specific config settings
+      - VIRUSTOTAL_URL_UPLOAD_UNSEEN=false # Whether to upload URLs that VirusTotal has no record of for analysis
       - VIRUSTOTAL_URL_INDICATOR_CREATE_POSITIVES=10 # Create an indicator for Url based observables once this positive theshold is reached. Note: specify 0 to disable indicator creation
       - VIRUSTOTAL_URL_INDICATOR_VALID_MINUTES=2880 # How long the indicator is valid for in minutes
       - VIRUSTOTAL_URL_INDICATOR_DETECT=true # Whether or not to set detection for the indicator to true

--- a/internal-enrichment/virustotal/src/config.yml.sample
+++ b/internal-enrichment/virustotal/src/config.yml.sample
@@ -18,26 +18,23 @@ virustotal:
 
   # File/Artifact specific config settings
   file_create_note_full_report: true # Whether or not to include the full report as a Note
-  file_upload_unseen_artifacts: false # Whether to upload artifacts (smaller than 32MB) that VirusTotal has no record of
-  ##### WAIT_FOR_ARTIFACT_ANALYSIS_COMPLETION DETAILS ##### VirusTotal (VT) analysis of a new file can take tens of minutes to process dependent on size and priority in the VT analysis queue. Since this connector is a blocking process, it will attempt to wait a maximum of 25 minutes for analysis of the artifact to finish before enriching it with VT data. This delay will push all other calls being sent to VT into this connector's queue until the analysis is complete. If your VT connector is set to automatic enrichment above (CONNECTOR_AUTO=true) and you expect it to be making requests to the VT API frequently, it is suggested you:
-  # 1) Disable the delaying block by changing the below VIRUSTOTAL_FILE_WAIT_FOR_ARTIFACT_ANALYSIS_COMPLETION to false. This will upload the artifact but will very likely require manually rerunning enrichment at a later time since the artifact is not analyzed immediately.
-  # 2) Change the number of replicas of this connector in the docker-compose yaml file (deploy->replicas) so that as one VT connector waits for analysis to finish, another one can concurrently fetch results from the VT API.
-  file_wait_for_artifact_analysis_completion: true # If upload unseen artifacts is enabled, have the connector wait for analysis completion and enrichment (within 25 minute timeout)
-  file_indicator_create_positives: 0 # Create an indicator for File/Artifact based observables once this positive threshold is reached. Note: specify 0 to disable indicator creation
+  file_upload_unseen_artifacts: false # Whether to upload artifacts (smaller than 32MB) that VirusTotal has no record of for analysis
+  file_indicator_create_positives: 10 # Create an indicator for File/Artifact based observables once this positive threshold is reached. Note: specify 0 to disable indicator creation
   file_indicator_valid_minutes: 2880 # How long the indicator is valid for in minutes
   file_indicator_detect: true # Whether or not to set detection for the indicator to true
 
   # IP specific config settings
-  ip_indicator_create_positives: 0 # Create an indicator for IPv4 based observables once this positive threshold is reached. Note: specify 0 to disable indicator creation
+  ip_indicator_create_positives: 10 # Create an indicator for IPv4 based observables once this positive threshold is reached. Note: specify 0 to disable indicator creation
   ip_indicator_valid_minutes: 2880 # How long the indicator is valid for in minutes
   ip_indicator_detect: true # Whether or not to set detection for the indicator to true
 
   # Domain specific config settings
-  domain_indicator_create_positives: 0 # Create an indicator for Domain based observables once this positive threshold is reached. Note: specify 0 to disable indicator creation
+  domain_indicator_create_positives: 10 # Create an indicator for Domain based observables once this positive threshold is reached. Note: specify 0 to disable indicator creation
   domain_indicator_valid_minutes: 2880 # How long the indicator is valid for in minutes
   domain_indicator_detect: true # Whether or not to set detection for the indicator to true
 
   # URL specific config settings
-  url_indicator_create_positives: 0 # Create an indicator for Url based observables once this positive threshold is reached. Note: specify 0 to disable indicator creation
+  url_upload_unseen: false # Whether to upload URLs that VirusTotal has no record of for analysis
+  url_indicator_create_positives: 10 # Create an indicator for Url based observables once this positive threshold is reached. Note: specify 0 to disable indicator creation
   url_indicator_valid_minutes: 2880 # How long the indicator is valid for in minutes
   url_indicator_detect: true # Whether or not to set detection for the indicator to true

--- a/internal-enrichment/virustotal/src/requirements.txt
+++ b/internal-enrichment/virustotal/src/requirements.txt
@@ -1,2 +1,2 @@
-pycti==5.5.2
+pycti==5.5.3
 plyara~=2.1.1

--- a/internal-enrichment/virustotal/src/virustotal/client.py
+++ b/internal-enrichment/virustotal/src/virustotal/client.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """Virustotal client module."""
-import base64
+import asyncio
+import hashlib
 import json
-from time import sleep
+import urllib.parse
 
 import requests
 from pycti import OpenCTIConnectorHelper
@@ -79,7 +80,7 @@ class VirusTotalClient:
             )
             return None
 
-    def _post(self, url, files):
+    def _post(self, url, data=None, files=None, additional_headers=None):
         """
         Execute a post to the Virustotal api.
 
@@ -87,8 +88,12 @@ class VirusTotalClient:
         ----------
         url : str
             Url to post to.
+        data : str
+            Data payload to be passed with the post.
         files : json
-            A JSON object with the files to be posted to VirusTotal
+            A JSON object with the files to be posted to VirusTotal.
+        additional_headers : dict
+            Headers to be added to the self.headers with the request.
 
         Returns
         -------
@@ -96,8 +101,13 @@ class VirusTotalClient:
             The result of the query, as JSON or None in case of failure.
         """
         response = None
+        headers = (
+            self.headers
+            if additional_headers == None
+            else self.headers | additional_headers
+        )
         try:
-            response = requests.post(url, files=files, headers=self.headers)
+            response = requests.post(url, data=data, files=files, headers=headers)
             response.raise_for_status()
         except requests.exceptions.HTTPError as errh:
             self.helper.log_error(f"[VirusTotal] Http error: {errh}")
@@ -153,42 +163,7 @@ class VirusTotalClient:
         """
         url = f"{self.url}/files"
         files = {"file": (artifact_name, artifact)}
-        return self._post(url, files)["data"]["id"]
-
-    def check_upload_status(self, name, analysis_id):
-        """
-        Wait for the uploaded queued artifact to finish being analyzed
-
-        Parameters
-        ----------
-        analysis_id : str
-            The ID returned by VirustTotal for the analysis job of the artifact
-        """
-        url = f"{self.url}/analyses/{analysis_id}"
-        retry_delay = 30  # in seconds
-        minimum_retry_delay = 60  # in seconds
-        maximum_retry_delay = 180  # in seconds
-        total_attempts = 10
-        i = 0
-        while i < total_attempts:
-            current_status = self._query(url)["data"]["attributes"]["status"]
-            current_retry_delay = min(
-                (i * retry_delay + minimum_retry_delay), maximum_retry_delay
-            )
-            i += 1
-            if not current_status == "completed":
-                self.helper.log_debug(
-                    f"[VirusTotal] Uploaded artifact {name} current VirusTotal "
-                    f"analysis status: {current_status}. Checking status update "
-                    f"attempt #{i} of {total_attempts} in {current_retry_delay} seconds."
-                )
-                sleep(current_retry_delay)
-            else:
-                return
-        raise ValueError(
-            f"The uploaded artifact {name} was not analyzed by VirusTotal before the "
-            "timeout was reached. Please try enriching the file again at a later time."
-        )
+        return self._post(url, files=files)["data"]["id"]
 
     def get_yara_ruleset(self, ruleset_id) -> dict:
         """
@@ -255,22 +230,65 @@ class VirusTotalClient:
         dict
             URL Object, see https://developers.virustotal.com/reference/url-object
         """
-        url = f"{self.url}/urls/{VirusTotalClient.base64_encode_no_padding(url)}"
-        return self._query(url)
+        endpoint_url = f"{self.url}/urls/{hashlib.sha256(url.encode()).hexdigest()}"
+        return self._query(endpoint_url)
 
-    @staticmethod
-    def base64_encode_no_padding(contents):
+    def upload_url(self, url) -> str:
         """
-        Base64 encode a string and remove padding.
+        Upload a URL to VirusTotal for analysis
 
         Parameters
         ----------
-        contents : str
-            String to encode.
+        url : str
+            The URL being uploaded
 
         Returns
         -------
         str
-            Base64 encoded string without padding
+            Analysis id, see https://developers.virustotal.com/reference/analysis
         """
-        return base64.b64encode(contents.encode()).decode().replace("=", "")
+        endpoint_url = f"{self.url}/urls"
+        payload = f"url={urllib.parse.quote(url, safe='')}"
+        headers = {"content-type": "application/x-www-form-urlencoded"}
+        return self._post(endpoint_url, data=payload, additional_headers=headers)[
+            "data"
+        ]["id"]
+
+    async def check_upload_status(self, upload_type, name, analysis_id):
+        """
+        Wait for the uploaded queued artifact or URL to finish being analyzed
+
+        Parameters
+        ----------
+        upload_type : str
+            The type of the upload (artifact || URL)
+        name : str
+            The name of the upload
+        analysis_id : str
+            The ID returned by VirusTotal for the analysis job of the upload
+        """
+        url = f"{self.url}/analyses/{analysis_id}"
+        retry_delay = 30 if upload_type == "artifact" else 2  # in seconds
+        minimum_retry_delay = 60 if upload_type == "artifact" else 1  # in seconds
+        maximum_retry_delay = 180 if upload_type == "artifact" else 10  # in seconds
+        total_attempts = 10
+        i = 0
+        while i < total_attempts:
+            current_status = self._query(url)["data"]["attributes"]["status"]
+            current_retry_delay = min(
+                (i * retry_delay + minimum_retry_delay), maximum_retry_delay
+            )
+            i += 1
+            if not current_status == "completed":
+                self.helper.log_debug(
+                    f"[VirusTotal] Uploaded {upload_type} {name} current VirusTotal "
+                    f"analysis status: {current_status}. Checking status update "
+                    f"attempt #{i} of {total_attempts} in {current_retry_delay} seconds."
+                )
+                await asyncio.sleep(current_retry_delay)
+            else:
+                return
+        raise ValueError(
+            f"The uploaded {upload_type} {name} was not analyzed by VirusTotal before the "
+            f"timeout was reached. Please try enriching the {upload_type} again at a later time."
+        )

--- a/internal-enrichment/virustotal/src/virustotal/client.py
+++ b/internal-enrichment/virustotal/src/virustotal/client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Virustotal client module."""
 import asyncio
-import hashlib
+import base64
 import json
 import urllib.parse
 
@@ -230,7 +230,9 @@ class VirusTotalClient:
         dict
             URL Object, see https://developers.virustotal.com/reference/url-object
         """
-        endpoint_url = f"{self.url}/urls/{hashlib.sha256(url.encode()).hexdigest()}"
+        endpoint_url = (
+            f"{self.url}/urls/{VirusTotalClient.base64_encode_no_padding(url)}"
+        )
         return self._query(endpoint_url)
 
     def upload_url(self, url) -> str:
@@ -292,3 +294,18 @@ class VirusTotalClient:
             f"The uploaded {upload_type} {name} was not analyzed by VirusTotal before the "
             f"timeout was reached. Please try enriching the {upload_type} again at a later time."
         )
+
+    @staticmethod
+    def base64_encode_no_padding(contents):
+        """
+        Base64 encode a string and remove padding.
+        Parameters
+        ----------
+        contents : str
+            String to encode.
+        Returns
+        -------
+        str
+            Base64 encoded string without padding
+        """
+        return base64.b64encode(contents.encode()).decode().replace("=", "")

--- a/internal-enrichment/virustotal/src/virustotal/client.py
+++ b/internal-enrichment/virustotal/src/virustotal/client.py
@@ -2,6 +2,7 @@
 """Virustotal client module."""
 import asyncio
 import base64
+import hashlib
 import json
 import urllib.parse
 
@@ -230,10 +231,12 @@ class VirusTotalClient:
         dict
             URL Object, see https://developers.virustotal.com/reference/url-object
         """
-        endpoint_url = (
-            f"{self.url}/urls/{VirusTotalClient.base64_encode_no_padding(url)}"
-        )
-        return self._query(endpoint_url)
+        base64_url = f"{self.url}/urls/{VirusTotalClient.base64_encode_no_padding(url)}"
+        results = self._query(base64_url)
+        if "error" in results:
+            sha256_url = f"{self.url}/urls/{hashlib.sha256(url.encode()).hexdigest()}"
+            results = self._query(sha256_url)
+        return results
 
     def upload_url(self, url) -> str:
         """

--- a/internal-enrichment/virustotal/src/virustotal/virustotal.py
+++ b/internal-enrichment/virustotal/src/virustotal/virustotal.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """VirusTotal enrichment module."""
+import asyncio
 import json
 from pathlib import Path
-from time import sleep
 
 import stix2
 import yaml
@@ -70,11 +70,6 @@ class VirusTotalConnector:
             ["virustotal", "file_upload_unseen_artifacts"],
             config,
         )
-        self.file_wait_for_artifact_analysis_completion = get_config_variable(
-            "VIRUSTOTAL_FILE_WAIT_FOR_ARTIFACT_ANALYSIS_COMPLETION",
-            ["virustotal", "file_wait_for_artifact_analysis_completion"],
-            config,
-        )
         self.file_indicator_config = IndicatorConfig.load_indicator_config(
             config, "FILE"
         )
@@ -88,6 +83,11 @@ class VirusTotalConnector:
         )
 
         # Url specific settings
+        self.url_upload_unseen = get_config_variable(
+            "VIRUSTOTAL_URL_UPLOAD_UNSEEN",
+            ["virustotal", "url_upload_unseen"],
+            config,
+        )
         self.url_indicator_config = IndicatorConfig.load_indicator_config(config, "URL")
 
     def _retrieve_yara_ruleset(self, ruleset_id: str) -> dict:
@@ -111,7 +111,7 @@ class VirusTotalConnector:
             self.yara_cache[ruleset_id] = ruleset
         return ruleset
 
-    def _process_file(self, observable):
+    async def _process_file(self, observable):
         json_data = self.client.get_file_info(observable["observable_value"])
         assert json_data
         if (
@@ -126,7 +126,7 @@ class VirusTotalConnector:
             # Larger files can sometimes take a few seconds to propogate through the system and be added to the observable
             # It appears to be about 1 second for every 30-50MB
             if not len(observable["importFiles"]):
-                sleep(5)
+                await asyncio.sleep(5)
                 observable = self.helper.api.stix_cyber_observable.read(
                     id=observable["id"]
                 )
@@ -152,19 +152,14 @@ class VirusTotalConnector:
                 raise ValueError(
                     f"[VirusTotal] Error occurred uploading artifact to VirusTotal: {err}"
                 )
-            if self.file_wait_for_artifact_analysis_completion:
-                try:
-                    self.client.check_upload_status(
-                        observable["observable_value"], analysis_id
-                    )
-                except Exception as err:
-                    raise ValueError(
-                        f"[VirusTotal] Error occurred while waiting for VirusTotal to analyze artifact: {err}"
-                    )
-            else:
-                message = f"{observable['observable_value']} was an unseen artifact submitted for analysis but connector skipping waiting for analysis completion. Enrichment will likely fail in next step but can be rerun later with success. Change configuration setting if you would like the connector to wait for artifact analysis completion"
-                self.helper.api.work.to_processed(self.helper.work_id, message)
-                self.helper.log_debug(message)
+            try:
+                await self.client.check_upload_status(
+                    "artifact", observable["observable_value"], analysis_id
+                )
+            except Exception as err:
+                raise ValueError(
+                    f"[VirusTotal] Error occurred while waiting for VirusTotal to analyze artifact: {err}"
+                )
             json_data = self.client.get_file_info(observable["observable_value"])
             assert json_data
         if "error" in json_data:
@@ -280,9 +275,34 @@ class VirusTotalConnector:
         builder.create_notes()
         return builder.send_bundle()
 
-    def _process_url(self, observable):
+    async def _process_url(self, observable):
         json_data = self.client.get_url_info(observable["observable_value"])
         assert json_data
+        if (
+            "error" in json_data
+            and json_data["error"]["code"] == "NotFoundError"
+            and self.url_upload_unseen
+        ):
+            message = f"The URL {observable['observable_value']} was not found in VirusTotal repositories. Beginning upload and analysis"
+            self.helper.api.work.to_received(self.helper.work_id, message)
+            self.helper.log_debug(message)
+            try:
+                analysis_id = self.client.upload_url(observable["observable_value"])
+            except Exception as err:
+                raise ValueError(
+                    f"[VirusTotal] Error occurred uploading URL to VirusTotal: {err}"
+                )
+            try:
+                await self.client.check_upload_status(
+                    "URL", observable["observable_value"], analysis_id
+                )
+            except Exception as err:
+                raise ValueError(
+                    f"[VirusTotal] Error occurred while waiting for VirusTotal to analyze URL: {err}"
+                )
+            json_data = self.client.get_url_info(observable["observable_value"])
+            assert json_data
+        print(json_data, flush=True)
         if "error" in json_data:
             raise ValueError(json_data["error"]["message"])
         if "data" not in json_data or "attributes" not in json_data["data"]:
@@ -303,7 +323,7 @@ class VirusTotalConnector:
         builder.create_notes()
         return builder.send_bundle()
 
-    def _process_message(self, data):
+    async def _process_message(self, data):
         entity_id = data["entity_id"]
         observable = self.helper.api.stix_cyber_observable.read(id=entity_id)
         if observable is None:
@@ -328,13 +348,13 @@ class VirusTotalConnector:
         )
         match observable["entity_type"]:
             case "StixFile" | "Artifact":
-                return self._process_file(observable)
+                return await self._process_file(observable)
             case "IPv4-Addr":
                 return self._process_ip(observable)
             case "Domain-Name":
                 return self._process_domain(observable)
             case "Url":
-                return self._process_url(observable)
+                return await self._process_url(observable)
             case _:
                 raise ValueError(
                     f'{observable["entity_type"]} is not a supported entity type.'


### PR DESCRIPTION
### Proposed changes

* Make the VirusTotal connector async
* Remove the wait for artifact analysis completion flag since it's async
* Add support for uploading unseen URLs to VT

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality