### PR TITLE
Connector-Elastic - allowing less privileged Elasticsearch access

### DIFF
--- a/stream/elastic/README.md
+++ b/stream/elastic/README.md
@@ -59,7 +59,9 @@ variable `CONNECTOR_JSON_CONFIG` takes a JSON equivalent of the `config.yml` and
 | `output.elasticsearch.password`   | `ELASTICSEARCH_PASSWORD`     | No        | The Elasticsearch password (ApiKey is recommended).                                                                                                                      |
 | `output.elasticsearch.username`   | `ELASTICSEARCH_USERNAME`     | No        | The Elasticsearch login user (ApiKey is recommended).                                                                                                                    |
 | `output.elasticsearch.ssl_verify` | `ELASTICSEARCH_SSL_VERIFY`   | No        | Set to `False` to disable TLS certificate validation. Defaults to `True`                                                                                                 |
+| `output.elasticsearch.reduced_privileges` | `ELASTICSEARCH_REDUCED_PRIVILEGES`   | No        | Set to `True` to disable additional access checks for Elasticsearch if the access does not includes ' manage" cluster-privileges. Defaults to `False`                                                                                                 |
 |                                   | `CONNECTOR_JSON_CONFIG`      | No        | (Optional) environment variable allowing full configuration via a single environment variable using JSON. Helpful for some container deployment scenarios.               |
+
 
 ## Building Container
 
@@ -137,6 +139,71 @@ POST /_security/api_key?pretty
             ]
           },
           "allow_restricted_indices": false
