### PR TITLE
Fix typo in CONNECTOR_NAME in threatfox/docker-compose.yml

### DIFF
--- a/external-import/threatfox/docker-compose.yml
+++ b/external-import/threatfox/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - OPENCTI_URL=http://opencti:8080
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
-      - "CONNECTOR_NAME=Abuse.ch | Threat Fox"
+      - "CONNECTOR_NAME=Abuse.ch | ThreatFox"
       - CONNECTOR_SCOPE=ThreatFox
       - CONNECTOR_CONFIDENCE_LEVEL=40 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_LOG_LEVEL=error


### PR DESCRIPTION
CONNECTOR_NAME had typo (Space between Threat and Fox)

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*       "CONNECTOR_NAME=Abuse.ch | Threat Fox" to "CONNECTOR_NAME=Abuse.ch | ThreatFox"
*    

### Related issues

* None
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ X] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [X ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

Nice and easy change for me.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
