### PR TITLE
Update flake8 line length to 120

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 ignore = E203, E266, E501, W503, F403, F401
-max-line-length = 89
+max-line-length = 120
 select = B,C,E,F,W,T4,B9


### PR DESCRIPTION
Line length equals to 89 is too low for nowadays and at same time, it requires that people who push the code would code better, otherwise, as soon as `black` is applied, the code will start to be unreadable.

![image](https://user-images.githubusercontent.com/4184292/228360223-0ede3d64-8eb9-4846-8dff-596314a29b3b.png)
