### PR TITLE
[taxii2] Fixed bug for compatibility with taxii 2.1

### DIFF
--- a/external-import/taxii2/src/taxii2.py
+++ b/external-import/taxii2/src/taxii2.py
@@ -4,9 +4,9 @@ import json
 import os
 import sys
 import time
+import uuid
 from datetime import datetime, timedelta
 from typing import Dict
-import uuid
 
 import taxii2client.v20 as tx20
 import taxii2client.v21 as tx21


### PR DESCRIPTION
### Proposed changes

This fix is to address the connectors compatability with taxii 2.1. When I added pagination in release 5.7.0, I was only able to test with a taxii 2.0 server and I had assumed that taxii 2.1 still would send the data as a bundle to the client. Upon getting access to a taxii 2.1 server, I realise this is not the case.

### Related issues

If using the 5.7.0 version of the client and a taxii 2.1 server, you will receive the following error:

  File "/opt/opencti-taxii2/taxii2.py", line 150, in run
    self.poll_all_roots(coll_title)
  File "/opt/opencti-taxii2/taxii2.py", line 189, in poll_all_roots
    self.poll_entire_root(root)
  File "/opt/opencti-taxii2/taxii2.py", line 221, in poll_entire_root
    self.poll(coll)
  File "/opt/opencti-taxii2/taxii2.py", line 257, in poll
    bundleid = response["id"]
KeyError: 'id'
Terminated

This error is created because of an assumption that we would be receiving a bundle. But "id" is not found.

A work around for those affected is to use the previous version of the connector until this code is merged.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This modified code will now get the response and check it to see what the spec version is before processing.
I also switched from reusing the original bundle id to generating a new bundle id using uuid.

I've tested this code on both taxii 2.0 and 2.1 and to my knowledge it is working correctly.
I had hoped to get this out before 5.7.1, but you all were too fast for me :-D
