### PR TITLE
Export only selected entities (#1741)

### DIFF
--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -177,6 +177,12 @@ class ExportFileCsv:
                                 id=entity_id
                             )
                         )
+                    if entity_data is None:
+                        entity_data = (
+                            self.helper.api_impersonate.stix_core_relationship.read(
+                                id=entity_id
+                            )
+                        )
                     entities_list.append(entity_data)
 
             else:  # export_scope = 'query'

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -240,7 +240,7 @@ class ExportFileCsv:
                     "Channel": self.helper.api_impersonate.channel.list,
                     "Event": self.helper.api_impersonate.event.list,
                     "Note": self.helper.api_impersonate.note.list,
-                    "ObservedData": self.helper.api_impersonate.observed_data.list,
+                    "Observed-Data": self.helper.api_impersonate.observed_data.list,
                     "Opinion": self.helper.api_impersonate.opinion.list,
                     "Report": self.helper.api_impersonate.report.list,
                     "Grouping": self.helper.api_impersonate.grouping.list,

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -299,13 +299,16 @@ class ExportFileCsv:
 
                 list_filters = json.dumps(list_params)
 
-            if "element_id" in data and entity_type == 'Report':   # treatment of reports in entity>Analysis
+            if (
+                "element_id" in data and entity_type == "Report"
+            ):  # treatment of reports in entity>Analysis
                 element_id = data["element_id"]
                 if element_id:  # filtering of the data to keep those in the container
                     new_entities_list = [
                         entity
                         for entity in entities_list
-                        if ("objectsIds" in entity) and (element_id in entity["objectsIds"])
+                        if ("objectsIds" in entity)
+                        and (element_id in entity["objectsIds"])
                     ]
                     entities_list = new_entities_list
 

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -240,7 +240,7 @@ class ExportFileCsv:
                     "Channel": self.helper.api_impersonate.channel.list,
                     "Event": self.helper.api_impersonate.event.list,
                     "Note": self.helper.api_impersonate.note.list,
-                    "Observed-Data": self.helper.api_impersonate.observed_data.list,
+                    "ObservedData": self.helper.api_impersonate.observed_data.list,
                     "Opinion": self.helper.api_impersonate.opinion.list,
                     "Report": self.helper.api_impersonate.report.list,
                     "Grouping": self.helper.api_impersonate.grouping.list,
@@ -299,34 +299,44 @@ class ExportFileCsv:
 
                 list_filters = json.dumps(list_params)
 
-            element_id = data["element_id"]
-            if element_id:  # filtering of the data to keep those in the container
-                new_entities_list = [
-                    entity
-                    for entity in entities_list
-                    if element_id in entity["objectsIds"]
-                ]
-                entities_list = new_entities_list
+            if "element_id" in data:
+                element_id = data["element_id"]
+                if element_id:  # filtering of the data to keep those in the container
+                    new_entities_list = [
+                        entity
+                        for entity in entities_list
+                        if element_id in entity["objectsIds"]
+                    ]
+                    entities_list = new_entities_list
 
-            csv_data = self.export_dict_list_to_csv(entities_list)
-            self.helper.log_info(
-                "Uploading: " + entity_type + "/" + export_type + " to " + file_name
-            )
-            if entity_type == "Stix-Cyber-Observable":
-                self.helper.api.stix_cyber_observable.push_list_export(
-                    file_name, csv_data, list_filters
+            if entities_list is not None:
+                csv_data = self.export_dict_list_to_csv(entities_list)
+                self.helper.log_info(
+                    "Uploading: " + entity_type + "/" + export_type + " to " + file_name
                 )
-            elif entity_type == "Stix-Core-Object":
-                self.helper.api.stix_core_object.push_list_export(
-                    entity_type, file_name, csv_data, list_filters
+                if entity_type == "Stix-Cyber-Observable":
+                    self.helper.api.stix_cyber_observable.push_list_export(
+                        file_name, csv_data, list_filters
+                    )
+                elif entity_type == "Stix-Core-Object":
+                    self.helper.api.stix_core_object.push_list_export(
+                        entity_type, file_name, csv_data, list_filters
+                    )
+                else:
+                    self.helper.api.stix_domain_object.push_list_export(
+                        entity_type, file_name, csv_data, list_filters
+                    )
+                self.helper.log_info(
+                    "Export done: "
+                    + entity_type
+                    + "/"
+                    + export_type
+                    + " to "
+                    + file_name
                 )
             else:
-                self.helper.api.stix_domain_object.push_list_export(
-                    entity_type, file_name, csv_data, list_filters
-                )
-            self.helper.log_info(
-                "Export done: " + entity_type + "/" + export_type + " to " + file_name
-            )
+                raise ValueError("An error occurred, the list is empty")
+
         return "Export done"
 
     # Start the main loop

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -299,13 +299,13 @@ class ExportFileCsv:
 
                 list_filters = json.dumps(list_params)
 
-            if "element_id" in data:
+            if "element_id" in data and entity_type == 'Report':   # treatment of reports in entity>Analysis
                 element_id = data["element_id"]
                 if element_id:  # filtering of the data to keep those in the container
                     new_entities_list = [
                         entity
                         for entity in entities_list
-                        if element_id in entity["objectsIds"]
+                        if ("objectsIds" in entity) and (element_id in entity["objectsIds"])
                     ]
                     entities_list = new_entities_list
 

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -104,7 +104,6 @@ class ExportFileCsv:
         entity_type = data["entity_type"]
 
         if export_scope == "single":
-            self.helper.log_info('SINGLE')
             entity_id = data["entity_id"]
             self.helper.log_info(
                 "Exporting: "

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -167,7 +167,7 @@ class ExportFileCsv:
             if export_scope == "selection":
                 selected_ids = data["selected_ids"]
                 self.helper.log_info('selected_ids' + str(selected_ids))
-                list_filters = 'via selected_ids'
+                list_filters = 'selected_ids'
                 entities_list = []
 
                 for entity_id in selected_ids:

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -98,7 +98,6 @@ class ExportFileCsv:
     def _process_message(self, data):
         file_name = data["file_name"]
         export_scope = data["export_scope"]  # query or selection or single
-        self.helper.log_info('export_scope' + export_scope)
         export_type = data["export_type"]  # Simple or Full
         # max_marking = data["max_marking"]  # TODO Implement marking restriction
         entity_type = data["entity_type"]
@@ -165,8 +164,7 @@ class ExportFileCsv:
         else:  # list export: export_scope = 'query' or 'selection'
             if export_scope == "selection":
                 selected_ids = data["selected_ids"]
-                self.helper.log_info('selected_ids' + str(selected_ids))
-                list_filters = 'selected_ids'
+                list_filters = "selected_ids"
                 entities_list = []
 
                 for entity_id in selected_ids:
@@ -174,8 +172,10 @@ class ExportFileCsv:
                         id=entity_id
                     )
                     if entity_data is None:
-                        entity_data = self.helper.api_impersonate.stix_cyber_observable.read(
-                            id=entity_id
+                        entity_data = (
+                            self.helper.api_impersonate.stix_cyber_observable.read(
+                                id=entity_id
+                            )
                         )
                     entities_list.append(entity_data)
 
@@ -259,7 +259,9 @@ class ExportFileCsv:
                 do_list = lister.get(
                     final_entity_type,
                     lambda **kwargs: self.helper.log_error(
-                        'Unknown object type "' + final_entity_type + '", doing nothing...'
+                        'Unknown object type "'
+                        + final_entity_type
+                        + '", doing nothing...'
                     ),
                 )
                 entities_list = do_list(
@@ -281,7 +283,9 @@ class ExportFileCsv:
                     fromTypes=list_params["fromTypes"]
                     if "fromTypes" in list_params
                     else None,
-                    toTypes=list_params["toTypes"] if "toTypes" in list_params else None,
+                    toTypes=list_params["toTypes"]
+                    if "toTypes" in list_params
+                    else None,
                     types=list_params["types"] if "types" in list_params else None,
                     getAll=True,
                 )

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -30,7 +30,6 @@ class ExportFileCsv:
 
     def export_dict_list_to_csv(self, data):
         output = io.StringIO()
-        self.helper.log_info('data' + str(data))
         headers = sorted(set().union(*(d.keys() for d in data)))
         if "hashes" in headers:
             headers = headers + [
@@ -302,10 +301,13 @@ class ExportFileCsv:
 
             element_id = data["element_id"]
             if element_id:  # filtering of the data to keep those in the container
-                new_entities_list = [entity for entity in entities_list if element_id in entity["objectsIds"]]
+                new_entities_list = [
+                    entity
+                    for entity in entities_list
+                    if element_id in entity["objectsIds"]
+                ]
                 entities_list = new_entities_list
 
-            self.helper.log_info('entities_list' + str(entities_list))
             csv_data = self.export_dict_list_to_csv(entities_list)
             self.helper.log_info(
                 "Uploading: " + entity_type + "/" + export_type + " to " + file_name

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -104,6 +104,7 @@ class ExportFileCsv:
         entity_type = data["entity_type"]
 
         if export_scope == "single":
+            self.helper.log_info('SINGLE')
             entity_id = data["entity_id"]
             self.helper.log_info(
                 "Exporting: "
@@ -161,112 +162,132 @@ class ExportFileCsv:
                 + ") to "
                 + file_name
             )
-        else:  # export_scope = 'query'
-            list_params = data["list_params"]
-            self.helper.log_info(
-                "Exporting list: "
-                + entity_type
-                + "/"
-                + export_type
-                + " to "
-                + file_name
-            )
 
-            final_entity_type = entity_type
-            if IdentityTypes.has_value(entity_type):
-                if list_params["filters"] is not None:
-                    list_params["filters"].append(
-                        {"key": "entity_type", "values": [entity_type]}
+        else:  # list export: export_scope = 'query' or 'selection'
+            if export_scope == "selection":
+                selected_ids = data["selected_ids"]
+                self.helper.log_info('selected_ids' + str(selected_ids))
+                list_filters = 'via selected_ids'
+                entities_list = []
+
+                for entity_id in selected_ids:
+                    entity_data = self.helper.api_impersonate.stix_domain_object.read(
+                        id=entity_id
                     )
-                else:
-                    list_params["filters"] = [
-                        {"key": "entity_type", "values": [entity_type]}
-                    ]
-                final_entity_type = "Identity"
+                    if entity_data is None:
+                        entity_data = self.helper.api_impersonate.stix_cyber_observable.read(
+                            id=entity_id
+                        )
+                    entities_list.append(entity_data)
 
-            if LocationTypes.has_value(entity_type):
-                if list_params["filters"] is not None:
-                    list_params["filters"].append(
-                        {"key": "entity_type", "values": [entity_type]}
-                    )
-                else:
-                    list_params["filters"] = [
-                        {"key": "entity_type", "values": [entity_type]}
-                    ]
-                final_entity_type = "Location"
+            else:  # export_scope = 'query'
+                list_params = data["list_params"]
+                self.helper.log_info(
+                    "Exporting list: "
+                    + entity_type
+                    + "/"
+                    + export_type
+                    + " to "
+                    + file_name
+                )
 
-            if StixCyberObservableTypes.has_value(entity_type):
-                if list_params["filters"] is not None:
-                    list_params["filters"].append(
-                        {"key": "entity_type", "values": [entity_type]}
-                    )
-                else:
-                    list_params["filters"] = [
-                        {"key": "entity_type", "values": [entity_type]}
-                    ]
-                final_entity_type = "Stix-Cyber-Observable"
+                final_entity_type = entity_type
+                if IdentityTypes.has_value(entity_type):
+                    if list_params["filters"] is not None:
+                        list_params["filters"].append(
+                            {"key": "entity_type", "values": [entity_type]}
+                        )
+                    else:
+                        list_params["filters"] = [
+                            {"key": "entity_type", "values": [entity_type]}
+                        ]
+                    final_entity_type = "Identity"
 
-            # List
-            print(list_params)
-            lister = {
-                "Stix-Core-Object": self.helper.api_impersonate.stix_core_object.list,
-                "Stix-Domain-Object": self.helper.api_impersonate.stix_domain_object.list,
-                "Attack-Pattern": self.helper.api_impersonate.attack_pattern.list,
-                "Campaign": self.helper.api_impersonate.campaign.list,
-                "Channel": self.helper.api_impersonate.channel.list,
-                "Event": self.helper.api_impersonate.event.list,
-                "Note": self.helper.api_impersonate.note.list,
-                "Observed-Data": self.helper.api_impersonate.observed_data.list,
-                "Opinion": self.helper.api_impersonate.opinion.list,
-                "Report": self.helper.api_impersonate.report.list,
-                "Grouping": self.helper.api_impersonate.grouping.list,
-                "Case": self.helper.api_impersonate.case.list,
-                "Course-Of-Action": self.helper.api_impersonate.course_of_action.list,
-                "Identity": self.helper.api_impersonate.identity.list,
-                "Indicator": self.helper.api_impersonate.indicator.list,
-                "Infrastructure": self.helper.api_impersonate.infrastructure.list,
-                "Intrusion-Set": self.helper.api_impersonate.intrusion_set.list,
-                "Location": self.helper.api_impersonate.location.list,
-                "Language": self.helper.api_impersonate.language.list,
-                "Malware": self.helper.api_impersonate.malware.list,
-                "Threat-Actor": self.helper.api_impersonate.threat_actor.list,
-                "Tool": self.helper.api_impersonate.tool.list,
-                "Narrative": self.helper.api_impersonate.narrative.list,
-                "Vulnerability": self.helper.api_impersonate.vulnerability.list,
-                "Incident": self.helper.api_impersonate.incident.list,
-                "Stix-Cyber-Observable": self.helper.api_impersonate.stix_cyber_observable.list,
-                "Stix-Core-Relationship": self.helper.api_impersonate.stix_core_relationship.list,
-                "stix-core-relationship": self.helper.api_impersonate.stix_core_relationship.list,
-            }
-            do_list = lister.get(
-                final_entity_type,
-                lambda **kwargs: self.helper.log_error(
-                    'Unknown object type "' + final_entity_type + '", doing nothing...'
-                ),
-            )
-            entities_list = do_list(
-                search=list_params["search"],
-                filters=list_params["filters"],
-                orderBy=list_params["orderBy"],
-                orderMode=list_params["orderMode"],
-                relationship_type=list_params["relationship_type"]
-                if "relationship_type" in list_params
-                else None,
-                elementId=list_params["elementId"]
-                if "elementId" in list_params
-                else None,
-                fromId=list_params["fromId"] if "fromId" in list_params else None,
-                toId=list_params["toId"] if "toId" in list_params else None,
-                elementWithTargetTypes=list_params["elementWithTargetTypes"]
-                if "elementWithTargetTypes" in list_params
-                else None,
-                fromTypes=list_params["fromTypes"]
-                if "fromTypes" in list_params
-                else None,
-                toTypes=list_params["toTypes"] if "toTypes" in list_params else None,
-                types=list_params["types"] if "types" in list_params else None,
-                getAll=True,
-            )
+                if LocationTypes.has_value(entity_type):
+                    if list_params["filters"] is not None:
+                        list_params["filters"].append(
+                            {"key": "entity_type", "values": [entity_type]}
+                        )
+                    else:
+                        list_params["filters"] = [
+                            {"key": "entity_type", "values": [entity_type]}
+                        ]
+                    final_entity_type = "Location"
+
+                if StixCyberObservableTypes.has_value(entity_type):
+                    if list_params["filters"] is not None:
+                        list_params["filters"].append(
+                            {"key": "entity_type", "values": [entity_type]}
+                        )
+                    else:
+                        list_params["filters"] = [
+                            {"key": "entity_type", "values": [entity_type]}
+                        ]
+                    final_entity_type = "Stix-Cyber-Observable"
+
+                # List
+                print(list_params)
+                lister = {
+                    "Stix-Core-Object": self.helper.api_impersonate.stix_core_object.list,
+                    "Stix-Domain-Object": self.helper.api_impersonate.stix_domain_object.list,
+                    "Attack-Pattern": self.helper.api_impersonate.attack_pattern.list,
+                    "Campaign": self.helper.api_impersonate.campaign.list,
+                    "Channel": self.helper.api_impersonate.channel.list,
+                    "Event": self.helper.api_impersonate.event.list,
+                    "Note": self.helper.api_impersonate.note.list,
+                    "Observed-Data": self.helper.api_impersonate.observed_data.list,
+                    "Opinion": self.helper.api_impersonate.opinion.list,
+                    "Report": self.helper.api_impersonate.report.list,
+                    "Grouping": self.helper.api_impersonate.grouping.list,
+                    "Case": self.helper.api_impersonate.case.list,
+                    "Course-Of-Action": self.helper.api_impersonate.course_of_action.list,
+                    "Identity": self.helper.api_impersonate.identity.list,
+                    "Indicator": self.helper.api_impersonate.indicator.list,
+                    "Infrastructure": self.helper.api_impersonate.infrastructure.list,
+                    "Intrusion-Set": self.helper.api_impersonate.intrusion_set.list,
+                    "Location": self.helper.api_impersonate.location.list,
+                    "Language": self.helper.api_impersonate.language.list,
+                    "Malware": self.helper.api_impersonate.malware.list,
+                    "Threat-Actor": self.helper.api_impersonate.threat_actor.list,
+                    "Tool": self.helper.api_impersonate.tool.list,
+                    "Narrative": self.helper.api_impersonate.narrative.list,
+                    "Vulnerability": self.helper.api_impersonate.vulnerability.list,
+                    "Incident": self.helper.api_impersonate.incident.list,
+                    "Stix-Cyber-Observable": self.helper.api_impersonate.stix_cyber_observable.list,
+                    "Stix-Core-Relationship": self.helper.api_impersonate.stix_core_relationship.list,
+                    "stix-core-relationship": self.helper.api_impersonate.stix_core_relationship.list,
+                }
+                do_list = lister.get(
+                    final_entity_type,
+                    lambda **kwargs: self.helper.log_error(
+                        'Unknown object type "' + final_entity_type + '", doing nothing...'
+                    ),
+                )
+                entities_list = do_list(
+                    search=list_params["search"],
+                    filters=list_params["filters"],
+                    orderBy=list_params["orderBy"],
+                    orderMode=list_params["orderMode"],
+                    relationship_type=list_params["relationship_type"]
+                    if "relationship_type" in list_params
+                    else None,
+                    elementId=list_params["elementId"]
+                    if "elementId" in list_params
+                    else None,
+                    fromId=list_params["fromId"] if "fromId" in list_params else None,
+                    toId=list_params["toId"] if "toId" in list_params else None,
+                    elementWithTargetTypes=list_params["elementWithTargetTypes"]
+                    if "elementWithTargetTypes" in list_params
+                    else None,
+                    fromTypes=list_params["fromTypes"]
+                    if "fromTypes" in list_params
+                    else None,
+                    toTypes=list_params["toTypes"] if "toTypes" in list_params else None,
+                    types=list_params["types"] if "types" in list_params else None,
+                    getAll=True,
+                )
+
+                list_filters = json.dumps(list_params)
 
             csv_data = self.export_dict_list_to_csv(entities_list)
             self.helper.log_info(
@@ -274,15 +295,15 @@ class ExportFileCsv:
             )
             if entity_type == "Stix-Cyber-Observable":
                 self.helper.api.stix_cyber_observable.push_list_export(
-                    file_name, csv_data, json.dumps(list_params)
+                    file_name, csv_data, list_filters
                 )
             elif entity_type == "Stix-Core-Object":
                 self.helper.api.stix_core_object.push_list_export(
-                    entity_type, file_name, csv_data, json.dumps(list_params)
+                    entity_type, file_name, csv_data, list_filters
                 )
             else:
                 self.helper.api.stix_domain_object.push_list_export(
-                    entity_type, file_name, csv_data, json.dumps(list_params)
+                    entity_type, file_name, csv_data, list_filters
                 )
             self.helper.log_info(
                 "Export done: " + entity_type + "/" + export_type + " to " + file_name

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -97,7 +97,8 @@ class ExportFileCsv:
 
     def _process_message(self, data):
         file_name = data["file_name"]
-        export_scope = data["export_scope"]  # single or list
+        export_scope = data["export_scope"]  # query or selection or single
+        self.helper.log_info('export_scope' + export_scope)
         export_type = data["export_type"]  # Simple or Full
         # max_marking = data["max_marking"]  # TODO Implement marking restriction
         entity_type = data["entity_type"]
@@ -160,7 +161,7 @@ class ExportFileCsv:
                 + ") to "
                 + file_name
             )
-        else:
+        else:  # export_scope = 'query'
             list_params = data["list_params"]
             self.helper.log_info(
                 "Exporting list: "

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -30,6 +30,7 @@ class ExportFileCsv:
 
     def export_dict_list_to_csv(self, data):
         output = io.StringIO()
+        self.helper.log_info('data' + str(data))
         headers = sorted(set().union(*(d.keys() for d in data)))
         if "hashes" in headers:
             headers = headers + [
@@ -261,6 +262,7 @@ class ExportFileCsv:
                     "Stix-Cyber-Observable": self.helper.api_impersonate.stix_cyber_observable.list,
                     "Stix-Core-Relationship": self.helper.api_impersonate.stix_core_relationship.list,
                     "stix-core-relationship": self.helper.api_impersonate.stix_core_relationship.list,
+                    "stix-sighting-relationship": self.helper.api_impersonate.stix_sighting_relationship.list,
                 }
                 do_list = lister.get(
                     final_entity_type,
@@ -303,6 +305,7 @@ class ExportFileCsv:
                 new_entities_list = [entity for entity in entities_list if element_id in entity["objectsIds"]]
                 entities_list = new_entities_list
 
+            self.helper.log_info('entities_list' + str(entities_list))
             csv_data = self.export_dict_list_to_csv(entities_list)
             self.helper.log_info(
                 "Uploading: " + entity_type + "/" + export_type + " to " + file_name

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -298,6 +298,11 @@ class ExportFileCsv:
 
                 list_filters = json.dumps(list_params)
 
+            element_id = data["element_id"]
+            if element_id:  # filtering of the data to keep those in the container
+                new_entities_list = [entity for entity in entities_list if element_id in entity["objectsIds"]]
+                entities_list = new_entities_list
+
             csv_data = self.export_dict_list_to_csv(entities_list)
             self.helper.log_info(
                 "Uploading: " + entity_type + "/" + export_type + " to " + file_name

--- a/internal-export-file/export-file-stix/src/export-file-stix.py
+++ b/internal-export-file/export-file-stix/src/export-file-stix.py
@@ -67,6 +67,12 @@ class ExportFileStix:
                                 id=entity_id
                             )
                         )
+                    if entity_data is None:
+                        entity_data = (
+                            self.helper.api_impersonate.stix_core_relationship.read(
+                                id=entity_id
+                            )
+                        )
                     entities_list.append(entity_data)
 
                 bundle = self.helper.api_impersonate.stix2.export_selected(

--- a/internal-export-file/export-file-stix/src/export-file-stix.py
+++ b/internal-export-file/export-file-stix/src/export-file-stix.py
@@ -20,7 +20,7 @@ class ExportFileStix:
 
     def _process_message(self, data):
         file_name = data["file_name"]
-        export_scope = data["export_scope"]  # single or list
+        export_scope = data["export_scope"]  # query or selection or single
         export_type = data["export_type"]  # Simple or Full
         max_marking = data["max_marking"]
         entity_type = data["entity_type"]

--- a/internal-export-file/export-file-stix/src/export-file-stix.py
+++ b/internal-export-file/export-file-stix/src/export-file-stix.py
@@ -52,7 +52,10 @@ class ExportFileStix:
             )
 
         else:  # export_scope = 'query' or 'selection'
-            element_id = data["element_id"]
+            if "element_id" in data:
+                element_id = data["element_id"]
+            else:
+                element_id = None
 
             if export_scope == "selection":
                 selected_ids = data["selected_ids"]

--- a/internal-export-file/export-file-stix/src/export-file-stix.py
+++ b/internal-export-file/export-file-stix/src/export-file-stix.py
@@ -54,8 +54,7 @@ class ExportFileStix:
         else:  # export_scope = 'query' or 'selection'
             if export_scope == "selection":
                 selected_ids = data["selected_ids"]
-                self.helper.log_info('selected_ids' + str(selected_ids))
-                list_filters = 'selected_ids'
+                list_filters = "selected_ids"
                 entities_list = []
 
                 for entity_id in selected_ids:
@@ -63,12 +62,16 @@ class ExportFileStix:
                         id=entity_id
                     )
                     if entity_data is None:
-                        entity_data = self.helper.api_impersonate.stix_cyber_observable.read(
-                            id=entity_id
+                        entity_data = (
+                            self.helper.api_impersonate.stix_cyber_observable.read(
+                                id=entity_id
+                            )
                         )
                     entities_list.append(entity_data)
 
-                bundle = self.helper.api_impersonate.stix2.export_selected(entities_list, max_marking)
+                bundle = self.helper.api_impersonate.stix2.export_selected(
+                    entities_list, max_marking
+                )
 
             else:  # export_scope = 'query'
                 list_params = data["list_params"]

--- a/internal-export-file/export-file-stix/src/export-file-stix.py
+++ b/internal-export-file/export-file-stix/src/export-file-stix.py
@@ -52,6 +52,8 @@ class ExportFileStix:
             )
 
         else:  # export_scope = 'query' or 'selection'
+            element_id = data["element_id"]
+
             if export_scope == "selection":
                 selected_ids = data["selected_ids"]
                 list_filters = "selected_ids"
@@ -76,7 +78,7 @@ class ExportFileStix:
                     entities_list.append(entity_data)
 
                 bundle = self.helper.api_impersonate.stix2.export_selected(
-                    entities_list, max_marking
+                    entities_list, max_marking, element_id
                 )
 
             else:  # export_scope = 'query'
@@ -104,6 +106,7 @@ class ExportFileStix:
                     list_params.get("fromTypes"),
                     list_params.get("toTypes"),
                     list_params.get("relationship_type"),
+                    element_id,
                 )
                 list_filters = json.dumps(list_params)
 

--- a/internal-export-file/export-file-stix/src/export-file-stix.py
+++ b/internal-export-file/export-file-stix/src/export-file-stix.py
@@ -24,6 +24,7 @@ class ExportFileStix:
         export_type = data["export_type"]  # Simple or Full
         max_marking = data["max_marking"]
         entity_type = data["entity_type"]
+
         if export_scope == "single":
             entity_id = data["entity_id"]
             self.helper.log_info(
@@ -49,51 +50,74 @@ class ExportFileStix:
                 + ") to "
                 + file_name
             )
-        else:
-            list_params = data["list_params"]
-            self.helper.log_info(
-                "Exporting list: "
-                + entity_type
-                + "/"
-                + export_type
-                + " to "
-                + file_name
-            )
-            bundle = self.helper.api_impersonate.stix2.export_list(
-                entity_type,
-                list_params["search"],
-                list_params["filters"],
-                list_params["orderBy"],
-                list_params["orderMode"],
-                max_marking,
-                list_params.get("types"),
-                list_params.get("elementId"),
-                list_params.get("fromId"),
-                list_params.get("toId"),
-                list_params.get("elementWithTargetTypes"),
-                list_params.get("fromTypes"),
-                list_params.get("toTypes"),
-                list_params.get("relationship_type"),
-            )
+
+        else:  # export_scope = 'query' or 'selection'
+            if export_scope == "selection":
+                selected_ids = data["selected_ids"]
+                self.helper.log_info('selected_ids' + str(selected_ids))
+                list_filters = 'selected_ids'
+                entities_list = []
+
+                for entity_id in selected_ids:
+                    entity_data = self.helper.api_impersonate.stix_domain_object.read(
+                        id=entity_id
+                    )
+                    if entity_data is None:
+                        entity_data = self.helper.api_impersonate.stix_cyber_observable.read(
+                            id=entity_id
+                        )
+                    entities_list.append(entity_data)
+
+                bundle = self.helper.api_impersonate.stix2.export_selected(entities_list, max_marking)
+
+            else:  # export_scope = 'query'
+                list_params = data["list_params"]
+                self.helper.log_info(
+                    "Exporting list: "
+                    + entity_type
+                    + "/"
+                    + export_type
+                    + " to "
+                    + file_name
+                )
+                bundle = self.helper.api_impersonate.stix2.export_list(
+                    entity_type,
+                    list_params["search"],
+                    list_params["filters"],
+                    list_params["orderBy"],
+                    list_params["orderMode"],
+                    max_marking,
+                    list_params.get("types"),
+                    list_params.get("elementId"),
+                    list_params.get("fromId"),
+                    list_params.get("toId"),
+                    list_params.get("elementWithTargetTypes"),
+                    list_params.get("fromTypes"),
+                    list_params.get("toTypes"),
+                    list_params.get("relationship_type"),
+                )
+                list_filters = json.dumps(list_params)
+
             json_bundle = json.dumps(bundle, indent=4)
             self.helper.log_info(
                 "Uploading: " + entity_type + "/" + export_type + " to " + file_name
             )
             if entity_type == "Stix-Cyber-Observable":
                 self.helper.api.stix_cyber_observable.push_list_export(
-                    file_name, json_bundle, json.dumps(list_params)
+                    file_name, json_bundle, list_filters
                 )
             elif entity_type == "Stix-Core-Object":
                 self.helper.api.stix_core_object.push_list_export(
-                    entity_type, file_name, json_bundle, json.dumps(list_params)
+                    entity_type, file_name, json_bundle, list_filters
                 )
             else:
                 self.helper.api.stix_domain_object.push_list_export(
-                    entity_type, file_name, json_bundle, json.dumps(list_params)
+                    entity_type, file_name, json_bundle, list_filters
                 )
             self.helper.log_info(
                 "Export done: " + entity_type + "/" + export_type + " to " + file_name
             )
+
         return "Export done"
 
     # Start the main loop

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -31,150 +31,153 @@ class ExportFileTxt:
         if export_scope == "single":
             raise ValueError("This connector only supports list exports")
 
-        elif export_scope == "selection":
+        else:  # export_scope = 'selection' or 'query'
             element_id = data["element_id"]
-            selected_ids = data["selected_ids"]
-            entities_list = []
-            list_filters = "selected_ids"
 
-            for entity_id in selected_ids:
-                entity_data = self.helper.api_impersonate.stix_domain_object.read(
-                    id=entity_id
-                )
-                if entity_data is None:
-                    entity_data = (
-                        self.helper.api_impersonate.stix_cyber_observable.read(
-                            id=entity_id
-                        )
+            if export_scope == "selection":
+                selected_ids = data["selected_ids"]
+                entities_list = []
+                list_filters = "selected_ids"
+
+                for entity_id in selected_ids:
+                    entity_data = self.helper.api_impersonate.stix_domain_object.read(
+                        id=entity_id
                     )
-                if entity_data is None:
-                    entity_data = (
-                        self.helper.api_impersonate.stix_core_relationship.read(
-                            id=entity_id
+                    if entity_data is None:
+                        entity_data = (
+                            self.helper.api_impersonate.stix_cyber_observable.read(
+                                id=entity_id
+                            )
                         )
+                    if entity_data is None:
+                        entity_data = (
+                            self.helper.api_impersonate.stix_core_relationship.read(
+                                id=entity_id
+                            )
+                        )
+                    entities_list.append(entity_data)
+
+            else:  # export_scope = 'query'
+                list_params = data["list_params"]
+                final_entity_type = entity_type
+                if final_entity_type != '':
+                    if StixCyberObservableTypes.has_value(entity_type):
+                        if list_params["filters"] is not None:
+                            list_params["filters"].append(
+                                {"key": "entity_type", "values": [entity_type]}
+                            )
+                        else:
+                            list_params["filters"] = [
+                                {"key": "entity_type", "values": [entity_type]}
+                            ]
+                        final_entity_type = "Stix-Cyber-Observable"
+
+                # List
+                lister = {
+                    "Stix-Core-Object": self.helper.api_impersonate.stix_core_object.list,
+                    "Stix-Domain-Object": self.helper.api_impersonate.stix_domain_object.list,
+                    "Attack-Pattern": self.helper.api_impersonate.attack_pattern.list,
+                    "Campaign": self.helper.api_impersonate.campaign.list,
+                    "Channel": self.helper.api_impersonate.channel.list,
+                    "Event": self.helper.api_impersonate.event.list,
+                    "Note": self.helper.api_impersonate.note.list,
+                    "Observed-Data": self.helper.api_impersonate.observed_data.list,
+                    "Opinion": self.helper.api_impersonate.opinion.list,
+                    "Report": self.helper.api_impersonate.report.list,
+                    "Grouping": self.helper.api_impersonate.grouping.list,
+                    "Case": self.helper.api_impersonate.case.list,
+                    "Course-Of-Action": self.helper.api_impersonate.course_of_action.list,
+                    "Identity": self.helper.api_impersonate.identity.list,
+                    "Language": self.helper.api_impersonate.language.list,
+                    "Indicator": self.helper.api_impersonate.indicator.list,
+                    "Infrastructure": self.helper.api_impersonate.infrastructure.list,
+                    "Intrusion-Set": self.helper.api_impersonate.intrusion_set.list,
+                    "Location": self.helper.api_impersonate.location.list,
+                    "Malware": self.helper.api_impersonate.malware.list,
+                    "Threat-Actor": self.helper.api_impersonate.threat_actor.list,
+                    "Tool": self.helper.api_impersonate.tool.list,
+                    "Narrative": self.helper.api_impersonate.narrative.list,
+                    "Vulnerability": self.helper.api_impersonate.vulnerability.list,
+                    "Incident": self.helper.api_impersonate.incident.list,
+                    "Stix-Cyber-Observable": self.helper.api_impersonate.stix_cyber_observable.list,
+                    "Stix-Core-Relationship": self.helper.api_impersonate.stix_core_relationship.list,
+                    "stix-core-relationship": self.helper.api_impersonate.stix_core_relationship.list,
+                    "stix-sighting-relationship": self.helper.api_impersonate.stix_sighting_relationship.list,
+                }
+                do_list = lister.get(
+                    final_entity_type,
+                    lambda **kwargs: self.helper.log_error(
+                        'Unknown object type "' + final_entity_type + '", doing nothing...'
+                    ),
+                )
+                self.helper.log_info("list_params" + str(list_params))
+                entities_list = do_list(
+                    search=list_params["search"],
+                    filters=list_params["filters"],
+                    orderBy=list_params["orderBy"],
+                    orderMode=list_params["orderMode"],
+                    relationship_type=list_params["relationship_type"]
+                    if "relationship_type" in list_params
+                    else None,
+                    elementId=list_params["elementId"]
+                    if "elementId" in list_params
+                    else None,
+                    fromId=list_params["fromId"] if "fromId" in list_params else None,
+                    toId=list_params["toId"] if "toId" in list_params else None,
+                    elementWithTargetTypes=list_params["elementWithTargetTypes"]
+                    if "elementWithTargetTypes" in list_params
+                    else None,
+                    fromTypes=list_params["fromTypes"]
+                    if "fromTypes" in list_params
+                    else None,
+                    toTypes=list_params["toTypes"] if "toTypes" in list_params else None,
+                    types=list_params["types"] if "types" in list_params else None,
+                    getAll=True,
+                )
+                self.helper.log_info("Uploading: " + entity_type + " to " + file_name)
+                list_filters = json.dumps(list_params)
+
+            if entities_list is not None:
+                # treatment of data in a container
+                self.helper.log_info("element_id" + str(element_id))
+                self.helper.log_info("entities_list" + str(entities_list))
+                if element_id:
+                    self.helper.log_info("entities_list objectsIds" + str([f["objectsIds"] for f in entities_list if f["objectsIds"]]))
+                    new_entities_list = [entity for entity in entities_list if element_id in entity["objectsIds"]]
+                    entities_list = new_entities_list
+                self.helper.log_info("new_entities_list" + str([f["name"] for f in entities_list if "name" in f]))
+
+                if entity_type == "Stix-Cyber-Observable":
+                    observable_values = [
+                        f["observable_value"]
+                        for f in entities_list
+                        if "observable_value" in f
+                    ]
+                    observable_values_bytes = "\n".join(observable_values)
+                    self.helper.api.stix_cyber_observable.push_list_export(
+                        file_name, observable_values_bytes, list_filters
                     )
-                entities_list.append(entity_data)
-
-        else:  # export_scope = 'query'
-            list_params = data["list_params"]
-            final_entity_type = entity_type
-            if final_entity_type != '':
-                if StixCyberObservableTypes.has_value(entity_type):
-                    if list_params["filters"] is not None:
-                        list_params["filters"].append(
-                            {"key": "entity_type", "values": [entity_type]}
-                        )
-                    else:
-                        list_params["filters"] = [
-                            {"key": "entity_type", "values": [entity_type]}
-                        ]
-                    final_entity_type = "Stix-Cyber-Observable"
-
-            # List
-            lister = {
-                "Stix-Core-Object": self.helper.api_impersonate.stix_core_object.list,
-                "Stix-Domain-Object": self.helper.api_impersonate.stix_domain_object.list,
-                "Attack-Pattern": self.helper.api_impersonate.attack_pattern.list,
-                "Campaign": self.helper.api_impersonate.campaign.list,
-                "Channel": self.helper.api_impersonate.channel.list,
-                "Event": self.helper.api_impersonate.event.list,
-                "Note": self.helper.api_impersonate.note.list,
-                "Observed-Data": self.helper.api_impersonate.observed_data.list,
-                "Opinion": self.helper.api_impersonate.opinion.list,
-                "Report": self.helper.api_impersonate.report.list,
-                "Grouping": self.helper.api_impersonate.grouping.list,
-                "Case": self.helper.api_impersonate.case.list,
-                "Course-Of-Action": self.helper.api_impersonate.course_of_action.list,
-                "Identity": self.helper.api_impersonate.identity.list,
-                "Language": self.helper.api_impersonate.language.list,
-                "Indicator": self.helper.api_impersonate.indicator.list,
-                "Infrastructure": self.helper.api_impersonate.infrastructure.list,
-                "Intrusion-Set": self.helper.api_impersonate.intrusion_set.list,
-                "Location": self.helper.api_impersonate.location.list,
-                "Malware": self.helper.api_impersonate.malware.list,
-                "Threat-Actor": self.helper.api_impersonate.threat_actor.list,
-                "Tool": self.helper.api_impersonate.tool.list,
-                "Narrative": self.helper.api_impersonate.narrative.list,
-                "Vulnerability": self.helper.api_impersonate.vulnerability.list,
-                "Incident": self.helper.api_impersonate.incident.list,
-                "Stix-Cyber-Observable": self.helper.api_impersonate.stix_cyber_observable.list,
-                "Stix-Core-Relationship": self.helper.api_impersonate.stix_core_relationship.list,
-                "stix-core-relationship": self.helper.api_impersonate.stix_core_relationship.list,
-            }
-            do_list = lister.get(
-                final_entity_type,
-                lambda **kwargs: self.helper.log_error(
-                    'Unknown object type "' + final_entity_type + '", doing nothing...'
-                ),
-            )
-            self.helper.log_info("list_params" + str(list_params))
-            entities_list = do_list(
-                search=list_params["search"],
-                filters=list_params["filters"],
-                orderBy=list_params["orderBy"],
-                orderMode=list_params["orderMode"],
-                relationship_type=list_params["relationship_type"]
-                if "relationship_type" in list_params
-                else None,
-                elementId=list_params["elementId"]
-                if "elementId" in list_params
-                else None,
-                fromId=list_params["fromId"] if "fromId" in list_params else None,
-                toId=list_params["toId"] if "toId" in list_params else None,
-                elementWithTargetTypes=list_params["elementWithTargetTypes"]
-                if "elementWithTargetTypes" in list_params
-                else None,
-                fromTypes=list_params["fromTypes"]
-                if "fromTypes" in list_params
-                else None,
-                toTypes=list_params["toTypes"] if "toTypes" in list_params else None,
-                types=list_params["types"] if "types" in list_params else None,
-                getAll=True,
-            )
-            self.helper.log_info("Uploading: " + entity_type + " to " + file_name)
-            list_filters = json.dumps(list_params)
-
-        if entities_list is not None:
-            # treatment of data in a container
-            self.helper.log_info("element_id" + str(element_id))
-            self.helper.log_info("entities_list" + str(entities_list))
-            if element_id:
-                self.helper.log_info("entities_list objectsIds" + str([f["objectsIds"] for f in entities_list if f["objectsIds"]]))
-                new_entities_list = [entity for entity in entities_list if element_id in entity["objectsIds"]]
-                entities_list = new_entities_list
-            self.helper.log_info("new_entities_list" + str([f["name"] for f in entities_list if "name" in f]))
-
-            if entity_type == "Stix-Cyber-Observable":
-                observable_values = [
-                    f["observable_value"]
-                    for f in entities_list
-                    if "observable_value" in f
-                ]
-                observable_values_bytes = "\n".join(observable_values)
-                self.helper.api.stix_cyber_observable.push_list_export(
-                    file_name, observable_values_bytes, list_filters
-                )
-            elif entity_type == "Stix-Core-Object":
-                entities_values = [f["name"] for f in entities_list if "name" in f]
-                entities_values_bytes = "\n".join(entities_values)
-                self.helper.api.stix_core_object.push_list_export(
-                    entity_type,
-                    file_name,
-                    entities_values_bytes,
-                    list_filters,
-                )
+                elif entity_type == "Stix-Core-Object":
+                    entities_values = [f["name"] for f in entities_list if "name" in f]
+                    entities_values_bytes = "\n".join(entities_values)
+                    self.helper.api.stix_core_object.push_list_export(
+                        entity_type,
+                        file_name,
+                        entities_values_bytes,
+                        list_filters,
+                    )
+                else:
+                    entities_values = [f["name"] for f in entities_list if "name" in f]
+                    entities_values_bytes = "\n".join(entities_values)
+                    self.helper.api.stix_domain_object.push_list_export(
+                        entity_type,
+                        file_name,
+                        entities_values_bytes,
+                        list_filters,
+                    )
+                self.helper.log_info("Export done: " + entity_type + " to " + file_name)
             else:
-                entities_values = [f["name"] for f in entities_list if "name" in f]
-                entities_values_bytes = "\n".join(entities_values)
-                self.helper.api.stix_domain_object.push_list_export(
-                    entity_type,
-                    file_name,
-                    entities_values_bytes,
-                    list_filters,
-                )
-            self.helper.log_info("Export done: " + entity_type + " to " + file_name)
-        else:
-            raise ValueError("An error occurred, the list is empty")
+                raise ValueError("An error occurred, the list is empty")
 
         return "Export done"
 

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -28,9 +28,9 @@ class ExportFileTxt:
         if export_scope == "single":
             raise ValueError("This connector only supports list exports")
 
-        if entity_type == "stix-sighting-relationship" or entity_type == "ObservedData":
+        if entity_type == "stix-sighting-relationship" or entity_type == "ObservedData" or entity_type == "Artifact":
             raise ValueError(
-                "Text/plain export not available for Sightings and Observed Data"
+                "Text/plain export is not available for this entity type."
             )
             # to do: print defaultValue (instead of name) for sightings
 
@@ -142,15 +142,13 @@ class ExportFileTxt:
                 list_filters = json.dumps(list_params)
 
             if entities_list is not None:
-                if "element_id" in data:  # treatment of data in a container
+                if "element_id" in data and entity_type == "Report":  # treatment of reports in entity>Analysis
                     element_id = data["element_id"]
-                    if (
-                        element_id
-                    ):  # filtering of the data to keep those in the container
+                    if element_id:  # filtering of the data to keep those in the container
                         new_entities_list = [
                             entity
                             for entity in entities_list
-                            if element_id in entity["objectsIds"]
+                            if ("objectsIds" in entity) and (element_id in entity["objectsIds"])
                         ]
                         entities_list = new_entities_list
 

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -20,12 +20,9 @@ class ExportFileTxt:
         self.helper = OpenCTIConnectorHelper(config)
 
     def _process_message(self, data):
-        self.helper.log_info("txt export")
-        self.helper.log_info("data" + str(data))
         file_name = data["file_name"]
         # max_marking = data["max_marking"]  # TODO Implement marking restriction
         entity_type = data["entity_type"]
-        self.helper.log_info("entity_type" + entity_type)
         export_scope = data["export_scope"]
 
         if export_scope == "single":
@@ -60,7 +57,7 @@ class ExportFileTxt:
             else:  # export_scope = 'query'
                 list_params = data["list_params"]
                 final_entity_type = entity_type
-                if final_entity_type != '':
+                if final_entity_type != "":
                     if StixCyberObservableTypes.has_value(entity_type):
                         if list_params["filters"] is not None:
                             list_params["filters"].append(
@@ -107,10 +104,11 @@ class ExportFileTxt:
                 do_list = lister.get(
                     final_entity_type,
                     lambda **kwargs: self.helper.log_error(
-                        'Unknown object type "' + final_entity_type + '", doing nothing...'
+                        'Unknown object type "'
+                        + final_entity_type
+                        + '", doing nothing...'
                     ),
                 )
-                self.helper.log_info("list_params" + str(list_params))
                 entities_list = do_list(
                     search=list_params["search"],
                     filters=list_params["filters"],
@@ -130,7 +128,9 @@ class ExportFileTxt:
                     fromTypes=list_params["fromTypes"]
                     if "fromTypes" in list_params
                     else None,
-                    toTypes=list_params["toTypes"] if "toTypes" in list_params else None,
+                    toTypes=list_params["toTypes"]
+                    if "toTypes" in list_params
+                    else None,
                     types=list_params["types"] if "types" in list_params else None,
                     getAll=True,
                 )
@@ -139,13 +139,13 @@ class ExportFileTxt:
 
             if entities_list is not None:
                 # treatment of data in a container
-                self.helper.log_info("element_id" + str(element_id))
-                self.helper.log_info("entities_list" + str(entities_list))
                 if element_id:
-                    self.helper.log_info("entities_list objectsIds" + str([f["objectsIds"] for f in entities_list if f["objectsIds"]]))
-                    new_entities_list = [entity for entity in entities_list if element_id in entity["objectsIds"]]
+                    new_entities_list = [
+                        entity
+                        for entity in entities_list
+                        if element_id in entity["objectsIds"]
+                    ]
                     entities_list = new_entities_list
-                self.helper.log_info("new_entities_list" + str([f["name"] for f in entities_list if "name" in f]))
 
                 if entity_type == "Stix-Cyber-Observable":
                     observable_values = [

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -44,6 +44,12 @@ class ExportFileTxt:
                             id=entity_id
                         )
                     )
+                if entity_data is None:
+                    entity_data = (
+                        self.helper.api_impersonate.stix_core_relationship.read(
+                            id=entity_id
+                        )
+                    )
                 entities_list.append(entity_data)
 
         else:  # export_scope = 'query'

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -20,82 +20,108 @@ class ExportFileTxt:
         self.helper = OpenCTIConnectorHelper(config)
 
     def _process_message(self, data):
+        self.helper.log_info('data' + str(data))
         file_name = data["file_name"]
         # max_marking = data["max_marking"]  # TODO Implement marking restriction
         entity_type = data["entity_type"]
 
-        list_params = data["list_params"]
-        self.helper.log_info(data)
+        export_scope = data["export_scope"]
 
-        final_entity_type = entity_type
-        if StixCyberObservableTypes.has_value(entity_type):
-            if list_params["filters"] is not None:
-                list_params["filters"].append(
-                    {"key": "entity_type", "values": [entity_type]}
+        if export_scope == "selection":
+            selected_ids = data["selected_ids"]
+            self.helper.log_info('selected_ids' + str(selected_ids))
+            entities_list = []
+            list_filters = 'via selected_ids'
+
+            for entity_id in selected_ids:
+                entity_data = self.helper.api_impersonate.stix_domain_object.read(
+                    id=entity_id
                 )
-            else:
-                list_params["filters"] = [
-                    {"key": "entity_type", "values": [entity_type]}
-                ]
-            final_entity_type = "Stix-Cyber-Observable"
+                if entity_data is None:
+                    entity_data = self.helper.api_impersonate.stix_cyber_observable.read(
+                        id=entity_id
+                    )
+                self.helper.log_info('entity_data' + str(entity_data))
 
-        # List
-        lister = {
-            "Stix-Core-Object": self.helper.api_impersonate.stix_core_object.list,
-            "Stix-Domain-Object": self.helper.api_impersonate.stix_domain_object.list,
-            "Attack-Pattern": self.helper.api_impersonate.attack_pattern.list,
-            "Campaign": self.helper.api_impersonate.campaign.list,
-            "Channel": self.helper.api_impersonate.channel.list,
-            "Event": self.helper.api_impersonate.event.list,
-            "Note": self.helper.api_impersonate.note.list,
-            "Observed-Data": self.helper.api_impersonate.observed_data.list,
-            "Opinion": self.helper.api_impersonate.opinion.list,
-            "Report": self.helper.api_impersonate.report.list,
-            "Grouping": self.helper.api_impersonate.grouping.list,
-            "Case": self.helper.api_impersonate.case.list,
-            "Course-Of-Action": self.helper.api_impersonate.course_of_action.list,
-            "Identity": self.helper.api_impersonate.identity.list,
-            "Language": self.helper.api_impersonate.language.list,
-            "Indicator": self.helper.api_impersonate.indicator.list,
-            "Infrastructure": self.helper.api_impersonate.infrastructure.list,
-            "Intrusion-Set": self.helper.api_impersonate.intrusion_set.list,
-            "Location": self.helper.api_impersonate.location.list,
-            "Malware": self.helper.api_impersonate.malware.list,
-            "Threat-Actor": self.helper.api_impersonate.threat_actor.list,
-            "Tool": self.helper.api_impersonate.tool.list,
-            "Narrative": self.helper.api_impersonate.narrative.list,
-            "Vulnerability": self.helper.api_impersonate.vulnerability.list,
-            "Incident": self.helper.api_impersonate.incident.list,
-            "Stix-Cyber-Observable": self.helper.api_impersonate.stix_cyber_observable.list,
-            "Stix-Core-Relationship": self.helper.api_impersonate.stix_core_relationship.list,
-            "stix-core-relationship": self.helper.api_impersonate.stix_core_relationship.list,
-        }
-        do_list = lister.get(
-            final_entity_type,
-            lambda **kwargs: self.helper.log_error(
-                'Unknown object type "' + final_entity_type + '", doing nothing...'
-            ),
-        )
-        entities_list = do_list(
-            search=list_params["search"],
-            filters=list_params["filters"],
-            orderBy=list_params["orderBy"],
-            orderMode=list_params["orderMode"],
-            relationship_type=list_params["relationship_type"]
-            if "relationship_type" in list_params
-            else None,
-            elementId=list_params["elementId"] if "elementId" in list_params else None,
-            fromId=list_params["fromId"] if "fromId" in list_params else None,
-            toId=list_params["toId"] if "toId" in list_params else None,
-            elementWithTargetTypes=list_params["elementWithTargetTypes"]
-            if "elementWithTargetTypes" in list_params
-            else None,
-            fromTypes=list_params["fromTypes"] if "fromTypes" in list_params else None,
-            toTypes=list_params["toTypes"] if "toTypes" in list_params else None,
-            types=list_params["types"] if "types" in list_params else None,
-            getAll=True,
-        )
-        self.helper.log_info("Uploading: " + entity_type + " to " + file_name)
+                entities_list.append(entity_data)
+
+        else:      # export_scope = 'query'
+            list_params = data["list_params"]
+            self.helper.log_info(data)
+
+            final_entity_type = entity_type
+            if StixCyberObservableTypes.has_value(entity_type):
+                if list_params["filters"] is not None:
+                    list_params["filters"].append(
+                        {"key": "entity_type", "values": [entity_type]}
+                    )
+                else:
+                    list_params["filters"] = [
+                        {"key": "entity_type", "values": [entity_type]}
+                    ]
+                final_entity_type = "Stix-Cyber-Observable"
+
+            # List
+            lister = {
+                "Stix-Core-Object": self.helper.api_impersonate.stix_core_object.list,
+                "Stix-Domain-Object": self.helper.api_impersonate.stix_domain_object.list,
+                "Attack-Pattern": self.helper.api_impersonate.attack_pattern.list,
+                "Campaign": self.helper.api_impersonate.campaign.list,
+                "Channel": self.helper.api_impersonate.channel.list,
+                "Event": self.helper.api_impersonate.event.list,
+                "Note": self.helper.api_impersonate.note.list,
+                "Observed-Data": self.helper.api_impersonate.observed_data.list,
+                "Opinion": self.helper.api_impersonate.opinion.list,
+                "Report": self.helper.api_impersonate.report.list,
+                "Grouping": self.helper.api_impersonate.grouping.list,
+                "Case": self.helper.api_impersonate.case.list,
+                "Course-Of-Action": self.helper.api_impersonate.course_of_action.list,
+                "Identity": self.helper.api_impersonate.identity.list,
+                "Language": self.helper.api_impersonate.language.list,
+                "Indicator": self.helper.api_impersonate.indicator.list,
+                "Infrastructure": self.helper.api_impersonate.infrastructure.list,
+                "Intrusion-Set": self.helper.api_impersonate.intrusion_set.list,
+                "Location": self.helper.api_impersonate.location.list,
+                "Malware": self.helper.api_impersonate.malware.list,
+                "Threat-Actor": self.helper.api_impersonate.threat_actor.list,
+                "Tool": self.helper.api_impersonate.tool.list,
+                "Narrative": self.helper.api_impersonate.narrative.list,
+                "Vulnerability": self.helper.api_impersonate.vulnerability.list,
+                "Incident": self.helper.api_impersonate.incident.list,
+                "Stix-Cyber-Observable": self.helper.api_impersonate.stix_cyber_observable.list,
+                "Stix-Core-Relationship": self.helper.api_impersonate.stix_core_relationship.list,
+                "stix-core-relationship": self.helper.api_impersonate.stix_core_relationship.list,
+            }
+            do_list = lister.get(
+                final_entity_type,
+                lambda **kwargs: self.helper.log_error(
+                    'Unknown object type "' + final_entity_type + '", doing nothing...'
+                ),
+            )
+            entities_list = do_list(
+                search=list_params["search"],
+                filters=list_params["filters"],
+                orderBy=list_params["orderBy"],
+                orderMode=list_params["orderMode"],
+                relationship_type=list_params["relationship_type"]
+                if "relationship_type" in list_params
+                else None,
+                elementId=list_params["elementId"] if "elementId" in list_params else None,
+                fromId=list_params["fromId"] if "fromId" in list_params else None,
+                toId=list_params["toId"] if "toId" in list_params else None,
+                elementWithTargetTypes=list_params["elementWithTargetTypes"]
+                if "elementWithTargetTypes" in list_params
+                else None,
+                fromTypes=list_params["fromTypes"] if "fromTypes" in list_params else None,
+                toTypes=list_params["toTypes"] if "toTypes" in list_params else None,
+                types=list_params["types"] if "types" in list_params else None,
+                getAll=True,
+            )
+            self.helper.log_info("Uploading: " + entity_type + " to " + file_name)
+            self.helper.log_info('entities_list' + str(entities_list))
+
+            list_filters = json.dumps(list_params)
+
         if entities_list is not None:
             if entity_type == "Stix-Cyber-Observable":
                 observable_values = [
@@ -105,7 +131,7 @@ class ExportFileTxt:
                 ]
                 observable_values_bytes = "\n".join(observable_values)
                 self.helper.api.stix_cyber_observable.push_list_export(
-                    file_name, observable_values_bytes, json.dumps(list_params)
+                    file_name, observable_values_bytes, list_filters
                 )
             elif entity_type == "Stix-Core-Object":
                 entities_values = [f["name"] for f in entities_list if "name" in f]
@@ -114,7 +140,7 @@ class ExportFileTxt:
                     entity_type,
                     file_name,
                     entities_values_bytes,
-                    json.dumps(list_params),
+                    list_filters,
                 )
             else:
                 entities_values = [f["name"] for f in entities_list if "name" in f]
@@ -123,11 +149,12 @@ class ExportFileTxt:
                     entity_type,
                     file_name,
                     entities_values_bytes,
-                    json.dumps(list_params),
+                    list_filters,
                 )
             self.helper.log_info("Export done: " + entity_type + " to " + file_name)
         else:
             raise ValueError("An error occurred, the list is empty")
+
         return "Export done"
 
     # Start the main loop

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -30,6 +30,7 @@ class ExportFileTxt:
 
         if (
             entity_type == "stix-sighting-relationship"
+            or entity_type == "stix-core-relationship"
             or entity_type == "ObservedData"
             or entity_type == "Artifact"
         ):

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -21,13 +21,17 @@ class ExportFileTxt:
 
     def _process_message(self, data):
         self.helper.log_info('data' + str(data))
+
         file_name = data["file_name"]
         # max_marking = data["max_marking"]  # TODO Implement marking restriction
         entity_type = data["entity_type"]
 
         export_scope = data["export_scope"]
 
-        if export_scope == "selection":
+        if export_scope == "single":
+            raise ValueError("This connector only supports list exports")
+
+        elif export_scope == "selection":
             selected_ids = data["selected_ids"]
             self.helper.log_info('selected_ids' + str(selected_ids))
             entities_list = []

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -31,7 +31,7 @@ class ExportFileTxt:
         if (
             entity_type == "stix-sighting-relationship"
             or entity_type == "stix-core-relationship"
-            or entity_type == "ObservedData"
+            or entity_type == "Observed-Data"
             or entity_type == "Artifact"
         ):
             raise ValueError("Text/plain export is not available for this entity type.")
@@ -85,7 +85,7 @@ class ExportFileTxt:
                     "Channel": self.helper.api_impersonate.channel.list,
                     "Event": self.helper.api_impersonate.event.list,
                     "Note": self.helper.api_impersonate.note.list,
-                    "ObservedData": self.helper.api_impersonate.observed_data.list,
+                    "Observed-Data": self.helper.api_impersonate.observed_data.list,
                     "Opinion": self.helper.api_impersonate.opinion.list,
                     "Report": self.helper.api_impersonate.report.list,
                     "Grouping": self.helper.api_impersonate.grouping.list,

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -31,7 +31,7 @@ class ExportFileTxt:
             selected_ids = data["selected_ids"]
             self.helper.log_info('selected_ids' + str(selected_ids))
             entities_list = []
-            list_filters = 'via selected_ids'
+            list_filters = 'selected_ids'
 
             for entity_id in selected_ids:
                 entity_data = self.helper.api_impersonate.stix_domain_object.read(

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -28,10 +28,12 @@ class ExportFileTxt:
         if export_scope == "single":
             raise ValueError("This connector only supports list exports")
 
-        if entity_type == "stix-sighting-relationship" or entity_type == "ObservedData" or entity_type == "Artifact":
-            raise ValueError(
-                "Text/plain export is not available for this entity type."
-            )
+        if (
+            entity_type == "stix-sighting-relationship"
+            or entity_type == "ObservedData"
+            or entity_type == "Artifact"
+        ):
+            raise ValueError("Text/plain export is not available for this entity type.")
             # to do: print defaultValue (instead of name) for sightings
 
         else:  # export_scope = 'selection' or 'query'
@@ -142,13 +144,18 @@ class ExportFileTxt:
                 list_filters = json.dumps(list_params)
 
             if entities_list is not None:
-                if "element_id" in data and entity_type == "Report":  # treatment of reports in entity>Analysis
+                if (
+                    "element_id" in data and entity_type == "Report"
+                ):  # treatment of reports in entity>Analysis
                     element_id = data["element_id"]
-                    if element_id:  # filtering of the data to keep those in the container
+                    if (
+                        element_id
+                    ):  # filtering of the data to keep those in the container
                         new_entities_list = [
                             entity
                             for entity in entities_list
-                            if ("objectsIds" in entity) and (element_id in entity["objectsIds"])
+                            if ("objectsIds" in entity)
+                            and (element_id in entity["objectsIds"])
                         ]
                         entities_list = new_entities_list
 

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -20,8 +20,6 @@ class ExportFileTxt:
         self.helper = OpenCTIConnectorHelper(config)
 
     def _process_message(self, data):
-        self.helper.log_info('data' + str(data))
-
         file_name = data["file_name"]
         # max_marking = data["max_marking"]  # TODO Implement marking restriction
         entity_type = data["entity_type"]
@@ -33,26 +31,23 @@ class ExportFileTxt:
 
         elif export_scope == "selection":
             selected_ids = data["selected_ids"]
-            self.helper.log_info('selected_ids' + str(selected_ids))
             entities_list = []
-            list_filters = 'selected_ids'
+            list_filters = "selected_ids"
 
             for entity_id in selected_ids:
                 entity_data = self.helper.api_impersonate.stix_domain_object.read(
                     id=entity_id
                 )
                 if entity_data is None:
-                    entity_data = self.helper.api_impersonate.stix_cyber_observable.read(
-                        id=entity_id
+                    entity_data = (
+                        self.helper.api_impersonate.stix_cyber_observable.read(
+                            id=entity_id
+                        )
                     )
-                self.helper.log_info('entity_data' + str(entity_data))
-
                 entities_list.append(entity_data)
 
-        else:      # export_scope = 'query'
+        else:  # export_scope = 'query'
             list_params = data["list_params"]
-            self.helper.log_info(data)
-
             final_entity_type = entity_type
             if StixCyberObservableTypes.has_value(entity_type):
                 if list_params["filters"] is not None:
@@ -110,20 +105,22 @@ class ExportFileTxt:
                 relationship_type=list_params["relationship_type"]
                 if "relationship_type" in list_params
                 else None,
-                elementId=list_params["elementId"] if "elementId" in list_params else None,
+                elementId=list_params["elementId"]
+                if "elementId" in list_params
+                else None,
                 fromId=list_params["fromId"] if "fromId" in list_params else None,
                 toId=list_params["toId"] if "toId" in list_params else None,
                 elementWithTargetTypes=list_params["elementWithTargetTypes"]
                 if "elementWithTargetTypes" in list_params
                 else None,
-                fromTypes=list_params["fromTypes"] if "fromTypes" in list_params else None,
+                fromTypes=list_params["fromTypes"]
+                if "fromTypes" in list_params
+                else None,
                 toTypes=list_params["toTypes"] if "toTypes" in list_params else None,
                 types=list_params["types"] if "types" in list_params else None,
                 getAll=True,
             )
             self.helper.log_info("Uploading: " + entity_type + " to " + file_name)
-            self.helper.log_info('entities_list' + str(entities_list))
-
             list_filters = json.dumps(list_params)
 
         if entities_list is not None:

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -28,9 +28,13 @@ class ExportFileTxt:
         if export_scope == "single":
             raise ValueError("This connector only supports list exports")
 
-        else:  # export_scope = 'selection' or 'query'
-            element_id = data["element_id"]
+        if entity_type == "stix-sighting-relationship" or entity_type == "ObservedData":
+            raise ValueError(
+                "Text/plain export not available for Sightings and Observed Data"
+            )
+            # to do: print defaultValue (instead of name) for sightings
 
+        else:  # export_scope = 'selection' or 'query'
             if export_scope == "selection":
                 selected_ids = data["selected_ids"]
                 entities_list = []
@@ -78,7 +82,7 @@ class ExportFileTxt:
                     "Channel": self.helper.api_impersonate.channel.list,
                     "Event": self.helper.api_impersonate.event.list,
                     "Note": self.helper.api_impersonate.note.list,
-                    "Observed-Data": self.helper.api_impersonate.observed_data.list,
+                    "ObservedData": self.helper.api_impersonate.observed_data.list,
                     "Opinion": self.helper.api_impersonate.opinion.list,
                     "Report": self.helper.api_impersonate.report.list,
                     "Grouping": self.helper.api_impersonate.grouping.list,
@@ -138,14 +142,17 @@ class ExportFileTxt:
                 list_filters = json.dumps(list_params)
 
             if entities_list is not None:
-                # treatment of data in a container
-                if element_id:
-                    new_entities_list = [
-                        entity
-                        for entity in entities_list
-                        if element_id in entity["objectsIds"]
-                    ]
-                    entities_list = new_entities_list
+                if "element_id" in data:  # treatment of data in a container
+                    element_id = data["element_id"]
+                    if (
+                        element_id
+                    ):  # filtering of the data to keep those in the container
+                        new_entities_list = [
+                            entity
+                            for entity in entities_list
+                            if element_id in entity["objectsIds"]
+                        ]
+                        entities_list = new_entities_list
 
                 if entity_type == "Stix-Cyber-Observable":
                     observable_values = [


### PR DESCRIPTION
By default, only filters and search keywords are taken into account during the export : selecting individual entities via the checkboxes is not taken into account by the list export functions.

Steps to create the smallest reproducible scenario:

1. Select multiple observables / indicators via the check boxes
2. Open the export panels and export to CSV or JSON
3. Returned format includes all observables or indicators, not the entities selected

### Proposed changes

When we select some entities via checkboxes, the file export should only contain those entities (=entities that are checked + respect the current filtering).
If no entities are selected: the workflow stay the same as it is

### Concerned exports
- txt exports (except for relationships and single entities)
- csv exports
- stix exports

### Associated PR in OpenCTI
https://github.com/OpenCTI-Platform/opencti/pull/2786

### Associated PR in client-python
https://github.com/OpenCTI-Platform/client-python/pull/323

### Related issues

https://github.com/OpenCTI-Platform/opencti/issues/1741

### Notion page

https://www.notion.so/filigran/Export-only-selected-entities-1741-7fcbf649eb5a4cd6a009d4c383ce62eb

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
