### PR TITLE
connector-vxvault/https-better-then-http-even-though-self-signed-and-…

### DIFF
--- a/external-import/vxvault/docker-compose.yml
+++ b/external-import/vxvault/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   connector-vxvault:
     image: opencti/connector-vxvault:5.9.6
@@ -12,7 +12,8 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=40 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_UPDATE_EXISTING_DATA=false
       - CONNECTOR_LOG_LEVEL=info
-      - VXVAULT_URL=http://vxvault.net/URL_List.php
+      - VXVAULT_URL=https://vxvault.net/URL_List.php
       - VXVAULT_CREATE_INDICATORS=true
       - VXVAULT_INTERVAL=3 # In days, must be strictly greater than 1
+      - VXVAULT_SSL_VERIFY=False
     restart: always

--- a/external-import/vxvault/src/config.yml.sample
+++ b/external-import/vxvault/src/config.yml.sample
@@ -13,6 +13,8 @@ connector:
   log_level: 'info'
 
 vxvault:
-  url: 'http://vxvault.net/URL_List.php'
+  url: 'https://vxvault.net/URL_List.php'
   create_indicators: True
   interval: 3 # In days, must be strictly greater than 1
+  ssl_verify: False
+

--- a/external-import/vxvault/src/vxvault.py
+++ b/external-import/vxvault/src/vxvault.py
@@ -36,6 +36,13 @@ class VXVault:
             False,
             True,
         )
+        self.verify_ssl = get_config_variable(
+            "VXVAULT_SSL_VERIFY",
+            ["vxvault", "ssl_verify"],
+            config,
+            False,
+            True,
+        )
         self.update_existing_data = get_config_variable(
             "CONNECTOR_UPDATE_EXISTING_DATA",
             ["connector", "update_existing_data"],
@@ -83,9 +90,14 @@ class VXVault:
                         self.helper.connect_id, friendly_name
                     )
                     try:
+                        ctx = ssl.create_default_context(cafile=certifi.where())
+                        if not bool(self.verify_ssl):
+                            ctx.check_hostname = False
+                            ctx.verify_mode = ssl.CERT_NONE
+
                         response = urllib.request.urlopen(
                             self.vxvault_url,
-                            context=ssl.create_default_context(cafile=certifi.where()),
+                            context=ctx,
                         )
                         image = response.read()
                         with open(


### PR DESCRIPTION
### Proposed changes

This PR gives the option to enforce https over http for organization having compliance issue with non encrypted traffic

### Related issues

* vxvault is currently being fetched with http instead of https, which is an issue from a compliance and security perspective
* vxvault is also reachable with https, however the certificate is self-signed and weak
* even though it is a self-signed and weak certificate, it is better to use https then http
* openCTI users can always keep the http url if they want

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


### Further comments

happy encrypted traffic and less discussion with your audit and compliance team
