### PR TITLE
Update Dockerfile

### DIFF
--- a/internal-enrichment/tagger/Dockerfile
+++ b/internal-enrichment/tagger/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.10-alpine
 
 # Copy the worker
 COPY src /opt/opencti-connector-tagger
+WORKDIR /opt/opencti-connector-tagger
 
 # Install Python modules
 # hadolint ignore=DL3003


### PR DESCRIPTION
Define Working Directory to fix error: python: can't open file '//connector.py': [Errno 2] No such file or directory when creating Tagger container

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Adding WORKDIR in dockerfile
*

### Related issues

* Error: _python: can't open file '//connector.py': [Errno 2] No such file or directory_ when creating Tagger container
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
