### PR TITLE
fix TypeError: string indices must be integers error

### DIFF
--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -107,7 +107,7 @@ class SplunkConnector:
             + "/storage/collections"
             + uri
         )
-        payload["stream_name"] = self.helper.get_stream_name()["name"]
+        payload["stream_name"] = self.helper.get_stream_name()
         if (
             "type" in payload
             and payload["type"] == "indicator"


### PR DESCRIPTION
Splunk connector giving following error:

{"timestamp": "2023-05-11T18:07:05.409708Z", "level": "INFO", "name": "pycti.connector", "message": "Query post on /data/opencti (url=https://splunk.example.com:8089)"} Exception in thread Thread-5 (_query_worker):
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/opencti-connector-splunk/splunk.py", line 189, in _query_worker
    self._query(
  File "/opt/opencti-connector-splunk/splunk.py", line 110, in _query
    payload["stream_name"] = self.helper.get_stream_name()["name"]
TypeError: string indices must be integers

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
