### PR TITLE
Feature: Allow Customization of Cape-Sandbox API URL via Environment Variables

### DIFF
--- a/internal-enrichment/cape-sandbox/docker-compose.yml
+++ b/internal-enrichment/cape-sandbox/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - CONNECTOR_AUTO=false # Enable/disable auto-enrichment of observables
       - CONNECTOR_CONFIDENCE_LEVEL=50 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_LOG_LEVEL=error
-      - CAPE_SANDBOX_URL=ChangeMe # Base URL
+      - CAPE_SANDBOX_API_URL=ChangeMe # https://Base_URL/apiv2
       - CAPE_SANDBOX_TOKEN=ChangeMe # Change if using auth
       - CAPE_SANDBOX_ROUTE=tor # Network routing, other examples include: none, internet, vpn0
       - CAPE_SANDBOX_TIMEOUT=300 # Maximum amount of seconds to run the analysis for

--- a/internal-enrichment/cape-sandbox/src/cape-sandbox.py
+++ b/internal-enrichment/cape-sandbox/src/cape-sandbox.py
@@ -46,7 +46,7 @@ class CapeSandboxConnector:
         self.cape_url = get_config_variable(
             "CAPE_SANDBOX_URL", ["cape_sandbox", "url"], config
         )
-        self.cape_api_url = f"{self.cape_url}/apiv2"
+        self.cape_api_url = f"{self.cape_url}"
         self.token = get_config_variable(
             "CAPE_SANDBOX_TOKEN", ["cape_sandbox", "token"], config
         )

--- a/internal-enrichment/cape-sandbox/src/config.yml.sample
+++ b/internal-enrichment/cape-sandbox/src/config.yml.sample
@@ -35,7 +35,7 @@ connector:
   log_level: 'info'
 
 cape_sandbox:
-  url: 'ChangeMe' # Base URL
+  api_url: 'ChangeMe' # https://Base_URL/apiv2
   token: 'ChangeMe' # Change if using auth
   route: 'tor' # Network routing, other examples include: none, internet, vpn0
   timeout: 300 # Maximum amount of seconds to run the analysis for


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community-driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added a feature to allow users to customize the Cape-Sandbox (Internal Enrichment) connector API URL through environment variables in the Docker container.
* Introduced the environment variable `CAPE_SANDBOX_API_URL` for users to set their desired API URL.

### Related issues

* [Link to any related issues or discussions, if applicable]

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

This change is designed to enhance the usability and flexibility of the Cape-Sandbox connector by allowing users to easily adapt the API URL to their specific requirements without modifying the code directly. I tested the feature thoroughly and updated the documentation accordingly. Looking forward to your feedback!

