### PR TITLE
[Tagger] Support for objectLabel search in Tagger 

### DIFF
--- a/internal-enrichment/tagger/README.md
+++ b/internal-enrichment/tagger/README.md
@@ -20,7 +20,7 @@ In order to configure the tagger logic, use the file `definitions.json` knowing 
 * scope: opencti scope like the ones that are used to configure `CONNECTOR_SCOPE`. Please note that if you are configuring report tagger rule, you must also specify `Report` in `CONNECTOR_SCOPE` setting.
 * label: the actual label that you want to associate to the object
 * search: the regular expression to identify the objects that need the label
-* attributes: list of attributes of the object where the search will be applied
+* attributes: list of attributes of the object where the search will be applied. Searches can also be done on labels, in this case specifiy the attribute `objectLabel` in the attribute list.
 
 As soon as you have the `definitions.json` configured, please execute the following command:
 ```

--- a/internal-enrichment/tagger/src/connector.py
+++ b/internal-enrichment/tagger/src/connector.py
@@ -41,9 +41,23 @@ class TaggerConnector:
                     flags = load_re_flags(rule)
 
                     for attribute in rule["attributes"]:
-                        if not re.search(
-                            rule["search"], entity[attribute], flags=flags
-                        ):
+                        self.helper.log_debug(entity)
+                        attr = entity[attribute]
+                        if attribute.lower() == "objectlabel":
+                            for el in attr:
+                                if not re.search(
+                                    rule["search"], el["value"], flags=flags
+                                ):
+                                    continue
+
+                                self.helper.api.stix_domain_object.add_label(
+                                    id=entity_id, label_name=rule["label"]
+                                )
+                                break
+
+                            continue
+
+                        if not re.search(rule["search"], attr, flags=flags):
                             continue
 
                         self.helper.api.stix_domain_object.add_label(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add an extra check for the attribute `objectLabel` along with handling of values.

### Related issues

* N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

It's a relatively small change and quite rigid, it could potentially be opened up and allow for more attributes that are lists to be searched.
But from what I can see there isn't many use cases for that in OpenCTI's data model.
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
