### PR TITLE
Update build dependencies for shodan-internetdb, import-file-stix

### DIFF
--- a/internal-enrichment/shodan-internetdb/Dockerfile
+++ b/internal-enrichment/shodan-internetdb/Dockerfile
@@ -9,6 +9,9 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 
 WORKDIR /opt/build
 
+# Install build deps
+RUN apk add --no-cache musl-dev gcc libffi-dev
+
 # Install poetry
 RUN apk add --no-cache git
 RUN pip3 install poetry

--- a/internal-import-file/import-file-stix/Dockerfile
+++ b/internal-import-file/import-file-stix/Dockerfile
@@ -8,7 +8,7 @@ COPY src /opt/opencti-connector-import-file-stix
 RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev gfortran musl-dev g++ openblas openblas-dev && \
     cd /opt/opencti-connector-import-file-stix && \
     pip3 install --no-cache-dir -r requirements.txt && \
-    apk del git build-base gfortran musl-dev g++ openblas openblas-dev
+    apk del git build-base gfortran musl-dev g++ openblas-dev
 
 # Expose and entrypoint
 COPY entrypoint.sh /


### PR DESCRIPTION
### Proposed changes

* Add `musl-dev`, `libffi-dev`, and `gcc` to the `build` container for the `shodan-internetdb` connector, as these missing was causing it to fail to build successfully in my environment
* Remove the `openblas` from the `apk del` command in `import-file-stix` because `numpy` may need this lib at run-time, or fail unexpectedly on some features
* Fix a missing newline at the end of the file in `shodan-internetdb`'s `Dockerfile`

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->