### PR TITLE
[VirusTotal] Ignore empty categories

### DIFF
--- a/internal-enrichment/virustotal/src/virustotal/builder.py
+++ b/internal-enrichment/virustotal/src/virustotal/builder.py
@@ -312,7 +312,7 @@ class VirusTotalBuilder:
                 )}\n```""",
             )
 
-        if "categories" in self.attributes:
+        if "categories" in self.attributes and len(self.attributes["categories"]) > 0:
             self.create_note(
                 "VirusTotal Categories",
                 f'```\n{json.dumps(self.attributes["categories"], indent=2)}\n```',


### PR DESCRIPTION
### Proposed changes

* Bugfix to ignore empty categories returned by VT

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
