### PR TITLE
[vt-livehunt] add author to created objects

### DIFF
--- a/external-import/virustotal-livehunt-notifications/src/virustotal-livehunt-notifications.py
+++ b/external-import/virustotal-livehunt-notifications/src/virustotal-livehunt-notifications.py
@@ -203,6 +203,7 @@ class VirustotalLivehuntNotifications:
                         file_contents,
                         file_name,
                         "Downloaded from Virustotal Livehunt Notifications.",
+                        self.identity,
                     )
 
                     # Set score
@@ -292,13 +293,14 @@ class VirustotalLivehuntNotifications:
             return True
         return False
 
-    def upload_artifact_opencti(self, file_contents, file_name, description):
+    def upload_artifact_opencti(self, file_contents, file_name, description, author):
         """
         Upload a file to OpenCTI.
 
         file_contents: a bytes object representing the file contents
         file_name: a str representing the name of the file
         description: a str representing the description for the upload
+        author: the author uploading the artefact (identity of the connector)
 
         returns: response of upload
         """
@@ -310,6 +312,7 @@ class VirustotalLivehuntNotifications:
             "data": file_contents,
             "mime_type": mime_type,
             "x_opencti_description": description,
+            "createdBy": author["id"],
         }
         return self.helper.api.stix_cyber_observable.upload_artifact(**kwargs)
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

The virustotal-livehunt-notifications connector does not link the author (identity object) to the newly created objects, making it difficult to see which objects are created by the connector. 

### Proposed changes

* Add the author when creating objects with the virustotal-livethunt-notifications connector

### Related issues

* N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Before: 
![image](https://github.com/OpenCTI-Platform/connectors/assets/7095119/e7bc9502-6d57-4791-8b11-62eeab196b72)

After:
![image](https://github.com/OpenCTI-Platform/connectors/assets/7095119/cc071099-d954-4549-aa39-103ec1b1ff29)
