### PR TITLE
start_epoch fix

### DIFF
--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -20,6 +20,16 @@ from pycti import (
 )
 from requests.auth import HTTPBasicAuth
 
+def parseInt(valInput,helper=False, valDefault = 1167609600):
+    if isinstance(valInput,int):
+        valOutput = valInput
+    elif isinstance(valInput,str):
+        valOutput = int(valInput.strip() or valDefault)
+    else:
+        if helper:
+            helper.log_info(f"[parseInt] the input type is not managed : type={type(valInput)}")
+        valOutput = valDefault
+    return valOutput
 
 class Mandiant:
     def __init__(self):
@@ -160,6 +170,7 @@ class Mandiant:
             params["end_epoch"] = str(int(end_epoch))
 
         r = requests.get(url, params=params, headers=headers)
+        
         if r.status_code == 200:
             return r.json()
         elif (r.status_code == 401 or r.status_code == 403) and not retry:
@@ -172,7 +183,10 @@ class Mandiant:
             if result and "error" in result:
                 if "future" in result["error"]:
                     return None
-            raise ValueError("An unknown error occurred")
+                if "message" in result["error"]:
+                    raise ValueError((result["error"])["message"])
+                else:
+                    raise ValueError("An unknown error occurred")
 
     def _getreportpdf(self, url, retry=False):
         headers = {
@@ -616,7 +630,7 @@ class Mandiant:
         url = self.mandiant_api_url + "/v4/vulnerability"
         no_more_result = False
         limit = 1000
-        start_epoch = current_state["vulnerability"]
+        start_epoch =  parseInt(current_state["vulnerability"],self.helper)
         end_epoch = start_epoch + 3600
         next = None
         while no_more_result is False:
@@ -708,7 +722,7 @@ class Mandiant:
         url = self.mandiant_api_url + "/v4/indicator"
         no_more_result = False
         limit = 1000
-        start_epoch = current_state["indicator"]
+        start_epoch =  parseInt(current_state["indicator"],self.helper)
         end_epoch = start_epoch + 3600
         next = None
         while no_more_result is False:
@@ -852,7 +866,7 @@ class Mandiant:
         url = self.mandiant_api_url + "/v4/reports"
         no_more_result = False
         limit = 1000
-        start_epoch = current_state["report"]
+        start_epoch =  parseInt(current_state["report"],self.helper) 
         end_epoch = start_epoch + 3600
         next = None
         while no_more_result is False:

--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -16,7 +16,7 @@ from pycti import (
     OpenCTIConnectorHelper,
     Report,
     StixCoreRelationship,
-    get_config_variable,
+    get_config_variable
 )
 from requests.auth import HTTPBasicAuth
 
@@ -170,7 +170,6 @@ class Mandiant:
             params["end_epoch"] = str(int(end_epoch))
 
         r = requests.get(url, params=params, headers=headers)
-        
         if r.status_code == 200:
             return r.json()
         elif (r.status_code == 401 or r.status_code == 403) and not retry:


### PR DESCRIPTION
Add a default start_epoch value and a control over the type

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add a parseInt function for the start_epoch value
* add the error message obtain from the API to the raise error

### Related issues

* ![error](https://user-images.githubusercontent.com/57862760/227483935-c0c27dc4-7245-49f3-b2ca-05e28aaa5ee0.PNG)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
