### PR TITLE
fix restore-files connector bug `AttributeError: 'NoneType' object has no attribute 'keys' `

### DIFF
--- a/external-import/restore-files/src/restore-files.py
+++ b/external-import/restore-files/src/restore-files.py
@@ -77,8 +77,9 @@ class RestoreFilesConnector:
                 not_in = next((x for x in acc if x["id"] == ref), None)
                 if not_in is None:
                     missing_element = self.find_element(dir_date, ref)
-                    acc.insert(0, missing_element)
-                    self.resolve_missing(dir_date, element_ids, missing_element, acc)
+                    if missing_element is not None:
+                        acc.insert(0, missing_element)
+                        self.resolve_missing(dir_date, element_ids, missing_element, acc)
 
     def restore_files(self):
         stix2_splitter = OpenCTIStix2Splitter()


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add missing test for `find_element` result like [there](https://github.com/OpenCTI-Platform/connectors/blob/2a5c0891e695aa5b5b4a08204918fe8d1d883be8/external-import/restore-files/src/restore-files.py#L121)

### Related issues

* Closes #842

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments
There was no test for `find_element` result and changes are fixes it. 
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
