### PR TITLE
[Misp/Misp Feed] Complete expected tag to handle for misp and misp-feed connectors

### DIFF
--- a/external-import/misp-feed/src/misp-feed.py
+++ b/external-import/misp-feed/src/misp-feed.py
@@ -650,9 +650,11 @@ class MispFeed:
                         )
                         added_names.append(name)
             # Get the linked attack_patterns
-            if tag["name"].startswith("misp-galaxy:attack-pattern") or tag[
-                "name"
-            ].startswith("mitre-attack:attack-pattern"):
+            if (
+                tag["name"].startswith("misp-galaxy:mitre-attack-pattern")
+                or tag["name"].startswith("misp-galaxy:attack-pattern")
+                or tag["name"].startswith("mitre-attack:attack-pattern")
+            ):
                 tag_value_split = tag["name"].split('="')
                 if len(tag_value_split) > 1 and len(tag_value_split[1]) > 0:
                     tag_value = tag_value_split[1][:-1].strip()
@@ -1908,7 +1910,9 @@ class MispFeed:
             # Report in STIX lib must have at least one object_refs
             if len(object_refs) == 0:
                 # Put a fake ID in the report
-                object_refs.append("intrusion-set--fc5ee88d-7987-4c00-991e-a863e9aa8a0e")
+                object_refs.append(
+                    "intrusion-set--fc5ee88d-7987-4c00-991e-a863e9aa8a0e"
+                )
             report = stix2.Report(
                 id=Report.generate_id(
                     event["Event"]["info"],

--- a/external-import/misp/src/misp.py
+++ b/external-import/misp/src/misp.py
@@ -904,7 +904,9 @@ class Misp:
                 # Report in STIX lib must have at least one object_refs
                 if len(object_refs) == 0:
                     # Put a fake ID in the report
-                    object_refs.append("intrusion-set--fc5ee88d-7987-4c00-991e-a863e9aa8a0e")
+                    object_refs.append(
+                        "intrusion-set--fc5ee88d-7987-4c00-991e-a863e9aa8a0e"
+                    )
                 attributes = filter_event_attributes(
                     event, **self.misp_report_description_attribute_filter
                 )
@@ -2017,9 +2019,11 @@ class Misp:
                         )
                         added_names.append(name)
             # Get the linked attack_patterns
-            if tag["name"].startswith("misp-galaxy:attack-pattern") or tag[
-                "name"
-            ].startswith("mitre-attack:attack-pattern"):
+            if (
+                tag["name"].startswith("misp-galaxy:mitre-attack-pattern")
+                or tag["name"].startswith("misp-galaxy:attack-pattern")
+                or tag["name"].startswith("mitre-attack:attack-pattern")
+            ):
                 tag_value_split = tag["name"].split('="')
                 if len(tag_value_split) > 1 and len(tag_value_split[1]) > 0:
                     tag_value = tag_value_split[1][:-1].strip()


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Complete expected tag to handle for misp and misp-feed connectors, add `misp-galaxy:mitre-attack-pattern`

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/1827#issuecomment-1956735479

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
