### PR TITLE
setting Attribute key to empty array if not present

### DIFF
--- a/external-import/misp-feed/src/misp-feed.py
+++ b/external-import/misp-feed/src/misp-feed.py
@@ -1479,7 +1479,7 @@ class MispFeed:
         event_external_references = []
         indicators = []
         # Get attributes of event
-        for attribute in event["Event"]["Attribute"]:
+        for attribute in event["Event"].get("Attribute", []):
             indicator = self._process_attribute(
                 author,
                 event_elements,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* setting `Attribute` key to an empty array if it doesn't exist

### Related issues

* #1008

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
