### PR TITLE
Connector splunk/issue-1386/kvstore friendly format instead of stix

### DIFF
--- a/stream/splunk/README.md
+++ b/stream/splunk/README.md
@@ -41,5 +41,15 @@ This connector allows organizations to feed a **Splunk** KV Store using OpenCTI 
 - You may have to whitelist your connector EGRESS IP address to hit the API endpoint: Settings > Server Settings > IP allow list > Search head API Access (tab)
 - As a splunk_url, it is recommended to use your search head instance, so that the created kvstore is replicated across your other splunk instances. Note that any kvstore created on "non-search head" won't be replicated nor visible on the search head.
 - The connector will create a kvstore named as per splunk_kv_store_name field value. Note that no other existing object in your splunk instance can have the same name.
-- Once the kvstore created, you want to create some lookup definitions for CRUD operations against your kvstore: Settings > Knowledge > Lookups > Lookup definitions > Add new
-  - As an example of lookup definition, you may want to extract the following supported fields `_key,type,value,hashes,pattern,created_at,updated_at,score,labels,splunk_queries.queries,created_by`
+- Once the kvstore is created, you want to create some lookup definitions for CRUD operations against your kvstore: Settings > Knowledge > Lookups > Lookup definitions > Add new
+  - As an example of lookup definition, you may want to extract the following supported fields:
+
+| type        | supported fields                                                                         |
+| ----------- | ---------------------------------------------------------------------------------------- |
+| domain-name | `_key,type,value,created_at,updated_at,score,labels,created_by`                          |
+| url         | `_key,type,value,created_at,updated_at,score,labels,created_by`                          |
+| ipv4-addr   | `_key,type,value,created_at,updated_at,score,labels,created_by`                          |
+| url         | `_key,type,value,created_at,updated_at,score,labels,created_by`                          |
+| file        | `_key,type,hashes,created_at,updated_at,score,labels,created_by`                         |
+| indicator   | `_key,type,pattern,created_at,updated_at,score,labels,splunk_queries.queries,created_by` |
+| ...         | ...etc...                                                                                |

--- a/stream/splunk/README.md
+++ b/stream/splunk/README.md
@@ -10,26 +10,36 @@ This connector allows organizations to feed a **Splunk** KV Store using OpenCTI 
 
 ### Configuration
 
