### PR TITLE
[Taxii2] Enumerated main observable type

### DIFF
--- a/external-import/taxii2/src/taxii2.py
+++ b/external-import/taxii2/src/taxii2.py
@@ -258,14 +258,27 @@ class Taxii2Connector:
                 if self.add_custom_label == True:
                     new_labels.append(self.custom_label)
                     object["labels"] = new_labels
-                # Force name to be pattern
+                # Force name to be pattern and enumerate main observable type.
                 if self.force_pattern_as_name == True and object["type"] == "indicator":
+                    match = re.search(r"\[(.*?):.*'(.*?)\'\]", object["pattern"])
+                    if match != None:
+                        if match[1] == "ipv4-addr":
+                            object["x_opencti_main_observable_type"] = "IPv4-Addr"
+                        elif match[1] == "ipv6-addr":
+                            object["x_opencti_main_observable_type"] = "IPv6-Addr"
+                        elif match[1] == "file":
+                            object["x_opencti_main_observable_type"] = "File"
+                        elif match[1] == "domain-name":
+                            object["x_opencti_main_observable_type"] = "Domain-Name"
+                        elif match[1] == "url":
+                            object["x_opencti_main_observable_type"] = "Url"
+                        elif match[1] == "email-addr":
+                            object["x_opencti_main_observable_type"] = "Email-Addr"
                     if " AND " in object["pattern"] or " OR " in object["pattern"]:
                         object["name"] = self.force_multiple_pattern_name
                     else:
-                        match = re.search(r"=.?\'(.*?)\'\]", object["pattern"])
                         if match != None:
-                            object["name"] = match[1]
+                            object["name"] = match[2]
                 objects.append(object)
             return objects
 


### PR DESCRIPTION
### Proposed changes

I have added code to enumerate the x_opencti_main_observable_type field. Users will now be able to filter on the main observable type from the Indicators view. It also allows them to share indicators by their observable type.

This is done by running regex on the pattern to extract the observable type. Have tested this on a Taxii 2.0 and Taxii 2.1 feed and it works fine.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments
Please note: If the pattern has multiple indicators in it, the regex will extract the first entry. I couldn't think of a better way to do this as we are unable to prompt the user for what they would like it to be.
