### PR TITLE
[import-document] [import-file-stix] Update version of dependencies

### DIFF
--- a/internal-import-file/import-document/src/requirements.txt
+++ b/internal-import-file/import-document/src/requirements.txt
@@ -1,9 +1,10 @@
 pycti==5.5.6
 urllib3==1.26.5
-beautifulsoup4==4.9.3
-pdfminer.six==20220319
+beautifulsoup4==4.11.2
+pdfminer.six==20221105
 stix==1.2.0.11
 pydantic==1.8.2
-ioc-finder==6.0.1
-dateparser==1.0.0
+ioc-finder==7.3.0
+dateparser==1.1.7
 pyhumps==3.8.0
+chardet==5.1.0

--- a/internal-import-file/import-file-stix/src/requirements.txt
+++ b/internal-import-file/import-file-stix/src/requirements.txt
@@ -1,4 +1,4 @@
 pycti==5.5.6
 maec==4.1.0.17
 numpy==1.24.2
-stix2-elevator==4.0.1
+stix2-elevator==4.1.7


### PR DESCRIPTION
### Proposed changes

* Update Python dependency versions of `beautifulsoup4`, `pdfminer.stix`, `ioc-finder`, `dateparser` and add missing dependency `chardet` for `import-document` connector, to latest versions
* Update `stix2-elevator` for `import-file-stix` connector to latest version

These newer versions add some improved performance as well as some reported bug fixes, compared to the versions the project uses today. I have been doing various tests with the PDF import feature in order to iron out some bugs that I've encountered, and this is the byproduct of some of that testing. I am still seeing some errors with import, but these changes appear to have cleared a few of the common `import-stix-file` connector-reported bugs. As well, the fixes in the newer ioc-parser library should make it faster, as well as help eliminate some of the common punctuation-related mistaken IOC identification.

* https://github.com/fhightower/ioc-finder/blob/main/CHANGELOG.md
* https://github.com/oasis-open/cti-stix-elevator/blob/master/CHANGELOG

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Related Notes

I've tested on a few documents that I had issues with in the past. This doesn't fix ALL the problems, but it doesn't seem to make anything worse in the tests I've done, and it does make some of the data import errors go away for my dataset.