### PR TITLE
[Mandiant] Bug fix for mscore implementation

### DIFF
--- a/external-import/mandiant/README.md
+++ b/external-import/mandiant/README.md
@@ -1,3 +1,20 @@
 # OpenCTI Mandiant Connector
 
 This connector connects to the Mandiant Advantage API V4 and gather all data from a given date.
+
+## Configuration
+
+The connector can be configured with the following variables:
+
+| Config Parameter | Docker env var | Default | Description |
+| ---------------------------- | ---------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `api_url` | `MANDIANT_API_URL` | `https://api.intelligence.mandiant.com` | The base URL for the Mandiant API. |
+| `api_v4_key_id` | `MANDIANT_API_V4_KEY_ID` | `ChangeMe` | The Mandiant API client ID. |
+| `api_v4_key_secret` | `MANDIANT_API_V4_KEY_SECRET` | `ChangeMe` | The Mandiant API client secret. |
+| `collections` | `MANDIANT_COLLECTIONS` | `actor,malware,indicator,vulnerability,report` | Specify what Collections you want to pull. |
+| `threat_actor_as_intrusion_set` | `MANDIANT_THREAT_ACTOR_AS_INTRUSION_SET` | `true` | If true, then threat actors will be added to intrusion set. |
+| `import_start_date` | `MANDIANT_IMPORT_START_DATE` | `2023-02-03` | The Mandiant API limits the import start date to be 90 days. |
+| `interval` | `MANDIANT_INTERVAL` | `60` | In minutes, the amount of time between each run of the connector. |
+| `update_existing_data` | `CONNECTOR_UPDATE_EXISTING_DATA` | `false` | If true, then the connector will update existing data. |
+| `report_types_ignored` | `MANDIANT_REPORT_TYPES_IGNORED` | `Vulnerability Report` | This ignores certain report types, the amount of reports daily and the amount of repetitive software creating extensive delay processing reports. |
+| `mscore` | `MANDIANT_MSCORE` | `0` | Defines the minimum Indicator Confidence Score to return. |

--- a/external-import/mandiant/README.md
+++ b/external-import/mandiant/README.md
@@ -13,8 +13,8 @@ The connector can be configured with the following variables:
 | `api_v4_key_secret` | `MANDIANT_API_V4_KEY_SECRET` | `ChangeMe` | The Mandiant API client secret. |
 | `collections` | `MANDIANT_COLLECTIONS` | `actor,malware,indicator,vulnerability,report` | Specify what Collections you want to pull. |
 | `threat_actor_as_intrusion_set` | `MANDIANT_THREAT_ACTOR_AS_INTRUSION_SET` | `true` | If true, then threat actors will be added to intrusion set. |
-| `import_start_date` | `MANDIANT_IMPORT_START_DATE` | `2023-02-03` | The Mandiant API limits the import start date to be 90 days. |
+| `days_before_start` | `MANDIANT_DAYS_BEFORE_START` | `89` | The Mandiant API limits the import start date to be less than 90 days. |
 | `interval` | `MANDIANT_INTERVAL` | `60` | In minutes, the amount of time between each run of the connector. |
 | `update_existing_data` | `CONNECTOR_UPDATE_EXISTING_DATA` | `false` | If true, then the connector will update existing data. |
 | `report_types_ignored` | `MANDIANT_REPORT_TYPES_IGNORED` | `Vulnerability Report` | This ignores certain report types, the amount of reports daily and the amount of repetitive software creating extensive delay processing reports. |
-| `mscore` | `MANDIANT_MSCORE` | `0` | Defines the minimum Indicator Confidence Score to return. |
+| `mscore` | `MANDIANT_MSCORE` | `0` | Defines the minimum Indicator Confidence Score to return. A good starting point is 80 if looking for malicious indicators. |

--- a/external-import/mandiant/docker-compose.yml
+++ b/external-import/mandiant/docker-compose.yml
@@ -16,8 +16,9 @@ services:
       - MANDIANT_API_V4_KEY_ID=ChangeMe
       - MANDIANT_API_V4_KEY_SECRET=ChangeMe
       - MANDIANT_COLLECTIONS=actor,malware,indicator,vulnerability,report
