### PR TITLE
[RST Cloud] Jan 2024 Updates

### DIFF
--- a/external-import/rst-report-hub/src/config.yml.sample
+++ b/external-import/rst-report-hub/src/config.yml.sample
@@ -12,7 +12,7 @@ connector:
   run_and_terminate: true
   log_level: 'info'
 
-reporthub:
+rst-report-hub:
   base_url: 'https://api.rstcloud.net/v1'
   api_key: 'ChangeMe'
   connection_timeout: 10

--- a/external-import/rst-threat-feed/src/config.yml.sample
+++ b/external-import/rst-threat-feed/src/config.yml.sample
@@ -11,7 +11,7 @@ connector:
   update_existing_data: true
   log_level: "info"
 
-rstcloud:
+rst-threat-feed:
   baseurl: "https://api.rstcloud.net/v1/"
   apikey: "ChangeMe"
   contimeout: 10
@@ -24,6 +24,7 @@ rstcloud:
   min_score_detection_domain: 45
   min_score_detection_url: 30
   min_score_detection_hash: 25
-  only_new: True
+  only_new: true
+  only_attributed: true
   dirs_tmp: "./"
   dirs_state: "./"

--- a/external-import/rst-threat-feed/src/main.py
+++ b/external-import/rst-threat-feed/src/main.py
@@ -54,6 +54,11 @@ class RSTThreatFeed:
             config,
             isNumber=True,
         )
+        self.update_existing_data = get_config_variable(
+            "CONNECTOR_UPDATE_EXISTING_DATA",
+            ["connector", "update_existing_data"],
+            config,
+        )
         self._min_score_import = int(self.get_config("min_score_import", config, 20))
         self._min_score_detection = {
             "IPv4-Addr": self.get_config(
@@ -78,6 +83,7 @@ class RSTThreatFeed:
             ),
         }
         self._only_new = bool(self.get_config("only_new", config, True))
+        self._only_attributed = bool(self.get_config("only_attributed", config, True))
 
     @staticmethod
     def get_config(name: str, config, default=None):
@@ -161,6 +167,7 @@ class RSTThreatFeed:
             feed_type,
             self._min_score_import,
             self._only_new,
+            self._only_attributed
         )
 
         self.helper.log_info(
@@ -210,7 +217,7 @@ class RSTThreatFeed:
                 modified=ioc["collect"],
                 created_by_ref=organization.id,
                 object_marking_refs=[stix2.TLP_WHITE],
-                confidence=self._confidence_level,
+                confidence=int(ioc["score"]),
                 external_references=external_references,
                 custom_properties={
                     "x_opencti_score": ioc["score"],
@@ -324,6 +331,16 @@ class RSTThreatFeed:
                     confidence=self._confidence_level,
                     external_references=external_references,
                 )
+            elif threat["type"] == ThreatTypes.VULNERABILITY:
+                malicious_object = stix2.v21.Vulnerability(
+                    id=threat_key,
+                    name=threat["name"],
+                    created_by_ref=organization.id,
+                    confidence=self._confidence_level,
+                    external_references=[stix2.v21.ExternalReference(
+                        source_name=threat["name"], url="https://www.cve.org/CVERecord?id="+threat["name"])
+                                         ],
+                )
             if malicious_object:
                 stix_bundle.append(malicious_object)
 
@@ -392,7 +409,7 @@ class RSTThreatFeed:
         bundle = stix2.v21.Bundle(objects=stix_bundle, allow_custom=True)
         self.helper.send_stix2_bundle(
             bundle=bundle.serialize(),
-            update=True,
+            update=self.update_existing_data,
             work_id=work_id,
         )
         # Finish the work

--- a/external-import/rst-threat-feed/src/main.py
+++ b/external-import/rst-threat-feed/src/main.py
@@ -13,6 +13,7 @@ from pycti import (
     StixCoreRelationship,
     get_config_variable,
 )
+
 from rstcloud import (
     FeedDownloader,
     FeedType,
@@ -167,7 +168,7 @@ class RSTThreatFeed:
             feed_type,
             self._min_score_import,
             self._only_new,
-            self._only_attributed
+            self._only_attributed,
         )
 
         self.helper.log_info(
@@ -337,9 +338,12 @@ class RSTThreatFeed:
                     name=threat["name"],
                     created_by_ref=organization.id,
                     confidence=self._confidence_level,
-                    external_references=[stix2.v21.ExternalReference(
-                        source_name=threat["name"], url="https://www.cve.org/CVERecord?id="+threat["name"])
-                                         ],
+                    external_references=[
+                        stix2.v21.ExternalReference(
+                            source_name=threat["name"],
+                            url="https://www.cve.org/CVERecord?id=" + threat["name"],
+                        )
+                    ],
                 )
             if malicious_object:
                 stix_bundle.append(malicious_object)

--- a/external-import/rst-threat-feed/src/rstcloud/__init__.py
+++ b/external-import/rst-threat-feed/src/rstcloud/__init__.py
@@ -122,7 +122,12 @@ def custom_mapping_industry_sector(input_name):
 
 
 def feed_converter(
-    tmp_dir: str, state: dict, feed_type: str, min_score=0, only_new=True, attributed_only=True
+    tmp_dir: str,
+    state: dict,
+    feed_type: str,
+    min_score=0,
+    only_new=True,
+    attributed_only=True,
 ):
     ret_iocs: Dict = dict()
     ret_threats: Dict = dict()
@@ -136,7 +141,7 @@ def feed_converter(
 
                 if only_new and (ioc_raw["lseen"] != ioc_raw["collect"]):
                     continue
-                
+
                 # Skip IOCs w/o attribution
                 threats: List = ioc_raw.get("threat", [])
                 if attributed_only:
@@ -161,7 +166,6 @@ def feed_converter(
                 ioc["collect"] = datetime.datetime.fromtimestamp(
                     ioc_raw["collect"], tz=datetime.timezone.utc
                 )
-
 
                 indicator_pattern = None
                 indicator_name = None


### PR DESCRIPTION
### Proposed changes

* an ability to import only attributed vs all indicators
* only_new behaviour changed to get all recently updated indicators
* vuln objects are added to the stix bundle to ensure that indicator->vuln references are imported correctly

### Related issues

* config sample files using the old connector names
* url value format for indicators corrected

### Checklist
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


### Further comments
