### PR TITLE
[hygiene] Reduce data fetched in pycti read by using customAttributes

### DIFF
--- a/internal-enrichment/hygiene/src/hygiene.py
+++ b/internal-enrichment/hygiene/src/hygiene.py
@@ -254,8 +254,15 @@ class HygieneConnector:
             return "Observable value found on warninglist and tagged accordingly"
 
     def _process_message(self, data) -> str:
+        custom_attributes = """
+            id
+            entity_type
+            parent_types
+            observable_value
+            standard_id
+        """
         opencti_entity = self.helper.api.stix_cyber_observable.read(
-            id=data["entity_id"]
+            id=data["entity_id"], customAttributes=custom_attributes
         )
         if opencti_entity is None:
             raise ValueError(


### PR DESCRIPTION
### Proposed changes

Add limited set of `cuistomAttributes` to the SCO read in `src/hygiene.py` to minimize data that is retrieved from the backend. This should speed up execution time, as well as reduce unnecessary lookups against S3/MinIO.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality