### PR TITLE
[harfanglab] Fix error when there is no data (security events)

### DIFF
--- a/stream/harfanglab/src/sightings.py
+++ b/stream/harfanglab/src/sightings.py
@@ -154,13 +154,17 @@ class Sightings(threading.Thread):
     def create_incident(self, last_run=None):
         alert_filtered = self.get_alerts_filtered()
         alerts_filtered_total_count = int(alert_filtered["count"])
+
+        if alerts_filtered_total_count == 0:
+            return self.helper.log_info("[INCIDENTS] No security events have been detected at HarfangLab")
+
         alerts_filtered = self.get_alerts_filtered(alerts_filtered_total_count)
         alerts_filtered_by_date = self.filtered_by_date(
             alerts_filtered["results"], "@event_create_date", last_run
         )
 
         if alerts_filtered_by_date is None:
-            return self.helper.log_info("[INCIDENTS] No new alerts have been detection")
+            return self.helper.log_info("[INCIDENTS] No new security events have been detection")
 
         convert_marking_for_stix2 = self.handle_marking()
 

--- a/stream/harfanglab/src/sightings.py
+++ b/stream/harfanglab/src/sightings.py
@@ -156,7 +156,9 @@ class Sightings(threading.Thread):
         alerts_filtered_total_count = int(alert_filtered["count"])
 
         if alerts_filtered_total_count == 0:
-            return self.helper.log_info("[INCIDENTS] No security events have been detected at HarfangLab")
+            return self.helper.log_info(
+                "[INCIDENTS] No security events have been detected at HarfangLab"
+            )
 
         alerts_filtered = self.get_alerts_filtered(alerts_filtered_total_count)
         alerts_filtered_by_date = self.filtered_by_date(
@@ -164,7 +166,9 @@ class Sightings(threading.Thread):
         )
 
         if alerts_filtered_by_date is None:
-            return self.helper.log_info("[INCIDENTS] No new security events have been detection")
+            return self.helper.log_info(
+                "[INCIDENTS] No new security events have been detection"
+            )
 
         convert_marking_for_stix2 = self.handle_marking()
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

The problem has been identified, this error comes from the fact that when launching the connector there are no security events at HarfangLab.

* Setting up a condition and an info log to warn that there is no security event data at harfanglab

### Related issues

* #1771
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
