### PR TITLE
Update requirements.txt - Mistake with "validators" module

### DIFF
--- a/external-import/threatfox/src/requirements.txt
+++ b/external-import/threatfox/src/requirements.txt
@@ -1,3 +1,3 @@
 pycti==5.11.2
 urllib3==2.0.6
-validator==0.7.1
+validators==0.22.0


### PR DESCRIPTION
In my previous commit https://github.com/OpenCTI-Platform/connectors/pull/1489 I made a mistake using "validator" python module (wich exist too)  instead of "valadators" module. Here is a quick fix to solve this issue.

