### PR TITLE
[vt-livehunt] modification of alert description and labels

### DIFF
--- a/external-import/virustotal-livehunt-notifications/src/livehunt/builder.py
+++ b/external-import/virustotal-livehunt-notifications/src/livehunt/builder.py
@@ -194,11 +194,15 @@ class LivehuntBuilder:
             id=incident_id,
             incident_type="alert",
             name=name,
-            description=f'Snippet:\n{vtobj._context_attributes["notification_snippet"]}',
+            description=f'Date of the alert on VirusTotal: {datetime.datetime.fromtimestamp(vtobj._context_attributes["notification_date"])}',
             source=self._SOURCE,
             created_by_ref=self.author["standard_id"],
             confidence=self.helper.connect_confidence_level,
-            labels=vtobj._context_attributes["notification_tags"],
+            labels=[
+                t
+                for t in vtobj._context_attributes["notification_tags"]
+                if t not in {vtobj.id, self.tag}
+            ],
             external_references=[external_reference],
             allow_custom=True,
         )

--- a/external-import/virustotal-livehunt-notifications/src/livehunt/livehunt.py
+++ b/external-import/virustotal-livehunt-notifications/src/livehunt/livehunt.py
@@ -125,6 +125,7 @@ class VirustotalLivehuntNotifications:
             ["virustotal_livehunt_notifications", "min_positives"],
             config,
             True,
+            default=1,
         )
 
         upload_artifact = get_config_variable(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove the snippet from the description of the alert and add the date of the notification
* Remove the id of the vt object and the filtered tag from the labels of the alert
* Set a default for the minimal number of positives

### Related issues

* N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
