### PR TITLE
[connectors] replace `method_whitelist` by `allowed_methods`

### DIFF
--- a/external-import/riskiq/src/riskiq/client.py
+++ b/external-import/riskiq/src/riskiq/client.py
@@ -50,7 +50,7 @@ class RiskIQClient:
         retry_strategy = Retry(
             total=3,
             status_forcelist=[429, 500, 502, 503, 504],
-            method_whitelist=["HEAD", "GET", "OPTIONS"],
+            allowed_methods=["HEAD", "GET", "OPTIONS"],
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         http = requests.Session()

--- a/stream/virustotal-livehunt-rules/src/client.py
+++ b/stream/virustotal-livehunt-rules/src/client.py
@@ -49,7 +49,7 @@ class VirusTotalClient:
         retry_strategy = Retry(
             total=3,
             status_forcelist=[429, 500, 502, 503, 504],
-            method_whitelist=["HEAD", "GET", "OPTIONS", "POST", "DELETE"],
+            allowed_methods=["HEAD", "GET", "OPTIONS", "POST", "DELETE"],
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         http = requests.Session()


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->
The RiskIQ connector is not working, having the following error: 

```
"Retry.__init__() got an unexpected keyword argument 'method_whitelist'"
```

This occurs since the commit of the renovate bot, that upgraded `urllib3` to v2 and the `method_whitelist` argument has been removed since v2.

I changed the argument name in the `stream/virustotal-livehunt-rules` connector as well to avoid a similar issue. 

### Proposed changes

*  Replace `method_whitelist` by `allowed_methods`

### Related issues

* Linked to the same issue for the VirusTotal enrichment connector: #1276 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
