### PR TITLE
Update link to connector dev docs in template

### DIFF
--- a/template/src/main.py
+++ b/template/src/main.py
@@ -23,7 +23,7 @@ class TemplateConnector:
     ####
     # TODO add your code according to your connector type
     # For details: see
-    # https://filigran.notion.site/Connector-Development-06b2690697404b5ebc6e3556a1385940
+    # https://docs.opencti.io/latest/development/connectors/
     ####
 
 


### PR DESCRIPTION
### Proposed changes

* Update a link in the connector template's code comments to point to the new location of dev docs

### Related issues

N/A

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Docs moved from Notion to `docs.opencti.io`