### PR TITLE
[connector-urlhaus] exception handling clean-up

### DIFF
--- a/external-import/urlhaus/src/urlhaus.py
+++ b/external-import/urlhaus/src/urlhaus.py
@@ -96,11 +96,17 @@ class URLhaus:
                 if self.threats_from_labels:
                     treat_cache = {}
 
-            
-                response = urllib.request.urlopen(
-                    self.urlhaus_csv_url,
-                    context=ssl.create_default_context(cafile=certifi.where()),
-                )
+                try: 
+                    response = urllib.request.urlopen(
+                        self.urlhaus_csv_url,
+                        context=ssl.create_default_context(cafile=certifi.where()),
+                    )
+                except urllib.error.HTTPError:
+                    # we only accept HTTPError
+                    self.helper.log_error(traceback.format_exc())
+                    time.sleep(60)
+                    continue
+
                 image = response.read()
                 with open(
                     os.path.dirname(os.path.abspath(__file__)) + "/data.csv",
@@ -335,8 +341,14 @@ class URLhaus:
 if __name__ == "__main__":
     try:
         URLhausConnector = URLhaus()
-        URLhausConnector.run()
     except Exception:
         print(traceback.format_exc())
         time.sleep(10)
         sys.exit(0)
+    
+    try: 
+        URLhausConnector.run()
+    except Exception:
+        URLhausConnector.helper.log_error(traceback.format_exc())
+        time.sleep(10)
+        sys.exit(0)   

--- a/external-import/urlhaus/src/urlhaus.py
+++ b/external-import/urlhaus/src/urlhaus.py
@@ -66,271 +66,264 @@ class URLhaus:
     def run(self):
         self.helper.log_info("Fetching URLhaus dataset...")
         while True:
-            try:
-                # Get the current timestamp and check
-                timestamp = int(time.time())
-                current_state = self.helper.get_state()
-                if current_state is not None and "last_run" in current_state:
-                    last_run = current_state["last_run"]
-                    self.helper.log_info(
-                        "Connector last run: "
-                        + datetime.datetime.utcfromtimestamp(last_run).strftime(
-                            "%Y-%m-%d %H:%M:%S"
-                        )
+
+            # Get the current timestamp and check
+            timestamp = int(time.time())
+            current_state = self.helper.get_state()
+            if current_state is not None and "last_run" in current_state:
+                last_run = current_state["last_run"]
+                self.helper.log_info(
+                    "Connector last run: "
+                    + datetime.datetime.utcfromtimestamp(last_run).strftime(
+                        "%Y-%m-%d %H:%M:%S"
                     )
-                else:
-                    last_run = None
-                    self.helper.log_info("Connector has never run")
-                # If the last_run is more than interval-1 day
-                if last_run is None or (
-                    (timestamp - last_run) > self.get_interval(offset=-1)
+                )
+            else:
+                last_run = None
+                self.helper.log_info("Connector has never run")
+            # If the last_run is more than interval-1 day
+            if last_run is None or (
+                (timestamp - last_run) > self.get_interval(offset=-1)
+            ):
+                self.helper.log_info("Connector will run!")
+                now = datetime.datetime.utcfromtimestamp(timestamp)
+                friendly_name = "URLhaus run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
+                work_id = self.helper.api.work.initiate_work(
+                    self.helper.connect_id, friendly_name
+                )
+
+                # initialize the threat cache with each run
+                if self.threats_from_labels:
+                    treat_cache = {}
+
+            
+                response = urllib.request.urlopen(
+                    self.urlhaus_csv_url,
+                    context=ssl.create_default_context(cafile=certifi.where()),
+                )
+                image = response.read()
+                with open(
+                    os.path.dirname(os.path.abspath(__file__)) + "/data.csv",
+                    "wb",
+                ) as file:
+                    file.write(image)
+                fp = open(
+                    os.path.dirname(os.path.abspath(__file__)) + "/data.csv",
+                    "r",
+                )
+                rdr = csv.reader(filter(lambda row: row[0] != "#", fp))
+                bundle_objects = []
+                ## the csv-file hast the following columns
+                # id,dateadded,url,url_status,last_online,threat,tags,urlhaus_link,reporter
+
+                if (
+                    current_state is not None
+                    and "last_processed_entry" in current_state
                 ):
-                    self.helper.log_info("Connector will run!")
-                    now = datetime.datetime.utcfromtimestamp(timestamp)
-                    friendly_name = "URLhaus run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
-                    work_id = self.helper.api.work.initiate_work(
-                        self.helper.connect_id, friendly_name
-                    )
-
-                    # initialize the threat cache with each run
-                    if self.threats_from_labels:
-                        treat_cache = {}
-
-                    try:
-                        response = urllib.request.urlopen(
-                            self.urlhaus_csv_url,
-                            context=ssl.create_default_context(cafile=certifi.where()),
-                        )
-                        image = response.read()
-                        with open(
-                            os.path.dirname(os.path.abspath(__file__)) + "/data.csv",
-                            "wb",
-                        ) as file:
-                            file.write(image)
-                        fp = open(
-                            os.path.dirname(os.path.abspath(__file__)) + "/data.csv",
-                            "r",
-                        )
-                        rdr = csv.reader(filter(lambda row: row[0] != "#", fp))
-                        bundle_objects = []
-                        ## the csv-file hast the following columns
-                        # id,dateadded,url,url_status,last_online,threat,tags,urlhaus_link,reporter
-
-                        if (
-                            current_state is not None
-                            and "last_processed_entry" in current_state
-                        ):
-                            last_processed_entry = current_state[
-                                "last_processed_entry"
-                            ]  # epoch time format
-                        else:
-                            self.helper.log_info(
-                                "'last_processed_entry' state not found, setting it to epoch start."
-                            )
-                            last_processed_entry = 0  # start of the epoch
-
-                        last_processed_entry_running_max = last_processed_entry
-
-                        for i, row in enumerate(rdr):
-                            entry_date = parse(row[1])
-
-                            if i % 5000 == 0:
-                                self.helper.log_info(
-                                    f"Process entry {i} with dateadded='{entry_date.strftime('%Y-%m-%d %H:%M:%S')}'"
-                                )
-
-                            # skip entry if newer events already processed in the past
-                            if last_processed_entry > entry_date.timestamp():
-                                continue
-                            last_processed_entry_running_max = max(
-                                entry_date.timestamp(), last_processed_entry_running_max
-                            )
-
-                            if row[3] == "online" or self.urlhaus_import_offline:
-                                external_reference = stix2.ExternalReference(
-                                    source_name="Abuse.ch URLhaus",
-                                    url=row[7],
-                                    description="URLhaus repository URL",
-                                )
-                                pattern = "[url:value = '" + row[2] + "']"
-                                stix_indicator = stix2.Indicator(
-                                    id=Indicator.generate_id(pattern),
-                                    name=row[2],
-                                    description="Threat: "
-                                    + row[5]
-                                    + " - Reporter: "
-                                    + row[8]
-                                    + " - Status: "
-                                    + row[3],
-                                    created_by_ref=self.identity["standard_id"],
-                                    confidence=self.helper.connect_confidence_level,
-                                    pattern_type="stix",
-                                    pattern=pattern,
-                                    external_references=[external_reference],
-                                    object_marking_refs=[stix2.TLP_WHITE],
-                                    custom_properties={
-                                        "x_opencti_score": 80,
-                                        "x_opencti_main_observable_type": "IPv6-Addr",
-                                    },
-                                )
-                                stix_observable = stix2.URL(
-                                    value=row[2],
-                                    object_marking_refs=[stix2.TLP_WHITE],
-                                    custom_properties={
-                                        "description": "Threat: "
-                                        + row[5]
-                                        + " - Reporter: "
-                                        + row[8]
-                                        + " - Status: "
-                                        + row[3],
-                                        "x_opencti_score": 80,
-                                        "labels": [x for x in row[6].split(",") if x],
-                                        "created_by_ref": self.identity["standard_id"],
-                                        "external_references": [external_reference],
-                                    },
-                                )
-                                stix_relationship = stix2.Relationship(
-                                    id=StixCoreRelationship.generate_id(
-                                        "based-on",
-                                        stix_indicator.id,
-                                        stix_observable.id,
-                                    ),
-                                    relationship_type="based-on",
-                                    source_ref=stix_indicator.id,
-                                    target_ref=stix_observable.id,
-                                    object_marking_refs=[stix2.TLP_WHITE],
-                                )
-                                bundle_objects.append(stix_indicator)
-                                bundle_objects.append(stix_observable)
-                                bundle_objects.append(stix_relationship)
-                                if self.threats_from_labels:
-                                    for label in row[6].split(","):
-                                        if label:
-                                            # implementing a primitive caching
-                                            try:
-                                                threat = treat_cache[label]
-                                            except KeyError:
-                                                custom_attributes = """
-                                                    id
-                                                    standard_id
-                                                    entity_type
-                                                """
-                                                threat = self.helper.api.stix_domain_object.read(
-                                                    filters=[
-                                                        {
-                                                            "key": "name",
-                                                            "values": [label],
-                                                        }
-                                                    ],
-                                                    first=1,
-                                                    customAttributes=custom_attributes,
-                                                )
-                                                treat_cache[label] = threat
-
-                                            if threat is not None:
-                                                stix_threat_relation_indicator = stix2.Relationship(
-                                                    id=StixCoreRelationship.generate_id(
-                                                        "indicates",
-                                                        stix_indicator.id,
-                                                        threat["standard_id"],
-                                                        entry_date,
-                                                        entry_date,
-                                                    ),
-                                                    source_ref=stix_indicator.id,
-                                                    target_ref=threat["standard_id"],
-                                                    relationship_type="indicates",
-                                                    start_time=entry_date,
-                                                    stop_time=entry_date
-                                                    + datetime.timedelta(0, 3),
-                                                    confidence=self.helper.connect_confidence_level,
-                                                    created_by_ref=self.identity[
-                                                        "standard_id"
-                                                    ],
-                                                    object_marking_refs=[
-                                                        stix2.TLP_WHITE
-                                                    ],
-                                                    created=entry_date,
-                                                    modified=entry_date,
-                                                    allow_custom=True,
-                                                )
-                                                stix_threat_relation_observable = stix2.Relationship(
-                                                    id=StixCoreRelationship.generate_id(
-                                                        "related-to",
-                                                        stix_observable.id,
-                                                        threat["standard_id"],
-                                                        entry_date,
-                                                        entry_date,
-                                                    ),
-                                                    source_ref=stix_observable.id,
-                                                    target_ref=threat["standard_id"],
-                                                    relationship_type="related-to",
-                                                    start_time=entry_date,
-                                                    stop_time=entry_date
-                                                    + datetime.timedelta(0, 3),
-                                                    confidence=self.helper.connect_confidence_level,
-                                                    created_by_ref=self.identity[
-                                                        "standard_id"
-                                                    ],
-                                                    object_marking_refs=[
-                                                        stix2.TLP_WHITE
-                                                    ],
-                                                    created=entry_date,
-                                                    modified=entry_date,
-                                                    allow_custom=True,
-                                                )
-                                                bundle_objects.append(
-                                                    stix_threat_relation_indicator
-                                                )
-                                                bundle_objects.append(
-                                                    stix_threat_relation_observable
-                                                )
-                        fp.close()
-                        bundle = stix2.Bundle(
-                            objects=bundle_objects, allow_custom=True
-                        ).serialize()
-                        self.helper.send_stix2_bundle(
-                            bundle,
-                            update=self.update_existing_data,
-                            work_id=work_id,
-                        )
-                        if os.path.exists(
-                            os.path.dirname(os.path.abspath(__file__)) + "/data.csv"
-                        ):
-                            os.remove(
-                                os.path.dirname(os.path.abspath(__file__)) + "/data.csv"
-                            )
-                    except Exception:
-                        self.helper.log_error(traceback.format_exc())
-                    # Store the current timestamp as a last run
-                    message = "Connector successfully run, storing last_run as " + str(
-                        timestamp
-                    )
-                    self.helper.log_info(message)
-                    self.helper.set_state(
-                        {
-                            "last_run": timestamp,
-                            "last_processed_entry": last_processed_entry_running_max,
-                        }
-                    )
-                    self.helper.api.work.to_processed(work_id, message)
-                    self.helper.log_info(
-                        "Last_run stored, next run in: "
-                        + str(round(self.get_interval() / 60 / 60 / 24, 2))
-                        + " days"
-                    )
+                    last_processed_entry = current_state[
+                        "last_processed_entry"
+                    ]  # epoch time format
                 else:
-                    new_interval = self.get_interval() - (timestamp - last_run)
                     self.helper.log_info(
-                        "Connector will not run, next run in: "
-                        + str(round(new_interval / 60 / 60 / 24, 2))
-                        + " days"
+                        "'last_processed_entry' state not found, setting it to epoch start."
+                    )
+                    last_processed_entry = 0  # start of the epoch
+
+                last_processed_entry_running_max = last_processed_entry
+
+                for i, row in enumerate(rdr):
+                    entry_date = parse(row[1])
+
+                    if i % 5000 == 0:
+                        self.helper.log_info(
+                            f"Process entry {i} with dateadded='{entry_date.strftime('%Y-%m-%d %H:%M:%S')}'"
+                        )
+
+                    # skip entry if newer events already processed in the past
+                    if last_processed_entry > entry_date.timestamp():
+                        continue
+                    last_processed_entry_running_max = max(
+                        entry_date.timestamp(), last_processed_entry_running_max
                     )
 
-            except (KeyboardInterrupt, SystemExit):
-                self.helper.log_info("Connector stop")
-                sys.exit(0)
-            except Exception:
-                self.helper.log_error(traceback.format_exc())
+                    if row[3] == "online" or self.urlhaus_import_offline:
+                        external_reference = stix2.ExternalReference(
+                            source_name="Abuse.ch URLhaus",
+                            url=row[7],
+                            description="URLhaus repository URL",
+                        )
+                        pattern = "[url:value = '" + row[2] + "']"
+                        stix_indicator = stix2.Indicator(
+                            id=Indicator.generate_id(pattern),
+                            name=row[2],
+                            description="Threat: "
+                            + row[5]
+                            + " - Reporter: "
+                            + row[8]
+                            + " - Status: "
+                            + row[3],
+                            created_by_ref=self.identity["standard_id"],
+                            confidence=self.helper.connect_confidence_level,
+                            pattern_type="stix",
+                            pattern=pattern,
+                            external_references=[external_reference],
+                            object_marking_refs=[stix2.TLP_WHITE],
+                            custom_properties={
+                                "x_opencti_score": 80,
+                                "x_opencti_main_observable_type": "IPv6-Addr",
+                            },
+                        )
+                        stix_observable = stix2.URL(
+                            value=row[2],
+                            object_marking_refs=[stix2.TLP_WHITE],
+                            custom_properties={
+                                "description": "Threat: "
+                                + row[5]
+                                + " - Reporter: "
+                                + row[8]
+                                + " - Status: "
+                                + row[3],
+                                "x_opencti_score": 80,
+                                "labels": [x for x in row[6].split(",") if x],
+                                "created_by_ref": self.identity["standard_id"],
+                                "external_references": [external_reference],
+                            },
+                        )
+                        stix_relationship = stix2.Relationship(
+                            id=StixCoreRelationship.generate_id(
+                                "based-on",
+                                stix_indicator.id,
+                                stix_observable.id,
+                            ),
+                            relationship_type="based-on",
+                            source_ref=stix_indicator.id,
+                            target_ref=stix_observable.id,
+                            object_marking_refs=[stix2.TLP_WHITE],
+                        )
+                        bundle_objects.append(stix_indicator)
+                        bundle_objects.append(stix_observable)
+                        bundle_objects.append(stix_relationship)
+                        if self.threats_from_labels:
+                            for label in row[6].split(","):
+                                if label:
+                                    # implementing a primitive caching
+                                    try:
+                                        threat = treat_cache[label]
+                                    except KeyError:
+                                        custom_attributes = """
+                                            id
+                                            standard_id
+                                            entity_type
+                                        """
+                                        threat = self.helper.api.stix_domain_object.read(
+                                            filters=[
+                                                {
+                                                    "key": "name",
+                                                    "values": [label],
+                                                }
+                                            ],
+                                            first=1,
+                                            customAttributes=custom_attributes,
+                                        )
+                                        treat_cache[label] = threat
+
+                                    if threat is not None:
+                                        stix_threat_relation_indicator = stix2.Relationship(
+                                            id=StixCoreRelationship.generate_id(
+                                                "indicates",
+                                                stix_indicator.id,
+                                                threat["standard_id"],
+                                                entry_date,
+                                                entry_date,
+                                            ),
+                                            source_ref=stix_indicator.id,
+                                            target_ref=threat["standard_id"],
+                                            relationship_type="indicates",
+                                            start_time=entry_date,
+                                            stop_time=entry_date
+                                            + datetime.timedelta(0, 3),
+                                            confidence=self.helper.connect_confidence_level,
+                                            created_by_ref=self.identity[
+                                                "standard_id"
+                                            ],
+                                            object_marking_refs=[
+                                                stix2.TLP_WHITE
+                                            ],
+                                            created=entry_date,
+                                            modified=entry_date,
+                                            allow_custom=True,
+                                        )
+                                        stix_threat_relation_observable = stix2.Relationship(
+                                            id=StixCoreRelationship.generate_id(
+                                                "related-to",
+                                                stix_observable.id,
+                                                threat["standard_id"],
+                                                entry_date,
+                                                entry_date,
+                                            ),
+                                            source_ref=stix_observable.id,
+                                            target_ref=threat["standard_id"],
+                                            relationship_type="related-to",
+                                            start_time=entry_date,
+                                            stop_time=entry_date
+                                            + datetime.timedelta(0, 3),
+                                            confidence=self.helper.connect_confidence_level,
+                                            created_by_ref=self.identity[
+                                                "standard_id"
+                                            ],
+                                            object_marking_refs=[
+                                                stix2.TLP_WHITE
+                                            ],
+                                            created=entry_date,
+                                            modified=entry_date,
+                                            allow_custom=True,
+                                        )
+                                        bundle_objects.append(
+                                            stix_threat_relation_indicator
+                                        )
+                                        bundle_objects.append(
+                                            stix_threat_relation_observable
+                                        )
+                fp.close()
+                bundle = stix2.Bundle(
+                    objects=bundle_objects, allow_custom=True
+                ).serialize()
+                self.helper.send_stix2_bundle(
+                    bundle,
+                    update=self.update_existing_data,
+                    work_id=work_id,
+                )
+                if os.path.exists(
+                    os.path.dirname(os.path.abspath(__file__)) + "/data.csv"
+                ):
+                    os.remove(
+                        os.path.dirname(os.path.abspath(__file__)) + "/data.csv"
+                    )
+                
+                # Store the current timestamp as a last run
+                message = "Connector successfully run, storing last_run as " + str(
+                    timestamp
+                )
+                self.helper.log_info(message)
+                self.helper.set_state(
+                    {
+                        "last_run": timestamp,
+                        "last_processed_entry": last_processed_entry_running_max,
+                    }
+                )
+                self.helper.api.work.to_processed(work_id, message)
+                self.helper.log_info(
+                    "Last_run stored, next run in: "
+                    + str(round(self.get_interval() / 60 / 60 / 24, 2))
+                    + " days"
+                )
+            else:
+                new_interval = self.get_interval() - (timestamp - last_run)
+                self.helper.log_info(
+                    "Connector will not run, next run in: "
+                    + str(round(new_interval / 60 / 60 / 24, 2))
+                    + " days"
+                )
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")


### PR DESCRIPTION
Problem: most exceptions were generically caught and their stacktrace printed via the logger helper. The connector, however, was not terminated but let running.

This lead to issues when the opencti api helper failed due to "ConnectionResetError: [Errno 104] Connection reset by peer" (the connection to opencti) or similar occurings and did not recover itself. The connector halted its functions but kept running, requireing an inspect and a manual restart of the container. 

Therefore, I have simplified the exception handling of the connector significantly, see proposed changes. 


### Proposed changes

* first, removing all exception handlers
* then, adding a generic exception handlers around the run function, catching all exceptions, printing the stacktrace and then terminating the execution, leading to a restart of the container. 
* The only "allowed" exceptions are HTTP-connection issues arising due to network unstabilities (urllib.error.HTTPError) when connecting the urlhaus server. In such cases, the stacktrace is printed but no restart. 

### Related issues

* see introduction. 

### Checklist

- [ x] I consider the submitted work as finished
- [ x] I tested the code for its functionality using different use cases
- [ x] I added/update the relevant documentation (either on github or on notion)
- [x ] Where necessary I refactored code to improve the overall quality

### Further comments

