### PR TITLE
[TWEETFEED CONNECTOR]

### DIFF
--- a/external-import/tweetfeed/src/tweetfeed.py
+++ b/external-import/tweetfeed/src/tweetfeed.py
@@ -217,7 +217,7 @@ class TweetFeed:
 
                 if last_run is None or (
                     (timestamp - last_run)
-                    > ((int(self.tweetfeed_interval) - 1) * 60 * 60 * 24)
+                    > ((int(self.tweetfeed_interval)) * 60 * 60 * 24)
                 ):
                     self.helper.log_info("Connector will run!")
                     datetimex = datetime.utcfromtimestamp(timestamp).strftime(
@@ -232,6 +232,10 @@ class TweetFeed:
                         + str(timestamp)
                     )
                     self.helper.set_state({"last_run": timestamp})
+                    message = "Connector successfully run, storing last_run as " + str(
+                        timestamp
+                    )
+                    self.helper.api.work.to_processed(self.workid, message)
                     self.helper.log_info(
                         "Last_run stored, next run in: "
                         + str(round(self.get_interval() / 60 / 60 / 24, 2))
@@ -339,7 +343,7 @@ class TweetFeed:
                 indicator = self.helper.api.indicator.create(
                     name=ioc["value"],
                     description="TWEETFEED IOC " + ioc["value"],
-                    pattern_type="stix2",
+                    pattern_type="stix",
                     pattern=f"[{type_ioc.lower()} = '" + ioc["value"] + "']",
                     x_opencti_main_observable_type=type_ioc.split(":")[0],
                     objectMarking=[stix2.TLP_GREEN["id"]],
@@ -356,7 +360,7 @@ class TweetFeed:
                 indicator = self.helper.api.indicator.create(
                     name=ioc["value"],
                     description="TWEETFEED IOC " + ioc["value"],
-                    pattern_type="stix2",
+                    pattern_type="stix",
                     pattern=f"[{type_ioc.lower()} = '" + ioc["value"] + "']",
                     x_opencti_main_observable_type=type_ioc.split(":")[0],
                     objectMarking=[stix2.TLP_GREEN["id"]],


### PR DESCRIPTION
Fix, stix pattern type unsopported in some openCTI instance

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fixing the running schedule issue
* Fixing the "pattern_type" key during indicator creation, it was changed from "stix2" to "stix", this should fix some compatibility issues.

### Related issues

* //
* //

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
