### PR TITLE
Connector-Mandiant -- reduced errors due to 'redacted' content

### DIFF
--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -112,8 +112,11 @@ class Mandiant:
             return None
         return object[key]
 
+    def _exists_and_not_redacted(self, key, object):
+        return key in object and object[key] != "redacted"
+
     def _process_aliases(self, object):
-        if "aliases" in object and object["aliases"] != "redacted":
+        if self._exists_and_not_redacted("aliases", object):
             aliases = []
             for alias in object["aliases"]:
                 aliases.append(re.sub("[\(\[].*?[\)\]]", "", alias["name"]).strip())
@@ -234,7 +237,7 @@ class Mandiant:
                         objects.append(stix_actor)
                         # Get the actor
                         result_actor = self._query(url + "/" + actor["id"])
-                        if "industries" in result_actor:
+                        if self._exists_and_not_redacted("industries", result_actor):
                             for industry in result_actor["industries"]:
                                 stix_identity = stix2.Identity(
                                     id=industry["id"],
@@ -271,7 +274,7 @@ class Mandiant:
                                 )
                                 objects.append(stix_identity)
                                 objects.append(stix_relationship)
-                        if "cve" in result_actor:
+                        if self._exists_and_not_redacted("cve", result_actor):
                             for cve in result_actor["cve"]:
                                 stix_vulnerability = stix2.Vulnerability(
                                     id=cve["id"],
@@ -307,8 +310,8 @@ class Mandiant:
                                 )
                                 objects.append(stix_vulnerability)
                                 objects.append(stix_relationship)
-                        if "locations" in result_actor:
-                            if "source" in result_actor["locations"]:
+                        if self._exists_and_not_redacted("locations", result_actor):
+                            if self._exists_and_not_redacted("source", result_actor["locations"]):
                                 for source in result_actor["locations"]["source"]:
                                     if "country" in source:
                                         stix_location = stix2.Location(
@@ -350,7 +353,7 @@ class Mandiant:
                                         )
                                         objects.append(stix_location)
                                         objects.append(stix_relationship)
-                            if "target" in result_actor["locations"]:
+                            if self._exists_and_not_redacted("target", result_actor["locations"]):
                                 for target in result_actor["locations"]["target"]:
                                     if "country" in target:
                                         stix_location = stix2.Location(
@@ -392,7 +395,7 @@ class Mandiant:
                                         )
                                         objects.append(stix_location)
                                         objects.append(stix_relationship)
-                        if "malware" in result_actor:
+                        if self._exists_and_not_redacted("malware", result_actor):
                             for malware in result_actor["malware"]:
                                 stix_malware = stix2.Malware(
                                     id=malware["id"],
@@ -428,7 +431,7 @@ class Mandiant:
                                 )
                                 objects.append(stix_malware)
                                 objects.append(stix_relationship)
