### PR TITLE
[Connector] Fix report error in front for import-external-reference

### DIFF
--- a/internal-enrichment/import-external-reference/README.md
+++ b/internal-enrichment/import-external-reference/README.md
@@ -11,6 +11,7 @@ OpenCTI data is coming from *import* connectors.
 ### Requirements
 
 - OpenCTI Platform >= 5.0.0
+- Install wkhtmltopdf
 
 ### Configuration
 
@@ -26,7 +27,8 @@ OpenCTI data is coming from *import* connectors.
 | `connector_log_level`                        | `CONNECTOR_LOG_LEVEL`                        | Yes       | Connector logging verbosity, could be `debug`, `info`, `warn` or `error` (less verbose). |
 | `import_external_reference_import_as_pdf`    | `IMPORT_EXTERNAL_REFERENCE_IMPORT_AS_PDF`    | Yes       | Import as PDF file                                                                       |
 | `import_external_reference_import_as_md`     | `IMPORT_EXTERNAL_REFERENCE_IMPORT_AS_MD`     | Yes       | Import as MD file                                                                        |
-| `IMPORT_EXTERNAL_REFERENCE_IMPORT_PDF_AS_MD` | `IMPORT_EXTERNAL_REFERENCE_IMPORT_PDF_AS_MD` | Yes       | If import_as_md is true, try to convert PDF as Markdown                                  |
+| `import_external_reference_import_pdf_as_md` | `IMPORT_EXTERNAL_REFERENCE_IMPORT_PDF_AS_MD` | Yes       | If import_as_md is true, try to convert PDF as Markdown                                  | 
+| `wkhtmltopdf_path`                           | `WKHTMLTOPDF_PATH`                           | Yes       | If the environment variable does not work, set the wkhtmltopdf installation path here    |
 After adding the connector, you should be able to extract information from a report.
 
 *Reference: https://docs.oasis-open.org/cti/stix/v2.1/cs01/stix-v2.1-cs01.html*

--- a/internal-enrichment/import-external-reference/docker-compose.yml
+++ b/internal-enrichment/import-external-reference/docker-compose.yml
@@ -14,4 +14,5 @@ services:
       - IMPORT_EXTERNAL_REFERENCE_IMPORT_AS_PDF=true # Import as PDF file
       - IMPORT_EXTERNAL_REFERENCE_IMPORT_AS_MD=true # Import as MarkDown file
       - IMPORT_EXTERNAL_REFERENCE_IMPORT_PDF_AS_MD=true # If import_as_md is true, try to convert PDF as Markdown
+      - WKHTMLTOPDF_PATH=ChangeMe
     restart: always

--- a/internal-enrichment/import-external-reference/src/config.yml.sample
+++ b/internal-enrichment/import-external-reference/src/config.yml.sample
@@ -15,3 +15,4 @@ import_external_reference:
   import_as_pdf: true # Import as PDF file
   import_as_md: true # Import as MarkDown file
   import_pdf_as_md: true # If import_as_md is true, try to convert PDF as Markdown
+  wkhtmltopdf_path: ChangeMe # Example 'C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe'

--- a/internal-enrichment/import-external-reference/src/import-external-reference.py
+++ b/internal-enrichment/import-external-reference/src/import-external-reference.py
@@ -86,7 +86,9 @@ class ImportExternalReferenceConnector:
                                 ),
                             ],
                         }
-                        data = pdfkit.from_url(url_to_import, False, options=options)
+                        path_wkhtmltopdf = "C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe"
+                        config = pdfkit.configuration(wkhtmltopdf=path_wkhtmltopdf)
+                        data = pdfkit.from_url(url_to_import, False, options=options, configuration=config)
                         self.helper.api.external_reference.add_file(
                             id=external_reference["id"],
                             file_name=file_name,
@@ -97,7 +99,7 @@ class ImportExternalReferenceConnector:
                         if "Done" not in str(e):
                             raise e
             except Exception as e:
-                self.helper.log_error(e)
+                raise ValueError(e)
         if self.import_as_md:
             if url_to_import.endswith(".pdf") and self.import_pdf_as_md:
                 try:

--- a/internal-enrichment/import-external-reference/src/import-external-reference.py
+++ b/internal-enrichment/import-external-reference/src/import-external-reference.py
@@ -44,6 +44,11 @@ class ImportExternalReferenceConnector:
             True,
         )
         self.headers = {"User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64)"}
+        self.wkhtmltopdf_path = get_config_variable(
+            "WKHTMLTOPDF_PATH",
+            ["import_external_reference", "wkhtmltopdf_path"],
+            config,
+        )
 
     def delete_files(self):
         if os.path.exists("data.html"):
@@ -86,7 +91,8 @@ class ImportExternalReferenceConnector:
                                 ),
                             ],
                         }
-                        data = pdfkit.from_url(url_to_import, False, options=options)
+                        config = pdfkit.configuration(wkhtmltopdf=self.wkhtmltopdf_path)
+                        data = pdfkit.from_url(url_to_import, False, options=options, configuration=config)
                         self.helper.api.external_reference.add_file(
                             id=external_reference["id"],
                             file_name=file_name,

--- a/internal-enrichment/import-external-reference/src/import-external-reference.py
+++ b/internal-enrichment/import-external-reference/src/import-external-reference.py
@@ -86,9 +86,7 @@ class ImportExternalReferenceConnector:
                                 ),
                             ],
                         }
-                        path_wkhtmltopdf = "C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe"
-                        config = pdfkit.configuration(wkhtmltopdf=path_wkhtmltopdf)
-                        data = pdfkit.from_url(url_to_import, False, options=options, configuration=config)
+                        data = pdfkit.from_url(url_to_import, False, options=options)
                         self.helper.api.external_reference.add_file(
                             id=external_reference["id"],
                             file_name=file_name,

--- a/internal-enrichment/import-external-reference/src/import-external-reference.py
+++ b/internal-enrichment/import-external-reference/src/import-external-reference.py
@@ -92,7 +92,9 @@ class ImportExternalReferenceConnector:
                             ],
                         }
                         config = pdfkit.configuration(wkhtmltopdf=self.wkhtmltopdf_path)
-                        data = pdfkit.from_url(url_to_import, False, options=options, configuration=config)
+                        data = pdfkit.from_url(
+                            url_to_import, False, options=options, configuration=config
+                        )
                         self.helper.api.external_reference.add_file(
                             id=external_reference["id"],
                             file_name=file_name,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* While waiting to find a new lib, we will correctly display the error on the front
* (Edit - Add variable wkhtmltopdf_path in config.yml)


### Related issues

* #1812 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
* to test this connector you will first need to install [wkhtmltopdf](https://wkhtmltopdf.org/downloads.html)
* After installation, setting up the path for testing (l.89):
`path_wkhtmltopdf = "C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe"`
`config = pdfkit.configuration(wkhtmltopdf=path_wkhtmltopdf)`
`data = pdfkit.from_url(url_to_import, output_path=None, options=options, configuration=config)`

What you must have:
![image](https://github.com/OpenCTI-Platform/connectors/assets/14902945/6f518be0-1d48-4154-b558-103f963c3920)

URLs to test for external references:
- https://www.trendmicro.com/en_us/research/24/b/cve202421412-water-hydra-targets-traders-with-windows-defender-s.html
- https://securityaffairs.com/159074/reports/ransomfeed-q3-report-2023-ransomware.html