### PR TITLE
[taxii2] Add API key as an auth option for remote TAXII2 server url

### DIFF
--- a/external-import/taxii2/README.md
+++ b/external-import/taxii2/README.md
@@ -14,6 +14,9 @@ There are a number of configuration options, which are set either in `docker-com
 | TAXII2_PASSWORD     | password        | Password credential to access TAXII Server
 | TAXII2_USE_TOKEN    | false           | Switch from using username and password to using a single token as authentication method.
 | TAXII2_TOKEN        | token           | Token string from taxii server.
+| TAXII2_USE_APIKEY   | false           | Switch from using username and password to using a key/value pair as authentication method.
+| TAXII2_APIKEY_KEY   | apikey          | API key - name of the HTTP header.
+| TAXII2_APIKEY_VALUE | value           | The secret value set as the header value.
 | TAXII2_v21          | v2.1            | Boolean statement to determine if the TAXII Server is V2.0 or V2.1. Defaults to False (V2.0)
 | TAXII2_COLLECTIONS  | collections     | Specify what TAXII Collections you want to poll. Syntax Detailed below
 | TAXII2_INITIAL_HISTORY| initial_history| In hours, the "lookback" window for the intial Poll. This will limit the respones only to STIX2 objects that were added to the collection during the specified lookback time. In all subsequent polls, the `interval` configuration option is used to determine the lookback window

--- a/external-import/taxii2/src/taxii2.py
+++ b/external-import/taxii2/src/taxii2.py
@@ -13,7 +13,7 @@ import taxii2client.v20 as tx20
 import taxii2client.v21 as tx21
 import yaml
 from pycti import OpenCTIConnectorHelper, StixCyberObservableTypes, get_config_variable
-from requests.auth import HTTPBasicAuth, AuthBase
+from requests.auth import AuthBase, HTTPBasicAuth
 from requests.exceptions import HTTPError
 from taxii2client.common import TokenAuth
 from taxii2client.exceptions import TAXIIServiceException


### PR DESCRIPTION
### Proposed changes

* Add an API key as an authentication method to the remote TAXII server. Passed via a header on HTTP requests, using a key (header name), and a value (header value) mechanism.  

### Related issues

none

### Checklist

- [x ] I consider the submitted work as finished
- [x ] I tested the code for its functionality using different use cases
- [x ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

