### PR TITLE
Fix YARA connector

### DIFF
--- a/internal-enrichment/yara/src/main.py
+++ b/internal-enrichment/yara/src/main.py
@@ -23,24 +23,8 @@ class YaraConnector:
 
     def _get_artifact(self, entity_id):
         self.helper.log_debug("Getting Artifact from OpenCTI")
-
-        customAttributes = """
-        id
-        standard_id
-        observable_value
-        ... on Artifact {
-                importFiles {
-                        edges {
-                                node {
-                                    id
-                                    name
-                                }
-                            }
-                        }
-        }
-        """
         observable = self.helper.api.stix_cyber_observable.read(
-            id=entity_id, customAttributes=customAttributes
+            id=entity_id, withFiles=True
         )
         return observable
 

--- a/internal-enrichment/yara/src/main.py
+++ b/internal-enrichment/yara/src/main.py
@@ -24,7 +24,7 @@ class YaraConnector:
     def _get_artifact(self, entity_id):
         self.helper.log_debug("Getting Artifact from OpenCTI")
         max_retries = 5
-        wait = 1 # seconds
+        wait = 1  # seconds
 
         for i in range(max_retries):
             observable = self.helper.api.stix_cyber_observable.read(
@@ -32,7 +32,9 @@ class YaraConnector:
             )
             if observable["importFiles"]:
                 break
-            self.helper.log_debug(f"Artifact files not ready yet, retrying ({i+1}/{max_retries})...")
+            self.helper.log_debug(
+                f"Artifact files not ready yet, retrying ({i+1}/{max_retries})..."
+            )
             time.sleep(wait)
 
         if not observable["importFiles"]:


### PR DESCRIPTION
### Proposed changes

* Use new `withFiles` option with `stix_cyber_observable.read()` to fetch file IDs for an Artifact when enriching with the YARA connector, based on https://github.com/OpenCTI-Platform/connectors/commit/1b8f610249ad04c0d87981052bc5269f58b9ec28#
* When fetching an Artifact's file contents, retry 5 times by default in case OpenCTI is not ready if auto-enriching a new Artifact

### Related issues

* Resolves https://github.com/OpenCTI-Platform/connectors/issues/1703

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

None