### PR TITLE
Refactoring of Splunk connector: various structural improvements

### DIFF
--- a/stream/splunk/README.md
+++ b/stream/splunk/README.md
@@ -10,21 +10,26 @@ This connector allows organizations to feed a **Splunk** KV Store using OpenCTI 
 
 ### Configuration
 
-| Parameter                            | Docker envvar                       | Mandatory    | Description                                                                                   |
-| ------------------------------------ | ----------------------------------- | ------------ |-----------------------------------------------------------------------------------------------|
-| `opencti_url`                        | `OPENCTI_URL`                       | Yes          | The URL of the OpenCTI platform.                                                              |
-| `opencti_token`                      | `OPENCTI_TOKEN`                     | Yes          | The default admin token configured in the OpenCTI platform parameters file.                   |
-| `connector_id`                       | `CONNECTOR_ID`                      | Yes          | A valid arbitrary `UUIDv4` that must be unique for this connector.                            |
-| `connector_type`                     | `CONNECTOR_TYPE`                    | Yes          | Must be `STREAM` (this is the connector type).                                                |
-| `connector_name`                     | `CONNECTOR_NAME`                    | Yes          | The name of the Splunk instance, to identify it if you have multiple Splunk connectors.       |
-| `connector_scope`                    | `CONNECTOR_SCOPE`                   | Yes          | Must be `splunk`, not used in this connector.                                                 |
-| `connector_confidence_level`         | `CONNECTOR_CONFIDENCE_LEVEL`        | Yes          | The default confidence level for created sightings (a number between 1 and 4).                |
-| `connector_log_level`                | `CONNECTOR_LOG_LEVEL`               | Yes          | The log level for this connector, could be `debug`, `info`, `warn` or `error` (less verbose). |
-| `splunk_url`                         | `SPLUNK_URL`                        | Yes          | The Splunk instances REST API URLs as array                                                   |
-| `splunk_login`                       | `SPLUNK_LOGIN`                      | Yes          | The Splunk login users as array (same order as URLs)                                          |
-| `splunk_password`                    | `SPLUNK_PASSWORD`                   | Yes          | The Splunk passwords as array (same order as URLs)                                            |
-| `splunk_owner`                       | `SPLUNK_OWNER`                      | Yes          | The Splunk KV store owners as array (same order as URLs)                                      |
-| `splunk_ssl_verify`                  | `SPLUNK_SSL_VERIFY`                 | Yes          | Enable the SSL certificate check for all instances (default: `true`)                          |
-| `splunk_app`                         | `SPLUNK_APP`                        | Yes          | The app of the KV Store for all instances.                                                    |
-| `splunk_kv_store_name`               | `SPLUNK_KV_STORE_NAME`              | Yes          | The name of the KV Store for all instances.                                                   |
-| `splunk_ignore_types`                | `SPLUNK_IGNORE_TYPES`               | Yes          | The list of entity types to ignore.                                                           |
+| Parameter                              | Docker envvar                          | Mandatory    | Description                                                                                   |
+| -------------------------------------- | -------------------------------------- | ------------ |-----------------------------------------------------------------------------------------------|
+| `opencti_url`                          | `OPENCTI_URL`                          | Yes          | The URL of the OpenCTI platform.                                                              |
+| `opencti_token`                        | `OPENCTI_TOKEN`                        | Yes          | The default admin token configured in the OpenCTI platform parameters file.                   |
+| `connector_id`                         | `CONNECTOR_ID`                         | Yes          | A valid arbitrary `UUIDv4` that must be unique for this connector.                            |
+| `connector_type`                       | `CONNECTOR_TYPE`                       | Yes          | Must be `STREAM` (this is the connector type).                                                |
+| `connector_name`                       | `CONNECTOR_NAME`                       | Yes          | The name of the Splunk instance, to identify it if you have multiple Splunk connectors.       |
+| `connector_scope`                      | `CONNECTOR_SCOPE`                      | Yes          | Must be `splunk`, not used in this connector.                                                 |
+| `connector_confidence_level`           | `CONNECTOR_CONFIDENCE_LEVEL`           | Yes          | The default confidence level for created sightings (a number between 1 and 4).                |
+| `connector_log_level`                  | `CONNECTOR_LOG_LEVEL`                  | Yes          | The log level for this connector, could be `debug`, `info`, `warn` or `error` (less verbose). |
+| `connector_consumer_count`             | `CONNECTOR_CONSUMER_COUNT`             | No           | Number of consumer/worker that will push data to Splunk.                                      |
+| `connector_live_stream_start_timestamp`| `CONNECTOR_LIVE_STREAM_START_TIMESTAMP`| No           | Start timestamp used on connector first start.                                                |
+| `splunk_url`                           | `SPLUNK_URL`                           | Yes          | The Splunk instances REST API URLs as array                                                   |
+| `splunk_login`                         | `SPLUNK_LOGIN`                         | Yes          | The Splunk login users as array (same order as URLs)                                          |
+| `splunk_password`                      | `SPLUNK_PASSWORD`                      | Yes          | The Splunk passwords as array (same order as URLs)                                            |
+| `splunk_owner`                         | `SPLUNK_OWNER`                         | Yes          | The Splunk KV store owners as array (same order as URLs)                                      |
+| `splunk_ssl_verify`                    | `SPLUNK_SSL_VERIFY`                    | Yes          | Enable the SSL certificate check for all instances (default: `true`)                          |
+| `splunk_app`                           | `SPLUNK_APP`                           | Yes          | The app of the KV Store for all instances.                                                    |
+| `splunk_kv_store_name`                 | `SPLUNK_KV_STORE_NAME`                 | Yes          | The name of the KV Store for all instances.                                                   |
+| `splunk_ignore_types`                  | `SPLUNK_IGNORE_TYPES`                  | Yes          | The list of entity types to ignore.                                                           |
+| `metrics_enable`                       | `METRICS_ENABLE`                       | No           | Whether or not Prometheus metrics should be enabled.                                          |
+| `metrics_addr`                         | `METRICS_ADDR`                         | No           | Bind IP address to use for metrics endpoint.                                                  |
+| `metrics_port`                         | `METRICS_PORT`                         | No           | Port to use for metrics endpoint.                                                             |