-      - MANDIANT_IMPORT_START_DATE=2022-04-01
+      - MANDIANT_IMPORT_START_DATE=2023-02-03 # API limit of 90 Days
       - MANDIANT_THREAT_ACTOR_AS_INTRUSION_SET=true
       - MANDIANT_INTERVAL=60 # Required, in minutes
       - "MANDIANT_REPORT_TYPES_IGNORED=Vulnerability Report" # Separated by commas, highly suggest to ignore "Vulnerability Report" due the amount of reports daily and the amount of repetitive software creating extensive delay processing reports.
+      - MANDIANT_MSCORE=80
     restart: always

--- a/external-import/mandiant/docker-compose.yml
+++ b/external-import/mandiant/docker-compose.yml
@@ -20,5 +20,5 @@ services:
       - MANDIANT_THREAT_ACTOR_AS_INTRUSION_SET=true
       - MANDIANT_INTERVAL=60 # Required, in minutes
       - "MANDIANT_REPORT_TYPES_IGNORED=Vulnerability Report" # Separated by commas, highly suggest to ignore "Vulnerability Report" due the amount of reports daily and the amount of repetitive software creating extensive delay processing reports.
-      - MANDIANT_MSCORE=80
+      - MANDIANT_MSCORE=0
     restart: always

--- a/external-import/mandiant/docker-compose.yml
+++ b/external-import/mandiant/docker-compose.yml
@@ -16,9 +16,9 @@ services:
       - MANDIANT_API_V4_KEY_ID=ChangeMe
       - MANDIANT_API_V4_KEY_SECRET=ChangeMe
       - MANDIANT_COLLECTIONS=actor,malware,indicator,vulnerability,report
-      - MANDIANT_IMPORT_START_DATE=2023-02-03 # API limit of 90 Days
+      - MANDIANT_DAYS_BEFORE_START=89
       - MANDIANT_THREAT_ACTOR_AS_INTRUSION_SET=true
       - MANDIANT_INTERVAL=60 # Required, in minutes
       - "MANDIANT_REPORT_TYPES_IGNORED=Vulnerability Report" # Separated by commas, highly suggest to ignore "Vulnerability Report" due the amount of reports daily and the amount of repetitive software creating extensive delay processing reports.
-      - MANDIANT_MSCORE=0
+      - MANDIANT_MSCORE=0 # From 0 to 100 (Malicious)
     restart: always

--- a/external-import/mandiant/src/config.yml.sample
+++ b/external-import/mandiant/src/config.yml.sample
@@ -20,4 +20,4 @@ mandiant:
   threat_actor_as_intrusion_set: true
   report_types_ignored: 'Vulnerability Report' # Separated by commas, highly suggest to ignore "Vulnerability Report" due the amount of reports daily and the amount of repetitive software creating extensive delay processing reports.
   interval: 60 # Required, in minutes
-  mscore: 80
+  mscore: 0

--- a/external-import/mandiant/src/config.yml.sample
+++ b/external-import/mandiant/src/config.yml.sample
@@ -20,3 +20,4 @@ mandiant:
   threat_actor_as_intrusion_set: true
   report_types_ignored: 'Vulnerability Report' # Separated by commas, highly suggest to ignore "Vulnerability Report" due the amount of reports daily and the amount of repetitive software creating extensive delay processing reports.
   interval: 60 # Required, in minutes
+  mscore: 80

--- a/external-import/mandiant/src/config.yml.sample
+++ b/external-import/mandiant/src/config.yml.sample
@@ -16,7 +16,7 @@ mandiant:
   api_v4_key_id: 'ChangeMe'
   api_v4_key_secret: 'ChangeMe'
   collections: 'actor,malware,indicator,vulnerability,report'
-  import_start_date: '2022-04-01'
+  days_before_start: '89'
   threat_actor_as_intrusion_set: true
   report_types_ignored: 'Vulnerability Report' # Separated by commas, highly suggest to ignore "Vulnerability Report" due the amount of reports daily and the amount of repetitive software creating extensive delay processing reports.
   interval: 60 # Required, in minutes

--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -51,10 +51,11 @@ class Mandiant:
             False,
             True,
         )
