### PR TITLE
Fix start_epoch error

### DIFF
--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -20,6 +20,14 @@ from pycti import (
 )
 from requests.auth import HTTPBasicAuth
 
+def parseInt(valInput, valDefault = 0):
+    if isinstance(valInput,int):
+        valOutput = valInput
+    elif isinstance(valInput,str):
+        valOutput = int(valInput.strip() or valDefault)
+    else:
+        valOutput = valDefault
+    return valOutput
 
 class Mandiant:
     def __init__(self):
@@ -172,7 +180,10 @@ class Mandiant:
             if result and "error" in result:
                 if "future" in result["error"]:
                     return None
-            raise ValueError("An unknown error occurred")
+                if "message" in result["error"]:
+                    raise ValueError((result["error"])["message"])
+                else:
+                    raise ValueError("An unknown error occurred")
 
     def _getreportpdf(self, url, retry=False):
         headers = {
@@ -616,7 +627,7 @@ class Mandiant:
         url = self.mandiant_api_url + "/v4/vulnerability"
         no_more_result = False
         limit = 1000
-        start_epoch = current_state["vulnerability"]
+        start_epoch =  parseInt(current_state["vulnerability"], 1167609600)
         end_epoch = start_epoch + 3600
         next = None
         while no_more_result is False:
@@ -708,7 +719,7 @@ class Mandiant:
         url = self.mandiant_api_url + "/v4/indicator"
         no_more_result = False
         limit = 1000
-        start_epoch = current_state["indicator"]
+        start_epoch =  parseInt(current_state["indicator"], 1167609600)
         end_epoch = start_epoch + 3600
         next = None
         while no_more_result is False:
@@ -852,7 +863,7 @@ class Mandiant:
         url = self.mandiant_api_url + "/v4/reports"
         no_more_result = False
         limit = 1000
-        start_epoch = current_state["report"]
+        start_epoch =  parseInt(current_state["report"], 1167609600) 
         end_epoch = start_epoch + 3600
         next = None
         while no_more_result is False:


### PR DESCRIPTION
Add a function for parsing to int start_epoch that sometimes turned into string Plus add a default value obtain form the API v4 bad request ("error": "code=400, message=start_epoch must be 1,167,609,600 or greater") if there is no value

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add a function for parsing to int even string value or already int value (not dealing other type for now , no other errors occured)
* Add the default value obtained through a bad request error with the API v4

### Related issues

* ![error](https://user-images.githubusercontent.com/57862760/227489473-7c9ee120-41fa-4f76-b543-5aa9b9fb3678.PNG)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
