### PR TITLE
[cve] Refactor Pagination (#1661)

### DIFF
--- a/external-import/cve/src/services/client/vulnerability.py
+++ b/external-import/cve/src/services/client/vulnerability.py
@@ -1,5 +1,3 @@
-import math
-
 from .api import CVEClient
 
 
@@ -19,19 +17,20 @@ class CVEVulnerability(CVEClient):
             )
 
         page_size = cve_collection["resultsPerPage"]
-        cve_vulnerabilities_total = []
+        cve_vulnerabilities_total = cve_collection["vulnerabilities"]
         total_items = cve_collection["totalResults"]
 
         if page_size == 0:
             msg = "[API] No Vulnerabilities to retrieve..."
             self.helper.log_info(msg)
-        else:
-            start_index = 0
-            current_page = 1
-            total_page = math.ceil(total_items / page_size)
-
-            msg = "[API] Start pagination..."
+        elif page_size >= total_items:
+            msg = f"[API] Received all {page_size} items. Pagination not required."
             self.helper.log_info(msg)
+        else:
+            msg = f"[API] Received first {page_size} items of {total_items} total items, start pagination..."
+            self.helper.log_info(msg)
+
+            start_index = page_size
 
             while start_index < total_items:
                 cve_params.update(
@@ -46,34 +45,32 @@ class CVEVulnerability(CVEClient):
                         "Wait for connector to re-run..."
                     )
 
-                page_msg = f"[API] Retrieve CVE based on CVSS 3.1 from page {current_page} out of {total_page}"
-                self.helper.log_info(page_msg)
-
-                cve_vulnerabilities = cve_collection["vulnerabilities"]
-                cve_vulnerabilities_filtered = []
-
                 page_size = cve_collection["resultsPerPage"]
-                start_index = start_index + page_size + 1
-                current_page += 1
+                start_index += page_size
 
-                for cve_vulnerability in cve_vulnerabilities:
-                    metric_exist = cve_vulnerability["cve"]["metrics"]
-                    if metric_exist:
-                        for key, value in metric_exist.items():
-                            if key == "cvssMetricV31":
-                                cve_vulnerabilities_filtered.append(cve_vulnerability)
+                msg = f"[API] Received next {page_size} items, currently received {start_index} items of {total_items} total items."
+                self.helper.log_info(msg)
 
-                info_msg = (
-                    f"[API] Getting {len(cve_vulnerabilities_filtered)} vulnerabilities"
-                )
+                cve_vulnerabilities_total += cve_collection["vulnerabilities"]
 
-                self.helper.log_info(info_msg)
-                cve_vulnerabilities_total += cve_vulnerabilities_filtered
+        info_msg = (
+            f"[API] All CVEs are retrieved. "
+            f"Getting {len(cve_vulnerabilities_total)} vulnerabilities in total"
+        )
+        self.helper.log_info(info_msg)
 
-            info_msg = (
-                f"[API] All CVEs are retrieved. "
-                f"Getting {len(cve_vulnerabilities_total)} vulnerabilities in total"
-            )
-            self.helper.log_info(info_msg)
+        cve_vulnerabilities_filtered = []
+        for cve_vulnerability in cve_vulnerabilities_total:
+            metric_exist = cve_vulnerability["cve"]["metrics"]
+            if metric_exist:
+                for key, value in metric_exist.items():
+                    if key == "cvssMetricV31":
+                        cve_vulnerabilities_filtered.append(cve_vulnerability)
 
-        return cve_vulnerabilities_total
+        info_msg = (
+            f"[API] Filter for only CVSS 3.1 CVEs. "
+            f"Getting {len(cve_vulnerabilities_filtered)} vulnerabilities in total"
+        )
+        self.helper.log_info(info_msg)
+
+        return cve_vulnerabilities_filtered


### PR DESCRIPTION
### Proposed changes
The changes proposed here help to address the pagination issues described in #1661. The connector will now detect if the first request yields a total results larger than the page size and will initiate pagination.

The filtering of CVEs for only the CVSS 3.1 CVEs is moved to just prior the function returning and will return this filtered list.

There isn't really a need to calculate or track "pages", so this code will only make use of the start_index and how many items are remaining.

### Related issues
* #1661

### Checklist
- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality using different use cases
- [X] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

### Further comments
The code here will also require the code changes made in https://github.com/OpenCTI-Platform/connectors/pull/1666 which address the API Rate limiting issues


### Screenshot
Here is a screenshot of the connector running with the debug output for additional reference
![OpenCTI CVE connector](https://github.com/OpenCTI-Platform/connectors/assets/2822632/fd0db6a9-ca3d-479f-abd4-a8851c022d2d)