--- a/stream/splunk/docker-compose.yml
+++ b/stream/splunk/docker-compose.yml
@@ -3,22 +3,22 @@ services:
   connector-splunk:
     image: opencti/connector-splunk:5.7.6
     environment:
-      - OPENCTI_URL=http://localhost
-      - OPENCTI_TOKEN=ChangeMe
-      - CONNECTOR_ID=ChangeMe
-      - CONNECTOR_TYPE=STREAM
-      - CONNECTOR_LIVE_STREAM_ID=live # ID of the live stream created in the OpenCTI UI
-      - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=true
-      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true
-      - "CONNECTOR_NAME=OpenCTI Splunk Connector"
-      - CONNECTOR_SCOPE=elastic
-      - CONNECTOR_CONFIDENCE_LEVEL=80 # From 0 (Unknown) to 100 (Fully trusted)
-      - CONNECTOR_LOG_LEVEL=info
-      - "SPLUNK_URL=https://splunk1.changeme.com:8089,https://splunk2.changeme.com:8089"
-      - "SPLUNK_TOKEN=Token1,Token2"
-      - "SPLUNK_OWNER=nobody,nobody"
-      - SPLUNK_SSL_VERIFY=true
-      - SPLUNK_APP=search
-      - SPLUNK_KV_STORE_NAME=opencti
-      - SPLUNK_IGNORE_TYPES=label,marking-definition,identity
+      OPENCTI_URL: http://localhost
+      OPENCTI_TOKEN: ChangeMe
+      CONNECTOR_ID: ChangeMe
+      CONNECTOR_TYPE: STREAM
+      CONNECTOR_LIVE_STREAM_ID: live # ID of the live stream created in the OpenCTI UI
+      CONNECTOR_LIVE_STREAM_LISTEN_DELETE: true
+      CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES: true
+      CONNECTOR_NAME: OpenCTI Splunk Connector
+      CONNECTOR_SCOPE: elastic
+      CONNECTOR_CONFIDENCE_LEVEL: 80 # From 0 (Unknown) to 100 (Fully trusted)
+      CONNECTOR_LOG_LEVEL: info
+      SPLUNK_URL: https://splunk1.changeme.com:8089
+      SPLUNK_TOKEN: Token1
+      SPLUNK_OWNER: nobody
+      SPLUNK_SSL_VERIFY: true
+      SPLUNK_APP: search
+      SPLUNK_KV_STORE_NAME: opencti
+      SPLUNK_IGNORE_TYPES: label,marking-definition,identity
     restart: always

--- a/stream/splunk/src/config.yml.sample
+++ b/stream/splunk/src/config.yml.sample
@@ -12,12 +12,18 @@ connector:
   scope: 'splunk' # Reserved
   confidence_level: 80 # From 0 (Unknown) to 100 (Fully trusted)
   log_level: 'info'
+  consumer_count: 5 # number of consumer/worker used to push data to splunk
 
 splunk:
-  url: 'https://splunk1.changeme.com:8089,https://splunk2.changeme.com:8089'
-  token: 'Token1,Token2'
-  owner: 'nobody,nobody'
+  url: 'https://splunk1.changeme.com:8089'
+  token: 'Token'
+  owner: 'nobody'
   ssl_verify: true
   app: 'search'
   kv_store_name: 'opencti'
   ignore_types: 'label,marking-definition,identity'
+
+metrics:
+  enable: true # set to true to expose prometheus metrics
+  port: 9113 # port on which metrics should be exposed
+  addr: 0.0.0.0 # ip on which metrics should be exposed

--- a/stream/splunk/src/requirements.txt
+++ b/stream/splunk/src/requirements.txt
@@ -2,3 +2,4 @@ pycti==5.7.6
 stix-shifter==4.5.2
 stix-shifter-utils==4.5.2
 stix-shifter-modules-splunk==4.5.2
+prometheus-client==0.16.0

--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -3,16 +3,18 @@
 ################################
 
 import json
+import logging
 import os
-import queue
-import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from queue import Queue
 
 import requests
 import yaml
+from prometheus_client import Counter, Gauge, start_http_server
 from pycti import OpenCTIConnectorHelper, get_config_variable
 from stix_shifter.stix_translation import stix_translation
-
-q = queue.Queue()
 
 
 def sanitize_key(key):
@@ -31,94 +33,162 @@ def sanitize_key(key):
     return key.replace(".", ":").replace("'", "")
 
 
