### PR TITLE
Optimize SDO .read() operations in [hygiene] and [shodan-internetdb] enrichment connectors

### DIFF
--- a/internal-enrichment/hygiene/src/hygiene.py
+++ b/internal-enrichment/hygiene/src/hygiene.py
@@ -198,7 +198,23 @@ class HygieneConnector:
 
     def _process_message(self, data) -> str:
         entity_id = data["entity_id"]
-        observable = self.helper.api.stix_cyber_observable.read(id=entity_id)
+
+        custom_attributes = """
+            id
+            observable_value
+            entity_type
+            indicators {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+        """
+        observable = self.helper.api.stix_cyber_observable.read(
+            id=entity_id, customAttributes=custom_attributes
+        )
+
         if observable is None:
             raise ValueError(
                 "Observable not found (or the connector does not has access to this observable, check the group of the connector user)"

--- a/internal-enrichment/shodan-internetdb/src/shodan_internetdb/connector.py
+++ b/internal-enrichment/shodan-internetdb/src/shodan_internetdb/connector.py
@@ -65,7 +65,24 @@ class ShodanInternetDBConnector:
         # Fetch the observable being processed
         entity_id = data["entity_id"]
 
-        observable = self._helper.api.stix_cyber_observable.read(id=entity_id)
+        custom_attributes = """
+            id
+            entity_type
+            objectMarking {
+              edges {
+                node {
+                  id
+                  definition_type
+                  definition
+                }
+              }
+            }
+            observable_value
+        """
+        observable = self._helper.api.stix_cyber_observable.read(
+            id=entity_id, customAttributes=custom_attributes
+        )
+
         if observable is None:
             log.error("Observable not found with entity_id %s", entity_id)
             return "Observable not found"


### PR DESCRIPTION
The `hygiene` and `shodan-internetdb` enrichment connectors were pulling down the entirety of the observables that they operate on, despite only using a small number of those fields. One major consequence of this approach is that these `read()` requests would cause OpenCTI to perform an S3 ListObjectsV2 operation each time the `read()` was called, which could amount to 100's or 1000's of attempts. As the LIST requests in AWS are 10x more expensive than the GET or HEAD requests, this easily caused S3 costs to be more expensive than EC2 costs, when using enrichment connectors like these.

An added benefit is that this change eliminated a lot of latency that previously existed in performing these operations, which speeds up the connectors, too.

### Proposed changes

* Limit data requests for `hygiene` to exactly what data is needed for the connector to work, using the `customAttributes` parameter in `.read()`
* Limit data requests for `shodan-internetdb` to exactly what data is needed for the connector to work, using the `customAttributes` parameter in `.read()`

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Other comments

I would recommend that the other enrichment connectors be analyzed for the same behavior. I don't have access to many of those other services, especially not the paid-for ones, so I cannot test these in my environment.