### PR TITLE
Connector-Elastic - allowing self-termination

### DIFF
--- a/stream/elastic/Dockerfile
+++ b/stream/elastic/Dockerfile
@@ -37,4 +37,11 @@ COPY --from=builder /runtime /runtime
 # Expose and entrypoint
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+
+# Add Tini
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
+# Run your program under Tini
+ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]


### PR DESCRIPTION
In our Kybernetes-setup, the connector-elastic container did not terminate itself if the module pycti tries to reset itself on connection interupt (e.g., when restting the connector via GUI). 

The pycti module throws "SIGTERM" to terminate the process. That, however, does not work as the process is the primary process within the container and the SIGTERM signal is not sent to the process. This also because the connector-elastic process is multi-threaded. 

We solve this by including "tini" spawing the connector python process. This may also be applicable to other connectors. 

### Proposed changes

* introducing a tini abstraction layer when starting the container
*

### Related issues



### Checklist


- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


### Further comments
