### PR TITLE
[hygiene] fix hash value report in error message as well

### DIFF
--- a/internal-enrichment/hygiene/src/hygiene.py
+++ b/internal-enrichment/hygiene/src/hygiene.py
@@ -157,7 +157,8 @@ class HygieneConnector:
         # Iterate over the hits
         if result:
             self.helper.log_info(
-                "Hit found for %s in warninglists" % (stix_entity["value"])
+                "Hit found for %s in warninglists"
+                % (opencti_entity["observable_value"])
             )
 
             for hit in result:


### PR DESCRIPTION
### Proposed changes

Line `160` still refers to `stix_entity["value"]`. Change to `opencti_entity["observable_value"]` like in https://github.com/OpenCTI-Platform/connectors/commit/05356194b9570965fa23b3718732abfb96844bb1. This causes an exception to be thrown when the connector tries to write the logging message.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality