### PR TITLE
Connector Elastic - new features and bugfixes

### DIFF
--- a/stream/elastic/README.md
+++ b/stream/elastic/README.md
@@ -1,9 +1,11 @@
 # Elastic Threat Intel Connector
 
-This connector allows organizations to feed their Elastic platform using OpenCTI knowledge. It has two modes: `ecs` and `stix`.
+This connector allows organizations to feed their Elastic platform using OpenCTI knowledge. It has three modes: `ecs`, `ecs_no_signals`, and `stix`.
 
 `ecs` mode writes indicator objects in ECS format to Elasticsearch for the purpose of using ECS-formatted "[indicator match](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-indicator-rule)"
 rules in the Detection Engine. It will also create a background thread to poll for matches in the `.siem-signals-*` indices and will record them in OpenCTI as Sightings.
+
+`ecs_no_signals` is the similar, it just avoids the polling of signals. Usefull, for example, if multiple elastic connectors are running for the same target instance. 
 
 `stix` mode writes the raw STIX objects used internally by OpenCTI to the index specified.
 
@@ -46,7 +48,7 @@ variable `CONNECTOR_JSON_CONFIG` takes a JSON equivalent of the `config.yml` and
 | `connector.confidence_level`      | `CONNECTOR_CONFIDENCE_LEVEL` | Yes       | The default confidence level for created sightings (a number between 0 and 100).                                                                                         |
 | `connector.id`                    | `CONNECTOR_ID`               | Yes       | A valid arbitrary `UUIDv4` that must be unique for this connector.                                                                                                       |
 | `connector.log_level`             | `CONNECTOR_LOG_LEVEL`        | Yes       | The log level for this connector, could be `debug`, `info`, `warn` or `error` (less verbose).                                                                            |
-| `connector.mode`                  | `CONNECTOR_MODE`             | No        | Must be 'ecs' for ECS-formatted threat indicator documents or 'stix' for raw OpenCTI STIX documents. Defaults to 'ecs'.                                                  |
+| `connector.mode`                  | `CONNECTOR_MODE`             | No        | Must be 'ecs' for ECS-formatted threat indicator documents, 'ecs_no_signals' if signal polling is not desired, or 'stix' for raw OpenCTI STIX documents. Defaults to 'ecs'.                                                  |
 | `connector.name`                  | `CONNECTOR_NAME`             | Yes       | The name of the Elastic instance, to identify it if you have multiple Elastic instances connectors.                                                                      |
 | `connector.scope`                 | `CONNECTOR_SCOPE`            | Yes       | Must be `elastic`, not used in this connector.                                                                                                                           |
 | `connector.type`                  | `CONNECTOR_TYPE`             | Yes       | Must be `STREAM` (this is the connector type).                                                                                                                           |

--- a/stream/elastic/config.reference.yml
+++ b/stream/elastic/config.reference.yml
@@ -16,7 +16,8 @@ connector:
   live_stream_id: 'live'
   live_stream_listen_delete: true
   start_timestamp: '1655890657402' ### format example Wed, 22 Jun 2022 09:46:24 GMT
-  mode: ecs # Options are 'ecs' (indicators only) or 'stix' (raw STIX documents)
+  mode: ecs # Options are 'ecs' (indicators only), 'ecs_no_signals' (same as 'ecs' but no signal import) 
+            # or 'stix' (raw STIX documents)
 
 # =============================== Elastic Cloud ================================
 # The cloud.id setting overwrites the `elastic.hosts`
@@ -27,27 +28,31 @@ connector:
 # API key is recommended
 #cloud.auth:
 
-output.elasticsearch:
-  # ---------------------------- Elasticsearch Output ----------------------------
-  # Array of hosts to connect to.
-  # Scheme and port can be left out and will be set to the default (http and 9200)
-  # In case you specify an additional path, the scheme is required: http://localhost:9200/path
-  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
-  hosts: ["localhost:9200"]
-  # Authentication credentials - either API key or username/password.
-  #api_key: "id:api_key"
-  #username: "elastic"
-  #password: "changeme"
-  ssl_verify: true
+output:
+  elasticsearch:
+    # ---------------------------- Elasticsearch Output ----------------------------
+    # Array of hosts to connect to.
+    # Scheme and port can be left out and will be set to the default (http and 9200)
+    # In case you specify an additional path, the scheme is required: http://localhost:9200/path
+    # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+    hosts: ["localhost:9200"]
+    # Authentication credentials - either API key or username/password.
+    #api_key: "id:api_key"
+    #username: "elastic"
+    #password: "changeme"
+    ssl_verify: true
 
-  # Optional index name. The default is "opencti" plus the date. Uses Elastic date math syntax.
-  # Custom index settings are ignored when ILM is enabled.  Be sure to update
-  # `setup.template.pattern` if you change the output index.
-  #index: "opencti-{now/d}"
+    # Optional index name. The default is "opencti" plus the date. Uses Elastic date math syntax.
+    # Custom index settings are ignored when ILM is enabled.  Be sure to update
+    # `setup.template.pattern` if you change the output index.
+    #index: "opencti-{now/d}"
 
