### PR TITLE
[Taxii2] Bugfix for no manifest available

### DIFF
--- a/external-import/taxii2/src/taxii2.py
+++ b/external-import/taxii2/src/taxii2.py
@@ -245,12 +245,12 @@ class Taxii2Connector:
         response = collection.get_objects(**filters)
         if "objects" in response:
             objects = []
+            if "spec_version" in response:
+                version = response["spec_version"]
+            else:
+                version = response["objects"][0]["spec_version"]
             while total != 0:
                 # Taxii 2.1 servers are not required to send data in bundle
-                if "spec_version" not in response:
-                    version = response["objects"][0]["spec_version"]
-                else:
-                    version = response["spec_version"]
                 total = len(response["objects"])
                 if total > 0:
                     for object in response["objects"]:

--- a/external-import/taxii2/src/taxii2.py
+++ b/external-import/taxii2/src/taxii2.py
@@ -269,14 +269,20 @@ class Taxii2Connector:
                     # Get the manifest for the last object
                     last_obj = response["objects"][-1]
                     manifest = collection.get_manifest(id=last_obj["id"])
-                    date_added = manifest["objects"][0]["date_added"]
-                    filters["added_after"] = date_added
 
-                    # Get the next set of objects
-                    response = collection.get_objects(**filters)
-                    if "objects" in response and len(response["objects"]) > 0:
-                        total = len(response["objects"])
+                    # Check manifest size
+                    if len(manifest["objects"]) > 0:
+                        date_added = manifest["objects"][0]["date_added"]
+                        filters["added_after"] = date_added
+
+                        # Get the next set of objects
+                        response = collection.get_objects(**filters)
+                        if "objects" in response and len(response["objects"]) > 0:
+                            total = len(response["objects"])
+                        else:
+                            total = 0
                     else:
+                        self.helper.log_info("No manifest found. Stopping pagination")
                         total = 0
 
             # Create bundle


### PR DESCRIPTION
### Proposed changes

This pagination method relies on having a manifest available so an accurate date added can be retrieved and used to poll for further indicators. But it turns out not all Taxii servers return a manifest. Unfortunately the 3 Taxii servers I have access to, have a manifest, so it is hard for me to provide a workaround. So what I have done is moved the version variable to before the while loop (in case there is no data) and have made a way to exit the loop if the manifest is zero in size. So now it won't crash anymore and will continue to send the bundle to OpenCTI, but will only run once, like previous connector versions. 

### Related issues

https://github.com/OpenCTI-Platform/connectors/issues/1123

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

I know the team is working on a Taxii client built into the platform, so users might have to wait for this to come out to resolve their issues.