### PR TITLE
[Taxii2] Enabling Next Parameter for Taxii2.1 Feeds

### DIFF
--- a/external-import/taxii2/src/config.yml.sample
+++ b/external-import/taxii2/src/config.yml.sample
@@ -23,3 +23,5 @@ taxii2:
   verify_ssl: true
   create_indicators: true # Generate indicators for ingested observables
   create_observables: true # Generate observables for ingested indicators
+  force_pattern_as_name: true
+  force_multiple_pattern_name: 'Multiple Indicators'

--- a/external-import/taxii2/src/config.yml.sample
+++ b/external-import/taxii2/src/config.yml.sample
@@ -23,5 +23,7 @@ taxii2:
   verify_ssl: true
   create_indicators: true # Generate indicators for ingested observables
   create_observables: true # Generate observables for ingested indicators
-  force_pattern_as_name: true
+  add_custom_label: false
+  custom_label: ChangeMe
+  force_pattern_as_name: false
   force_multiple_pattern_name: 'Multiple Indicators'


### PR DESCRIPTION
### Proposed changes

I've allowed Taxii2.1 feeds to use the next parameter.
Duplicate code has been added to a function.
I simplified some code so it was a bit cleaner.
I've tested on my Taxii 2.0 and 2.1 servers.

### Related issues

https://github.com/OpenCTI-Platform/connectors/issues/1298

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Thanks to @mpatrini7 for the inspiration :-)