-  # Set the following flag to "true" if the elasticsearch access do not have cluster 
-  # "monitor" privileges
-  #reduced_privileges: false 
+    # Set the following flag to "true" if the elasticsearch access do not have cluster 
+    # "monitor" privileges
+    #reduced_privileges: false 
+  
+  # store STIX object labels with the indicators in elasticsearch if in 'ecs' or 'ecs_no_signals' mode. 
+  include_labels: False
 
 # ====================== Index Lifecycle Management (ILM) ======================
 

--- a/stream/elastic/elastic/conf.py
+++ b/stream/elastic/elastic/conf.py
@@ -38,7 +38,8 @@ defaults: dict = {
             "api_key": None,
             "index": "opencti-{now/d}",
             "reduced_privileges": "false",
-        }
+        },
+        "include_labels": False,
     },
     "setup": {
         "ilm": {

--- a/stream/elastic/elastic/elastic.py
+++ b/stream/elastic/elastic/elastic.py
@@ -57,7 +57,7 @@ class ElasticConnector:
                 opencti_client=self.helper,
                 elasticsearch_client=self.elasticsearch,
             )
-        if self.config["connector.mode"] == "ecs_no_signals":
+        elif self.config["connector.mode"] == "ecs_no_signals":
             self.import_manager = IntelManager(
                 self.helper, self.elasticsearch, self.config, datadir
             )

--- a/stream/elastic/elastic/elastic.py
+++ b/stream/elastic/elastic/elastic.py
@@ -57,6 +57,10 @@ class ElasticConnector:
                 opencti_client=self.helper,
                 elasticsearch_client=self.elasticsearch,
             )
+        if self.config["connector.mode"] == "ecs_no_signals":
+            self.import_manager = IntelManager(
+                self.helper, self.elasticsearch, self.config, datadir
+            )
         elif self.config["connector.mode"] == "stix":
             self.import_manager = StixManager(
                 self.helper, self.elasticsearch, self.config, datadir
@@ -65,7 +69,7 @@ class ElasticConnector:
             self.sightings_manager = None
         else:
             logger.error(
-                f"connector.mode: {self.config['connector.mode']} is unsupported. Should be 'ecs' or 'stix'"
+                f"connector.mode: {self.config['connector.mode']} is unsupported. Should be 'ecs', 'ecs_no_signals' or 'stix'"
             )
 
     def _connect_elasticsearch(self) -> None:

--- a/stream/elastic/elastic/elastic.py
+++ b/stream/elastic/elastic/elastic.py
@@ -158,7 +158,7 @@ class ElasticConnector:
             logger.error(f"Unable to process the message: {msg}")
             raise ValueError("Cannot process the message: " + msg)
 
-        logger.debug(f"[PROCESS] Message (id: {event_id}, date: {timestamp})")
+        logger.debug(f"[PROCESS] Message (id: {event_id}, date: {timestamp}, data: {data})")
 
         if msg.event == "create":
             return self.handle_create(timestamp, data)

--- a/stream/elastic/elastic/import_manager.py
+++ b/stream/elastic/elastic/import_manager.py
@@ -141,8 +141,8 @@ class IntelManager(object):
         from string import Template
 
         logger.info("Setting up Elasticsearch for OpenCTI Connector")
-        if self.config.get("output.elasticsearch.reduced_privileges", True):
-            return self.es_client.ping()
+        if not self.config.get("output.elasticsearch.reduced_privileges", False):
+            assert self.es_client.ping()
 
         _ilm_enabled: bool = self.config.get("setup.ilm.enabled", True)
         _policy_name: str = self.config.get("setup.ilm.policy_name", "opencti")

--- a/stream/elastic/elastic/import_manager.py
+++ b/stream/elastic/elastic/import_manager.py
@@ -398,6 +398,9 @@ class IntelManager(object):
                 f"/dashboard/observations/indicators/{entity['id']}",
             )
 
+        if self.config.get("output.include_labels", False):
+            _document["labels"] = OpenCTIConnectorHelper.get_attribute_in_extension("labels", entity),
+
         _document["event"][
             "risk_score"
         ] = OpenCTIConnectorHelper.get_attribute_in_extension("score", entity)

--- a/stream/elastic/elastic/import_manager.py
+++ b/stream/elastic/elastic/import_manager.py
@@ -398,8 +398,8 @@ class IntelManager(object):
                 f"/dashboard/observations/indicators/{entity['id']}",
             )
 
-        if self.config.get("output.include_labels", False):
-            _document["labels"] = OpenCTIConnectorHelper.get_attribute_in_extension("labels", entity),
+        if self.config.get("output.include_labels", False) and data.get("labels", None) is not None:
+            _document["labels"] = data.get("labels")
 
         _document["event"][
             "risk_score"

--- a/stream/elastic/elastic/sightings_manager.py
+++ b/stream/elastic/elastic/sightings_manager.py
@@ -176,10 +176,10 @@ class SignalsManager(Thread):
                                 )
                                 continue
 