-                        if "tool" in result_actor:
+                        if self._exists_and_not_redacted("tool", result_actor):
                             for tool in result_actor["tool"]:
                                 stix_tool = stix2.Tool(
                                     id=tool["id"],
@@ -511,7 +514,7 @@ class Mandiant:
                         objects.append(stix_malware)
                         # Get the malware
                         result_malware = self._query(url + "/" + malware["id"])
-                        if "industries" in result_malware:
+                        if self._exists_and_not_redacted("industries", result_malware):
                             for industry in result_malware["industries"]:
                                 stix_identity = stix2.Identity(
                                     id=industry["id"],
@@ -548,7 +551,7 @@ class Mandiant:
                                 )
                                 objects.append(stix_identity)
                                 objects.append(stix_relationship)
-                        if "cve" in result_malware and result_malware['cve'] != "redacted":
+                        if self._exists_and_not_redacted("cve", result_malware):
                             for cve in result_malware["cve"]:
                                 stix_vulnerability = stix2.Vulnerability(
                                     id=cve["id"],

--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 import time
+import traceback
 
 import requests
 import stix2
@@ -463,7 +464,7 @@ class Mandiant:
                                 objects.append(stix_tool)
                                 objects.append(stix_relationship)
                     except Exception as e:
-                        self.helper.log_error(str(e))
+                        self.helper.log_error(traceback.format_exc())
                 self.helper.send_stix2_bundle(
                     stix2.Bundle(
                         objects=objects,
@@ -584,7 +585,7 @@ class Mandiant:
                                 objects.append(stix_vulnerability)
                                 objects.append(stix_relationship)
                     except Exception as e:
-                        self.helper.log_error(str(e))
+                        self.helper.log_error(traceback.format_exc())
                 if len(objects) > 0:
                     self.helper.send_stix2_bundle(
                         stix2.Bundle(
@@ -665,7 +666,7 @@ class Mandiant:
                         )
                         vulnerabilities.append(stix_vulnerability)
                     except Exception as e:
-                        self.helper.log_error(str(e))
+                        self.helper.log_error(traceback.format_exc())
                 if len(vulnerabilities) > 0:
                     self.helper.send_stix2_bundle(
                         stix2.Bundle(
@@ -809,7 +810,7 @@ class Mandiant:
                                     )
                                     objects.append(stix_relationship)
                     except Exception as e:
-                        self.helper.log_error(str(e))
+                        self.helper.log_error(traceback.format_exc())
                 if len(objects) > 0:
                     self.helper.send_stix2_bundle(
                         stix2.Bundle(
@@ -971,7 +972,7 @@ class Mandiant:
                                 "Failed to process News Analysis Report "
                                 + str(reportOut.get("report_id"))
                             )
-                            self.helper.log_info("ERROR: " + str(e))
+                            self.helper.log_info("ERROR: " + traceback.format_exc())
                     else:
                         stix_bundle = None
                         try:
@@ -1107,7 +1108,7 @@ class Mandiant:
                                 "Failed to process News Analyis Report "
                                 + str(reportOut.get("report_id"))
                             )
-                            self.helper.log_info("ERROR: " + str(e))
+                            self.helper.log_info("ERROR: " + traceback.format_exc())
                         # Creating and sending the bundle to OCTI
                         try:
                             bundle = stix2.Bundle(
@@ -1124,7 +1125,7 @@ class Mandiant:
                                 "Failed to process this report ID "
                                 + str(reportOut.get("report_id"))
                             )
-                            self.helper.log_info("ERROR: " + str(e))
+                            self.helper.log_info("ERROR: " + traceback.format_exc())
                 next_pointer = result.get("next")
                 self.helper.log_debug("Report next_pointer ID " + str(next_pointer))
             elif end_epoch > int(time.time()):
@@ -1220,7 +1221,7 @@ class Mandiant:
                 sys.exit(0)
 
             except Exception as e:
-                self.helper.log_error(str(e))
+                self.helper.log_error(traceback.format_exc())
 
                 if self.helper.connect_run_and_terminate:
                     self.helper.log_info("Connector stop")
@@ -1234,6 +1235,6 @@ if __name__ == "__main__":
         mandiantConnector = Mandiant()
         mandiantConnector.run()
     except Exception as e:
-        print(e)
+        print(traceback.format_exc())
         time.sleep(10)
         sys.exit(0)

--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -113,7 +113,7 @@ class Mandiant:
         return object[key]
 
     def _process_aliases(self, object):
-        if "aliases" in object:
+        if "aliases" in object and object["aliases"] != "redacted":
             aliases = []
             for alias in object["aliases"]:
                 aliases.append(re.sub("[\(\[].*?[\)\]]", "", alias["name"]).strip())
@@ -548,7 +548,7 @@ class Mandiant:
                                 )
                                 objects.append(stix_identity)
                                 objects.append(stix_relationship)
-                        if "cve" in result_malware:
+                        if "cve" in result_malware and result_malware['cve'] != "redacted":
                             for cve in result_malware["cve"]:
                                 stix_vulnerability = stix2.Vulnerability(
                                     id=cve["id"],

--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -82,6 +82,8 @@ class Mandiant:
         self.cache = {}
 
     def cleanhtml(self, raw_html):
+        if raw_html is None:
+            return None
         CLEANR = re.compile("<.*?>|&([a-z0-9]+|#[0-9]{1,6}|#x[0-9a-f]{1,6});")
         cleantext = re.sub(CLEANR, "", raw_html)
         return cleantext
@@ -113,16 +115,19 @@ class Mandiant:
         return object[key]
 
     def _exists_and_not_redacted(self, key, object):
-        return key in object and object[key] != "redacted"
+        # in contrast to self._redacted_as_none that returns a 'NoneType', 
+        # this function returns a boolean
+        return key in object and object[key] != "redacted"        
 
     def _process_aliases(self, object):
-        if self._exists_and_not_redacted("aliases", object):
-            aliases = []
-            for alias in object["aliases"]:
-                aliases.append(re.sub("[\(\[].*?[\)\]]", "", alias["name"]).strip())
-            object["aliases"] = aliases
-            return self._redacted_as_none("aliases", object)
-        return None
+        if not self._exists_and_not_redacted("aliases", object):
+            return None 
+        aliases = []
+        for alias in object["aliases"]:
+            aliases.append(re.sub("[\(\[].*?[\)\]]", "", alias["name"]).strip())
+        object["aliases"] = aliases
+        return self._redacted_as_none("aliases", object)
+        
 
     def _query(
         self,

--- a/external-import/urlhaus/src/urlhaus.py
+++ b/external-import/urlhaus/src/urlhaus.py
@@ -5,6 +5,7 @@ import ssl
 import sys
 import time
 import urllib.request
+import traceback
 
 import certifi
 import stix2
@@ -31,7 +32,7 @@ class URLhaus:
             "URLHAUS_IMPORT_OFFLINE", ["urlhaus", "import_offline"], config, False, True
         )
         self.urlhaus_interval = get_config_variable(
-            "URLHAUS_INTERVAL", ["urlhaus", "interval"], config, True
+            "URLHAUS_INTERVAL", ["urlhaus", "interval"], config, False
         )
         self.create_indicators = get_config_variable(
             "URLHAUS_CREATE_INDICATORS",
@@ -58,8 +59,8 @@ class URLhaus:
             description="abuse.ch is operated by a random swiss guy fighting malware for non-profit, running a couple of projects helping internet service providers and network operators protecting their infrastructure from malware.",
         )
 
-    def get_interval(self):
-        return int(self.urlhaus_interval) * 60 * 60 * 24
+    def get_interval(self, offset=0):
+        return (float(self.urlhaus_interval) + offset) * 60 * 60 * 24
 
     def next_run(self, seconds):
         return
@@ -83,10 +84,7 @@ class URLhaus:
                     last_run = None
                     self.helper.log_info("Connector has never run")
                 # If the last_run is more than interval-1 day
-                if last_run is None or (
-                    (timestamp - last_run)
-                    > ((int(self.urlhaus_interval) - 1) * 60 * 60 * 24)
-                ):
+                if last_run is None or ((timestamp - last_run) > self.get_interval(offset=-1)):
                     self.helper.log_info("Connector will run!")
                     now = datetime.datetime.utcfromtimestamp(timestamp)
                     friendly_name = "URLhaus run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
@@ -94,8 +92,10 @@ class URLhaus:
                         self.helper.connect_id, friendly_name
                     )
 
+                    # initialize the threat cache with each run
                     if self.threats_from_labels:
                         treat_cache = {}
+
                     try:
                         response = urllib.request.urlopen(
                             self.urlhaus_csv_url,
@@ -113,8 +113,26 @@ class URLhaus:
                         )
                         rdr = csv.reader(filter(lambda row: row[0] != "#", fp))
                         bundle_objects = []
+                        ## the csv-file hast the following columns 
                         # id,dateadded,url,url_status,last_online,threat,tags,urlhaus_link,reporter
-                        for row in rdr:
+                        
+                        if  current_state is not None and "last_processed_entry" in current_state:
+                            last_processed_entry = current_state["last_processed_entry"]  # epoch time format
+                        else:
+                            self.helper.log_info("'last_processed_entry' state not found, setting it to epoch start.")
+                            last_processed_entry = 0  # start of the epoch
+                        
+                        for i, row in enumerate(rdr):
+                            entry_date = parse(row[1])
+
+                            if i % 5000 == 0: 
+                                self.helper.log_info(f"Process entry {i} with dateadded='{entry_date.strftime('%Y-%m-%d %H:%M:%S')}'")
+
+                            # skip entry if newer events already processed in the past
+                            if last_processed_entry > entry_date.timestamp():
+                                continue
+                            last_processed_entry = entry_date.timestamp()
+
                             if row[3] == "online" or self.urlhaus_import_offline:
                                 external_reference = stix2.ExternalReference(
                                     source_name="Abuse.ch URLhaus",
@@ -161,20 +179,19 @@ class URLhaus:
                                                 treat_cache[label] = threat
 
                                             if threat is not None:
-                                                date = parse(row[1])
                                                 relation = stix2.Relationship(
                                                     id=StixCoreRelationship.generate_id(
                                                         "related-to",
                                                         stix_observable.id,
                                                         threat["standard_id"],
-                                                        date,
-                                                        date,
+                                                        entry_date,
+                                                        entry_date,
                                                     ),
                                                     source_ref=stix_observable.id,
                                                     target_ref=threat["standard_id"],
                                                     relationship_type="related-to",
-                                                    start_time=date,
-                                                    stop_time=date
+                                                    start_time=entry_date,
+                                                    stop_time=entry_date
                                                     + datetime.timedelta(0, 3),
                                                     confidence=self.helper.connect_confidence_level,
                                                     created_by_ref=self.identity[
@@ -183,8 +200,8 @@ class URLhaus:
                                                     object_marking_refs=[
                                                         stix2.TLP_WHITE
                                                     ],
-                                                    created=date,
-                                                    modified=date,
+                                                    created=entry_date,
+                                                    modified=entry_date,
                                                     allow_custom=True,
                                                 )
                                                 bundle_objects.append(relation)
@@ -204,13 +221,13 @@ class URLhaus:
                                 os.path.dirname(os.path.abspath(__file__)) + "/data.csv"
                             )
                     except Exception as e:
-                        self.helper.log_error(str(e))
+                        self.helper.log_error(traceback.format_exc())
                     # Store the current timestamp as a last run
                     message = "Connector successfully run, storing last_run as " + str(
                         timestamp
                     )
                     self.helper.log_info(message)
-                    self.helper.set_state({"last_run": timestamp})
+                    self.helper.set_state({"last_run": timestamp, "last_processed_entry": last_processed_entry})
                     self.helper.api.work.to_processed(work_id, message)
                     self.helper.log_info(
                         "Last_run stored, next run in: "
@@ -229,7 +246,7 @@ class URLhaus:
                 self.helper.log_info("Connector stop")
                 sys.exit(0)
             except Exception as e:
-                self.helper.log_error(str(e))
+                self.helper.log_error(traceback.format_exc())
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
@@ -243,6 +260,6 @@ if __name__ == "__main__":
         URLhausConnector = URLhaus()
         URLhausConnector.run()
     except Exception as e:
-        print(e)
+        print(traceback.format_exc())
         time.sleep(10)
         sys.exit(0)


### PR DESCRIPTION
We had a few issues with 'redacted' entries due to our limited mandiant subscription. This PR fixes the errors that we encountered.  

### Proposed changes

* added a function _exists_and_not_redacted(.,.) that returns a boolean
* a few more checks for 'redacted' and Nones.
* logged errors now contains a back-trace for easier debugging

### Related issues


### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments
