### PR TITLE
[import-file-stix] Add numpy to requirements.txt and install build dependencies

### DIFF
--- a/internal-import-file/import-file-stix/Dockerfile
+++ b/internal-import-file/import-file-stix/Dockerfile
@@ -8,7 +8,7 @@ COPY src /opt/opencti-connector-import-file-stix
 RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev && \
     cd /opt/opencti-connector-import-file-stix && \
     pip3 install --no-cache-dir -r requirements.txt && \
-    apk del git build-base
+    apk del git build-base gfortran musl-dev g++ openblas openblas-dev
 
 # Expose and entrypoint
 COPY entrypoint.sh /

--- a/internal-import-file/import-file-stix/src/requirements.txt
+++ b/internal-import-file/import-file-stix/src/requirements.txt
@@ -1,3 +1,4 @@
 pycti==5.5.5
 maec==4.1.0.17
+numpy==1.24.2
 stix2-elevator==4.0.1


### PR DESCRIPTION
### Proposed changes

* Add `numpy==1.24.2` to the `requirements.txt` of the `import-file-stix` connector
* Install the `gfortran`, `musl-dev`, `g++`, `openblas`, and `openblas-dev` alpine packages, which provide necessary build dependencies for `numpy`. In the case of `openblas`, it is necessary because otherwise it defaults to a very slow BLAS implementation.

### Related issues

* Does not completely solve #941 but addresses one of the issues encountered

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality