### PR TITLE
[threatfox] handle both /full/ and /recent/ urls

### DIFF
--- a/external-import/threatfox/src/main.py
+++ b/external-import/threatfox/src/main.py
@@ -124,10 +124,16 @@ class ThreatFox:
                             self.threatfox_csv_url,
                             context=ssl.create_default_context(),
                         )
-                        zipped_file = io.BytesIO(response.read())
-                        with zipfile.ZipFile(zipped_file, "r") as zip_ref:
-                            with zip_ref.open("full.csv") as full_file:
-                                csv_data = full_file.read()
+                        data = response.read()
+                        try:
+                            zipped_file = io.BytesIO(data)
+                            with zipfile.ZipFile(zipped_file, "r") as zip_ref:
+                                with zip_ref.open("full.csv") as full_file:
+                                    csv_data = full_file.read()
+                        except zipfile.BadZipFile:
+                            # Treat as an unzipped CSV from /recent/
+                            csv_data = data
+
                         with open(
                             os.path.dirname(os.path.abspath(__file__)) + "/data.csv",
                             "wb",

--- a/external-import/threatfox/src/main.py
+++ b/external-import/threatfox/src/main.py
@@ -410,6 +410,7 @@ class ThreatFox:
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
+                self.helper.force_ping()
                 sys.exit(0)
 
             time.sleep(60)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* handle both the /full (zipped) and /recent (unzipped) url flavors
* add force_ping after run_and_terminate, just like #1611 

### Related issues

* #1594 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

Instead of try/except we could do `data.startswith(b"PK")` or just let the zipfile fail and try failover to csv instead as is committed.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
