### PR TITLE
[thehive] - Add support for new indicator types and fix error when task owner is not defined

### DIFF
--- a/external-import/thehive/README.md
+++ b/external-import/thehive/README.md
@@ -1,0 +1,73 @@
+# TheHive Connector for OpenCTI
+
+The **TheHive Connector** allows for integration of TheHive's alert and case management capabilities into OpenCTI. This connector imports TheHive's cases, alerts, tasks, and observables into OpenCTI. The connector uses the Python modules `thehive4py` and will work on version 4 and 5.  
+
+## Configuration:
+
+Setting up TheHive Connector is straightforward. The following table provides details on the necessary parameters:
+
+| Parameter                       | Docker envvar                 | Mandatory | Description                                                     |
+|---------------------------------|-------------------------------|-----------|-----------------------------------------------------------------|
+| `opencti.url`                   | `OPENCTI_URL`                 | Yes       | The URL of the OpenCTI platform.                                |
+| `opencti.token`                 | `OPENCTI_TOKEN`               | Yes       | The token for accessing OpenCTI.                                |
+| `connector.id`                  | `CONNECTOR_ID`                | Yes       | A unique `UUIDv4` identifier for this connector instance.       |
+| `connector.type`                | `CONNECTOR_TYPE`              | Yes       | Should always be set to `EXTERNAL_IMPORT` for this connector.   |
+| `connector.name`                | `CONNECTOR_NAME`              | Yes       | Name of the connector. Should always be "TheHive".              |
+| `connector.scope`               | `CONNECTOR_SCOPE`             | Yes       | The scope of data the connector is importing.                   |
+| `connector.confidence_level`    | `CONNECTOR_CONFIDENCE_LEVEL`  | Yes       | Confidence level for the data imported.                         |
+| `connector.update_existing_data`| `CONNECTOR_UPDATE_EXISTING_DATA`| Yes     | Decide whether the connector should update already existing data.|
+| `connector.log_level`           | `CONNECTOR_LOG_LEVEL`         | Yes       | Logging level. Choices: `info`, `error`, etc.                   |
+| `thehive.url`                   | `THEHIVE_URL`                 | Yes       | URL of your TheHive instance.                                   |
+| `thehive.api_key`               | `THEHIVE_API_KEY`             | Yes       | Your API Key for accessing TheHive.                             |
+| `thehive.check_ssl`             | `THEHIVE_CHECK_SSL`           | Yes       | Whether to validate the SSL certificate of TheHive instance.   |
+| `thehive.organization_name`     | `THEHIVE_ORGANIZATION_NAME`   | Yes       | Name of your organization in TheHive.                           |
+| `thehive.import_from_date`      | `THEHIVE_IMPORT_FROM_DATE`    | No        | Date from which to start importing data.                        |
+| `thehive.import_only_tlp`       | `THEHIVE_IMPORT_ONLY_TLP`     | No        | Levels of the Traffic Light Protocol (TLP) to be imported.      |
+| `thehive.import_alerts`         | `THEHIVE_IMPORT_ALERTS`       | No        | Whether to import alerts from TheHive.                          |
+| `thehive.severity_mapping`      | `THEHIVE_SEVERITY_MAPPING`    | No        | Mapping of severity levels between TheHive and OpenCTI. e.g., `1:low,2:medium,3:high,4:critical`         |
+| `thehive.case_status_mapping`   | `THEHIVE_CASE_STATUS_MAPPING` | No        | Status mapping for cases. e.g., `hive_status_1:opencti_status_id_2,hive_status_2:opencti_status_id_2`                                       |
+| `thehive.task_status_mapping`   | `THEHIVE_TASK_STATUS_MAPPING` | No        | Status mapping for tasks. e.g., `hive_status_1:opencti_status_id_2,hive_status_2:opencti_status_id_2`                                             |
+| `thehive.alert_status_mapping`  | `THEHIVE_ALERT_STATUS_MAPPING`| No        | Status mapping for alerts. e.g., `hive_status_1:opencti_status_id_2,hive_status_2:opencti_status_id_2`                                            |
+| `thehive.user_mapping`          | `THEHIVE_USER_MAPPING`        | No        | Mapping of TheHive assignees to OpenCTI users. e.g., `user@contoso.com:opencti_user_id,user2@contoso.com:opencti_user_id_2`                 |
+| `thehive.interval`              | `THEHIVE_INTERVAL`            | Yes       | Frequency of running the connector in minutes.                  |
+
+## Supported Indicator Field Names
+The following is a list of indicator Field Names supported by this integration and the prescribed value types. Indicators of this field name will be imported into OpenCTI as the STIX object defined. Please ensure that the field names are receiving standardized values to avoid potential import errors (e.g., and IP is an IP).
+
+| TheHive Indicator Name        | STIX Object      |
+|------------------------|--------------------------------|
+| asset                  | Identity (system)                           |
+| autonomous-system      | Autonomous System (AS)        |
+| cve                    | Vulnerability             |
+| domain                 | Domain Name              |
+| file                   | File: Checks the length and determines the hash type (supported: MD5, SHA-1, SHA-256)                            |
+| file_md5               | File                |
+| file_sha1              | File              |
+| file_sha256            | File            |
+| filename               | File                      |
+| fqdn                   | Domain Name                 |
+| hostname               | Identity (system)                 |
+| hash                   | File: Checks the length and determines the hash type (supported: MD5, SHA-1, SHA-256)                           |
+| identity               | Identity                  |
+| ip                     | IPv4 Address or IPv6 Address, supports ipv4, ipv6, and cidr notation of both.                            |
+| ipv4                   | IPv4 Address                |
+| ipv6                   | IPv6 Address                |
+| mail                   | Email Message (body)             |
+| mail-subject           | Email Message (subject)            |
+| mail_subject           | Email Message (subject)          |
+| email_subject          | Email Message (subject)          |
+| email_address          | Email Message (email-addr)            |
+| other                  | Custom Observable                     |
+| organisation           | Identity (organization)                           |
+| organization           | Identity (organization)                  |
+| regexp                 | Custom Observable Text                     |
+| registry               | Windows Registry Key       |
+| risk_object_asset      | Identity (system)                           |
+| risk_object_identity   | Identity (identity)                           |
+| system                 | Identity (system)                  |
+| uri_path               | Url                     |
+| url                    | Url                      |
+| user-agent             | Custom Observable User Agent               |
+| user_agent             | Custom Observable User Agent               |
+| supplier               | Identity (organization)                           |
+| vendor                 | Identity (organization)                           |

--- a/external-import/thehive/docker-compose.yml
+++ b/external-import/thehive/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - THEHIVE_IMPORT_FROM_DATE=2021-01-01T00:00:00 # Optional
       - THEHIVE_IMPORT_ONLY_TLP=0,1,2,3,4
       - THEHIVE_IMPORT_ALERTS=true
-      - "THEHIVE_SEVERITY_MAPPING= 1:01 - low,2:02 - medium,3:03 - high,4:04 - critical"
+      - "THEHIVE_SEVERITY_MAPPING=1:low,2:medium,3:high,4:critical"
       - THEHIVE_CASE_STATUS_MAPPING= # TheHive_ExtStatus_Text1:OpenCTI_Status_ID1,TheHive_ExtStatus_Text2:OpenCTI_Status_ID2
       - THEHIVE_TASK_STATUS_MAPPING= # Waiting:OpenCTI_Status_ID1,InProgress:OpenCTI_Status_ID2,Completed:OpenCTI_Status_ID2
       - THEHIVE_ALERT_STATUS_MAPPING= # TheHive_ExtStatus_Text1:OpenCTI_Status_ID1,TheHive_ExtStatus_Text2:OpenCTI_Status_ID2

--- a/external-import/thehive/src/config.yml.sample
+++ b/external-import/thehive/src/config.yml.sample
@@ -19,7 +19,7 @@ thehive:
   import_from_date: '2021-01-01T00:00:00' # Optional
   import_only_tlp: '0,1,2,3,4'
   import_alerts: true
-  severity_mapping: '1:01 - low,2:02 - medium,3:03 - high,4:04 - critical'
+  severity_mapping: '1:low,2:medium,3:high,4:critical'
   case_status_mapping: '' # TheHive_ExtStatus_Text1:OpenCTI_Status_ID1,TheHive_ExtStatus_Text2:OpenCTI_Status_ID2
   task_status_mapping: '' # Waiting:OpenCTI_Status_ID1,InProgress:OpenCTI_Status_ID2,Completed:OpenCTI_Status_ID2
   alert_status_mapping: '' # TheHive_ExtStatus_Text1:OpenCTI_Status_ID1,TheHive_ExtStatus_Text2:OpenCTI_Status_ID2