+        }
+      ],
+      "run_as": []
+    },
+    "protections_privileges": {
+      "cluster": [],
+      "indices": [
+        {
+          "names": [
+            ".siem-signals-*"
+          ],
+          "privileges": [
+            "read"
+          ],
+          "field_security": {
+            "grant": [
+              "*"
+            ],
+            "except": []
+          },
+          "allow_restricted_indices": false
+        }
+      ],
+      "run_as": []
+    }
+  },
+  "metadata": {
+    "application": "opencti",
+    "environment": {
+      "tags": [
+        "dev",
+        "staging"
+      ]
+    }
+  }
+}
+```
+
+### Using a Constrained API key without cluster privileges
+
+In combination with the configuration flag "output.elasticsearch.reduced_privileges", the following API request generates API-keys that allow access only to the specific index pattern `opencti*`. 
+
+```
+POST /_security/api_key?pretty
+{
+  "name": "opencti",
+  "expiration": "365d",
+  "role_descriptors": {
+    "opencti_privileges": {
+      "cluster": [],
+      "indices": [{
+        "names": [
+          "opencti*"
+        ],
+        "privileges": [
+          "all",
+          "manage_follow_index",
+          "view_index_metadata" 
+        ],
+        "field_security": {
+          "grant": [
+            "*"
+          ]
+        },
+        "allow_restricted_indices": false
         }
       ],
       "run_as": []

--- a/stream/elastic/README.md
+++ b/stream/elastic/README.md
@@ -194,9 +194,7 @@ POST /_security/api_key?pretty
           "opencti*"
         ],
         "privileges": [
-          "all",
-          "manage_follow_index",
-          "view_index_metadata" 
+          "all"
         ],
         "field_security": {
           "grant": [

--- a/stream/elastic/config.reference.yml
+++ b/stream/elastic/config.reference.yml
@@ -45,6 +45,10 @@ output.elasticsearch:
   # `setup.template.pattern` if you change the output index.
   #index: "opencti-{now/d}"
 
+  # Set the following flag to "true" if the elasticsearch access do not have cluster 
+  # "monitor" privileges
+  #reduced_privileges: false 
+
 # ====================== Index Lifecycle Management (ILM) ======================
 
 # Configure index lifecycle management (ILM). These settings create a write

--- a/stream/elastic/elastic/conf.py
+++ b/stream/elastic/elastic/conf.py
@@ -37,6 +37,7 @@ defaults: dict = {
             "password": None,
             "api_key": None,
             "index": "opencti-{now/d}",
+            "reduced_privileges": "false",
         }
     },
     "setup": {

--- a/stream/elastic/elastic/console.py
+++ b/stream/elastic/elastic/console.py
@@ -91,6 +91,7 @@ def __process_config(argv={}, config={}) -> dict:
                 "username": os.environ.get("ELASTICSEARCH_USERNAME", None),
                 "password": os.environ.get("ELASTICSEARCH_PASSWORD", None),
                 "ssl_verify": os.environ.get("ELASTICSEARCH_SSL_VERIFY", None),
+                "reduced_privileges": os.environ.get("ELASTICSEARCH_REDUCED_PRIVILEGES", None),
             }
         },
         "elastic": {

--- a/stream/elastic/elastic/import_manager.py
+++ b/stream/elastic/elastic/import_manager.py
@@ -1,5 +1,6 @@
 import re
 import urllib.parse
+import warnings
 from datetime import datetime, timezone
 from logging import getLogger
 
@@ -138,18 +139,19 @@ class IntelManager(object):
         from string import Template
 
         logger.info("Setting up Elasticsearch for OpenCTI Connector")
-        assert self.es_client.ping()
+        if not self.config.get("output.elasticsearch.reduced_privileges", True):
+            assert self.es_client.ping()
 
         _ilm_enabled: bool = self.config.get("setup.ilm.enabled", True)
         _policy_name: str = self.config.get("setup.ilm.policy_name", "opencti")
         _policy: str = None
 
-        try:
-            _policy: str = self.es_client.ilm.get_lifecycle(policy=_policy_name)
-        except NotFoundError as err:
-            logger.warning(f"HTTP {err.status_code}: {err.info['error']['reason']}")
-
         if _ilm_enabled is True:
+            try:
+                _policy: str = self.es_client.ilm.get_lifecycle(policy=_policy_name)
+            except NotFoundError as err:
+                logger.warning(f"HTTP {err.status_code}: {err.info['error']['reason']}")
+
             # Create ILM policy if needed
             if (_policy is None) or (
                 self.config.get("setup.ilm.overwrite", None) is True
@@ -182,14 +184,11 @@ class IntelManager(object):
 
         # Create initial index, if needed
         logger.debug(f"Checking if index pattern exists: {self.idx_pattern}")
-        if (
-            len(
-                self.es_client.indices.resolve_index(name=self.idx_pattern).get(
-                    "indices", []
-                )
-            )
-            < 1
-        ):
+        with warnings.catch_warnings(record=True) as w:
+            matching_indices = self.es_client.indices.resolve_index(
+                name=self.idx_pattern).get("indices", [])
+        
+        if len(matching_indices) < 1:
             logger.debug("No indices matching pattern exist.")
 
             if _ilm_enabled is True:

--- a/stream/elastic/elastic/import_manager.py
+++ b/stream/elastic/elastic/import_manager.py
@@ -233,7 +233,6 @@ class IntelManager(object):
 
                 self.write_idx = _alias
             else:
-                logger.info(f"Alias {_alias} already exists or not being used")
                 _settings = "{}"
 
             self.es_client.index(index=_initial_idx, body=_settings)

--- a/stream/elastic/elastic/sightings_manager.py
+++ b/stream/elastic/elastic/sightings_manager.py
@@ -61,7 +61,9 @@ class SignalsManager(Thread):
             "elastic.signals.lookback_interval", DEFAULT_LOOKBACK
         )
 
-        assert self.es_client.ping()
+        if not self.config.get("output.elasticsearch.reduced_privileges", True):
+            assert self.es_client.ping()
+
         self.signals_search: dict = (
             Search(using=self.es_client, index=self.search_idx)
             .from_dict(_query)


### PR DESCRIPTION
The current connector-elastic module requieres the "manage" cluster privilege on its target Elasticseach instance. In case ILM or index-templates are not deployed, these privileges are not required as well. The connector, however, does a few actions that lead to aborting when not permitted the elevated rights. 

This pull-request adds an additional flag `output.elasticsearch.reduced_privilege` to the configuration that disables these additional actions and allows for tailoring the access to a specific index only. 

### Proposed changes

* adding the flag `output.elasticsearch.reduced_privilege` to the configuration in defaults, config.yaml and env-variables
* disable the elastic_helper.ping() method that requieres "manage" cluster privileges.
* Extending the README accordingly. 
* Fixing a but where the variable `_alias` is referenced even without ILM enabled where the code defines `_alias` only when ILM is enabled. 
* Shifting a few lines of code around such that they are only executed if ILM is enabled. 

### Related issues

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