-class SplunkConnector:
-    def __init__(self):
-        # Initialize parameters and OpenCTI helper
-        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
-        self.helper = OpenCTIConnectorHelper(config)
-
-        self.splunk_url = get_config_variable(
-            "SPLUNK_URL", ["splunk", "url"], config
-        ).split(",")
-        self.splunk_token = get_config_variable(
-            "SPLUNK_TOKEN", ["splunk", "token"], config
-        ).split(",")
-        self.splunk_owner = get_config_variable(
-            "SPLUNK_OWNER", ["splunk", "owner"], config
-        ).split(",")
-        self.splunk_ssl_verify = get_config_variable(
-            "SPLUNK_SSL_VERIFY", ["splunk", "ssl_verify"], config, False, True
-        )
-        self.splunk_app = get_config_variable("SPLUNK_APP", ["splunk", "app"], config)
-        self.splunk_kv_store_name = get_config_variable(
-            "SPLUNK_KV_STORE_NAME", ["splunk", "kv_store_name"], config
-        )
-        self.splunk_ignore_types = get_config_variable(
-            "SPLUNK_IGNORE_TYPES", ["splunk", "ignore_types"], config
-        ).split(",")
-
-        if (
-            self.helper.connect_live_stream_id is None
-            or self.helper.connect_live_stream_id == "ChangeMe"
-        ):
-            raise ValueError("Missing Live Stream ID")
-
-        # Initialize the threads
-        thread1 = threading.Thread(target=self._query_worker)
-        thread2 = threading.Thread(target=self._query_worker)
-        thread3 = threading.Thread(target=self._query_worker)
-        thread4 = threading.Thread(target=self._query_worker)
-        thread1.start()
-        thread2.start()
-        thread3.start()
-        thread4.start()
-
-        # Initialize the KV Store
-        self._distribute_works("post", "/config", {"name": self.splunk_kv_store_name})
-
-    def _query(
+class KVStore:
+    def __init__(
         self,
-        splunk_url,
-        splunk_token,
-        splunk_owner,
-        method,
-        uri,
-        payload=None,
-        is_json=False,
-    ):
-        if "type" in payload and payload["type"] in self.splunk_ignore_types:
-            self.helper.log_info("Ignoring " + payload["id"])
-            return
+        splunk_url: str,
+        splunk_token: str,
+        splunk_app: str,
+        splunk_owner: str,
+        splunk_kv_store_name: str,
+        splunk_ssl_verify: bool,
+    ) -> None:
+        self.splunk_url = splunk_url
+        self.splunk_token = splunk_token
+        self.splunk_app = splunk_app
+        self.splunk_owner = splunk_owner
+        self.splunk_kv_store_name = splunk_kv_store_name
+        self.splunk_ssl_verify = splunk_ssl_verify
 
-        self.helper.log_info(
-            "Query " + method + " on " + uri + " (url=" + splunk_url + ")"
+    @property
+    def collection_url(self) -> str:
+        return f"{self.splunk_url}/servicesNS/{self.splunk_owner}/{self.splunk_app}/storage/collections/"
+
+    @property
+    def headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self.splunk_token}",
+            "Content-Type": "application/json",
+        }
+
+    def init(self) -> bool:
+        r = requests.post(
+            f"{self.collection_url}/config",
+            data={"name": self.splunk_kv_store_name},
+            headers=self.headers,
+            verify=self.splunk_ssl_verify,
         )
