### PR TITLE
Connector-Urlhaus -- Caching and state output

### DIFF
--- a/external-import/urlhaus/src/urlhaus.py
+++ b/external-import/urlhaus/src/urlhaus.py
@@ -228,7 +228,7 @@ class URLhaus:
                             os.remove(
                                 os.path.dirname(os.path.abspath(__file__)) + "/data.csv"
                             )
-                    except Exception as e:
+                    except Exception:
                         self.helper.log_error(traceback.format_exc())
                     # Store the current timestamp as a last run
                     message = "Connector successfully run, storing last_run as " + str(
@@ -253,7 +253,7 @@ class URLhaus:
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 sys.exit(0)
-            except Exception as e:
+            except Exception:
                 self.helper.log_error(traceback.format_exc())
 
             if self.helper.connect_run_and_terminate:
@@ -267,7 +267,7 @@ if __name__ == "__main__":
     try:
         URLhausConnector = URLhaus()
         URLhausConnector.run()
-    except Exception as e:
+    except Exception:
         print(traceback.format_exc())
         time.sleep(10)
         sys.exit(0)

--- a/external-import/urlhaus/src/urlhaus.py
+++ b/external-import/urlhaus/src/urlhaus.py
@@ -4,8 +4,8 @@ import os
 import ssl
 import sys
 import time
-import urllib.request
 import traceback
+import urllib.request
 
 import certifi
 import stix2


### PR DESCRIPTION
The connector-urlhaus has been sped up by implementing the following additions: 

### Proposed changes

* URLHAUS_INTERVAL can now also be a float, allowing the connector to run more often than once a day. 
* a simple caching procedure of threats. Instead of asking opencti for every threat individually, identical requests are now cached. It is now 98% faster. 
* instead of parsing and uploading the full csv file to opencti, the newest entry timestamp is saved and only the new entries are processed.
* seamless upgrade from old connector state to the new one.
* every 5000k processed entries, a notification is printed to the info log. 
* errors output now a stacktrace, simplifying debugging. 

### Related issues

*

### Checklist



- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


### Further comments