-| Parameter                              | Docker envvar                          | Mandatory    | Description                                                                                   |
-| -------------------------------------- | -------------------------------------- | ------------ |-----------------------------------------------------------------------------------------------|
-| `opencti_url`                          | `OPENCTI_URL`                          | Yes          | The URL of the OpenCTI platform.                                                              |
-| `opencti_token`                        | `OPENCTI_TOKEN`                        | Yes          | The default admin token configured in the OpenCTI platform parameters file.                   |
-| `connector_id`                         | `CONNECTOR_ID`                         | Yes          | A valid arbitrary `UUIDv4` that must be unique for this connector.                            |
-| `connector_type`                       | `CONNECTOR_TYPE`                       | Yes          | Must be `STREAM` (this is the connector type).                                                |
-| `connector_name`                       | `CONNECTOR_NAME`                       | Yes          | The name of the Splunk instance, to identify it if you have multiple Splunk connectors.       |
-| `connector_scope`                      | `CONNECTOR_SCOPE`                      | Yes          | Must be `splunk`, not used in this connector.                                                 |
-| `connector_confidence_level`           | `CONNECTOR_CONFIDENCE_LEVEL`           | Yes          | The default confidence level for created sightings (a number between 1 and 4).                |
-| `connector_log_level`                  | `CONNECTOR_LOG_LEVEL`                  | Yes          | The log level for this connector, could be `debug`, `info`, `warn` or `error` (less verbose). |
-| `connector_consumer_count`             | `CONNECTOR_CONSUMER_COUNT`             | No           | Number of consumer/worker that will push data to Splunk.                                      |
-| `connector_live_stream_start_timestamp`| `CONNECTOR_LIVE_STREAM_START_TIMESTAMP`| No           | Start timestamp used on connector first start.                                                |
-| `splunk_url`                           | `SPLUNK_URL`                           | Yes          | The Splunk instances REST API URLs as array                                                   |
-| `splunk_login`                         | `SPLUNK_LOGIN`                         | Yes          | The Splunk login users as array (same order as URLs)                                          |
-| `splunk_password`                      | `SPLUNK_PASSWORD`                      | Yes          | The Splunk passwords as array (same order as URLs)                                            |
-| `splunk_owner`                         | `SPLUNK_OWNER`                         | Yes          | The Splunk KV store owners as array (same order as URLs)                                      |
-| `splunk_ssl_verify`                    | `SPLUNK_SSL_VERIFY`                    | Yes          | Enable the SSL certificate check for all instances (default: `true`)                          |
-| `splunk_app`                           | `SPLUNK_APP`                           | Yes          | The app of the KV Store for all instances.                                                    |
-| `splunk_kv_store_name`                 | `SPLUNK_KV_STORE_NAME`                 | Yes          | The name of the KV Store for all instances.                                                   |
-| `splunk_ignore_types`                  | `SPLUNK_IGNORE_TYPES`                  | Yes          | The list of entity types to ignore.                                                           |
-| `metrics_enable`                       | `METRICS_ENABLE`                       | No           | Whether or not Prometheus metrics should be enabled.                                          |
-| `metrics_addr`                         | `METRICS_ADDR`                         | No           | Bind IP address to use for metrics endpoint.                                                  |
-| `metrics_port`                         | `METRICS_PORT`                         | No           | Port to use for metrics endpoint.                                                             |
+| Parameter                               | Docker envvar                           | Mandatory | Description                                                                                   |
+| --------------------------------------- | --------------------------------------- | --------- | --------------------------------------------------------------------------------------------- |
+| `opencti_url`                           | `OPENCTI_URL`                           | Yes       | The URL of the OpenCTI platform.                                                              |
+| `opencti_token`                         | `OPENCTI_TOKEN`                         | Yes       | The default admin token configured in the OpenCTI platform parameters file.                   |
+| `connector_id`                          | `CONNECTOR_ID`                          | Yes       | A valid arbitrary `UUIDv4` that must be unique for this connector.                            |
+| `connector_type`                        | `CONNECTOR_TYPE`                        | Yes       | Must be `STREAM` (this is the connector type).                                                |
+| `connector_name`                        | `CONNECTOR_NAME`                        | Yes       | The name of the Splunk instance, to identify it if you have multiple Splunk connectors.       |
+| `connector_scope`                       | `CONNECTOR_SCOPE`                       | Yes       | Must be `splunk`, not used in this connector.                                                 |
+| `connector_confidence_level`            | `CONNECTOR_CONFIDENCE_LEVEL`            | Yes       | The default confidence level for created sightings (a number between 1 and 4).                |
+| `connector_log_level`                   | `CONNECTOR_LOG_LEVEL`                   | Yes       | The log level for this connector, could be `debug`, `info`, `warn` or `error` (less verbose). |
+| `connector_consumer_count`              | `CONNECTOR_CONSUMER_COUNT`              | No        | Number of consumer/worker that will push data to Splunk.                                      |
+| `connector_live_stream_start_timestamp` | `CONNECTOR_LIVE_STREAM_START_TIMESTAMP` | No        | Start timestamp used on connector first start.                                                |
+| `splunk_url`                            | `SPLUNK_URL`                            | Yes       | The Splunk instances REST API URLs as array                                                   |
+| `splunk_login`                          | `SPLUNK_LOGIN`                          | Yes       | The Splunk login users as array (same order as URLs)                                          |
+| `splunk_password`                       | `SPLUNK_PASSWORD`                       | Yes       | The Splunk passwords as array (same order as URLs)                                            |
+| `splunk_owner`                          | `SPLUNK_OWNER`                          | Yes       | The Splunk KV store owners as array (same order as URLs)                                      |
+| `splunk_ssl_verify`                     | `SPLUNK_SSL_VERIFY`                     | Yes       | Enable the SSL certificate check for all instances (default: `true`)                          |
+| `splunk_app`                            | `SPLUNK_APP`                            | Yes       | The app of the KV Store for all instances.                                                    |
+| `splunk_kv_store_name`                  | `SPLUNK_KV_STORE_NAME`                  | Yes       | The name of the KV Store for all instances.                                                   |
+| `splunk_ignore_types`                   | `SPLUNK_IGNORE_TYPES`                   | Yes       | The list of entity types to ignore.                                                           |
+| `metrics_enable`                        | `METRICS_ENABLE`                        | No        | Whether or not Prometheus metrics should be enabled.                                          |
+| `metrics_addr`                          | `METRICS_ADDR`                          | No        | Bind IP address to use for metrics endpoint.                                                  |
+| `metrics_port`                          | `METRICS_PORT`                          | No        | Port to use for metrics endpoint.                                                             |
+
+### Usage
+
+- This connector will connect your Splunk API as the user specified in field splunk_owner (recommended value is `nobody` which is the default for splunk to create a kvstore)
+- You have to create a token in Splunk (beware of expiration time): Settings > Users and Authentication > Tokens
+- You may have to whitelist your connector EGRESS IP address to hit the API endpoint: Settings > Server Settings > IP allow list > Search head API Access (tab)
+- As a splunk_url, it is recommended to use your search head instance, so that the created kvstore is replicated across your other splunk instances. Note that any kvstore created on "non-search head" won't be replicated nor visible on the search head.
+- The connector will create a kvstore named as per splunk_kv_store_name field value. Note that no other existing object in your splunk instance can have the same name.
+- Once the kvstore created, you want to create some lookup definitions for CRUD operations against your kvstore: Settings > Knowledge > Lookups > Lookup definitions > Add new
+  - As an example of lookup definition, you may want to extract the following supported fields `_key,type,value,hashes,pattern,created_at,updated_at,score,labels,splunk_queries.queries,created_by`