-                        ecs_version_lt8 = version.parse(
-                            hit["_source"]["ecs"]["version"]
+                        kbn_version_lt8 = version.parse(
+                            hit["_source"]["kibana.version"]
                         ) < version.parse("8.0.0")
-                        if ecs_version_lt8:
+                        if kbn_version_lt8:
                             _timestamp = hit["_source"]["signal"]["original_time"]
                         else:
                             _timestamp = hit["_source"]["kibana.alert.original_time"]
@@ -198,6 +198,18 @@ class SignalsManager(Thread):
                             elif _timestamp > ids_dict[_opencti_id]["last_seen"]:
                                 ids_dict[_opencti_id]["last_seen"] = _timestamp
 
+<<<<<<< HEAD
+=======
+                        # only supported if Kibana version >= 8.0.0
+                        if self.config.get("elastic.sightings_label_rule_id", "false") and not kbn_version_lt8:
+                            ids_dict[_opencti_id]['labels'].add(hit["_source"]["kibana.alert.rule.parameters"]["rule_id"])
+                        if self.config.get("elastic.sightings_label_organization", "false") and not kbn_version_lt8:
+                            try:
+                                ids_dict[_opencti_id]['labels'].add(hit["_source"]["organization"]['name'])
+                            except KeyError:
+                                logger.info(("Cannot extract 'organization.name' property from signal."))
+
+>>>>>>> dbc41ca2... bugfixes
                 # Loop through signal hits and create new sightings
                 for k, v in ids_dict.items():
                     # Check if indicator exists

--- a/stream/elastic/elastic/sightings_manager.py
+++ b/stream/elastic/elastic/sightings_manager.py
@@ -201,18 +201,6 @@ class SignalsManager(Thread):
                             elif _timestamp > ids_dict[_opencti_id]["last_seen"]:
                                 ids_dict[_opencti_id]["last_seen"] = _timestamp
 
-<<<<<<< HEAD
-=======
-                        # only supported if Kibana version >= 8.0.0
-                        if self.config.get("elastic.sightings_label_rule_id", "false") and not kbn_version_lt8:
-                            ids_dict[_opencti_id]['labels'].add(hit["_source"]["kibana.alert.rule.parameters"]["rule_id"])
-                        if self.config.get("elastic.sightings_label_organization", "false") and not kbn_version_lt8:
-                            try:
-                                ids_dict[_opencti_id]['labels'].add(hit["_source"]["organization"]['name'])
-                            except KeyError:
-                                logger.info(("Cannot extract 'organization.name' property from signal."))
-
->>>>>>> dbc41ca2... bugfixes
                 # Loop through signal hits and create new sightings
                 for k, v in ids_dict.items():
                     # Check if indicator exists
@@ -241,11 +229,12 @@ class SignalsManager(Thread):
                             created=None,
                             modified=None,
                             confidence=confidence,
-                            created_by=entity_id,
-                            object_marking=None,
-                            object_label=None,
-                            external_references=None,
+                            createdBy=entity_id,
+                            objectMarking=None,
+                            objectLabel=None,
+                            externalReferences=None,
                             update=False,
+                            x_opencti_stix_ids=None,
                         )
 
                 # Wait allows us to return earlier during a shutdown

--- a/stream/elastic/elastic/sightings_manager.py
+++ b/stream/elastic/elastic/sightings_manager.py
@@ -120,6 +120,8 @@ class SignalsManager(Thread):
                 )
                 ids_dict = {}
 
+                logger.debug(f"Signal request result: {results}")
+
                 # Parse the results
                 for hit in results["hits"]["hits"]:
                     # This depends on ECS mappings >= 1.11
@@ -138,6 +140,7 @@ class SignalsManager(Thread):
                             continue
 
                         if _doc["found"] is not True:
+                            logger.debug(f"Document with indicator id '{indicator['matched']['id']}' not found. Continue")
                             continue
 
                         if (


### PR DESCRIPTION

### Proposed changes

* added ability and configuration abilities to push indicator labels on the ElasticSearch database, if enabled. The newly introduced configuration flag 'include_labels' allows for enabling this feature, defaults to false. 
* added a new mode 'ecs_no_signals' that allows the connector to run in 'ecs' mode without signals importing enabled. This is useful, for example, if two Elastic connectors are running for the same ElasticSearch database but the sightings should be imported only by one of them. 
* reverted the changes for the Elastic connector in PR1132 (https://github.com/OpenCTI-Platform/connectors/pull/1132). The mentioned administrator privileges where exactly the reason, I introduced the flag. Moreover, the changes by PR1132 break the connector if low privileges are required (the return statement makes no sense). It defaults now to false to mimic the default behaviour before I initially introduced the flag. 
* fixed kwargs when callig 'self.helper.api.stix_sighting_relationship.create'
* fixing a small bug on the Kibana version detection that became visible when we updated to ElasticSearch v8.7.1
* added a few debug outputs which I found helpful in finding errors. 

### Related issues

*

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments