### PR TITLE
Update mandiant.py

### DIFF
--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -852,7 +852,7 @@ class Mandiant:
         url = self.mandiant_api_url + "/v4/reports"
         no_more_result = False
         limit = 1000
-        start_epoch = current_state["report"]
+        start_epoch = int((current_state["report"]).strip() or 0)
         end_epoch = start_epoch + 3600
         next = None
         while no_more_result is False:

--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -20,6 +20,16 @@ from pycti import (
 )
 from requests.auth import HTTPBasicAuth
 
+def parseInt(valInput,helper=false, valDefault = 0):
+    if isinstance(valInput,int):
+        valOutput = valInput
+    elif isinstance(valInput,str):
+        valOutput = int(valInput.strip() or valDefault)
+    else:
+        if helper:
+            helper.log_info(f"[parseInt] the input type is not managed : type={type(valInput)}")
+        valOutput = valDefault
+    return valOutput
 
 class Mandiant:
     def __init__(self):
@@ -616,7 +626,7 @@ class Mandiant:
         url = self.mandiant_api_url + "/v4/vulnerability"
         no_more_result = False
         limit = 1000
-        start_epoch = current_state["vulnerability"]
+        start_epoch =  parseInt(current_state["vulnerability"],self.helper)
         end_epoch = start_epoch + 3600
         next = None
         while no_more_result is False:
@@ -708,7 +718,7 @@ class Mandiant:
         url = self.mandiant_api_url + "/v4/indicator"
         no_more_result = False
         limit = 1000
-        start_epoch = current_state["indicator"]
+        start_epoch =  parseInt(current_state["indicator"],self.helper)
         end_epoch = start_epoch + 3600
         next = None
         while no_more_result is False:
@@ -852,7 +862,7 @@ class Mandiant:
         url = self.mandiant_api_url + "/v4/reports"
         no_more_result = False
         limit = 1000
-        start_epoch = int((current_state["report"]).strip() or 0)
+        start_epoch =  parseInt(current_state["report"],self.helper) 
         end_epoch = start_epoch + 3600
         next = None
         while no_more_result is False:


### PR DESCRIPTION
For avoiding a type error, i propose to start epoch in import_report at 0 if it is not already a number : int((current_state["report"]).strip() or 0)

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* line 855: start_epoch = int((current_state["report"]).strip() or 0)

### Related issues

* if current_state["report"]=="\n" or not a number at least, then : line 856: end_epoch = start_epoch + 3600 raise a type error ( try to concatenate a str and a int)
* ![error](https://user-images.githubusercontent.com/57862760/226635887-b8db793c-fbe5-4f19-b374-8c1c63e5f0ae.PNG)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