--- a/stream/splunk/docker-compose.yml
+++ b/stream/splunk/docker-compose.yml
@@ -20,5 +20,5 @@ services:
       - SPLUNK_SSL_VERIFY=true
       - SPLUNK_APP=search
       - SPLUNK_KV_STORE_NAME=opencti
-      - SPLUNK_IGNORE_TYPES=label,marking-definition,identity
+      - SPLUNK_IGNORE_TYPES="attack-pattern,campaign,course-of-action,data-component,data-source,external-reference,identity,intrusion-set,kill-chain-phase,label,location,malware,marking-definition,relationship,threat-actor,tool,vocabulary,vulnerability"
     restart: always

--- a/stream/splunk/src/config.yml.sample
+++ b/stream/splunk/src/config.yml.sample
@@ -21,7 +21,7 @@ splunk:
   ssl_verify: true
   app: 'search'
   kv_store_name: 'opencti'
-  ignore_types: 'label,marking-definition,identity'
+  ignore_types: 'attack-pattern,campaign,course-of-action,data-component,data-source,external-reference,identity,intrusion-set,kill-chain-phase,label,location,malware,marking-definition,relationship,threat-actor,tool,vocabulary,vulnerability'
 
 metrics:
   enable: true # set to true to expose prometheus metrics

--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -209,9 +209,6 @@ class SplunkConnector:
                     except:
                         payload["mapped_values"] = []
 
-                payload["value"] = payload["pattern"]
-                del payload["pattern"]
-
             # add creator's name
             created_by = payload.get("created_by_ref", None)
             if created_by is not None:

--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -217,8 +217,7 @@ class SplunkConnector:
                     payload["created_by"] = org_name
 
         if "extensions" in payload:
-            to_remove = []
-            for k, extension_definition in payload["extensions"].items():
+            for extension_definition in payload["extensions"].values():
                 for attribute_name in [
                     "score",
                     "created_at",
@@ -229,10 +228,8 @@ class SplunkConnector:
                     attribute_value = extension_definition.get(attribute_name)
                     if attribute_value:
                         payload[attribute_name] = attribute_value
-                to_remove.append(k)
-            # remove extension-definition-UUID
-            for k in to_remove:
-                del payload["extensions"][k]
+            # remove extensions
+            del payload["extensions"]
 
         return payload
 


### PR DESCRIPTION
https://github.com/OpenCTI-Platform/connectors/issues/1386

amend payload sent to splunk kvstore because it is not STIX friendly to extract fields from extension-definition-UUID

### Proposed changes

* extract several fields from extension-definition-UUID, such as:
  * created_at
  * updated_at
  * score
  * labels
  * is_inferred
* get rid of extensions since it is no longer needed once the above fields have been added to the payload
* amend readme with some guidelines how to leverage the opencti kvstore on splunk

### Related issues

* issue-1386

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Related issue-1386 mention few more changes that I decided not to implement because I found those changes not so relevant since we can define different lookup definition per type. Among those mentionned changes that are not part of of this PR are (1) normalization of type=file by leveraging the field value and (2) changing the type to the actual hash type.
