### PR TITLE
connector-mandiant - catch 'redacted' entries in actor data-struct

### DIFF
--- a/external-import/mandiant/src/mandiant/actors.py
+++ b/external-import/mandiant/src/mandiant/actors.py
@@ -21,7 +21,7 @@ def process(connector, actor):
     for industry in utils.sanitizer("industries", actor_details, []):
         items += create_stix_industry(connector, stix_intrusionset, industry)
 
-    for cve in utils.sanitizer("cve", actor_details, default=[]):
+    for cve in utils.sanitizer("cve", actor_details, []):
         items += create_stix_vulnerability(connector, stix_intrusionset, cve)
 
     for malware in utils.sanitizer("malware", actor_details, []):

--- a/external-import/mandiant/src/mandiant/actors.py
+++ b/external-import/mandiant/src/mandiant/actors.py
@@ -18,13 +18,13 @@ def process(connector, actor):
 
     items = [stix_intrusionset]
 
-    for industry in actor_details.get("industries", []):
+    for industry in utils.sanitizer("industries", actor_details, []):
         items += create_stix_industry(connector, stix_intrusionset, industry)
 
-    for cve in actor_details.get("cve", []):
+    for cve in utils.sanitizer("cve", actor_details, default=[]):
         items += create_stix_vulnerability(connector, stix_intrusionset, cve)
 
-    for malware in actor_details.get("malware", []):
+    for malware in utils.sanitizer("malware", actor_details, []):
         items += create_stix_malware(connector, stix_intrusionset, malware)
 
     for tool in actor_details.get("tool", []):


### PR DESCRIPTION
Our Mandiant subscription seems to redact some fields. These fields are not empty (i.e., key does not exists) but contain a string "redacted". This leads to failure in the connector-mandiant code as some fields are expected to contain lists, which Python strings can be addresses as, but further processing fails. 

This patch catches these cases. In our setup, the connector now runs without error. 

### Proposed changes

* sanitizing the reading of certain properties
*

### Related issues


### Checklist



- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality



### Further comments


