### PR TITLE
[connectors] Txt location export bug fix (#2821)

### DIFF
--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -261,7 +261,6 @@ class ExportFileCsv:
                             }
                         ]
                     final_entity_type = "Stix-Domain-Object"
-
                 # List
                 lister = {
                     "Stix-Core-Object": self.helper.api_impersonate.stix_core_object.list,

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -5,7 +5,7 @@ import time
 
 import yaml
 from pycti import OpenCTIConnectorHelper
-from pycti.utils.constants import StixCyberObservableTypes
+from pycti.utils.constants import IdentityTypes, LocationTypes, StixCyberObservableTypes
 
 
 class ExportFileTxt:
@@ -63,8 +63,31 @@ class ExportFileTxt:
 
             else:  # export_scope = 'query'
                 list_params = data["list_params"]
+
                 final_entity_type = entity_type
                 if final_entity_type != "":
+                    if IdentityTypes.has_value(entity_type):
+                        if list_params["filters"] is not None:
+                            list_params["filters"].append(
+                                {"key": "entity_type", "values": [entity_type]}
+                            )
+                        else:
+                            list_params["filters"] = [
+                                {"key": "entity_type", "values": [entity_type]}
+                            ]
+                        final_entity_type = "Identity"
+
+                    if LocationTypes.has_value(entity_type):
+                        if list_params["filters"] is not None:
+                            list_params["filters"].append(
+                                {"key": "entity_type", "values": [entity_type]}
+                            )
+                        else:
+                            list_params["filters"] = [
+                                {"key": "entity_type", "values": [entity_type]}
+                            ]
+                        final_entity_type = "Location"
+
                     if StixCyberObservableTypes.has_value(entity_type):
                         if list_params["filters"] is not None:
                             list_params["filters"].append(

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -33,9 +33,11 @@ class ExportFileTxt:
             or entity_type == "stix-core-relationship"
             or entity_type == "Observed-Data"
             or entity_type == "Artifact"
+            or entity_type == "Note"
+            or entity_type == "Opinion"
         ):
             raise ValueError("Text/plain export is not available for this entity type.")
-            # to do: print defaultValue (instead of name) for sightings
+            # to do: print defaultValue (instead of name)
 
         else:  # export_scope = 'selection' or 'query'
             if export_scope == "selection":


### PR DESCRIPTION
when exporting a location (country, adminstrative area..) in txt: error, list empty
![image](https://user-images.githubusercontent.com/75783086/217285174-f72c9223-5608-4102-b14f-2f89a7bf8e2f.png)


### Related issues

https://github.com/OpenCTI-Platform/opencti/issues/2821 (bug 3)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
