### PR TITLE
[urlhaus] & [malwarebazaar] Minimize data from SDO read() operation

### DIFF
--- a/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
+++ b/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
@@ -215,8 +215,13 @@ class MalwareBazaarRecentAdditions:
         returns: a bool indicidating the aforementioned
         """
 
+        custom_attributes = """
+            id
+            entity_type
+        """
         response = self.helper.api.stix_cyber_observable.read(
-            filters=[{"key": "hashes_SHA256", "values": [sha256]}]
+            filters=[{"key": "hashes_SHA256", "values": [sha256]}],
+            customAttributes=custom_attributes,
         )
 
         if response:

--- a/external-import/urlhaus/src/urlhaus.py
+++ b/external-import/urlhaus/src/urlhaus.py
@@ -139,6 +139,11 @@ class URLhaus:
                                 if self.threats_from_labels:
                                     for label in row[6].split(","):
                                         if label:
+                                            custom_attributes = """
+                                                id
+                                                standard_id
+                                                entity_type
+                                            """
                                             threat = (
                                                 self.helper.api.stix_domain_object.read(
                                                     filters=[
@@ -148,6 +153,7 @@ class URLhaus:
                                                         }
                                                     ],
                                                     first=1,
+                                                    customAttributes=custom_attributes,
                                                 )
                                             )
                                             if threat is not None:


### PR DESCRIPTION
In the stix_domain_object read operation, don't fetch fields that won't be used by the connector.

### Proposed changes

* Only fetch `id`, `standard_id`, and `entity_type` when performing a `stix_domain_object` `read()` operation. This will prevent attempts to perform LIST operations against S3 buckets when those results won't be used
* Only fetch `id` and `entity_type` when performing an existence test using `read()` in `malwarebazaar-recent-additions`

### Related issues

* Same problem as #1028 just found in another connector

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality