### PR TITLE
[yara] Use customAttributes to limit overhead of yara sig list() call

### DIFF
--- a/internal-enrichment/yara/src/main.py
+++ b/internal-enrichment/yara/src/main.py
@@ -56,6 +56,13 @@ class YaraConnector:
         self.helper.log_debug("Getting all YARA Indicators in OpenCTI")
 
         data = {"pagination": {"hasNextPage": True, "endCursor": None}}
+        customAttributes = """
+        id
+        name
+        standard_id
+        pattern
+        pattern_type
+        """
         while data["pagination"]["hasNextPage"]:
             after = data["pagination"]["endCursor"]
             data = self.helper.api.indicator.list(
@@ -65,6 +72,7 @@ class YaraConnector:
                 orderBy="created_at",
                 orderMode="asc",
                 withPagination=True,
+                customAttributes=customAttributes,
             )
         return data["entities"]
 


### PR DESCRIPTION
Since an Indicator can have `importFiles` associated with it, when the list call is performed to get all Indicators that match the `pattern_type="yara`" filter, it also attempts to retrieve any `importFiles` or `exportFiles` (by performing an S3 LIST operation), but the results of this will never be used. In fact, the yara connector only cares about `id`, `standard_id`, `pattern`, `name`, and `pattern_type`. 

### Proposed changes

This change limits the Indicator `list()` request to fetch only the fields: `id`, `standard_id`, `pattern`, `name` and `pattern_type`. This ensures that OpenCTI never attempts a S3 LIST operation. This drastically speeds up execution, as well as significantly reduces monetary charges when using AWS S3 as the file storage backend.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

It is not a complex change, but the version of the code without this change has significant runtime performance issues, and also can easily get quite expensive, if a user is hosting their files on AWS S3 instead of MinIO. This change fixes that, and the result is near-zero cost overhead, as well as extremely fast run-time performance.