### PR TITLE
[import-external-reference] Fix arm64 build for connector

### DIFF
--- a/internal-enrichment/import-external-reference/Dockerfile
+++ b/internal-enrichment/import-external-reference/Dockerfile
@@ -7,9 +7,10 @@ COPY src /opt/opencti-connector-import-external-reference
 # hadolint ignore=DL3003
 RUN apt-get update && \
     apt-get install -y git build-essential libmagic-dev libffi-dev libxml2-dev libxslt-dev libssl-dev cargo libjpeg-dev zlib1g-dev && \
-    wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.bullseye_amd64.deb && \
-    apt-get install -y ./wkhtmltox_0.12.6.1-2.bullseye_amd64.deb && \
-    rm wkhtmltox_0.12.6.1-2.bullseye_amd64.deb && \
+    ARCH=`echo -n $(uname -m) | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/'` && \
+        wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.bullseye_${ARCH}.deb && \
+        apt-get install -y ./wkhtmltox_0.12.6.1-2.bullseye_${ARCH}.deb && \
+        rm wkhtmltox_0.12.6.1-2.bullseye_${ARCH}.deb && \
     cd /opt/opencti-connector-import-external-reference && \
     pip3 install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
### Proposed changes
Check for build architecture and install arm64 or amd64 version of package as needed. Currently, this `Dockerfile` always assumes `amd64` despite the `wkhtmltox` package having an arm64 distribution. The changes determine this at build time based upon the build platform architecture (via `uname -m`). Unfortunately, the output of `uname -m` produces different architecture names than what the packages use, so `sed` is used inline to translate these appropriately.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

Tested build on both amd64 and arm64 (AWS Graviton)
