### PR TITLE
Comment documenting units used for abuse-ssl interval

### DIFF
--- a/external-import/abuse-ssl/docker-compose.yml
+++ b/external-import/abuse-ssl/docker-compose.yml
@@ -13,5 +13,5 @@ services:
       - CONNECTOR_UPDATE_EXISTING_DATA=true
       - CONNECTOR_LOG_LEVEL=info
       - ABUSESSL_URL=https://sslbl.abuse.ch/blacklist/sslipblacklist.csv
-      - ABUSESSL_INTERVAL=10
+      - ABUSESSL_INTERVAL=10 # Time to wait in minutes between subsequent requests
     restart: always


### PR DESCRIPTION
Comment documenting units used for abuse-ssl interval - most connectors document with a comment what unit the interval field uses (seconds, days etc.), but this one was missing.

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This just adds a comment that explains that the abuse_ssl connector's interval is in minutes.