### PR TITLE
Modification of debian distro and utility version used in connector import-external-reference

### DIFF
--- a/internal-enrichment/import-external-reference/Dockerfile
+++ b/internal-enrichment/import-external-reference/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-bookworm
+FROM python:3.11-bullseye
 
 # Copy the connector
 COPY src /opt/opencti-connector-import-external-reference
@@ -6,7 +6,10 @@ COPY src /opt/opencti-connector-import-external-reference
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apt-get update && \
-    apt-get install -y git build-essential libmagic-dev libffi-dev libxml2-dev libxslt-dev libssl-dev cargo libjpeg-dev zlib1g-dev wkhtmltopdf && \
+    apt-get install -y git build-essential libmagic-dev libffi-dev libxml2-dev libxslt-dev libssl-dev cargo libjpeg-dev zlib1g-dev && \
+    wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.bullseye_amd64.deb && \
+    apt-get install -y ./wkhtmltox_0.12.6.1-2.bullseye_amd64.deb && \
+    rm wkhtmltox_0.12.6.1-2.bullseye_amd64.deb && \
     cd /opt/opencti-connector-import-external-reference && \
     pip3 install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
Modification of debian distro and utility version used in connector import-external-reference

Everything is explain in the issue https://github.com/OpenCTI-Platform/connectors/issues/1710


### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/1710

### Checklist

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion) -> N/A
- [ ] Where necessary I refactored code to improve the overall quality -> N/A