-        self.mandiant_import_start_date = get_config_variable(
-            "MANDIANT_IMPORT_START_DATE",
-            ["mandiant", "import_start_date"],
+        self.mandiant_days_before_start = get_config_variable(
+            "MANDIANT_DAYS_BEFORE_START",
+            ["mandiant", "days_before_start"],
             config,
+            default="89",
         )
         self.mandiant_interval = get_config_variable(
             "MANDIANT_INTERVAL", ["mandiant", "interval"], config, True
@@ -69,11 +70,14 @@ class Mandiant:
             ["mandiant", "report_types_ignored"],
             config,
         ).split(",")
-        self.added_after = int(parse(self.mandiant_import_start_date).timestamp())
+        self.added_after = int(time.time()) - (
+            86400 * int(self.mandiant_days_before_start)
+        )
         self.mandiant_mscore = get_config_variable(
             "MANDIANT_MSCORE",
             ["mandiant", "mscore"],
             config,
+            default="0",
         )
 
         self.identity = self.helper.api.identity.create(
@@ -625,9 +629,10 @@ class Mandiant:
     def _import_vulnerability(self, work_id, current_state):
         url = self.mandiant_api_url + "/v4/vulnerability"
         no_more_result = False
-        limit = 1000
+        limit = 25
+        current_epoch = int(time.time())
         start_epoch = current_state["vulnerability"]
-        end_epoch = start_epoch + 3600
+        end_epoch = current_epoch
         next = None
         while no_more_result is False:
             self.helper.log_info(
@@ -638,7 +643,10 @@ class Mandiant:
                 + ", next="
                 + str(next)
             )
-            result = self._query(url, limit, None, next, start_epoch, end_epoch)
+            if next is None:
+                result = self._query(url, limit, None, next, start_epoch, end_epoch)
+            if next is not None:
+                result = self._query(url, None, None, next)
             if (
                 result is not None
                 and result["vulnerability"] is not None
@@ -697,29 +705,27 @@ class Mandiant:
                         update=self.update_existing_data,
                         work_id=work_id,
                     )
-            elif end_epoch > int(time.time()):
-                no_more_result = True
             if (
                 result is not None
                 and result["vulnerability"] is not None
-                and len(result["vulnerability"]) == 1000
+                and len(result["vulnerability"]) > 0
                 and "next" in result
                 and len(result["next"]) > 0
             ):
                 next = result["next"]
             else:
                 next = None
-                start_epoch = end_epoch
-                end_epoch = start_epoch + 3600
-                current_state["vulnerability"] = int(start_epoch)
+                no_more_result = True
+                current_state["vulnerability"] = current_epoch
         return current_state
 
     def _import_indicator(self, work_id, current_state):
         url = self.mandiant_api_url + "/v4/indicator"
         no_more_result = False
-        limit = 1000
+        limit = 25
+        current_epoch = int(time.time())
         start_epoch = current_state["indicator"]
-        end_epoch = start_epoch + 3600
+        end_epoch = current_epoch
         gte_mscore = self.mandiant_mscore
         next = None
         while no_more_result is False:
@@ -731,9 +737,12 @@ class Mandiant:
                 + ", next="
                 + str(next)
             )
-            result = self._query(
-                url, limit, None, next, start_epoch, end_epoch, gte_mscore
-            )
+            if next is None:
+                result = self._query(
+                    url, limit, None, next, start_epoch, end_epoch, gte_mscore
+                )
+            if next is not None:
+                result = self._query(url, None, None, next)
             if (
                 result is not None
                 and result["indicators"] is not None
@@ -844,29 +853,27 @@ class Mandiant:
                         update=self.update_existing_data,
                         work_id=work_id,
                     )
-            elif end_epoch > int(time.time()):
-                no_more_result = True
             if (
                 result is not None
                 and result["indicators"] is not None
-                and len(result["indicators"]) == 1000
+                and len(result["indicators"]) > 0
                 and "next" in result
                 and len(result["next"]) > 0
             ):
                 next = result["next"]
             else:
                 next = None
-                start_epoch = end_epoch
-                end_epoch = start_epoch + 3600
-                current_state["indicator"] = int(start_epoch)
+                no_more_result = True
+                current_state["indicator"] = current_epoch
         return current_state
 
     def _import_report(self, work_id, current_state):
         url = self.mandiant_api_url + "/v4/reports"
         no_more_result = False
-        limit = 1000
+        limit = 25
+        current_epoch = int(time.time())
         start_epoch = current_state["report"]
-        end_epoch = start_epoch + 3600
+        end_epoch = current_epoch
         next = None
         while no_more_result is False:
             self.helper.log_info(
@@ -877,7 +884,10 @@ class Mandiant:
                 + ", next="
                 + str(next)
             )
-            result = self._query(url, limit, None, next, start_epoch, end_epoch)
+            if next is None:
+                result = self._query(url, limit, None, next, start_epoch, end_epoch)
+            if next is not None:
+                result = self._query(url, None, None, next)
             if (
                 result is not None
                 and result["objects"] is not None
@@ -1152,21 +1162,18 @@ class Mandiant:
                             self.helper.log_info("ERROR: " + traceback.format_exc())
                 next_pointer = result.get("next")
                 self.helper.log_debug("Report next_pointer ID " + str(next_pointer))
-            elif end_epoch > int(time.time()):
-                no_more_result = True
             if (
                 result is not None
                 and result["objects"] is not None
-                and len(result["objects"]) == 1000
+                and len(result["objects"]) > 0
                 and "next" in result
                 and len(result["next"]) > 0
             ):
                 next = result["next"]
             else:
                 next = None
-                start_epoch = end_epoch
-                end_epoch = start_epoch + 3600
-                current_state["report"] = int(start_epoch)
+                no_more_result = True
+                current_state["report"] = current_epoch
         return current_state
 
     def run(self):

--- a/external-import/mandiant/src/mandiant.py
+++ b/external-import/mandiant/src/mandiant.py
@@ -137,11 +137,11 @@ class Mandiant:
         self,
         url,
         limit=None,
-        gte_mscore=None,
         offset=None,
         next=None,
         start_epoch=None,
         end_epoch=None,
+        gte_mscore=None,
         retry=False,
         app_header=None,
     ):
@@ -173,7 +173,7 @@ class Mandiant:
         elif (r.status_code == 401 or r.status_code == 403) and not retry:
             self._get_token()
             return self._query(
-                url, limit, gte_mscore, offset, next, start_epoch, end_epoch, True
+                url, limit, offset, next, start_epoch, end_epoch, gte_mscore, True
             )
         elif r.status_code == 401 or r.status_code == 403:
             raise ValueError("Query failed, permission denied")
@@ -732,7 +732,7 @@ class Mandiant:
                 + str(next)
             )
             result = self._query(
-                url, limit, gte_mscore, None, next, start_epoch, end_epoch
+                url, limit, None, next, start_epoch, end_epoch, gte_mscore
             )
             if (
                 result is not None


### PR DESCRIPTION
### Proposed changes

This PR is to fix the bug I created when implementing mscore.
What started off as a bug fix turned into multiple after I was unable to test my original changes effectively.

1) Fixed issue with callers not being updated when mscore was first introduced.
2) Changed import_start_day to be days_before_start to make configuration easier.
3) Mandiant requires next to be the only parameter if it is being used.
4) Next parameter now equals variable from response. This was hard coded as None. This fixes a lot of the end_epoch being in the future issues.
5) Mandiant doesn't provide next in the response if there is no next page. Added no_more_result = True
6) Current_state now equals the time it was initially run for vulnerability, indicator and report.
7) I changed the limits to the defaults, I did this when I was debugging, thought it wouldn't hurt leaving them in. Feel free to modify these if you want.

I've run the collections separately and all together. I *think* I've got it working to a sufficient standard.
I hope this works for everyone!

### Related issues
https://github.com/OpenCTI-Platform/connectors/issues/1119

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

For actor and malware, offset is used rather than a start_epoch timestamp. Currently offset + limit is being saved as current state. This is not equal to the number of actors or malware in OpenCTI. What this means is that the next time there is a poll, the offset could potentially be greater than the API is expecting. Not sure if you want to switch to timestamps, that could break existing connectors during the upgrade. Maybe a simple count could can be implemented so the offset code can be kept as is.
