### PR TITLE
Connector Abuse-SSL - fixed STIX attribute string: ipv4 -> ipv4-addr

### DIFF
--- a/external-import/abuse-ssl/src/abuse-ssl.py
+++ b/external-import/abuse-ssl/src/abuse-ssl.py
@@ -143,7 +143,7 @@ class AbuseSSLImportConnector:
                 created_by_ref=f"{self.author.id}",
                 confidence=self.helper.connect_confidence_level,
                 pattern_type="stix",
-                pattern=f"[ipv4:value = '{observable.value}']",
+                pattern=f"[ipv4-addr:value = '{observable.value}']",
                 labels="osint",
             )
             indicators.append(indicator)


### PR DESCRIPTION
The connector "abuse-ssl" formats a STIX attribute wrongly. 

See: http://docs.oasis-open.org/cti/stix/v2.0/cs01/part4-cyber-observable-objects/stix-v2.0-cs01-part4-cyber-observable-objects.html#_Toc496716225

### Proposed changes

* connector-abuse-ssl: fixed STIX-attribute string ipv4 -> ipv4-addr

### Related issues

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments


