### PR TITLE
[vt-hunt] Refine the imported entities and change the endpoint used

### DIFF
--- a/external-import/virustotal-livehunt-notifications/src/config.yml.sample
+++ b/external-import/virustotal-livehunt-notifications/src/config.yml.sample
@@ -26,3 +26,9 @@ virustotal_livehunt_notifications:
   create_yara_rule: True # If True, create a yara indicator and link it to the alert and the file
   delete_notification: False # If True, remove the notification on VT
   filter_with_tag: "" # (Optional) Tag to filter the notifications, empty = no filtering
+  alert_prefix: 'VT' # Prefix that is added in alert title
+  av_list: 'Avast,BitDefender,ClamAV,CrowdStrike,Cybereason,ESET-NOD32,FireEye,Fortinet,Kaspersky,Paloalto,Symantec,TrendMicro' # List of AVs to add in description
+  yara_label_prefix: 'vt:yara:' # Prefix that is added in yara label
+  livehunt_label_prefix: 'vt:lh:' # Prefix that is added in livehunt label
+  livehunt_tag_prefix: '' # Prefix used to state that the tag is imported from Livehunt
+  enable_label_enrichment: True # Add livehunt name and matched yara rules label to the alert

--- a/external-import/virustotal-livehunt-notifications/src/livehunt/builder.py
+++ b/external-import/virustotal-livehunt-notifications/src/livehunt/builder.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """Livehunt builder module."""
-import re
 import datetime
 import io
 import json
 import logging
+import re
 from typing import List, Optional
 
 import magic

--- a/external-import/virustotal-livehunt-notifications/src/livehunt/builder.py
+++ b/external-import/virustotal-livehunt-notifications/src/livehunt/builder.py
@@ -44,7 +44,7 @@ class LivehuntBuilder:
         yara_label_prefix: str,
         livehunt_label_prefix: str,
         livehunt_tag_prefix: str,
-        enable_label_enrichment: bool
+        enable_label_enrichment: bool,
     ) -> None:
         """Initialize Virustotal builder."""
         self.client = client
@@ -514,11 +514,7 @@ class LivehuntBuilder:
 
     def retrieve_labels(self, vtobj) -> List[str]:
         ctx_attributes = vtobj._context_attributes
-        labels = [
-            t
-            for t in ctx_attributes["tags"]
-            if t not in {vtobj.id, self.tag}
-        ]
+        labels = [t for t in ctx_attributes["tags"] if t not in {vtobj.id, self.tag}]
 
         if not self.enable_label_enrichment:
             return labels

--- a/external-import/virustotal-livehunt-notifications/src/livehunt/livehunt.py
+++ b/external-import/virustotal-livehunt-notifications/src/livehunt/livehunt.py
@@ -135,6 +135,50 @@ class VirustotalLivehuntNotifications:
             config,
         )
 
+        alert_prefix = get_config_variable(
+            "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_ALERT_PREFIX",
+            ["virustotal_livehunt_notifications", "alert_prefix"],
+            config,
+            default="VT "
+        )
+
+        av_list = get_config_variable(
+            "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_AV_LIST",
+            ["virustotal_livehunt_notifications", "av_list"],
+            config,
+            default=[],
+        )
+        if isinstance(av_list, str):
+            av_list = av_list.split(",")
+
+        yara_label_prefix = get_config_variable(
+            "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_YARA_LABEL_PREFIX",
+            ["virustotal_livehunt_notifications", "yara_label_prefix"],
+            config,
+            default="vt:yara:"
+        )
+
+        livehunt_label_prefix = get_config_variable(
+            "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_LIVEHUNT_LABEL_PREFIX",
+            ["virustotal_livehunt_notifications", "livehunt_label_prefix"],
+            config,
+            default="vt:lh:"
+        )
+
+        livehunt_tag_prefix = get_config_variable(
+            "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_LIVEHUNT_TAG_PREFIX",
+            ["virustotal_livehunt_notifications", "livehunt_tag_prefix"],
+            config,
+            default="",
+        )
+
+        enable_label_enrichment = get_config_variable(
+            "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_ENABLE_LABEL_ENRICHMENT",
+            ["virustotal_livehunt_notifications", "enable_label_enrichment"],
+            config,
+            default=True,
+        )
+
         self.builder = LivehuntBuilder(
             client,
             self.helper,
@@ -151,6 +195,12 @@ class VirustotalLivehuntNotifications:
             min_file_size,
             max_file_size,
             min_positives,
+            alert_prefix,
+            av_list,
+            yara_label_prefix,
+            livehunt_label_prefix,
+            livehunt_tag_prefix,
+            enable_label_enrichment,
         )
 
     @staticmethod
@@ -226,6 +276,7 @@ class VirustotalLivehuntNotifications:
                         )
                     ),
                 )
+
                 if self._is_scheduled(last_run, timestamp):
                     self.helper.log_info(
                         f"[Virustotal Livehunt Notifications] starting run at: {current_state}"

--- a/external-import/virustotal-livehunt-notifications/src/livehunt/livehunt.py
+++ b/external-import/virustotal-livehunt-notifications/src/livehunt/livehunt.py
@@ -139,7 +139,7 @@ class VirustotalLivehuntNotifications:
             "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_ALERT_PREFIX",
             ["virustotal_livehunt_notifications", "alert_prefix"],
             config,
-            default="VT "
+            default="VT ",
         )
 
         av_list = get_config_variable(
@@ -155,14 +155,14 @@ class VirustotalLivehuntNotifications:
             "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_YARA_LABEL_PREFIX",
             ["virustotal_livehunt_notifications", "yara_label_prefix"],
             config,
-            default="vt:yara:"
+            default="vt:yara:",
         )
 
         livehunt_label_prefix = get_config_variable(
             "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_LIVEHUNT_LABEL_PREFIX",
             ["virustotal_livehunt_notifications", "livehunt_label_prefix"],
             config,
-            default="vt:lh:"
+            default="vt:lh:",
         )
 
         livehunt_tag_prefix = get_config_variable(


### PR DESCRIPTION
### Proposed changes

The changes are related to the Virustotal Livehunt connector. More precisely:

* the endpoint used is migrated to a non-deprecated endpoint,
* when alert are generated, the name of the livehunt session as well as the yara's name can be stored as label on the alert,
* the generated sample's description can contain the result per anti-virus used.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

By default, not many things are changed. For the changes to be visible, the connector's configuration has to be updated.