### PR TITLE
Introduce the Google DNS connector

### DIFF
--- a/internal-enrichment/google-dns/.dockerignore
+++ b/internal-enrichment/google-dns/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/internal-enrichment/google-dns/Dockerfile
+++ b/internal-enrichment/google-dns/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-alpine
+
+RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev && apk del git build-base
+
+WORKDIR /opt/opencti-google-dns
+
+COPY src/requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY src/*.py .
+
+ENTRYPOINT ["python3", "main.py"]

--- a/internal-enrichment/google-dns/README.md
+++ b/internal-enrichment/google-dns/README.md
@@ -1,0 +1,47 @@
+# OpenCTI Google DNS Connector
+
+This OpenCTI connector enriches Domain Name Observables by querying DNS for
+various record types using the Google Public DNS service:
+
+- `NS`
+- `A`
+- `CNAME`
+- `MX`
+- `TXT`
+
+The connector then creates Observables and Relationships among them based on the
+query answers.
+
+## Installation
+
+### Requirements
+
+- OpenCTI Platform >= 5.6.2
+
+### Configuration
+
+| Parameter                            | Docker envvar                       | Mandatory    | Description                                                                                                                                                |
+| ------------------------------------ | ----------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `opencti_url`                        | `OPENCTI_URL`                       | Yes          | The URL of the OpenCTI platform.                                                                                                                           |
+| `opencti_token`                      | `OPENCTI_TOKEN`                     | Yes          | The default admin token configured in the OpenCTI platform parameters file.                                                                                |
+| `connector_id`                       | `CONNECTOR_ID`                      | Yes          | A valid arbitrary `UUIDv4` that must be unique for this connector.                                                                                         |
+| `connector_type`                     | `CONNECTOR_TYPE`                    | Yes          | Must be `INTERNAL_ENRICHMENT` (this is the connector type).                                                                                                      |
+| `connector_name`                     | `CONNECTOR_NAME`                    | Yes          | Set to "Google DNS"                                                                                                                                          |
+| `connector_scope`                    | `CONNECTOR_SCOPE`                   | Yes          | Supported scope: Domain-Name                                                                                                 |
+| `connector_auto`                    | `CONNECTOR_AUTO`                   | Yes          | Enable or disable auto-enrichment (default: false)                                                                                                 |
+| `connector_confidence_level`         | `CONNECTOR_CONFIDENCE_LEVEL`        | Yes          | The default confidence level for created sightings (a number between 1 and 100).                                                                             |
+| `connector_log_level`                | `CONNECTOR_LOG_LEVEL`               | Yes          | The log level for this connector, could be `debug`, `info`, `warn` or `error` (less verbose).                                                              |
+
+### Debugging ###
+
+<!-- Any additional information to help future users debug and report detailed issues concerning this connector -->
+
+### Additional information
+
+<!--
+Any additional information about this connector
+* What information is ingested/updated/changed
+* What should the user take into account when using this connector
+* ...
+-->
+

--- a/internal-enrichment/google-dns/docker-compose.yml
+++ b/internal-enrichment/google-dns/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  connector-google-dns:
+    image: opencti/connector-google-dns:5.7.2
+    environment:
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=ChangeMe
+      - CONNECTOR_ID=ChangeMe
+      - CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+      - CONNECTOR_NAME=Google DNS
+      - CONNECTOR_SCOPE=Domain-Name # MIME type or Stix Object
+      - CONNECTOR_AUTO=false
+      - CONNECTOR_CONFIDENCE_LEVEL=100 # From 0 (Unknown) to 100 (Fully trusted)
+      - CONNECTOR_LOG_LEVEL=info
+    restart: always

--- a/internal-enrichment/google-dns/src/client.py
+++ b/internal-enrichment/google-dns/src/client.py
@@ -1,0 +1,67 @@
+import re
+
+import requests
+
+
+class GoogleDNSClient:
+    def __init__(self):
+        self.base_url = "https://dns.google.com/resolve"
+        self.rr_types = {
+            "A": 1,
+            "CNAME": 5,
+            "MX": 15,
+            "NS": 2,
+            "TXT": 16,
+        }
+
+    def _remove_dots(self, answers) -> list:
+        results = [answer.rstrip(".") for answer in answers]
+        return results
+
+    def query(self, host, query_type) -> list:
+        params = {"name": host, "type": query_type}
+        query_type_id = self.rr_types.get(query_type, 1)
+
+        try:
+            response = requests.get(self.base_url, params)
+            body = response.json()
+        except Exception as e:
+            print(e)
+            return []
+
+        if "Answer" in body.keys() and any(body["Answer"]):
+            answers = body["Answer"]
+            data = []
+
+            for answer in answers:
+                if answer["type"] == query_type_id:
+                    data.append(answer["data"])
+        else:
+            data = []
+
+        return data
+
+    def a(self, host) -> list:
+        data = self.query(host, "A")
+        return data
+
+    def cname(self, host) -> list:
+        data = self.query(host, "CNAME")
+        processed = self._remove_dots(data)
+        return processed
+
+    def mx(self, host) -> list:
+        data = self.query(host, "MX")
+        no_priority = [re.sub(r"(\d+)\s", "", answer) for answer in data]
+        no_dots = self._remove_dots(no_priority)
+        return no_dots
+
+    def ns(self, host) -> list:
+        data = self.query(host, "NS")
+        processed = self._remove_dots(data)
+        return processed
+
+    def txt(self, host) -> list:
+        data = self.query(host, "TXT")
+        processed = self._remove_dots(data)
+        return processed

--- a/internal-enrichment/google-dns/src/config.yml.sample
+++ b/internal-enrichment/google-dns/src/config.yml.sample
@@ -1,0 +1,12 @@
+opencti:
+  url: 'http://localhost:8080'
+  token: 'ChangeMe'
+
+connector:
+  id: 'ChangeMe'
+  type: 'INTERNAL_ENRICHMENT'
+  name: 'Google DNS'
+  scope: 'Domain-Name' # MIME type or SCO
+  auto: false # Enable/disable auto-enrichment of observables
+  confidence_level: 100 # From 0 (Unknown) to 100 (Fully trusted)
+  log_level: 'info'

--- a/internal-enrichment/google-dns/src/main.py
+++ b/internal-enrichment/google-dns/src/main.py
@@ -1,0 +1,267 @@
+import os
+import sys
+import time
+
+import yaml
+from client import GoogleDNSClient
+from pycti import OpenCTIConnectorHelper, StixCoreRelationship
+from stix2 import (
+    TLP_WHITE,
+    Bundle,
+    CustomObservable,
+    DomainName,
+    IPv4Address,
+    Relationship,
+)
+from stix2.properties import ListProperty, ReferenceProperty, StringProperty
+
+
+@CustomObservable(
+    "text",
+    [
+        ("value", StringProperty(required=True)),
+        ("spec_version", StringProperty(fixed="2.1")),
+        (
+            "object_marking_refs",
+            ListProperty(
+                ReferenceProperty(valid_types="marking-definition", spec_version="2.1")
+            ),
+        ),
+    ],
+    ["value"],
+)
+class Text:
+    pass
+
+
+class GoogleDNSConnector:
+    def __init__(self):
+        config_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
+        config = (
+            yaml.load(open(config_path), Loader=yaml.FullLoader)
+            if os.path.isfile(config_path)
+            else {}
+        )
+        self.helper = OpenCTIConnectorHelper(config)
+        self.dns_client = GoogleDNSClient()
+
+    def _get_domain(self, entity_id):
+        self.helper.log_debug("Getting Domain Name from OpenCTI")
+        observable = self.helper.api.stix_cyber_observable.read(id=entity_id)
+        return observable
+
+    def _build_ip_addrs(self, domain, a_records) -> list:
+        self.helper.log_debug("Creating and sending STIX bundle")
+
+        objects = []
+        for record in a_records:
+            # Create IPv4 Addr
+            ipv4 = IPv4Address(
+                value=record,
+                object_marking_refs=TLP_WHITE,
+            )
+            objects.append(ipv4)
+            self.helper.log_debug("Created IPv4 Addr")
+
+            # Create resolves-to Relationship from Domain Name to IPv4 Addr
+            relationship = Relationship(
+                id=StixCoreRelationship.generate_id(
+                    "resolves-to", domain["standard_id"], ipv4.id
+                ),
+                relationship_type="resolves-to",
+                source_ref=domain["standard_id"],
+                target_ref=ipv4.id,
+                object_marking_refs=TLP_WHITE,
+                confidence=100,
+            )
+            objects.append(relationship)
+            self.helper.log_debug("Created Relationship from Domain Name to IPv4 Addr")
+
+        return objects
+
+    def _build_nameservers(self, domain, ns_records) -> list:
+        self.helper.log_debug("Creating and sending STIX bundle")
+
+        objects = []
+        for record in ns_records:
+            # Create Domain Name
+            ns_domain = DomainName(
+                value=record,
+                object_marking_refs=TLP_WHITE,
+            )
+            objects.append(ns_domain)
+            self.helper.log_debug("Created Domain Name")
+
+            # Create resolves-to Relationship from Domain Name to Domain Name
+            relationship = Relationship(
+                id=StixCoreRelationship.generate_id(
+                    "resolves-to", domain["standard_id"], ns_domain.id
+                ),
+                relationship_type="resolves-to",
+                source_ref=domain["standard_id"],
+                target_ref=ns_domain.id,
+                description="name-server",
+                object_marking_refs=TLP_WHITE,
+                confidence=100,
+            )
+            objects.append(relationship)
+            self.helper.log_debug(
+                "Created Relationship from Domain Name to Domain Name"
+            )
+
+        return objects
+
+    def _build_cname_domains(self, domain, cname_records) -> list:
+        self.helper.log_debug("Creating and sending STIX bundle")
+
+        objects = []
+        for record in cname_records:
+            # Create Domain Name Addr
+            cname_domain = DomainName(
+                value=record,
+                object_marking_refs=TLP_WHITE,
+            )
+            objects.append(cname_domain)
+            self.helper.log_debug("Created Domain Name")
+
+            # Create resolves-to Relationship from Domain Name to Domain Name
+            relationship = Relationship(
+                id=StixCoreRelationship.generate_id(
+                    "resolves-to", domain["standard_id"], cname_domain.id
+                ),
+                relationship_type="resolves-to",
+                source_ref=domain["standard_id"],
+                target_ref=cname_domain.id,
+                description="cname",
+                object_marking_refs=TLP_WHITE,
+                confidence=100,
+            )
+            objects.append(relationship)
+            self.helper.log_debug(
+                "Created Relationship from Domain Name to Domain Name"
+            )
+
+        return objects
+
+    def _build_mx_domains(self, domain, mx_records) -> list:
+        self.helper.log_debug("Creating and sending STIX bundle")
+
+        objects = []
+        for record in mx_records:
+            # Create Domain Name Addr
+            mx_domain = DomainName(
+                value=record,
+                object_marking_refs=TLP_WHITE,
+            )
+            objects.append(mx_domain)
+            self.helper.log_debug("Created Domain Name")
+
+            # Create resolves-to Relationship from Domain Name to Domain Name
+            relationship = Relationship(
+                id=StixCoreRelationship.generate_id(
+                    "resolves-to", domain["standard_id"], mx_domain.id
+                ),
+                relationship_type="resolves-to",
+                source_ref=domain["standard_id"],
+                target_ref=mx_domain.id,
+                description="mx",
+                object_marking_refs=TLP_WHITE,
+                confidence=100,
+            )
+            objects.append(relationship)
+            self.helper.log_debug(
+                "Created Relationship from Domain Name to Domain Name"
+            )
+
+        return objects
+
+    def _build_txt_objects(self, domain, txt_records) -> list:
+        self.helper.log_debug("Creating and sending STIX bundle")
+
+        objects = []
+        for record in txt_records:
+            # Create a Text Observable
+            txt_object = Text(
+                value=record,
+                object_marking_refs=TLP_WHITE,
+            )
+            objects.append(txt_object)
+            self.helper.log_debug("Created Text Observable")
+
+            # Create related-to Relationship from Domain Name to Text
+            relationship = Relationship(
+                id=StixCoreRelationship.generate_id(
+                    "related-to", domain["standard_id"], txt_object.id
+                ),
+                relationship_type="related-to",
+                source_ref=domain["standard_id"],
+                target_ref=txt_object.id,
+                description="TXT",
+                object_marking_refs=TLP_WHITE,
+                confidence=100,
+            )
+            objects.append(relationship)
+            self.helper.log_debug("Created Relationship from Domain Name to Text")
+
+        return objects
+
+    def _process_message(self, data: dict) -> str:
+        entity_id = data["entity_id"]
+        self.helper.log_info(f"Enriching {entity_id}")
+        domain = self._get_domain(entity_id)
+
+        # Handle 'NS' records
+        self.helper.log_debug("Getting 'NS' records via Google Public DNS")
+        ns_records = self.dns_client.ns(domain["value"])
+        if any(ns_records):
+            ns_objects = self._build_nameservers(domain, ns_records)
+            bundle = Bundle(objects=ns_objects).serialize()
+            self.helper.send_stix2_bundle(bundle)
+
+        # Handle any 'A' records
+        self.helper.log_debug("Getting 'A' records via Google Public DNS")
+        a_records = self.dns_client.a(domain["value"])
+        if any(a_records):
+            ipv4_objects = self._build_ip_addrs(domain, a_records)
+            bundle = Bundle(objects=ipv4_objects).serialize()
+            self.helper.send_stix2_bundle(bundle)
+
+        # Handle any 'CNAME' records
+        self.helper.log_debug("Getting 'CNAME' records via Google Public DNS")
+        cname_records = self.dns_client.cname(domain["value"])
+        if any(cname_records):
+            domain_objects = self._build_cname_domains(domain, cname_records)
+            bundle = Bundle(objects=domain_objects).serialize()
+            self.helper.send_stix2_bundle(bundle)
+
+        # Handle any 'MX' records
+        self.helper.log_debug("Getting 'MX' records via Google Public DNS")
+        mx_records = self.dns_client.mx(domain["value"])
+        if any(mx_records):
+            domain_objects = self._build_mx_domains(domain, mx_records)
+            bundle = Bundle(objects=domain_objects).serialize()
+            self.helper.send_stix2_bundle(bundle)
+
+        # Handle any 'TXT' records
+        self.helper.log_debug("Getting 'TXT' records via Google Public DNS")
+        txt_records = self.dns_client.txt(domain["value"])
+        if any(txt_records):
+            txt_objects = self._build_txt_objects(domain, txt_records)
+            bundle = Bundle(objects=txt_objects).serialize()
+            self.helper.send_stix2_bundle(bundle)
+
+        return "Done"
+
+    def start(self) -> None:
+        self.helper.log_info("Google DNS connector started")
+        self.helper.listen(self._process_message)
+
+
+if __name__ == "__main__":
+    try:
+        connector = GoogleDNSConnector()
+        connector.start()
+    except Exception as e:
+        print(e)
+        time.sleep(10)
+        sys.exit(0)

--- a/internal-enrichment/google-dns/src/requirements.txt
+++ b/internal-enrichment/google-dns/src/requirements.txt
@@ -1,0 +1,3 @@
+pycti==5.7.2
+requests
+responses

--- a/internal-enrichment/google-dns/tests/test_client.py
+++ b/internal-enrichment/google-dns/tests/test_client.py
@@ -1,0 +1,150 @@
+import unittest
+
+import responses
+from src.client import GoogleDNSClient
+
+
+class GoogleDNSClientTest(unittest.TestCase):
+    def setUp(self):
+        self.client = GoogleDNSClient()
+
+    @responses.activate
+    def test_no_results(self):
+        responses.get(
+            url="https://dns.google.com/resolve",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"name": "fake.example.com", "type": "A"}
+                )
+            ],
+            json={},
+        )
+        results = self.client.a("fake.example.com")
+        self.assertEqual(results, [])
+
+    @responses.activate
+    def test_ns_records(self):
+        responses.get(
+            url="https://dns.google.com/resolve",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"name": "example.com", "type": "NS"}
+                )
+            ],
+            json={
+                "Answer": [
+                    {
+                        "name": "example.com.",
+                        "type": 2,
+                        "TTL": 16028,
+                        "data": "a.iana-servers.net.",
+                    },
+                    {
+                        "name": "example.com.",
+                        "type": 2,
+                        "TTL": 16028,
+                        "data": "b.iana-servers.net.",
+                    },
+                ]
+            },
+        )
+        results = self.client.ns("example.com")
+        self.assertEqual(results, ["a.iana-servers.net", "b.iana-servers.net"])
+
+    @responses.activate
+    def test_a_records(self):
+        responses.get(
+            url="https://dns.google.com/resolve",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"name": "example.com", "type": "A"}
+                )
+            ],
+            json={
+                "Answer": [
+                    {
+                        "name": "example.com.",
+                        "type": 1,
+                        "TTL": 21267,
+                        "data": "93.184.216.34",
+                    }
+                ]
+            },
+        )
+        results = self.client.a("example.com")
+        self.assertEqual(results, ["93.184.216.34"])
+
+    @responses.activate
+    def test_cname_records(self):
+        responses.get(
+            url="https://dns.google.com/resolve",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"name": "blog.google.com", "type": "CNAME"}
+                )
+            ],
+            json={
+                "Answer": [
+                    {
+                        "name": "blog.google.com.",
+                        "type": 5,
+                        "TTL": 138,
+                        "data": "www.blogger.com.",
+                    }
+                ]
+            },
+        )
+        results = self.client.cname("blog.google.com")
+        self.assertTrue("www.blogger.com" in results)
+
+    @responses.activate
+    def test_mx_records(self):
+        responses.get(
+            url="https://dns.google.com/resolve",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"name": "google.com", "type": "MX"}
+                )
+            ],
+            json={
+                "Answer": [
+                    {
+                        "name": "google.com.",
+                        "type": 15,
+                        "TTL": 219,
+                        "data": "10 smtp.google.com.",
+                    }
+                ]
+            },
+        )
+        results = self.client.mx("google.com")
+        self.assertEqual(results, ["smtp.google.com"])
+
+    @responses.activate
+    def test_txt_records(self):
+        responses.get(
+            url="https://dns.google.com/resolve",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"name": "google.com", "type": "TXT"}
+                )
+            ],
+            json={
+                "Answer": [
+                    {
+                        "name": "google.com.",
+                        "type": 16,
+                        "TTL": 2498,
+                        "data": "google-site-verification=TV9-DBe4R80X4v0M4U_bd_J9cpOJM0nikft0jAgjmsQ",
+                    },
+                    {
+                        "name": "google.com.",
+                        "type": 16,
+                        "TTL": 2498,
+                        "data": "v=spf1 include:_spf.google.com ~all",
+                    },
+                ]
+            },
+        )
+        results = self.client.txt("google.com")
+        self.assertTrue("v=spf1 include:_spf.google.com ~all" in results)


### PR DESCRIPTION
### Proposed changes


- Add a new connector that enriches Domain Name Observables using the [Google Public DNS API](https://developers.google.com/speed/public-dns/docs/doh/json)
- Supports these query types:
  - NS: creates Domain Names
  - A: creates IPv4 Addresses
  - CNAME: creates Domain Names
  - MX: creates Domain Names
  - TXT: creates Texts
- Between the enriched Domain Name and any additional Observables representing query results, the connector creates "resolves-to" Relationships and notes the type in its description. This is based on the DomainTools connector.

### Related issues

N/A

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
