### PR TITLE
[misp-feed] Ignore galaxy with missing namespace instead of failing completely

### DIFF
--- a/external-import/misp-feed/src/misp-feed.py
+++ b/external-import/misp-feed/src/misp-feed.py
@@ -306,6 +306,9 @@ class MispFeed:
         }
         added_names = []
         for galaxy in galaxies:
+            if "namespace" not in galaxy:
+                self.helper.log_info("Skipping galaxy without namespace")
+                continue
             # Get the linked intrusion sets
             if (
                 (
@@ -2043,15 +2046,19 @@ class MispFeed:
             self.helper.log_error(str(e))
 
     def run(self):
-        self.helper.log_info("Fetching MISP Feed...")
-        get_run_and_terminate = getattr(self.helper, "get_run_and_terminate", None)
-        if callable(get_run_and_terminate) and self.helper.get_run_and_terminate():
-            self.process_data()
-            self.helper.force_ping()
-        else:
-            while True:
+        try:
+            self.helper.log_info("Fetching MISP Feed...")
+            get_run_and_terminate = getattr(self.helper, "get_run_and_terminate", None)
+            if callable(get_run_and_terminate) and self.helper.get_run_and_terminate():
                 self.process_data()
-                time.sleep(60)
+                self.helper.force_ping()
+            else:
+                while True:
+                    self.process_data()
+                    time.sleep(60)
+        except Exception as e:
+            self.helper.log_error(str(e))
+            raise e
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Proposed changes

* Skip the galaxy without namespace instead of failing completely
* Log the error with the helper when the runer encounters an exception

### Related issues

N/A

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion): N/A
- [ ] Where necessary I refactored code to improve the overall quality: N/A

