### PR TITLE
[vt-livehunt] add file hash in alert name

### DIFF
--- a/external-import/virustotal-livehunt-notifications/src/livehunt/builder.py
+++ b/external-import/virustotal-livehunt-notifications/src/livehunt/builder.py
@@ -250,6 +250,11 @@ class LivehuntBuilder:
         except ZeroDivisionError as e:
             self.helper.log_error(f"Unable to compute score of file, err = {e}")
 
+        external_reference = self.create_external_reference(
+            f"https://www.virustotal.com/gui/file/{vtobj.sha256}",
+            "Virustotal Analysis",
+        )
+
         file = stix2.File(
             type="file",
             name=f'{vtobj.meaningful_name if hasattr(vtobj, "meaningful_name") else "unknown"}',
@@ -259,10 +264,12 @@ class LivehuntBuilder:
                 "SHA1": vtobj.sha1,
             },
             size=vtobj.size,
+            external_references=[external_reference],
             custom_properties={
                 "x_opencti_score": score,
                 "created_by_ref": self.author["standard_id"],
             },
+            allow_custom=True,
         )
         self.bundle.append(file)
         # Link to the incident if any.


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add the hash of the file that triggered the alert in the name
* Add external reference to VT on file
* Check if an alert with the same name exists before creating it
* Fix some `valid_from` dates that are not valid (month not between 1..12)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
