### PR TITLE
Connector-Elastic - ECS 8.0.0 compatibility

### DIFF
--- a/stream/elastic/elastic/sightings_manager.py
+++ b/stream/elastic/elastic/sightings_manager.py
@@ -2,6 +2,7 @@ import json
 from datetime import timedelta
 from logging import getLogger
 from threading import Event, Thread
+from packaging import version
 
 from elasticsearch import Elasticsearch, NotFoundError
 from elasticsearch_dsl import Search
@@ -170,7 +171,12 @@ class SignalsManager(Thread):
                             )
                             continue
 
-                    _timestamp = hit["_source"]["signal"]["original_time"]
+                    ecs_version_lt8 = version.parse(hit["_source"]["ecs"]["version"]) < version.parse("8.0.0")
+                    if ecs_version_lt8:
+                        _timestamp = hit["_source"]["signal"]["original_time"]
+                    else:
+                        _timestamp = hit["_source"]["kibana.alert.original_time"]
+
                     if _opencti_id not in ids_dict:
                         ids_dict[_opencti_id] = {
                             "first_seen": _timestamp,

--- a/stream/elastic/pyproject.toml
+++ b/stream/elastic/pyproject.toml
@@ -23,6 +23,7 @@ elasticsearch-dsl = ">=7.0.0,<8.0.0"
 python-datemath = "^1.5.5"
 arrow = "^1.1.1"
 PyYAML = "^6.0"
+packaging = "^22.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.0"


### PR DESCRIPTION
Made the signal import compatible with ECS8.0 alerts.

### Proposed changes

*  distingusih between the two alert formats "<= 7.17" and ">= 8.0.0"

### Related issues

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
