### PR TITLE
Python module "Validator" is missing

### DIFF
--- a/external-import/threatfox/src/requirements.txt
+++ b/external-import/threatfox/src/requirements.txt
@@ -1,2 +1,3 @@
 pycti==5.11.1
 urllib3==2.0.6
+validator==0.7.1


### PR DESCRIPTION
Validator module is missing in the 5.11.1 version, causing error on ThreatFox connector.

![image](https://github.com/OpenCTI-Platform/connectors/assets/120742137/0e6427ee-c05c-4381-9418-82c2efa52b54)

### Proposed changes

Add the following line in requirement.txt (latest version)
```
validator==0.7.1
```
