### PR TITLE
[misp] keep as-is configuration option for labels

### DIFF
--- a/external-import/misp/src/config.yml.sample
+++ b/external-import/misp/src/config.yml.sample
@@ -26,6 +26,7 @@ misp:
   guess_threats_from_tags: false # Optional, try to guess threats (threat actor, intrusion set, malware, etc.) from MISP tags when they are present in OpenCTI
   author_from_tags: false # Optional, map creator:XX=YY (author of event will be YY instead of the author of the event)
   markings_from_tags: false # Optional, map marking:XX=YY (in addition to TLP, add XX:YY as marking definition, where XX is marking type, YY is marking value)
+  keep_original_tags_as_label: "" # Optional, any tag that start with any of these comma-separated value are kept as-is
   enforce_warning_list: false # Optional, enforce warning list in MISP queries
   report_type: 'misp-event' # Optional, report_class if creating report for event
   report_status: 'New' # New, In progress, Analyzed and Closed

--- a/external-import/misp/src/misp.py
+++ b/external-import/misp/src/misp.py
@@ -169,6 +169,12 @@ class Misp:
             config,
             default=False,
         )
+        self.keep_original_tags_as_label = get_config_variable(
+            "MISP_KEEP_ORIGINAL_TAGS_AS_LABEL",
+            ["misp", "keep_original_tags_as_label"],
+            config,
+            default="",
+        ).split(",")
         self.misp_enforce_warning_list = get_config_variable(
             "MISP_ENFORCE_WARNING_LIST",
             ["misp", "enforce_warning_list"],
@@ -2182,7 +2188,16 @@ class Misp:
             return opencti_tags
 
         for tag in tags:
-            if (
+            # we take the tag as-is if it starts by a prefix stored in the keep_original_tags_as_label configuration
+            if any(
+                map(
+                    lambda s: s.startswith(tag["name"]),
+                    self.keep_original_tags_as_label,
+                )
+            ):
+                opencti_tags.append(tag["name"])
+
+            elif (
                 tag["name"] != "tlp:white"
                 and tag["name"] != "tlp:green"
                 and tag["name"] != "tlp:amber"


### PR DESCRIPTION
### Proposed changes
In certain situations, we want to be able to keep labels as they are sent (especially  when they contain special characters).

This PR allows you to configure a list of labels that will be kept as is.

### Checklist
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
