### PR TITLE
Rectified non absolute /tmp/ path

### DIFF
--- a/external-import/cve/src/cve.py
+++ b/external-import/cve/src/cve.py
@@ -69,13 +69,13 @@ class Cve:
             )
             image = response.read()
             with open(
-                os.path.dirname(os.path.abspath(__file__)) + "/tmp/data.json.gz", "wb"
+                "/tmp/data.json.gz", "wb"
             ) as file:
                 file.write(image)
             # Unzipping the file
             self.helper.log_info("Unzipping the file")
             with gzip.open(
-                os.path.dirname(os.path.abspath(__file__)) + "/tmp/data.json.gz", "rb"
+                "/tmp/data.json.gz", "rb"
             ) as f_in:
                 with open("/tmp/data.json", "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)


### PR DESCRIPTION
### Proposed changes

I've amended a couple of lines to rectify the filepath being written to (to be /tmp/), as in it's current state, the connector does not work properly.

### Related issues

https://github.com/OpenCTI-Platform/connectors/pull/1174

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

One of the previous pull requests ( #1174 ) looked to have the data files stored and processed in /opt/opencti-connector-cve/tmp/ directory. However, the majority of the lines amended in that request actually made reference to the absolute path of /tmp/, rather than the /opt/opencti-connector-cve/tmp/ path that was intended. 

However, due to /tmp/ being globally writeable by default, it works just as well as a solution to the original problem. This is a request to amend the two lines that do not actually make reference to /tmp/ to bring them in line with the rest of the changes.

#1174 amended all of the references to the data files to be prepended with /tmp/, which works for the majority of the original lines as they were originally relative filepaths: just filenames. Therefore the appendment of /tmp/ worked just fine, to make them absolute. However, the lines referred to in this pull request had os.path.dirname(os.path.abspath(__file__)) in addition to the added "/tmp/". This results in the actual filepath referred to in the original pull request, but actually breaks the connector.

os.path.dirname(os.path.abspath(__file__)) by default resolves to /opt/opencti-connector-cve, which is then appended to /tmp/data.json.gz on the two lines. This actually causes the connector to fail when trying to write the files as /opt/opencti-connector-cve/tmp does not exist by default. This pull request will bring all of the code in line and brings it back to working order.