### PR TITLE
Connector-Elastic - index pattern is used wrongly

### DIFF
--- a/stream/elastic/elastic/import_manager.py
+++ b/stream/elastic/elastic/import_manager.py
@@ -253,7 +253,10 @@ class IntelManager(object):
             id=OpenCTIConnectorHelper.get_attribute_in_extension("id", data)
         )
 
-        logger.debug(entity)
+        if entity is None:
+            id = OpenCTIConnectorHelper.get_attribute_in_extension("id", data)
+            logger.warning(f"For document id {id}, entity is '{entity}'. Skipping.")
+            return None
 
         _result: dict = {}
         _document: Cut = {}
@@ -274,7 +277,7 @@ class IntelManager(object):
                     f"Retrieving document id: {OpenCTIConnectorHelper.get_attribute_in_extension('id', data)}"
                 )
                 _result = self.es_client.get(
-                    index=self.idx_pattern,
+                    index=self.write_idx,
                     id=OpenCTIConnectorHelper.get_attribute_in_extension("id", data),
                     doc_type="_doc",
                 )
@@ -501,7 +504,7 @@ class IntelManager(object):
 
         try:
             _result = self.es_client.delete(
-                index=self.idx_pattern,
+                index=self.write_idx,
                 id=OpenCTIConnectorHelper.get_attribute_in_extension("id", data),
                 doc_type="_doc",
             )

--- a/stream/elastic/elastic/stix2ecs.py
+++ b/stream/elastic/elastic/stix2ecs.py
@@ -77,7 +77,7 @@ class UnknownIndicator(StixIndicator):
         super().__init__(**kwargs)
 
     def _parse(self, data: List[Tuple[str, str, str]]) -> Dict[str, str]:
-        raise NotImplementedError
+        raise NotImplementedError(f"Handler not found for data '{data}'")
 
 
 class ArtifactIndicator(StixIndicator):


### PR DESCRIPTION
A few changes. 

### Proposed changes

* Fixed the bug with the wildcard mentioned in the issue below. 
* Fixed the error when entity delivered by OpenCTI server is "none"
* Made the exception clearer that is thrown when unknown STIX attributes are encountered. This makes debugging easier. 

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/983

### Checklist

Code is tested in our production envorinment. 

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