-        url = (
-            splunk_url
-            + "/servicesNS/"
-            + splunk_owner
-            + "/"
-            + self.splunk_app
-            + "/storage/collections"
-            + uri
+
+        return r.status_code < 300
+
+    def create(self, id: str, payload: dict):
+        payload["_key"] = id
+        r = requests.post(
+            f"{self.collection_url}/data/{self.splunk_kv_store_name}",
+            json=payload,
+            headers=self.headers,
+            verify=self.splunk_ssl_verify,
         )
-        payload["stream_name"] = self.helper.get_stream_collection()["name"]
+        if r.status_code != 409:
+            r.raise_for_status()
+
+    def update(self, id: str, payload: dict):
+        payload["_key"] = id
+
+        r = requests.put(
+            f"{self.collection_url}/data/{self.splunk_kv_store_name}/{id}",
+            json=payload,
+            headers=self.headers,
+            verify=self.splunk_ssl_verify,
+        )
+
+        if r.status_code == 404:
+            self.create(id, payload)
+        else:
+            r.raise_for_status()
+
+    def delete(self, id: str):
+        r = requests.delete(
+            f"{self.collection_url}/data/{self.splunk_kv_store_name}/{id}",
+            headers=self.headers,
+            verify=self.splunk_ssl_verify,
+        )
+        if r.status_code != 404:
+            r.raise_for_status()
+
+
+class Metrics:
+    def __init__(self, name: str, addr: str, port: int) -> None:
+        self.name = name
+        self.addr = addr
+        self.port = port
+
+        self._processed_messages_counter = Counter(
+            "processed_messages", "Number of processed messages", ["name", "action"]
+        )
+        self._current_state_gauge = Gauge(
+            "current_state", "Current connector state", ["name"]
+        )
+
+    def msg(self, action: str):
+        self._processed_messages_counter.labels(self.name, action).inc()
+
+    def state(self, event_id: str):
+        """Set current state metric from an event id.
+
+        An event id looks like 1679004823824-0, it contains time information
+        about when the event was generated."""
+
+        ts = int(event_id.split("-")[0])
+        self._current_state_gauge.labels(self.name).set(ts)
+
+    def start_server(self):
+        start_http_server(self.port, addr=self.addr)
+
+
+class SplunkConnector:
+    def __init__(
+        self,
+        helper: OpenCTIConnectorHelper,
+        kvstore: KVStore,
+        queue: Queue,
+        ignore_types: list[str],
+        consumer_count: int,
+        metrics: Metrics | None = None,
+    ) -> None:
+        self.kvstore = kvstore
+        self.queue = queue
+        self.helper = helper
+        self.ignore_types = ignore_types
+        self.metrics = metrics
+        self.consumer_count = consumer_count
+
+        self._org_name_cache = {}
+
+    def is_filtered(self, data: dict):
+        return "type" in data and data["type"] in self.ignore_types
+
+    def get_org_name(self, entity_id: str) -> str | None:
+        if entity_id in self._org_name_cache:
+            return self._org_name_cache.get(entity_id)
+
+        entity = self.helper.api.stix_domain_object.read(id=entity_id)
+        org_name = entity.get("name")
+        self._org_name_cache[entity_id] = org_name
+
+        return org_name
+
+    def enrich_payload(self, payload: dict):
+        # add stream name
+        payload["stream_name"] = self.helper.get_stream_name()["name"]
+
         if (
             "type" in payload
             and payload["type"] == "indicator"
             and payload["pattern_type"].startswith("stix")
         ):
+            # add splunk query
             try:
                 translation = stix_translation.StixTranslation()
                 response = translation.translate(
                     "splunk", "query", "{}", payload["pattern"]
                 )
                 payload["splunk_queries"] = response
+            except:
+                pass
+
+            # add mapped values
+            try:
                 parsed = translation.translate(
                     "splunk", "parse", "{}", payload["pattern"]
                 )
@@ -140,145 +210,185 @@ class SplunkConnector:
                     payload["mapped_values"] = [formatted_value]
                 except:
                     payload["mapped_values"] = []
-                    pass
-        if method == "get":
-            r = requests.get(
-                url,
-                headers={"Authorization": "Bearer " + splunk_token},
-                params=payload,
-                verify=self.splunk_ssl_verify,
-            )
-        elif method == "post":
-            if is_json:
-                r = requests.post(
-                    url,
-                    headers={
-                        "Authorization": "Bearer " + splunk_token,
-                        "content-type": "application/json",
-                    },
-                    json=payload,
-                    verify=self.splunk_ssl_verify,
-                )
-            else:
-                r = requests.post(
-                    url,
-                    headers={"Authorization": "Bearer " + splunk_token},
-                    data=payload,
-                    verify=self.splunk_ssl_verify,
-                )
-        elif method == "delete":
-            r = requests.delete(
-                url,
-                headers={"Authorization": "Bearer " + splunk_token},
-                verify=self.splunk_ssl_verify,
-            )
-        else:
-            raise ValueError("Unsupported method")
 
-        if r.status_code < 500:
-            try:
-                return r.json()
-            except:
-                return r.text
-        else:
-            self.helper.log_info(r.text)
+            # add creator's name
+            created_by = payload.get("created_by_ref", None)
+            if created_by is not None:
+                org_name = self.get_org_name(created_by)
+                if org_name is not None:
+                    payload["created_by"] = org_name
 
-    def _query_worker(self):
-        while True:
-            item = q.get()
-            self._query(
-                item["splunk_url"],
-                item["splunk_token"],
-                item["splunk_owner"],
-                item["method"],
-                item["uri"],
-                item["data"],
-                item["is_json"],
-            )
-            q.task_done()
+        return payload
 
-    def _distribute_works(self, method, uri, data, is_json=False):
-        for x, url in enumerate(self.splunk_url):
-            if len(self.splunk_token) - 1 < x or len(self.splunk_owner) - 1 < x:
-                raise ValueError(
-                    "Token or owner do not have the same number of items as URLs"
-                )
-            item = {
-                "splunk_url": url,
-                "splunk_token": self.splunk_token[x],
-                "splunk_owner": self.splunk_owner[x],
-                "method": method,
-                "uri": uri,
-                "data": data,
-                "is_json": is_json,
-            }
-            q.put(item)
-        return "Sent " + str(len(self.splunk_url)) + " jobs for execution"
+    def register_producer(self):
+        self.helper.listen_stream(self.produce)
 
-    def _process_message(self, msg):
+    def produce(self, msg):
+        self.queue.put(msg)
+
+    def start_consumers(self):
+        self.helper.log_info(f"starting {self.consumer_count} consumer threads")
+        with ThreadPoolExecutor() as executor:
+            for _ in range(self.consumer_count):
+                executor.submit(self.consume)
+
+    def consume(self):
+        # ensure the process stop when there is an issue while
+        # processing message
         try:
-            data = json.loads(msg.data)["data"]
-            # Handle creation
-            if msg.event == "create":
-                self.helper.log_info(
-                    "[CREATE] Processing data {"
-                    + OpenCTIConnectorHelper.get_attribute_in_extension("id", data)
-                    + "}"
-                )
-                # Do any processing needed
-                data["_key"] = OpenCTIConnectorHelper.get_attribute_in_extension(
-                    "id", data
-                )
-
-                # Distribute the works on parallel threads for ingestion
-                return self._distribute_works(
-                    "post", "/data/" + self.splunk_kv_store_name, data, True
-                )
-            # Handle update
-            if msg.event == "update":
-                self.helper.log_info(
-                    "[UPDATE] Processing data {"
-                    + OpenCTIConnectorHelper.get_attribute_in_extension("id", data)
-                    + "}"
-                )
-                data["_key"] = OpenCTIConnectorHelper.get_attribute_in_extension(
-                    "id", data
-                )
-                return self._distribute_works(
-                    "post",
-                    "/data/"
-                    + self.splunk_kv_store_name
-                    + "/"
-                    + OpenCTIConnectorHelper.get_attribute_in_extension("id", data),
-                    data,
-                    True,
-                )
-            # Handle delete
-            elif msg.event == "delete":
-                self.helper.log_info(
-                    "[DELETE] Processing data {"
-                    + OpenCTIConnectorHelper.get_attribute_in_extension("id", data)
-                    + "}"
-                )
-                return self._distribute_works(
-                    "delete",
-                    "/data/"
-                    + self.splunk_kv_store_name
-                    + "/"
-                    + OpenCTIConnectorHelper.get_attribute_in_extension("id", data),
-                    data,
-                )
-            return None
-
+            self._consume()
         except Exception as e:
-            self.helper.log_error("[ERROR] Failed processing data {" + str(e) + "}")
-            self.helper.log_error("[ERROR] Message data {" + str(msg) + "}")
-            return None
+            self.helper.log_error("an error occurred while consuming messages")
+            self.helper.log_error(e)
+            os._exit(1)  # exit the current process, killing all threads
+
+    def _consume(self):
+        while True:
+            msg = self.queue.get()
+
+            payload = json.loads(msg.data)["data"]
+            id = OpenCTIConnectorHelper.get_attribute_in_extension("id", payload)
+
+            self.helper.log_debug(f"processing message with id {id}")
+
+            if self.is_filtered(payload):
+                self.helper.log_debug(f"item with id {id} is filtered")
+                continue
+
+            payload = self.enrich_payload(payload)
+
+            match msg.event:
+                case "create":
+                    self.kvstore.create(id, payload)
+                    self.helper.log_debug(f"kvstore item with id {id} created")
+
+                case "update":
+                    self.kvstore.update(id, payload)
+                    self.helper.log_debug(f"kvstore item with id {id} updated")
+
+                case "delete":
+                    self.helper.log_debug(f"kvstore item with id {id} deleted")
+                    self.kvstore.delete(id)
+
+            if self.metrics is not None:
+                self.metrics.msg(msg.event)
+                self.metrics.state(msg.id)
 
     def start(self):
-        self.helper.listen_stream(self._process_message)
+        if self.kvstore.init():
+            self.helper.log_info("kvstore created")
+        else:
+            self.helper.log_warning("unable to create kvstore")
+
+        self.register_producer()
+        self.start_consumers()
+
+
+def fix_loggers() -> None:
+    logging.getLogger(
+        "stix_shifter_modules.splunk.stix_translation.query_translator"
+    ).setLevel(logging.CRITICAL)
+    logging.getLogger("stix_shifter.stix_translation.stix_translation").setLevel(
+        logging.CRITICAL
+    )
+    logging.getLogger(
+        "stix_shifter_utils.stix_translation.stix_translation_error_mapper"
+    ).setLevel(logging.CRITICAL)
+
+
+def load_config_file() -> dict:
+    config_file = Path(__file__).parent / "config.yml"
+
+    if not config_file.is_file():
+        return {}
+
+    config_content = config_file.read_text()
+    config = yaml.safe_load(config_content)
+    return config
+
+
+def check_helper(helper: OpenCTIConnectorHelper) -> None:
+    if (
+        helper.connect_live_stream_id is None
+        or helper.connect_live_stream_id == "ChangeMe"
+    ):
+        helper.log_error("missing Live Stream ID")
+        exit(1)
 
 
 if __name__ == "__main__":
-    SplunkInstance = SplunkConnector()
-    SplunkInstance.start()
+    # fix loggers
+    fix_loggers()
+
+    # load and check config
+    config = load_config_file()
+    # create opencti helper
+    helper = OpenCTIConnectorHelper(config)
+    helper.log_info("connector helper initialized")
+    check_helper(helper)
+
+    # read config
+    ignore_types = get_config_variable(
+        "SPLUNK_IGNORE_TYPES", ["splunk", "ignore_types"], config
+    ).split(",")
+    splunk_url = get_config_variable("SPLUNK_URL", ["splunk", "url"], config)
+    splunk_token = get_config_variable("SPLUNK_TOKEN", ["splunk", "token"], config)
+    splunk_owner = get_config_variable("SPLUNK_OWNER", ["splunk", "owner"], config)
+    splunk_ssl_verify = get_config_variable(
+        "SPLUNK_SSL_VERIFY", ["splunk", "ssl_verify"], config, False, True
+    )
+    splunk_app = get_config_variable("SPLUNK_APP", ["splunk", "app"], config)
+    splunk_kv_store_name = get_config_variable(
+        "SPLUNK_KV_STORE_NAME", ["splunk", "kv_store_name"], config
+    )
+
+    # additional connector conf
+    consumer_count: int = get_config_variable(
+        "CONNECTOR_CONSUMER_COUNT",
+        ["connector", "consumer_count"],
+        config,
+        isNumber=True,
+        default=10,
+    )
+
+    # metrics conf
+    enable_prom_metrics: bool = get_config_variable(
+        "METRICS_ENABLE", ["metrics", "enable"], config, default=False
+    )
+    metrics_port: int = get_config_variable(
+        "METRICS_PORT", ["metrics", "port"], config, isNumber=True, default=9113
+    )
+    metrics_addr: str = get_config_variable(
+        "METRICS_ADDR", ["metrics", "addr"], config, default="0.0.0.0"
+    )
+
+    # create kvstore instance
+    kvstore = KVStore(
+        splunk_url,
+        splunk_token,
+        splunk_app,
+        splunk_owner,
+        splunk_kv_store_name,
+        splunk_ssl_verify,
+    )
+
+    # create queue
+    queue = Queue(maxsize=2 * consumer_count)
+
+    # create prom metrics
+    if enable_prom_metrics:
+        metrics = Metrics(helper.connect_name, metrics_addr, metrics_port)
+        helper.log_info(f"starting metrics server on {metrics_addr}:{metrics_port}")
+        metrics.start_server()
+    else:
+        metrics = None
+
+    # create connector and start
+    SplunkConnector(
+        helper,
+        kvstore,
+        queue,
+        ignore_types,
+        consumer_count,
+        metrics=metrics,
+    ).start()

--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -5,7 +5,6 @@
 import json
 import logging
 import os
-import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from queue import Queue


### PR DESCRIPTION
Hi, 

I create this PR to open a discussion on the current Splunk connector and its use on a production environment.

## Proposed changes

We faced several operational issues and are proposing solutions for each of them:

**1. Removing the "1 connector for multiple Splunk" feature**

The current version is able to push an entity to multiple Splunk, it allows to mutualize enrichment CPU usage.

However, it leads to inter-dependencies between Splunk instances. An issue with the first configured Splunk instance can impact the second one. Also, as OpenCTI / Splunk A and the OpenCTI / Splunk B share the same state internally, it is easy, when an incident occurs on Splunk A or B to get an inconsistent state.

It is actually way more simple and reliable to have on connector per Splunk instance. It also simplifies the code and the deployment model (so this feature is removed in this PR, which is a breaking change).

**2. Improving connector event processing speed**

With the current version, there is on thread per Splunk instance. Events are processed one at a time.
A huge sync delay can be observed it some cases:

1. When a huge bundle of new entities is created on OpenCTI
2. When performing the initial sync

In order to improve connector speed, this PR introduce a producer/consumer model. There is one producer putting events in a queue, and a configurable amount of consumer threads.

**3. Adding metrics**

We currently lacks a application monitoring system. This PR adds 2 Prometheus metrics that could allow users (who use a Prometheus-based monitoring stack) to have a dashboard/alerts on: 
- The number of events processed by each Splunk connector
- The timestamp of last processed event, to measure the connector delay

**4. Adding creator's**

The creator name is currently not available in Splunk KVstore, we get a `created_by_ref` field with the ID of this entity. Having the name instead of the ID is more convenient for Splunk users.

It is possible to enrich this field on Splunk using a lookup, but it means we have to manually maintain a mapping between `created_by_ref` value and the corresponding name (which is not convenient). 

This PR adds a step in the enrichment process to fetch the corresponding name on the API, values is stored in a field we named `created_by`. A cache system is used to prevent consumer threads to make to much requests to OpenCTI API.

**5. Code architecture changes**

Few architecture changes in the code:
1. Add of a `KVstore` class: encapsulate KVstore related code, make `SplunkConnector` code easier to read
2. Add of a `Metrics` class: encapsulate Prometheus metrics related code
3. Move initialization of `SplunkConnector`'s dependencies out of its constructor: make `SplunkConnector` code easier to read and test
4. Use of `match` keyword, only available in Python 3.10 (let me know if lower version should be supported, I see the Dockerfile is based on Python 3.10)
### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/1035: an handler is responsible of stopping the process if an "unexpected error" occurs in any thread, leaving the responsibility to another system to restart the connector when it crashs (docker, systemd, kubernetes...)
* https://github.com/OpenCTI-Platform/connectors/issues/1036: 
  * on update, entity is created if it does not exist
  * on create, 409 errors are ignored if entity already exist
  * on delete, 404 errors are ignored if entity does not exist

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

