### PR TITLE
added proper exception handling abuseipdb blacklist main.py

### DIFF
--- a/external-import/abuseipdb-ipblacklist/src/main.py
+++ b/external-import/abuseipdb-ipblacklist/src/main.py
@@ -266,6 +266,7 @@ if __name__ == "__main__":
     try:
         connector = abuseipdbipblacklistimport()
         connector.run()
-    except:
+    except Exception as e:
+        print(e)
         time.sleep(10)
         exit(0)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
old: 
```
if __name__ == "__main__":
    try:
        connector = abuseipdbipblacklistimport()
        connector.run()
    except:
        time.sleep(10)
        exit(0)
```

new: 
```
if __name__ == "__main__":
    try:
        connector = abuseipdbipblacklistimport()
        connector.run()
    except Exception as e:
        print(e)
        time.sleep(10)
        exit(0)
```

### Related issues
https://github.com/OpenCTI-Platform/connectors/issues/1721
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x ] I consider the submitted work as finished
- [ x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
