### PR TITLE
[Taxii2] Custom labels

### DIFF
--- a/external-import/taxii2/README.md
+++ b/external-import/taxii2/README.md
@@ -17,7 +17,10 @@ There are a number of configuration options, which are set either in `docker-com
 | TAXII2_INITIAL_HISTORY| initial_history| In hours, the "lookback" window for the intial Poll. This will limit the respones only to STIX2 objects that were added to the collection during the specified lookback time. In all subsequent polls, the `interval` configuration option is used to determine the lookback window
 | TAXII2_INTERVAL     | interval        | In hours, the amount of time between each run of the connector. This option also sets the "lookback" window for all polls except the first one
 | VERIFY_SSL          | verify_ssl      | Boolean statement on whether to require an SSL/TLS connection with the TAXII Server. Default to True
-
+| TAXII2_CREATE_INDICATORS | true | Boolean statement on whether to create indicators
+| TAXII2_CREATE_OBSERVABLES | true | Boolean statement on whether to create observables
+| TAXII2_ADD_CUSTOM_LABEL | false | Boolean statement on whether to add custom label to all indicators. Default to False
+| TAXII2_CUSTOM_LABEL | string | String to use for custom label.
 
 ### Collections and API roots
 TAXII 2.0 introduced a new concept into the TAXII standard called an "API Root." API Roots are logical groupings of TAXII Collections and Channels that allow for better organization and federated access. More information can be found in the [TAXII2 standard](https://docs.oasis-open.org/cti/taxii/v2.1/csprd01/taxii-v2.1-csprd01.pdf)

--- a/external-import/taxii2/docker-compose.yml
+++ b/external-import/taxii2/docker-compose.yml
@@ -23,4 +23,6 @@ services:
       - TAXII2_VERIFY_SSL=true
       - TAXII2_CREATE_INDICATORS=true # Generate indicators for ingested observables
       - TAXII2_CREATE_OBSERVABLES=true # Generate observables for ingested indicators
+      - TAXII2_ADD_CUSTOM_LABEL=false # Enable custom label
+      - TAXII2_CUSTOM_LABEL= # Custom label added to all objects
     restart: always

--- a/external-import/taxii2/src/taxii2.py
+++ b/external-import/taxii2/src/taxii2.py
@@ -93,6 +93,15 @@ class Taxii2Connector:
             ["connector", "update_existing_data"],
             config,
         )
+        self.add_custom_label = get_config_variable(
+            "TAXII2_ADD_CUSTOM_LABEL",
+            ["taxii2", "add_custom_label"],
+            config,
+            default=False,
+        )
+        self.custom_label = get_config_variable(
+            "TAXII2_CUSTOM_LABEL", ["taxii2", "custom_label"], config
+        )
 
     @staticmethod
     def _init_collection_table(colls):
@@ -248,6 +257,15 @@ class Taxii2Connector:
                         # If taxii feed is v2.0 append pattern_type
                         if version == "2.0":
                             object["pattern_type"] = "stix"
+                        # Add a custom label
+                        if "labels" in object:
+                            labels = list(object["labels"])
+                        if "labels" not in object:
+                            labels = []
+                        if self.add_custom_label == True:
+                            labels.append(self.custom_label)
+                        # Assign the new list of labels back to the object
+                        object["labels"] = labels
                         objects.append(object)
 
                     # Get the manifest for the last object

--- a/external-import/taxii2/src/taxii2.py
+++ b/external-import/taxii2/src/taxii2.py
@@ -258,14 +258,12 @@ class Taxii2Connector:
                         if version == "2.0":
                             object["pattern_type"] = "stix"
                         # Add a custom label
+                        new_labels = []
                         if "labels" in object:
-                            labels = list(object["labels"])
-                        if "labels" not in object:
-                            labels = []
+                            new_labels = object["labels"]
                         if self.add_custom_label == True:
-                            labels.append(self.custom_label)
-                        # Assign the new list of labels back to the object
-                        object["labels"] = labels
+                            new_labels.append(self.custom_label)
+                            object["labels"] = new_labels
                         objects.append(object)
 
                     # Get the manifest for the last object


### PR DESCRIPTION
### Proposed changes

Add the ability to add a custom label to an indicator/observable/incident.
The reason why I need this is due to sharing observables which have indicators from multiple sources.
If I want to share an observable from a particular feed, I have been filtering by author in the past, but if another author generated the observable, then the indicator will not be shared.
So by creating a label for each of my taxii feeds and creating a filter based on the label, I am able to share the observables without any being missed out

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments
