### PR TITLE
[malwarebazaar-recent-additions] Mark uploaded artifacts as TLP:CLEAR

### DIFF
--- a/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
+++ b/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
@@ -6,6 +6,7 @@ import time
 import magic
 import pyzipper
 import requests
+import stix2
 import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
 
@@ -246,6 +247,7 @@ class MalwareBazaarRecentAdditions:
             "data": file_contents,
             "mime_type": mime_type,
             "x_opencti_description": description,
+            "objectMarking": stix2.TLP_WHITE["id"],
         }
 
         return self.helper.api.stix_cyber_observable.upload_artifact(**kwargs)

--- a/external-import/malwarebazaar-recent-additions/src/requirements.txt
+++ b/external-import/malwarebazaar-recent-additions/src/requirements.txt
@@ -1,2 +1,3 @@
 pycti==5.11.12
 pyzipper==0.3.6
+stix2==3.0.1


### PR DESCRIPTION
### Proposed changes

* Add `stix2` as dependency to `malwarebazaar-recent-additions`
* Mark all artifacts downloaded from MB as `TLP:CLEAR` (within the `stix2` module, this is still referred to as `TLP_WHITE`)

### Related issues

* Details at: #1516 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

MalwareBazaar ToS states that all submitters are to consider their uploads `TLP:CLEAR`: https://bazaar.abuse.ch/faq/#tos