### PR TITLE
Connector-Elastic - datemath requires arrow instead of datetime  

### DIFF
--- a/stream/elastic/elastic/import_manager.py
+++ b/stream/elastic/elastic/import_manager.py
@@ -1,5 +1,6 @@
 import re
 import urllib.parse
+from arrow import Arrow
 from datetime import datetime, timezone
 from logging import getLogger
 
@@ -70,7 +71,7 @@ class StixManager(object):
                 if m.get("modulo", None) is not None:
                     _fmt = m.get("format") or DM_DEFAULT_FMT
                     logger.debug(f"{m['modulo']} -> {_fmt}")
-                    _val = dm(m.get("modulo"), now=timestamp).format(_fmt)
+                    _val = dm(m.get("modulo"), now=Arrow.fromdatetime(timestamp)).format(_fmt)
                     _write_idx = self.pattern.sub(_val, _write_idx)
 
             # Submit to Elastic index
@@ -471,7 +472,7 @@ class IntelManager(object):
                 if m.get("modulo", None) is not None:
                     _fmt = m.get("format") or DM_DEFAULT_FMT
                     logger.debug(f"{m['modulo']} -> {_fmt}")
-                    _val = dm(m.get("modulo"), now=timestamp).format(_fmt)
+                    _val = dm(m.get("modulo"), now=Arrow.fromdatetime(timestamp)).format(_fmt)
                     _write_idx = self.pattern.sub(_val, _write_idx)
 
             # Submit to Elastic index


### PR DESCRIPTION
The datetime module used in the connector-elastic connector requires the floor() method on timestamps which is not provided by datetime. 

### Proposed changes

* changed datetime to arrrow. No additional python modules required as datemath already loads arrow internally. 

### Related issues

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments
