### PR TITLE
Add external-import Comlaude to Connectors.

### DIFF
--- a/external-import/comlaude/Dockerfile
+++ b/external-import/comlaude/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-alpine
+
+# Copy the connector
+COPY src /opt/opencti-connector-comlaude
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev && \
+    cd /opt/opencti-connector-comlaude && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/comlaude/README.md
+++ b/external-import/comlaude/README.md
@@ -1,0 +1,38 @@
+# Comlaude Connector for OpenCTI
+
+The Comlaude Connector is designed to integrate with the [Comlaude API](https://api.comlaude.com/docs) to leverage the `Domain Search Endpoint`. This endpoint provides a comprehensive list of all domains within a specified group, along with detailed information for each domain.
+
+## Key Features:
+- **Domain Retrieval**: Fetches domain details from a specific group in the Comlaude system.
+- **OpenCTI Integration**: Imports the retrieved domains into OpenCTI.
+- **CTI Allowlists Support**: Enhances the capabilities of Cyber Threat Intelligence (CTI) allowlists by integrating domain details.
+
+By integrating Comlaude's domain information with OpenCTI, the connector aids in a more robust and informed CTI strategy.
+
+### Requirements
+
+- OpenCTI Platform >= 5.10.3
+- Username, Password, and API Key for Comlaude
+
+### Configuration
+
+| Parameter                            | Docker envvar                       | Mandatory    | Description                                                                                                                                                |
+| ------------------------------------ | ----------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `opencti_url`                        | `OPENCTI_URL`                       | Yes          | The URL of the OpenCTI platform.                                                                                                                           |
+| `opencti_token`                      | `OPENCTI_TOKEN`                     | Yes          | The default admin token configured in the OpenCTI platform parameters file.                                                                                |
+| `connector_id`                       | `CONNECTOR_ID`                      | Yes          | A valid arbitrary `UUIDv4` that must be unique for this connector.                                                                                         |
+| `connector_type`                     | `CONNECTOR_TYPE`                    | Yes          | Must be `Template_Type` (this is the connector type).                                                                                                      |
+| `connector_name`                     | `CONNECTOR_NAME`                    | Yes          | Option `Template`                                                                                                                                          |
+| `connector_scope`                    | `CONNECTOR_SCOPE`                   | Yes          | Supported scope: Template Scope (MIME Type or Stix Object)                                                                                                 |
+| `connector_confidence_level`         | `CONNECTOR_CONFIDENCE_LEVEL`        | Yes          | The default confidence level for created sightings (a number between 1 and 4).                                                                             |
+| `connector_log_level`                | `CONNECTOR_LOG_LEVEL`               | Yes          | The log level for this connector, could be `debug`, `info`, `warn` or `error` (less verbose).                                                              |
+| `connector_run_and_terminate`        | `CONNECTOR_RUN_AND_TERMINATE`       | Yes          | Terminate container after successful execution.                                                                                                            |
+| `config_update_existing_data`        | `CONFIG_UPDATE_EXISTING_DATA`       | Yes          | whether to updated data in the database.                                                                                                                   |
+| `config_interval`                    | `CONFIG_INTERVAL`                   | Yes          | Interval to run connector in hours.                                                                                                                        |
+| `config_username`                    | `COMLAUDE_USERNAME`                 | Yes          | Username for account that has API access in Comlaude.                                                                                                      |
+| `comlaude_password`                  | `COMLAUDE_PASSWORD`                 | Yes          | Password for account that has API access in Comlaude.                                                                                                      |
+| `comlaude_api_key`                   | `COMLAUDE_API_KEY`                  | Yes          | API Key for account that has API access in Comlaude.                                                                                                       |
+| `comlaude_group_id`                  | `COMLAUDE_GROUP_ID`                 | Yes          | Group ID for API in Comlaude.                                                                                                                              |
+| `comlaude_start_time`                | `COMLAUDE_START_TIME`               | Yes          | Earliest entry to retrieve (e.g., 1970-01-01T00:00:00Z).                                                                                                   |
+| `comlaude_labels`                    | `COMLAUDE_LABELS`                   | Yes          | Labels to apply to Stix Objects (e.g., comlaude,safelist).                                                                                                 |
+

--- a/external-import/comlaude/docker-compose.yml
+++ b/external-import/comlaude/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  connector-comlaude:
+    image: opencti/connector-comlaude:5.10.3
+    environment:
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=ChangeMe
+      - CONNECTOR_ID=ChangeMe
+      - CONNECTOR_TYPE=EXTERNAL_IMPORT
+      - CONNECTOR_NAME="Comlaude"
+      - CONNECTOR_SCOPE=comlaude,stix # MIME type or Stix Object
+      - CONNECTOR_CONFIDENCE_LEVEL=100 # From 0 (Unknown) to 100 (Fully trusted)
+      - CONNECTOR_LOG_LEVEL=info
+      - CONFIG_UPDATE_EXISTING_DATA=True
+      - CONFIG_INTERVAL=2
+      - COMLAUDE_USERNAME=ChangeMe
+      - COMLAUDE_PASSWORD=ChangeMe
+      - COMLAUDE_API_KEY=ChangeMe
+      - COMLAUDE_GROUP_ID=ChangeMe
+      - COMLAUDE_START_TIME=1970-01-01T00:00:00Z
+      - CONNECTOR_RUN_AND_TERMINATE=true
+      - COMLAUDE_LABELS="comlaude,safelist"
+    restart: always

--- a/external-import/comlaude/entrypoint.sh
+++ b/external-import/comlaude/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Correct working directory
+cd /opt/opencti-connector-comlaude
+
+# Start the connector
+python3 main.py

--- a/external-import/comlaude/src/comlaude/__init__.py
+++ b/external-import/comlaude/src/comlaude/__init__.py
@@ -1,0 +1,264 @@
+from datetime import datetime, timedelta
+import json
+import logging
+
+import jwt  # pip install pyjwt
+from requests import Session
+
+API_BASE_URL = 'https://api.comlaude.com'
+
+DEFAULT_PAGE_LIMIT = 500
+DEFAULT_TIMEOUT = 30
+
+LOGGER = logging.getLogger(__name__)
+
+# API Documentation: https://api.comlaude.com/docs
+
+
+class ComLaudeAuth(object):
+    """ComLaude API to collect audit data."""
+    def __init__(  # noqa: WPS211
+        self,
+        username,
+        password,
+        api_key,
+        comlaude_token=None,
+        http_session=None,
+        timeout=DEFAULT_TIMEOUT,
+    ):
+        """
+        Initialize the data object.
+        Args:
+            tenant: ComLaude tenant for organization
+                (https://{tenant}.api.identitynow.com)
+            username: Authorized User.
+            password: Authorized User Password.
+            api_key: ComLaude token.
+            comlaude_token: Authorization token.
+            http_session: Requests Session()
+            timeout: Requests timeout for throttling.
+        """
+
+        self._creds = {
+            'username': username,
+            'password': password,
+            'api_key': api_key,
+        }
+
+        if http_session is None:
+            self._http_session = Session()
+        else:
+            self._http_session = http_session
+
+        self._timeout = timeout
+        self._token = None
+        self._decoded_token = None
+        self.authorization_header = None
+        self.api_base_url = API_BASE_URL
+
+        self._load_token(comlaude_token)
+        self._verify_token()
+
+    def get_token(self):
+        """
+            Return authorization token for session.
+        Returns:
+            Returns the current JWT token.
+        """
+        return self._token
+
+    def refresh_token(self):
+        """Refresh authorization token for session."""
+        self.retrieve_token()
+
+    def retrieve_token(self):
+        """Return authorization token for session."""
+        self._load_token(self._request_token())
+
+    def _load_token(self, token):
+        """
+        Update _token, decode token, and auth header.
+        Args:
+            token: Authentication bearer token to be decoded.
+        """
+        jwt_options = {'verify_signature': False}
+        self._token = token
+        try:
+            self._decoded_token = jwt.decode(
+                self._token['access_token'],
+                options=jwt_options
+                )
+        except jwt.exceptions.DecodeError:
+            LOGGER.debug(
+                'Poorly formatted Access Token, fetching token using _creds'
+                )
+            self.retrieve_token()
+        except TypeError:
+            LOGGER.debug(
+                'Token TypeError, fetching token using _creds'
+                )
+            self.retrieve_token()
+
+        self.authorization_header = {
+            'authorization': 'Bearer {0}'.format(
+                self._token.get('access_token')
+                ),
+        }
+
+    def _request_token(self):
+        """
+        Request Authorization Payload.
+        Returns:
+            Return response Authentication Bearer token from request.
+        """
+        auth_endpoint = '{}{}'.format(
+            self.api_base_url,
+            '/api_login'
+            )
+        headers = {'content-type': 'application/json'}
+        response = self._http_session.request(
+            'POST',
+            auth_endpoint,
+            json=self._creds,
+            headers=headers,
+            timeout=self._timeout,
+        )
+
+        LOGGER.debug('Token JSON: %s', self._creds)  # noqa: WPS323
+        LOGGER.debug('Token Response: %s', response.text)  # noqa: WPS323
+
+        # Check for response errors.
+        _response_error("Can't get token for user {0}".format(
+                self._creds.get('username')
+                ),
+            response)
+
+        return json.loads(response.text)['data']
+
+    def _verify_token(self):
+        """Check to see if token is expiring in 12 hours."""
+        token_expiration = datetime.fromtimestamp(
+            self._decoded_token['exp']
+            )
+        time_difference = datetime.now() + timedelta(hours=12)  # noqa: E501
+        LOGGER.debug('Token expiration time: %s', token_expiration)  # noqa: E501
+        LOGGER.debug('Token comparison time: %s', time_difference)  # noqa: E501
+
+        if token_expiration <= time_difference:
+            self.refresh_token()
+
+
+class ComLaudeSearch(object):
+    """Get Domain List from ComLaude."""
+
+    def __init__(
+        self,
+        comlaude_auth,
+        group_id,
+        min_updated_time,
+        max_updated_time,
+        http_session=None,
+        timeout=DEFAULT_TIMEOUT,
+    ):
+        """
+        Initialize the data object.
+        Args:
+            comlaude_auth: Authentication object.
+            group_id: GroupID to search against.
+            min_updated_time: Minimum time created to search.
+            max_updated_time: Maximum time created to search.
+            http_session: Requests Session()
+            timeout: Requests timeout for throttling.
+        """
+        self._timeout = timeout
+        self._comlaude_auth = comlaude_auth
+        self._group_id = group_id
+
+        self.has_next = False
+        self.results = None
+        self.api_base_url = comlaude_auth.api_base_url
+
+        self.parameters = {
+                'limit': DEFAULT_PAGE_LIMIT,
+                'page': 1,  # Start on first page.
+                'filter[updated_before]': max_updated_time,
+                'filter[updated_after]': min_updated_time,
+                }
+
+        if http_session is None:
+            self._http_session = Session()
+        else:
+            self._http_session = http_session
+
+        self.get_search_results()
+
+    def _request_search(self):
+        api_search_url = '{}{}{}{}'.format(
+            self._comlaude_auth.api_base_url,
+            '/groups/',
+            self._group_id,
+            '/domains/search'
+            )
+
+        headers = dict(
+            {'content-type': 'application/json'},
+            **self._comlaude_auth.authorization_header
+            )
+
+        response = self._http_session.request(
+            'POST',
+            api_search_url,
+            headers=headers,
+            params=self.parameters,
+            timeout=self._timeout,
+        )
+
+        LOGGER.debug('get_events Response: %s', response.text)  # noqa: WPS323
+
+        # Check for response errors.
+        _response_error('Impossible to retreive events', response)
+        return response.json()
+
+    def get_search_results(self):
+        """
+            Return first events from ComLaude API
+            within specified period of time and limit.
+        """
+
+        self.results = self._request_search()
+
+        # Check if API_SEARCH_LIMIT event count is being returned.
+        if self.results['pagination']['next'] is not None:
+            self.has_next = True
+        else:
+            self.has_next = False
+
+    def get_next_page(self):
+        """
+            Return next set of events from ComLaude API
+            within specified period of time and limit.
+        """
+        if self.has_next:
+            self.parameters['page'] = self.parameters['page']+1
+            self.get_search_results()
+        else:
+            raise 'Next page DNE.'
+
+
+def _response_error(message, response):
+    if response.status_code == 200:  # noqa: WPS432
+        return
+
+    if response.status_code == 400:  # noqa: WPS432
+        error_message = json.loads(response.text)
+    else:
+        error_message = json.loads(response.text)
+
+    raise Exception(
+        """Message:{0}.
+            Response code returned:{1}.
+            Eror message returned:{2}.""".format(
+                                                message,
+                                                response.status_code,
+                                                error_message),
+    )

--- a/external-import/comlaude/src/comlaude/__init__.py
+++ b/external-import/comlaude/src/comlaude/__init__.py
@@ -1,6 +1,6 @@
-from datetime import datetime, timedelta
 import json
 import logging
+from datetime import datetime, timedelta
 
 import jwt  # pip install pyjwt
 from requests import Session

--- a/external-import/comlaude/src/comlaude/requirements.txt
+++ b/external-import/comlaude/src/comlaude/requirements.txt
@@ -1,0 +1,2 @@
+pyjwt
+requests

--- a/external-import/comlaude/src/config.yml.sample
+++ b/external-import/comlaude/src/config.yml.sample
@@ -1,0 +1,21 @@
+opencti:
+  url: 'http://localhost:8080'
+  token: 'ChangeMe'
+
+connector:
+  id: 'ChangeMe'
+  type: 'EXTERNAL_IMPORT'
+  name: 'Comlaude'
+  scope: 'SCO' # MIME type or SCO
+  confidence_level: 100 # From 0 (Unknown) to 100 (Fully trusted)
+  log_level: 'info'
+
+comlaude:
+  interval: 2
+  username: 'ChangeMe'
+  password: 'ChangeMe'
+  api_key: 'ChangeMe'
+  group_id: 'ChangeMe'
+  start_time: '1970-01-01T00:00:00Z'
+  update_existing_data: 'True'
+  labels: 'comlaude,safelist'

--- a/external-import/comlaude/src/main.py
+++ b/external-import/comlaude/src/main.py
@@ -1,0 +1,279 @@
+import os
+import sys
+import time
+import datetime
+import comlaude
+import yaml
+from pycti import OpenCTIConnectorHelper, get_config_variable
+from stix2 import DomainName, Bundle, Indicator
+
+CONFIG_FILE_PATH = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
+X_OPENCTI_PREFIX = "x_opencti_"
+
+
+def _format_time(utc_time):
+    """
+    Format the given UTC time to a specific string format.
+
+    :param utc_time: A datetime object representing UTC time.
+    :return: Formatted string representation of the datetime object.
+    """
+    return utc_time.strftime("%Y-%m-%dT%H:%M:%S") + "Z"
+
+
+# Defines a time delta of 5 minutes.
+TIME_DELTA = datetime.timedelta(minutes=5)
+COMLAUDE_END_TIME = _format_time(datetime.datetime.utcnow() - TIME_DELTA)
+
+
+def _convert_timestamp_to_zero_millisecond_format(timestamp: str) -> str:
+    """
+    Convert a timestamp from one format to another with zero milliseconds.
+
+    :param timestamp: String representing the timestamp in "%Y-%m-%dT%H:%M:%SZ".
+    :return: String timestamp with zero milliseconds in "%Y-%m-%dT%H:%M:%S.000000Z".
+    """
+    dt_object = datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
+    return dt_object.strftime("%Y-%m-%dT%H:%M:%S.000000Z")
+
+
+def _is_empty(value):
+    """
+    Check if a given value is empty or None.
+
+    :param value: Value to be checked.
+    :return: Boolean value, True if value is empty/None, otherwise False.
+    """
+    if value is None:
+        return True
+    if isinstance(value, (str, list, dict)) and not value:
+        return True
+    return False
+
+
+def _generate_dynamic_custom_properties(helper, domain_object):
+    """
+    Generate custom properties for domain objects dynamically with a specific prefix.
+
+    :param helper: OpenCTIConnectorHelper object.
+    :param domain_object: Dictionary containing domain properties.
+    :return: Tuple containing domain name and a dictionary of custom properties.
+    """
+    helper.log_debug(f"Generate Dynamic Properties with prefix ({X_OPENCTI_PREFIX})")
+    custom_properties = {}
+    for key, value in domain_object.items():
+        if not _is_empty(value):
+            custom_key = X_OPENCTI_PREFIX + key
+            custom_properties[custom_key] = value
+            helper.log_debug(f"Custom Key: {custom_key}")
+    domain_name = custom_properties.pop(f"{X_OPENCTI_PREFIX}name", None)
+    helper.log_debug(f"Pop domain_name: {domain_name}")
+    return domain_name, custom_properties
+
+
+def _create_stix_create_bundle(helper, domain_object, labels):
+    """
+    Create a STIX bundle containing domain and indicator objects.
+
+    :param helper: OpenCTIConnectorHelper object.
+    :param domain_object: Dictionary containing domain properties.
+    :param labels: List of labels to be associated with the STIX objects.
+    :return: Tuple containing domain name and a list of STIX objects.
+    """
+    domain_name, custom_properties = _generate_dynamic_custom_properties(
+        helper, domain_object
+    )
+    helper.log_debug(f"Create STIX Domain Name object: {domain_name}")
+
+    # Create DomainName object
+    sco_domain_name = DomainName(
+        value=domain_name,
+        type="domain-name",
+        allow_custom=True,
+        custom_properties=custom_properties,
+        labels=labels,
+    )
+    helper.log_debug(f"Create STIX Indicator object: {domain_name}")
+
+    # Create Indicator object
+    sdo_indicator = Indicator(
+        created=_convert_timestamp_to_zero_millisecond_format(
+            domain_object["created_at"]
+        ),
+        modified=_convert_timestamp_to_zero_millisecond_format(
+            domain_object["updated_at"]
+        ),
+        name=domain_name,
+        description="This domain is known infrastructure managed by Comlaude.",
+        pattern_type="stix",
+        pattern=f"[domain-name:value = '{domain_name}']",
+        valid_from=_convert_timestamp_to_zero_millisecond_format(
+            domain_object["created_at"]
+        ),
+        labels=labels,
+    )
+
+    helper.log_debug(f"Create relationships: {domain_name}")
+    helper.log_debug(f"Bundle Objects: {domain_name}")
+    return domain_name, [sco_domain_name, sdo_indicator]
+
+
+class ComlaudeConnector:
+    """
+    Connector class to interface with Comlaude and OpenCTI platforms.
+    """
+
+    def __init__(self):
+        """
+        Initialize the ComlaudeConnector with necessary configurations.
+        """
+
+        # Load configuration file and connection helper.
+        self.config = self._load_config()
+        self.helper = OpenCTIConnectorHelper(self.config)
+
+        # Get required configurations
+        self.config_interval = get_config_variable(
+            "CONFIG_INTERVAL", ["comlaude", "interval"], self.config, isNumber=True
+        )
+        self.update_existing_data = get_config_variable(
+            "CONFIG_UPDATE_EXISTING_DATA",
+            ["comlaude", "update_existing_data"],
+            self.config,
+            isNumber=True,
+        )
+        comlaude_username = get_config_variable(
+            "COMLAUDE_USERNAME", ["comlaude", "username"], self.config, False
+        )
+        comlaude_password = get_config_variable(
+            "COMLAUDE_PASSWORD", ["comlaude", "password"], self.config, False
+        )
+        comlaude_api_key = get_config_variable(
+            "COMLAUDE_API_KEY", ["comlaude", "api_key"], self.config, False
+        )
+        comlaude_group_id = get_config_variable(
+            "COMLAUDE_GROUP_ID", ["comlaude", "group_id"], self.config, False
+        )
+        comlaude_start_time = get_config_variable(
+            "COMLAUDE_START_TIME", ["comlaude", "start_time"], self.config, False
+        )
+
+        comlaude_labels = get_config_variable(
+            "COMLAUDE_LABELS", ["comlaude", "labels"], self.config, False
+        )
+
+        # Authenticate with Comlaude.
+        comlaude_auth_token = comlaude.ComLaudeAuth(
+            comlaude_username, comlaude_password, comlaude_api_key
+        )
+
+        self.comlaude_search = comlaude.ComLaudeSearch(
+            comlaude_auth_token,
+            comlaude_group_id,
+            comlaude_start_time,
+            COMLAUDE_END_TIME,
+        )
+
+        self.work_id = None
+        self.labels = comlaude_labels.split(",")
+
+    def _load_config(self) -> dict:
+        """
+        Load the configuration from the YAML file.
+
+        :return: Configuration dictionary.
+        """
+        config = (
+            yaml.load(open(CONFIG_FILE_PATH), Loader=yaml.FullLoader)
+            if os.path.isfile(CONFIG_FILE_PATH)
+            else {}
+        )
+        return config
+
+    def _get_interval(self):
+        """
+        Get the interval of execution in seconds.
+
+        :return: Interval in seconds.
+        """
+        return int(self.config_interval) * 60 * 60
+
+    def _refresh_work_id(self):
+        """
+        Refresh the work ID for the current process.
+        """
+        update_end_time = _format_time(datetime.datetime.utcnow() - TIME_DELTA)
+        friendly_name = f"Comlaude run @ {update_end_time}"
+        self.work_id = self.helper.api.work.initiate_work(
+            self.helper.connect_id, friendly_name
+        )
+        self.helper.log_info(f"{friendly_name}")
+
+    def _iterate_events(self):
+        """
+        Iterate through events from Comlaude, generate STIX bundles, and send them to OpenCTI.
+        """
+        self.helper.log_info(
+            "Process ({}) events.".format(len(self.comlaude_search.results["data"]))
+        )
+        if len(self.comlaude_search.results["data"]) > 0:
+            self._refresh_work_id()
+            stix_objects = []
+            for event in self.comlaude_search.results["data"]:
+                domain_name, objects = _create_stix_create_bundle(
+                    self.helper, event, self.labels
+                )
+                self.helper.log_debug(f"Adding Stix Objects for ({domain_name}).")
+                stix_objects.extend(objects)
+            bundle = Bundle(objects=stix_objects, allow_custom=True)
+            self.helper.log_info(
+                "Sending Bundle of ({}) events.".format(
+                    len(self.comlaude_search.results["data"])
+                )
+            )
+            self.helper.send_stix2_bundle(
+                bundle.serialize(),
+                update=self.update_existing_data,
+                work_id=self.work_id,
+            )
+
+    def run(self):
+        """
+        Main execution loop for the ComlaudeConnector.
+        """
+        self.helper.log_info(
+            "Start Comluade Connector ({}).".format(
+                _format_time(datetime.datetime.utcnow())
+            )
+        )
+        self._iterate_events()
+        while self.comlaude_search.has_next:
+            # Get next events and send data.
+            self.helper.log_info(
+                "Starting to update Comlaude page: ({}).".format(
+                    self.comlaude_search.parameters["page"]
+                )
+            )
+            self.comlaude_search.get_next_page()
+            self._iterate_events()
+
+        if self.helper.connect_run_and_terminate:
+            self.helper.log_info(
+                "Connector stop: ({})".format(_format_time(datetime.datetime.utcnow()))
+            )
+            sys.exit(0)
+        # Sleep for interval specified in Hours.
+        time.sleep(self._get_interval())
+
+
+if __name__ == "__main__":
+    """
+    Entry point of the script.
+    """
+    try:
+        connector = ComlaudeConnector()
+        connector.run()
+    except Exception as e:
+        print(e)
+        time.sleep(10)
+        sys.exit(0)

--- a/external-import/comlaude/src/main.py
+++ b/external-import/comlaude/src/main.py
@@ -3,11 +3,11 @@ import os
 import sys
 import time
 
-import comlaude
 import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
 from stix2 import Bundle, DomainName, Indicator
 
+import comlaude
 
 CONFIG_FILE_PATH = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
 X_OPENCTI_PREFIX = "x_opencti_"

--- a/external-import/comlaude/src/main.py
+++ b/external-import/comlaude/src/main.py
@@ -1,11 +1,13 @@
+import datetime
 import os
 import sys
 import time
-import datetime
-import comlaude
+
 import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
-from stix2 import DomainName, Bundle, Indicator
+from stix2 import Bundle, DomainName, Indicator
+
+import comlaude
 
 CONFIG_FILE_PATH = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
 X_OPENCTI_PREFIX = "x_opencti_"

--- a/external-import/comlaude/src/main.py
+++ b/external-import/comlaude/src/main.py
@@ -3,11 +3,11 @@ import os
 import sys
 import time
 
+import comlaude
 import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
 from stix2 import Bundle, DomainName, Indicator
 
-import comlaude
 
 CONFIG_FILE_PATH = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
 X_OPENCTI_PREFIX = "x_opencti_"

--- a/external-import/comlaude/src/main.py
+++ b/external-import/comlaude/src/main.py
@@ -1,3 +1,7 @@
+""" Comlaude main integration.
+
+   isort:skip_file
+"""
 import datetime
 import os
 import sys

--- a/external-import/comlaude/src/requirements.txt
+++ b/external-import/comlaude/src/requirements.txt
@@ -1,0 +1,3 @@
+pycti==5.10.3
+pyjwt
+requests


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->
The Comlaude Connector is designed to integrate with the [Comlaude API](https://api.comlaude.com/docs) to leverage the `Domain Search Endpoint`. This endpoint provides a comprehensive list of all domains within a specified group, along with detailed information for each domain.

### Proposed changes

* Add new integration for ComLaude to import known domain infrastructure to support SafeLists. 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
