### PR TITLE
[taxii2] Wrong Observable Type used for File

### DIFF
--- a/external-import/taxii2/src/taxii2.py
+++ b/external-import/taxii2/src/taxii2.py
@@ -283,7 +283,7 @@ class Taxii2Connector:
                         elif match[1] == "ipv6-addr":
                             object["x_opencti_main_observable_type"] = "IPv6-Addr"
                         elif match[1] == "file":
-                            object["x_opencti_main_observable_type"] = "File"
+                            object["x_opencti_main_observable_type"] = "StixFile"
                         elif match[1] == "domain-name":
                             object["x_opencti_main_observable_type"] = "Domain-Name"
                         elif match[1] == "url":


### PR DESCRIPTION
### Proposed changes

Changed the variable for x_opencti_main_observable_type when a file is used from File to StixFile.

### Related issues

Question asked in Slack.

### Checklist


- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

