### PR TITLE
[all] Remove certifi usage and leverage system OS default certificates

### DIFF
--- a/external-import/abuseipdb-ipblacklist/src/main.py
+++ b/external-import/abuseipdb-ipblacklist/src/main.py
@@ -7,7 +7,6 @@ import urllib
 from datetime import datetime
 from urllib import parse
 
-import certifi
 import stix2
 import yaml
 from pycti import (
@@ -109,7 +108,7 @@ class abuseipdbipblacklistimport:
 
                         response = urllib.request.urlopen(
                             req,
-                            context=ssl.create_default_context(cafile=certifi.where()),
+                            context=ssl.create_default_context(),
                             data=body,
                         )
                         image = response.read()

--- a/external-import/abuseipdb-ipblacklist/src/requirements.txt
+++ b/external-import/abuseipdb-ipblacklist/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.10.2
 urllib3==2.0.4
-certifi==2023.7.22

--- a/external-import/cape/src/requirements.txt
+++ b/external-import/cape/src/requirements.txt
@@ -1,5 +1,4 @@
 antlr4-python3-runtime
-certifi==2023.7.22
 chardet==5.2.0
 datefinder==0.7.3
 idna==3.4

--- a/external-import/cisa-known-exploited-vulnerabilities/src/main.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/main.py
@@ -7,7 +7,6 @@ import time
 import urllib
 from typing import Dict, Optional
 
-import certifi
 import stix2
 import yaml
 from pycti import (
@@ -87,7 +86,7 @@ class Cisa:
             return (
                 urllib.request.urlopen(
                     url,
-                    context=ssl.create_default_context(cafile=certifi.where()),
+                    context=ssl.create_default_context(),
                 )
                 .read()
                 .decode("utf-8")

--- a/external-import/cisa-known-exploited-vulnerabilities/src/requirements.txt
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.10.2
 urllib3==2.0.4
-certifi==2023.7.22

--- a/external-import/cuckoo/src/requirements.txt
+++ b/external-import/cuckoo/src/requirements.txt
@@ -1,5 +1,4 @@
 antlr4-python3-runtime
-certifi==2023.7.22
 chardet==5.2.0
 datefinder==0.7.3
 idna==3.4

--- a/external-import/cve/src/cve.py
+++ b/external-import/cve/src/cve.py
@@ -9,7 +9,6 @@ import time
 import urllib.request
 from datetime import datetime
 
-import certifi
 import yaml
 from cvetostix2 import convert
 from pycti import OpenCTIConnectorHelper, get_config_variable
@@ -64,9 +63,7 @@ class Cve:
         try:
             # Downloading json.gz file
             self.helper.log_info("Requesting the file " + url)
-            response = urllib.request.urlopen(
-                url, context=ssl.create_default_context(cafile=certifi.where())
-            )
+            response = urllib.request.urlopen(url, context=ssl.create_default_context())
             image = response.read()
             with open("/tmp/data.json.gz", "wb") as file:
                 file.write(image)

--- a/external-import/cve/src/requirements.txt
+++ b/external-import/cve/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.10.2
 urllib3==2.0.4
-certifi==2023.7.22

--- a/external-import/cyber-campaign-collection/src/cyber-campaign-collection.py
+++ b/external-import/cyber-campaign-collection/src/cyber-campaign-collection.py
@@ -9,7 +9,6 @@ import urllib
 from datetime import date, datetime
 from typing import Optional
 
-import certifi
 import requests
 import stix2
 import yaml
@@ -88,7 +87,7 @@ class CyberMonitor:
             return (
                 urllib.request.urlopen(
                     url,
-                    context=ssl.create_default_context(cafile=certifi.where()),
+                    context=ssl.create_default_context(),
                 )
                 .read()
                 .decode("utf-8")

--- a/external-import/cyber-campaign-collection/src/requirements.txt
+++ b/external-import/cyber-campaign-collection/src/requirements.txt
@@ -1,4 +1,3 @@
 pycti==5.10.2
 urllib3==2.0.4
-certifi==2023.7.22
 PyGithub==1.59.1

--- a/external-import/disarm-framework/src/disarm-framework.py
+++ b/external-import/disarm-framework/src/disarm-framework.py
@@ -8,7 +8,6 @@ import urllib
 from datetime import datetime
 from typing import Optional
 
-import certifi
 import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
 
@@ -59,7 +58,7 @@ class DisarmFramework:
             return (
                 urllib.request.urlopen(
                     url,
-                    context=ssl.create_default_context(cafile=certifi.where()),
+                    context=ssl.create_default_context(),
                 )
                 .read()
                 .decode("utf-8")

--- a/external-import/disarm-framework/src/requirements.txt
+++ b/external-import/disarm-framework/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.10.2
 urllib3==2.0.4
-certifi==2023.7.22

--- a/external-import/misp-feed/src/misp-feed.py
+++ b/external-import/misp-feed/src/misp-feed.py
@@ -8,7 +8,6 @@ import urllib.request
 from datetime import datetime
 from typing import Optional
 
-import certifi
 import pytz
 import stix2
 import yaml
@@ -202,7 +201,7 @@ class MispFeed:
             return (
                 urllib.request.urlopen(
                     url,
-                    context=ssl.create_default_context(cafile=certifi.where()),
+                    context=ssl.create_default_context(),
                 )
                 .read()
                 .decode("utf-8")

--- a/external-import/mitre/src/connector.py
+++ b/external-import/mitre/src/connector.py
@@ -7,7 +7,6 @@ import urllib
 from datetime import datetime
 from typing import Optional
 
-import certifi
 import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
 
@@ -118,7 +117,7 @@ class Mitre:
             serialized_bundle = (
                 urllib.request.urlopen(
                     url,
-                    context=ssl.create_default_context(cafile=certifi.where()),
+                    context=ssl.create_default_context(),
                 )
                 .read()
                 .decode("utf-8")

--- a/external-import/mitre/src/requirements.txt
+++ b/external-import/mitre/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.10.2
 urllib3==2.0.4
-certifi==2023.7.22

--- a/external-import/mwdb/src/requirements.txt
+++ b/external-import/mwdb/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.10.2
 urllib3==2.0.4
-certifi==2023.7.22

--- a/external-import/obstracts/src/requirements.txt
+++ b/external-import/obstracts/src/requirements.txt
@@ -1,6 +1,5 @@
 pycti==5.10.2
 antlr4-python3-runtime
-certifi
 chardet
 datefinder
 idna

--- a/external-import/opencsam/src/requirements.txt
+++ b/external-import/opencsam/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.10.2
 urllib3==2.0.4
-certifi==2023.7.22

--- a/external-import/opencti/src/connector.py
+++ b/external-import/opencti/src/connector.py
@@ -7,7 +7,6 @@ import urllib.request
 from datetime import datetime
 from typing import Optional
 
-import certifi
 import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
 
@@ -81,7 +80,7 @@ class OpenCTI:
             return json.loads(
                 urllib.request.urlopen(
                     url,
-                    context=ssl.create_default_context(cafile=certifi.where()),
+                    context=ssl.create_default_context(),
                 )
                 .read()
                 .decode("utf-8")

--- a/external-import/phishunt/src/phishunt.py
+++ b/external-import/phishunt/src/phishunt.py
@@ -6,7 +6,6 @@ import time
 import urllib.request
 from datetime import datetime
 
-import certifi
 import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
 from stix2 import TLP_WHITE, URL, Bundle, ExternalReference
@@ -87,7 +86,7 @@ class Phishunt:
                     try:
                         response = urllib.request.urlopen(
                             self.phishunt_url,
-                            context=ssl.create_default_context(cafile=certifi.where()),
+                            context=ssl.create_default_context(),
                         )
                         image = response.read()
                         with open(

--- a/external-import/phishunt/src/requirements.txt
+++ b/external-import/phishunt/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.10.2
 urllib3==2.0.4
-certifi==2023.7.22

--- a/external-import/recordedfuture-notes/src/requirements.txt
+++ b/external-import/recordedfuture-notes/src/requirements.txt
@@ -1,5 +1,4 @@
 antlr4-python3-runtime
-certifi
 chardet
 datefinder
 idna

--- a/external-import/siemrules/src/requirements.txt
+++ b/external-import/siemrules/src/requirements.txt
@@ -1,6 +1,5 @@
 pycti==5.10.2
 antlr4-python3-runtime
-certifi
 chardet
 datefinder
 idna

--- a/external-import/stixify/src/requirements.txt
+++ b/external-import/stixify/src/requirements.txt
@@ -1,6 +1,5 @@
 pycti==5.10.2
 antlr4-python3-runtime
-certifi
 chardet
 datefinder
 idna

--- a/external-import/stopforumspam/src/requirements.txt
+++ b/external-import/stopforumspam/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.10.2
 urllib3==2.0.4
-certifi==2023.7.22

--- a/external-import/stopforumspam/src/stopforumspam.py
+++ b/external-import/stopforumspam/src/stopforumspam.py
@@ -6,7 +6,6 @@ import time
 import urllib.request
 from datetime import datetime
 
-import certifi
 import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
 from stix2 import TLP_WHITE, Bundle, DomainName, ExternalReference
@@ -87,7 +86,7 @@ class Stopforumspam:
                     try:
                         response = urllib.request.urlopen(
                             self.stopforumspam_url,
-                            context=ssl.create_default_context(cafile=certifi.where()),
+                            context=ssl.create_default_context(),
                         )
                         image = response.read()
                         with open(

--- a/external-import/taxii2/src/requirements.txt
+++ b/external-import/taxii2/src/requirements.txt
@@ -1,6 +1,5 @@
 pycti==5.10.2
 antlr4-python3-runtime
-certifi
 chardet
 datefinder
 idna

--- a/external-import/threatfox/src/main.py
+++ b/external-import/threatfox/src/main.py
@@ -7,7 +7,6 @@ import time
 import traceback
 import urllib.request
 
-import certifi
 import stix2
 import yaml
 from pycti import (
@@ -107,7 +106,7 @@ class ThreatFox:
                     try:
                         response = urllib.request.urlopen(
                             self.threatfox_csv_url,
-                            context=ssl.create_default_context(cafile=certifi.where()),
+                            context=ssl.create_default_context(),
                         )
                         image = response.read()
                         with open(

--- a/external-import/threatfox/src/requirements.txt
+++ b/external-import/threatfox/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.10.2
 urllib3==2.0.4
-certifi==2023.7.22

--- a/external-import/urlhaus/src/requirements.txt
+++ b/external-import/urlhaus/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.10.2
 urllib3==2.0.4
-certifi==2023.7.22

--- a/external-import/urlhaus/src/urlhaus.py
+++ b/external-import/urlhaus/src/urlhaus.py
@@ -7,7 +7,6 @@ import time
 import traceback
 import urllib.request
 
-import certifi
 import stix2
 import yaml
 from dateutil.parser import parse
@@ -98,7 +97,7 @@ class URLhaus:
                 try:
                     response = urllib.request.urlopen(
                         self.urlhaus_csv_url,
-                        context=ssl.create_default_context(cafile=certifi.where()),
+                        context=ssl.create_default_context(),
                     )
                 except urllib.error.HTTPError:
                     # we only accept HTTPError

--- a/external-import/vulmatch/src/requirements.txt
+++ b/external-import/vulmatch/src/requirements.txt
@@ -1,6 +1,5 @@
 pycti==5.10.2
 antlr4-python3-runtime
-certifi
 chardet
 datefinder
 idna

--- a/external-import/vxvault/src/requirements.txt
+++ b/external-import/vxvault/src/requirements.txt
@@ -1,3 +1,2 @@
 pycti==5.10.2
 urllib3==2.0.4
-certifi==2023.7.22

--- a/external-import/vxvault/src/vxvault.py
+++ b/external-import/vxvault/src/vxvault.py
@@ -6,7 +6,6 @@ import time
 import urllib.request
 from datetime import datetime
 
-import certifi
 import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
 from stix2 import TLP_WHITE, URL, Bundle, ExternalReference
@@ -90,7 +89,7 @@ class VXVault:
                         self.helper.connect_id, friendly_name
                     )
                     try:
-                        ctx = ssl.create_default_context(cafile=certifi.where())
+                        ctx = ssl.create_default_context()
                         if not bool(self.verify_ssl):
                             ctx.check_hostname = False
                             ctx.verify_mode = ssl.CERT_NONE

--- a/internal-enrichment/import-external-reference/src/import-external-reference.py
+++ b/internal-enrichment/import-external-reference/src/import-external-reference.py
@@ -2,7 +2,6 @@ import os
 import ssl
 import urllib.request
 
-import certifi
 import html2text
 import pdfkit
 import yaml
@@ -65,7 +64,7 @@ class ImportExternalReferenceConnector:
                     file_name = url_to_import.split("/")[-1]
                     req = urllib.request.Request(url_to_import, headers=self.headers)
                     response = urllib.request.urlopen(
-                        req, context=ssl.create_default_context(cafile=certifi.where())
+                        req, context=ssl.create_default_context()
                     )
                     data = response.read()
                     self.helper.api.external_reference.add_file(
@@ -162,7 +161,7 @@ class ImportExternalReferenceConnector:
                     text_maker.mark_code = True
                     req = urllib.request.Request(url_to_import, headers=self.headers)
                     response = urllib.request.urlopen(
-                        req, context=ssl.create_default_context(cafile=certifi.where())
+                        req, context=ssl.create_default_context()
                     )
                     html = response.read().decode("utf-8")
                     data = text_maker.handle(html)

--- a/internal-enrichment/recordedfuture-enrichment/src/requirements.txt
+++ b/internal-enrichment/recordedfuture-enrichment/src/requirements.txt
@@ -1,5 +1,4 @@
 antlr4-python3-runtime
-certifi
 chardet
 datefinder
 idna


### PR DESCRIPTION
### Proposed changes

* Remove usage of certifi for reasons described in [1411](https://github.com/OpenCTI-Platform/connectors/issues/1411)


### Related issues

* [1411](https://github.com/OpenCTI-Platform/connectors/issues/1411)


### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This PR removes the usage of certifi from all connectors where it was being imported and used to provide an overide and hardcode the cafile to leveage the certifi.where() cafile rather than just leveraging the system OS default CA certificates. The import statement was removed and the library was removed from the requirements.txt file everywhere which some connectors at one point required this but was removed from the code but the library was not removed from the requirements.txt file for some unknown reason. These have been cleaned up