--- a/external-import/thehive/src/thehive.py
+++ b/external-import/thehive/src/thehive.py
@@ -36,7 +36,7 @@ from stix2 import (
 from thehive4py.api import TheHiveApi
 from thehive4py.query import Child, Gt, Or
 
-from utils import is_ipv4, is_ipv6
+from utils import is_ipv4, is_ipv6  # isort: skip
 
 OBSERVABLES_MAPPING = {
     "autonomous-system": "Autonomous-System.number",

--- a/external-import/thehive/src/thehive.py
+++ b/external-import/thehive/src/thehive.py
@@ -11,7 +11,6 @@ from pycti import (
     CaseIncident,
     CustomObjectCaseIncident,
     CustomObjectTask,
-    CustomObservableHostname,
     CustomObservableText,
     CustomObservableUserAgent,
     Incident,
@@ -195,7 +194,9 @@ class TheHive:
         observable_key = (
             OBSERVABLES_MAPPING[data_type] if data_type in OBSERVABLES_MAPPING else None
         )
-        self.helper.log_debug(f"Observable data_type ({data_type}) observable_key ({observable_key})")
+        self.helper.log_debug(
+            f"Observable data_type ({data_type}) observable_key ({observable_key})"
+        )
         if observable_key is not None:
             if data_type == "autonomous-system":
                 stix_observable = AutonomousSystem(
@@ -484,10 +485,16 @@ class TheHive:
                     },
                 )
             else:
-                self.helper.log_warning(f"Observable data_type ({data_type}) not supported: {observable}.")
+                self.helper.log_warning(
+                    f"Observable data_type ({data_type}) not supported: {observable}."
+                )
         else:
-            self.helper.log_warning(f"Observable data_type ({data_type}) not supported: {observable}.")
-        self.helper.log_debug(f"Observable data_type ({data_type}), stix observable: {stix_observable}.")
+            self.helper.log_warning(
+                f"Observable data_type ({data_type}) not supported: {observable}."
+            )
+        self.helper.log_debug(
+            f"Observable data_type ({data_type}), stix observable: {stix_observable}."
+        )
         return stix_observable
 
     def generate_case_bundle(self, case):

--- a/external-import/thehive/src/thehive.py
+++ b/external-import/thehive/src/thehive.py
@@ -26,13 +26,17 @@ from stix2 import (
     URL,
     AutonomousSystem,
     DomainName,
+    EmailAddress,
     EmailMessage,
     File,
     IPv4Address,
+    IPv6Address,
     WindowsRegistryKey,
 )
 from thehive4py.api import TheHiveApi
 from thehive4py.query import Child, Gt, Or
+
+from utils import is_ipv4, is_ipv6
 
 OBSERVABLES_MAPPING = {
     "autonomous-system": "Autonomous-System.number",
@@ -45,9 +49,14 @@ OBSERVABLES_MAPPING = {
     "fqdn": "Hostname.value",
     "hostname": "Hostname.value",
     "hash": None,
-    "ip": "IPv4-Addr.value",
+    "ip": None,
+    "ipv4": "IPv4-Addr.value",
+    "ipv6": "IPv6-Addr.value",
     "mail": "Email-Message.body",
     "mail-subject": "Email-Message.subject",
+    "mail_subject": "Email-Message.subject",
+    "email_subject": "Email-Message.subject",
+    "email_address": "Email-Address.value",
     "other": "Text.value",
     "regexp": "Text.value",
     "registry": "Windows-Registry-Key.key",
@@ -150,279 +159,308 @@ class TheHive:
 
     def convert_observable(self, observable, markings):
         stix_observable = None
-        if observable["dataType"] == "hash":
-            if len(observable["data"]) == 32:
+        if observable.get("dataType") == "hash":
+            if len(observable.get("data")) == 32:
                 data_type = "file_md5"
-            elif len(observable["data"]) == 40:
+            elif len(observable.get("data")) == 40:
                 data_type = "file_sha1"
-            elif len(observable["data"]) == 64:
+            elif len(observable.get("data")) == 64:
                 data_type = "file_sha256"
             else:
                 data_type = "unknown"
+        elif observable.get("dataType") == "ip" and is_ipv4(observable.get("data")):
+            data_type = "ipv4"
+        elif observable.get("dataType") == "ip" and is_ipv6(observable.get("data")):
+            data_type = "ipv6"
         else:
-            data_type = observable["dataType"]
+            data_type = observable.get("dataType")
         observable_key = (
             OBSERVABLES_MAPPING[data_type] if data_type in OBSERVABLES_MAPPING else None
         )
         if observable_key is not None:
             if data_type == "autonomous-system":
                 stix_observable = AutonomousSystem(
-                    number=observable["data"],
+                    number=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
-                        else None,
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "description": observable.get("message"),
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "domain":
                 stix_observable = DomainName(
-                    value=observable["data"],
+                    value=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
-                        else None,
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "description": observable.get("message"),
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "file_md5":
                 stix_observable = File(
-                    hashes={"MD5": observable["data"]},
+                    hashes={"MD5": observable.get("data")},
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
-                        else None,
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "description": observable.get("message"),
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "file_sha1":
                 stix_observable = File(
-                    hashes={"SHA-1": observable["data"]},
+                    hashes={"SHA-1": observable.get("data")},
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
-                        else None,
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "description": observable.get("message"),
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "file_sha256":
                 stix_observable = File(
-                    hashes={"SHA-256": observable["data"]},
+                    hashes={"SHA-256": observable.get("data")},
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
+                        "description": observable.get("message")
+                        if observable.get("message")
                         else "Imported from TheHive",
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "filename":
                 stix_observable = File(
-                    name=observable["data"],
+                    name=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
+                        "description": observable.get("message")
+                        if observable.get("message")
                         else "Imported from TheHive",
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "fqdn":
                 stix_observable = CustomObservableHostname(
-                    value=observable["data"],
+                    value=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
+                        "description": observable.get("message")
+                        if observable.get("message")
                         else "Imported from TheHive",
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "hostname":
                 stix_observable = CustomObservableHostname(
-                    value=observable["data"],
+                    value=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
+                        "description": observable.get("message")
+                        if observable.get("message")
                         else "Imported from TheHive",
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
-            elif data_type == "ip":
+            elif data_type == "ipv4":
                 stix_observable = IPv4Address(
-                    value=observable["data"],
+                    value=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
+                        "description": observable.get("message")
+                        if observable.get("message")
                         else "Imported from TheHive",
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
+                    },
+                )
+            elif data_type == "ipv6":
+                stix_observable = IPv6Address(
+                    value=observable.get("data"),
+                    object_marking_refs=markings,
+                    custom_properties={
+                        "description": observable.get("message")
+                        if observable.get("message")
+                        else "Imported from TheHive",
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "mail":
                 stix_observable = EmailMessage(
-                    body=observable["data"],
+                    body=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
+                        "description": observable.get("message")
+                        if observable.get("message")
                         else "Imported from TheHive",
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
-            elif data_type == "mail_subject":
+            elif data_type in ["mail_subject", "email_subject", "mail-subject"]:
                 stix_observable = EmailMessage(
-                    subject=observable["data"],
+                    type="email-message",
+                    is_multipart=False,
+                    subject=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
+                        "description": observable.get("message")
+                        if observable.get("message")
                         else "Imported from TheHive",
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
+                    },
+                )
+            elif data_type == "email_address":
+                stix_observable = EmailAddress(
+                    type="email-addr",
+                    value=observable.get("data"),
+                    object_marking_refs=markings,
+                    custom_properties={
+                        "description": observable.get("message")
+                        if observable.get("message")
+                        else "Imported from TheHive",
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "other":
                 stix_observable = CustomObservableText(
-                    value=observable["data"],
+                    value=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
+                        "description": observable.get("message")
+                        if observable.get("message")
                         else "Imported from TheHive",
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "regexp":
                 stix_observable = CustomObservableText(
-                    value=observable["data"],
+                    value=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
+                        "description": observable.get("message")
+                        if observable.get("message")
                         else "Imported from TheHive",
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "registry":
                 stix_observable = WindowsRegistryKey(
-                    key=observable["data"],
+                    key=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
+                        "description": observable.get("message")
+                        if observable.get("message")
                         else "Imported from TheHive",
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "uri_path":
                 stix_observable = URL(
-                    value=observable["data"],
+                    value=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
+                        "description": observable.get("message")
+                        if observable.get("message")
                         else "Imported from TheHive",
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "url":
                 stix_observable = URL(
-                    value=observable["data"],
+                    value=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
+                        "description": observable.get("message")
+                        if observable.get("message")
                         else "Imported from TheHive",
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
             elif data_type == "user-agent":
                 stix_observable = CustomObservableUserAgent(
-                    value=observable["data"],
+                    value=observable.get("data"),
                     object_marking_refs=markings,
                     custom_properties={
-                        "description": observable["message"]
-                        if "message" in observable
+                        "description": observable.get("message")
+                        if observable.get("message")
                         else "Imported from TheHive",
-                        "labels": observable["tags"] if "tags" in observable else [],
-                        "x_opencti_score": 80 if observable["ioc"] else 50,
-                        "created_by_ref": self.identity["standard_id"],
-                        "x_opencti_create_indicator": observable["ioc"],
+                        "labels": observable.get("tags"),
+                        "x_opencti_score": 80 if observable.get("ioc") else 50,
+                        "created_by_ref": self.identity.get("standard_id"),
+                        "x_opencti_create_indicator": observable.get("ioc"),
                     },
                 )
+        else:
+            self.helper.log_warning(f"Observable not supported: {observable}")
         return stix_observable
 
     def generate_case_bundle(self, case):
-        self.helper.log_info("Importing case '" + case["title"] + "'")
+        self.helper.log_info("Importing case '" + case.get("title") + "'")
         case_objects = []
         bundle_objects = []
         markings = []
-        if case["tlp"] == 0:
+        if case.get("tlp") == 0:
             markings.append(stix2.TLP_WHITE)
             bundle_objects.append(stix2.TLP_WHITE)
-        elif case["tlp"] == 1:
+        elif case.get("tlp") == 1:
             markings.append(stix2.TLP_GREEN)
             bundle_objects.append(stix2.TLP_GREEN)
-        elif case["tlp"] == 2:
+        elif case.get("tlp") == 2:
             markings.append(stix2.TLP_AMBER)
             bundle_objects.append(stix2.TLP_AMBER)
-        elif case["tlp"] == 3:
+        elif case.get("tlp") == 3:
             markings.append(stix2.TLP_RED)
             bundle_objects.append(stix2.TLP_RED)
-        elif case["tlp"] == 4:
+        elif case.get("tlp") == 4:
             marking = stix2.MarkingDefinition(
                 id=MarkingDefinition.generate_id("TLP", "TLP:AMBER+STRICT"),
                 definition_type="statement",
@@ -498,7 +536,9 @@ class TheHive:
             bundle_objects.append(marking)
 
         # Get observables
-        observables = self.thehive_api.get_case_observables(case_id=case["id"]).json()
+        observables = self.thehive_api.get_case_observables(
+            case_id=case.get("id")
+        ).json()
         for observable in observables:
             stix_observable = self.convert_observable(observable, markings)
             if stix_observable is not None:
@@ -511,57 +551,57 @@ class TheHive:
                     stix_sighting = stix2.Sighting(
                         id=StixSightingRelationship.generate_id(
                             stix_observable.id,
-                            self.identity["standard_id"],
+                            self.identity.get("standard_id"),
                             datetime.utcfromtimestamp(
-                                int(observable["startDate"] / 1000)
+                                int(observable.get("startDate") / 1000)
                             ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                             datetime.utcfromtimestamp(
-                                int(observable["startDate"] / 1000 + 3600)
+                                int(observable.get("startDate") / 1000 + 3600)
                             ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                         ),
                         confidence=int(self.helper.connect_confidence_level),
                         first_seen=datetime.utcfromtimestamp(
-                            int(observable["startDate"] / 1000)
+                            int(observable.get("startDate") / 1000)
                         ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                         last_seen=datetime.utcfromtimestamp(
-                            int(observable["startDate"] / 1000 + 3600)
+                            int(observable.get("startDate") / 1000 + 3600)
                         ).strftime("%Y-%m-%dT%H:%M:%SZ"),
-                        where_sighted_refs=[self.identity["standard_id"]],
+                        where_sighted_refs=[self.identity.get("standard_id")],
                         sighting_of_ref=fake_indicator_id,
                         custom_properties={
                             "x_opencti_sighting_of_ref": stix_observable.id
                         },
                     )
-                    case_objects.append(self.identity["standard_id"])
+                    case_objects.append(self.identity.get("standard_id"))
                     case_objects.append(stix_sighting.id)
                     bundle_objects.append(stix_sighting)
 
         # Create case
-        created = datetime.utcfromtimestamp(int(case["createdAt"] / 1000)).strftime(
+        created = datetime.utcfromtimestamp(int(case.get("createdAt") / 1000)).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
         )
         opencti_case_status = None
         if len(self.thehive_case_status_mapping) > 0:
             for case_status_mapping in self.thehive_case_status_mapping:
                 case_status_mapping_split = case_status_mapping.split(":")
-                if case["extendedStatus"] == case_status_mapping_split[0]:
+                if case.get("extendedStatus") == case_status_mapping_split[0]:
                     opencti_case_status = case_status_mapping_split[1]
         opencti_case_user = None
         if len(self.thehive_user_mapping) > 0:
             for user_mapping in self.thehive_user_mapping:
                 user_mapping_split = user_mapping.split(":")
-                if case["owner"] == user_mapping_split[0]:
+                if case.get("owner") == user_mapping_split[0]:
                     opencti_case_user = user_mapping_split[1]
         stix_case = CustomObjectCaseIncident(
-            id=CaseIncident.generate_id(case["title"], created),
-            name=case["title"],
-            description=case["description"],
+            id=CaseIncident.generate_id(case.get("title"), created),
+            name=case.get("title"),
+            description=case.get("description"),
             created=created,
             object_marking_refs=markings,
-            labels=case["tags"] if "tags" in case else [],
-            created_by_ref=self.identity["standard_id"],
-            severity=self.severity_mapping[case["severity"]]
-            if case["severity"] in self.severity_mapping
+            labels=case.get("tags") if case.get("tags") else None,
+            created_by_ref=self.identity.get("standard_id"),
+            severity=self.severity_mapping[case.get("severity")]
+            if case.get("severity") in self.severity_mapping
             else None,
             confidence=int(self.helper.connect_confidence_level),
             object_refs=case_objects,
@@ -573,30 +613,30 @@ class TheHive:
         bundle_objects.append(stix_case)
 
         # Get tasks
-        tasks = self.thehive_api.get_case_tasks(case_id=case["id"]).json()
+        tasks = self.thehive_api.get_case_tasks(case_id=case.get("id")).json()
         for task in tasks:
-            created = datetime.utcfromtimestamp(int(task["createdAt"] / 1000)).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            )
+            created = datetime.utcfromtimestamp(
+                int(task.get("createdAt") / 1000)
+            ).strftime("%Y-%m-%dT%H:%M:%SZ")
             opencti_task_status = None
             if len(self.thehive_task_status_mapping) > 0:
                 for task_status_mapping in self.thehive_task_status_mapping:
                     task_status_mapping_split = task_status_mapping.split(":")
-                    if task["status"] == task_status_mapping_split[0]:
+                    if task.get("status") == task_status_mapping_split[0]:
                         opencti_task_status = task_status_mapping_split[1]
             opencti_task_user = None
             if len(self.thehive_user_mapping) > 0:
                 for user_mapping in self.thehive_user_mapping:
                     user_mapping_split = user_mapping.split(":")
-                    if task["owner"] == user_mapping_split[0]:
+                    if task.get("owner") == user_mapping_split[0]:
                         opencti_task_user = user_mapping_split[1]
             stix_task = CustomObjectTask(
-                id=Task.generate_id(task["title"], created),
-                name=task["title"],
-                description=task["description"],
+                id=Task.generate_id(task.get("title"), created),
+                name=task.get("title"),
+                description=task.get("description"),
                 created=created,
                 due_date=datetime.utcfromtimestamp(
-                    int(task["dueDate"] / 1000)
+                    int(task.get("dueDate") / 1000)
                 ).strftime("%Y-%m-%dT%H:%M:%SZ")
                 if "dueDate" in task
                 else None,
@@ -613,22 +653,22 @@ class TheHive:
         return bundle
 
     def generate_alert_bundle(self, alert):
-        self.helper.log_info("Importing alert '" + alert["title"] + "'")
+        self.helper.log_info("Importing alert '" + alert.get("title") + "'")
         bundle_objects = []
         markings = []
-        if alert["tlp"] == 0:
+        if alert.get("tlp") == 0:
             markings.append(stix2.TLP_WHITE)
             bundle_objects.append(stix2.TLP_WHITE)
-        elif alert["tlp"] == 1:
+        elif alert.get("tlp") == 1:
             markings.append(stix2.TLP_GREEN)
             bundle_objects.append(stix2.TLP_GREEN)
-        elif alert["tlp"] == 2:
+        elif alert.get("tlp") == 2:
             markings.append(stix2.TLP_AMBER)
             bundle_objects.append(stix2.TLP_AMBER)
-        elif alert["tlp"] == 3:
+        elif alert.get("tlp") == 3:
             markings.append(stix2.TLP_RED)
             bundle_objects.append(stix2.TLP_RED)
-        elif alert["tlp"] == 4:
+        elif alert.get("tlp") == 4:
             marking = stix2.MarkingDefinition(
                 id=MarkingDefinition.generate_id("TLP", "TLP:AMBER+STRICT"),
                 definition_type="statement",
@@ -698,28 +738,26 @@ class TheHive:
             markings.append(marking)
             bundle_objects.append(marking)
 
-        created = datetime.utcfromtimestamp(int(alert["createdAt"] / 1000)).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
+        created = datetime.utcfromtimestamp(
+            int(alert.get("createdAt") / 1000)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
         stix_incident = stix2.Incident(
-            id=Incident.generate_id(alert["title"], created),
-            name=alert["title"],
+            id=Incident.generate_id(alert.get("title"), created),
+            name=alert.get("title"),
             description=alert["description"],
             object_marking_refs=markings,
-            labels=alert["tags"] if "tags" in alert else [],
-            created_by_ref=self.identity["standard_id"],
+            labels=alert.get("tags"),
+            created_by_ref=self.identity.get("standard_id"),
             confidence=int(self.helper.connect_confidence_level),
             allow_custom=True,
             custom_properties={
                 "source": alert["source"],
-                "severity": self.severity_mapping[alert["severity"]]
-                if alert["severity"] in self.severity_mapping
-                else None,
+                "severity": alert.get("severity"),
                 "incident_type": "alert",
             },
         )
         bundle_objects.append(stix_incident)
-        for observable in alert["artifacts"]:
+        for observable in alert.get("artifacts"):
             stix_observable = self.convert_observable(observable, markings)
             if stix_observable is not None:
                 stix_observable_relation = stix2.Relationship(
@@ -727,7 +765,7 @@ class TheHive:
                         "related-to", stix_observable.id, stix_incident.id
                     ),
                     relationship_type="related-to",
-                    created_by_ref=self.identity["standard_id"],
+                    created_by_ref=self.identity.get("standard_id"),
                     source_ref=stix_observable.id,
                     target_ref=stix_incident.id,
                     confidence=int(self.helper.connect_confidence_level),
@@ -795,7 +833,7 @@ class TheHive:
                 )
                 try:
                     for case in cases:
-                        if str(case["tlp"]) in self.thehive_import_only_tlp:
+                        if str(case.get("tlp")) in self.thehive_import_only_tlp:
                             stix_bundle = self.generate_case_bundle(case)
                             self.helper.send_stix2_bundle(
                                 stix_bundle,
@@ -805,11 +843,11 @@ class TheHive:
                             last_case_date = (
                                 (int(case["updatedAt"] / 1000) + 1)
                                 if "updatedAt" in case and case["updatedAt"] is not None
-                                else (int(case["createdAt"] / 1000) + 1)
+                                else (int(case.get("createdAt") / 1000) + 1)
                             )
                         else:
-                            self.helper.log_info(
-                                "Ignoring case '" + case["title"] + "' due TLP too high"
+                            self.helper.log_warn(
+                                f"Ignoring case ({case.get('title')}) due to TLP too high."
                             )
                 except Exception:
                     error_msg = traceback.format_exc()
@@ -824,7 +862,7 @@ class TheHive:
                     ).json()
                     try:
                         for alert in alerts:
-                            if str(alert["tlp"]) in self.thehive_import_only_tlp:
+                            if str(alert.get("tlp")) in self.thehive_import_only_tlp:
                                 stix_bundle = self.generate_alert_bundle(alert)
                                 self.helper.send_stix2_bundle(
                                     stix_bundle,
@@ -832,15 +870,15 @@ class TheHive:
                                     work_id=work_id,
                                 )
                                 last_alert_date = (
-                                    (int(alert["updatedAt"] / 1000) + 1)
+                                    (int(alert.get("updatedAt") / 1000) + 1)
                                     if "updatedAt" in alert
-                                    and alert["updatedAt"] is not None
-                                    else (int(alert["createdAt"] / 1000)) + 1
+                                    and alert.get("updatedAt") is not None
+                                    else (int(alert.get("createdAt") / 1000)) + 1
                                 )
                             else:
                                 self.helper.log_info(
                                     "Ignoring alert '"
-                                    + alert["title"]
+                                    + alert.get("title")
                                     + "' due TLP too high"
                                 )
                     except Exception:

--- a/external-import/thehive/src/thehive.py
+++ b/external-import/thehive/src/thehive.py
@@ -63,8 +63,8 @@ OBSERVABLES_MAPPING = {
     "email_subject": "Email-Message.subject",
     "email_address": "Email-Address.value",
     "other": "Text.value",
-    "organisation":  None,
-    "organization":  "Identity.name",
+    "organisation": None,
+    "organization": "Identity.name",
     "regexp": "Text.value",
     "registry": "Windows-Registry-Key.key",
     "risk_object_asset": None,
@@ -73,8 +73,8 @@ OBSERVABLES_MAPPING = {
     "uri_path": "Text.value",
     "url": "Url.value",
     "user-agent": "User-Agent.value",
-    "supplier":  None,
-    "vendor":  None,
+    "supplier": None,
+    "vendor": None,
 }
 
 
@@ -184,7 +184,7 @@ class TheHive:
             data_type = "identity"
         elif observable.get("dataType") in ["risk_object_asset", "asset"]:
             data_type = "system"
-        elif observable.get("dataType") in ["supplier", "vendor", "organisation"]: 
+        elif observable.get("dataType") in ["supplier", "vendor", "organisation"]:
             data_type = "organization"
         elif observable.get("dataType") == "ip" and is_ipv4(observable.get("data")):
             data_type = "ipv4"
@@ -331,7 +331,7 @@ class TheHive:
                     type="identity",
                     name=observable.get("data").lower(),
                     object_marking_refs=markings,
-                    identity_class='individual',
+                    identity_class="individual",
                     custom_properties={
                         "description": observable.get("message")
                         if observable.get("message")
@@ -403,7 +403,7 @@ class TheHive:
                     type="identity",
                     name=observable.get("data").title(),
                     object_marking_refs=markings,
-                    identity_class='organization',
+                    identity_class="organization",
                     custom_properties={
                         "description": observable.get("message")
                         if observable.get("message")
@@ -459,7 +459,7 @@ class TheHive:
                     type="identity",
                     name=observable.get("data").lower(),
                     object_marking_refs=markings,
-                    identity_class='system',
+                    identity_class="system",
                     custom_properties={
                         "description": observable.get("message")
                         if observable.get("message")

--- a/external-import/thehive/src/utils.py
+++ b/external-import/thehive/src/utils.py
@@ -13,6 +13,7 @@ def is_ipv6(ip_str):
         except (ipaddress.AddressValueError, ipaddress.NetmaskValueError):
             return False
 
+
 def is_ipv4(ip_str):
     """Determine whether the provided string is an IPv4 address or valid IPv4 CIDR."""
     try:

--- a/external-import/thehive/src/utils.py
+++ b/external-import/thehive/src/utils.py
@@ -2,18 +2,25 @@ import ipaddress
 
 
 def is_ipv6(ip_str):
-    """Determine whether the provided IP string is IPv6."""
+    """Determine whether the provided string is an IPv6 address or valid IPv6 CIDR."""
     try:
-        ipaddress.IPv6Address(ip_str)
+        ipaddress.IPv6Address(ip_str)  # Check for individual IP
         return True
     except ipaddress.AddressValueError:
-        return False
-
+        try:
+            ipaddress.IPv6Network(ip_str, strict=False)  # Check for CIDR notation
+            return True
+        except (ipaddress.AddressValueError, ipaddress.NetmaskValueError):
+            return False
 
 def is_ipv4(ip_str):
-    """Determine whether the provided IP string is IPv6."""
+    """Determine whether the provided string is an IPv4 address or valid IPv4 CIDR."""
     try:
-        ipaddress.IPv4Address(ip_str)
+        ipaddress.IPv4Address(ip_str)  # Check for individual IP
         return True
     except ipaddress.AddressValueError:
-        return False
+        try:
+            ipaddress.IPv4Network(ip_str, strict=False)  # Check for CIDR notation
+            return True
+        except (ipaddress.AddressValueError, ipaddress.NetmaskValueError):
+            return False

--- a/external-import/thehive/src/utils.py
+++ b/external-import/thehive/src/utils.py
@@ -1,0 +1,19 @@
+import ipaddress
+
+
+def is_ipv6(ip_str):
+    """Determine whether the provided IP string is IPv6."""
+    try:
+        ipaddress.IPv6Address(ip_str)
+        return True
+    except ipaddress.AddressValueError:
+        return False
+
+
+def is_ipv4(ip_str):
+    """Determine whether the provided IP string is IPv6."""
+    try:
+        ipaddress.IPv4Address(ip_str)
+        return True
+    except ipaddress.AddressValueError:
+        return False


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add support for indicator types ipv6, email_address, and email_subject.
* Add support for cve, vendor, supplier, organization, asset, and identity.
* Add support for ipv4 and ipv6 cidrs.
* Add README.
* Fix `KeyError` when the owner is not defined when importing a Task. 
  ```
  {
  "timestamp": "2023-10-14T06:16:00.622646Z",
  "level": "ERROR",
  "name": "pycti.connector",
  "message": "Traceback (most recent call last):\n File \"/opt/opencti-connector-thehive/thehive.py\", line 799, in run\n stix_bundle = self.generate_case_bundle(case)\n ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n File \"/opt/opencti-connector-thehive/thehive.py\", line 591, in generate_case_bundle\n if task[\"owner\"] == user_mapping_split[0]:\n ~~~~^^^^^^^^^\nKeyError: 'owner'\n"
  }
  ```

### README
# TheHive Connector for OpenCTI

The **TheHive Connector** allows for integration of TheHive's alert and case management capabilities into OpenCTI. This connector imports TheHive's cases, alerts, tasks, and observables into OpenCTI. The connector uses the Python modules `thehive4py` and will work on version 4 and 5.  

## Configuration:

Setting up TheHive Connector is straightforward. The following table provides details on the necessary parameters:

| Parameter                       | Docker envvar                 | Mandatory | Description                                                     |
|---------------------------------|-------------------------------|-----------|-----------------------------------------------------------------|
| `opencti.url`                   | `OPENCTI_URL`                 | Yes       | The URL of the OpenCTI platform.                                |
| `opencti.token`                 | `OPENCTI_TOKEN`               | Yes       | The token for accessing OpenCTI.                                |
| `connector.id`                  | `CONNECTOR_ID`                | Yes       | A unique `UUIDv4` identifier for this connector instance.       |
| `connector.type`                | `CONNECTOR_TYPE`              | Yes       | Should always be set to `EXTERNAL_IMPORT` for this connector.   |
| `connector.name`                | `CONNECTOR_NAME`              | Yes       | Name of the connector. Should always be "TheHive".              |
| `connector.scope`               | `CONNECTOR_SCOPE`             | Yes       | The scope of data the connector is importing.                   |
| `connector.confidence_level`    | `CONNECTOR_CONFIDENCE_LEVEL`  | Yes       | Confidence level for the data imported.                         |
| `connector.update_existing_data`| `CONNECTOR_UPDATE_EXISTING_DATA`| Yes     | Decide whether the connector should update already existing data.|
| `connector.log_level`           | `CONNECTOR_LOG_LEVEL`         | Yes       | Logging level. Choices: `info`, `error`, etc.                   |
| `thehive.url`                   | `THEHIVE_URL`                 | Yes       | URL of your TheHive instance.                                   |
| `thehive.api_key`               | `THEHIVE_API_KEY`             | Yes       | Your API Key for accessing TheHive.                             |
| `thehive.check_ssl`             | `THEHIVE_CHECK_SSL`           | Yes       | Whether to validate the SSL certificate of TheHive instance.   |
| `thehive.organization_name`     | `THEHIVE_ORGANIZATION_NAME`   | Yes       | Name of your organization in TheHive.                           |
| `thehive.import_from_date`      | `THEHIVE_IMPORT_FROM_DATE`    | No        | Date from which to start importing data.                        |
| `thehive.import_only_tlp`       | `THEHIVE_IMPORT_ONLY_TLP`     | No        | Levels of the Traffic Light Protocol (TLP) to be imported.      |
| `thehive.import_alerts`         | `THEHIVE_IMPORT_ALERTS`       | No        | Whether to import alerts from TheHive.                          |
| `thehive.severity_mapping`      | `THEHIVE_SEVERITY_MAPPING`    | No        | Mapping of severity levels between TheHive and OpenCTI. e.g., `1:low,2:medium,3:high,4:critical`         |
| `thehive.case_status_mapping`   | `THEHIVE_CASE_STATUS_MAPPING` | No        | Status mapping for cases. e.g., `hive_status_1:opencti_status_id_2,hive_status_2:opencti_status_id_2`                                       |
| `thehive.task_status_mapping`   | `THEHIVE_TASK_STATUS_MAPPING` | No        | Status mapping for tasks. e.g., `hive_status_1:opencti_status_id_2,hive_status_2:opencti_status_id_2`                                             |
| `thehive.alert_status_mapping`  | `THEHIVE_ALERT_STATUS_MAPPING`| No        | Status mapping for alerts. e.g., `hive_status_1:opencti_status_id_2,hive_status_2:opencti_status_id_2`                                            |
| `thehive.user_mapping`          | `THEHIVE_USER_MAPPING`        | No        | Mapping of TheHive assignees to OpenCTI users. e.g., `user@contoso.com:opencti_user_id,user2@contoso.com:opencti_user_id_2`                 |
| `thehive.interval`              | `THEHIVE_INTERVAL`            | Yes       | Frequency of running the connector in minutes.                  |

## Supported Indicator Field Names
The following is a list of indicator Field Names supported by this integration and the prescribed value types. Indicators of this field name will be imported into OpenCTI as the STIX object defined. Please ensure that the field names are receiving standardized values to avoid potential import errors (e.g., and IP is an IP).

| TheHive Indicator Name        | STIX Object      |
|------------------------|--------------------------------|
| asset                  | Identity (system)                           |
| autonomous-system      | Autonomous System (AS)        |
| cve                    | Vulnerability             |
| domain                 | Domain Name              |
| file                   | File: Checks the length and determines the hash type (supported: MD5, SHA-1, SHA-256)                            |
| file_md5               | File                |
| file_sha1              | File              |
| file_sha256            | File            |
| filename               | File                      |
| fqdn                   | Domain Name                 |
| hostname               | Identity (system)                 |
| hash                   | File: Checks the length and determines the hash type (supported: MD5, SHA-1, SHA-256)                           |
| identity               | Identity                  |
| ip                     | IPv4 Address or IPv6 Address, supports ipv4, ipv6, and cidr notation of both.                            |
| ipv4                   | IPv4 Address                |
| ipv6                   | IPv6 Address                |
| mail                   | Email Message (body)             |
| mail-subject           | Email Message (subject)            |
| mail_subject           | Email Message (subject)          |
| email_subject          | Email Message (subject)          |
| email_address          | Email Message (email-addr)            |
| other                  | Custom Observable                     |
| organisation           | Identity (organization)                           |
| organization           | Identity (organization)                  |
| regexp                 | Custom Observable Text                     |
| registry               | Windows Registry Key       |
| risk_object_asset      | Identity (system)                           |
| risk_object_identity   | Identity (identity)                           |
| system                 | Identity (system)                  |
| uri_path               | Url                     |
| url                    | Url                      |
| user-agent             | Custom Observable User Agent               |
| user_agent             | Custom Observable User Agent               |
| supplier               | Identity (organization)                           |
| vendor                 | Identity (organization)                           |


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
