### PR TITLE
[Greynoise] Delete method not used

### DIFF
--- a/internal-enrichment/greynoise/src/greynoise.py
+++ b/internal-enrichment/greynoise/src/greynoise.py
@@ -70,20 +70,6 @@ class GreyNoiseConnector:
         self.tlp = None
         self.stix_objects = []
 
-    def _get_entity_in_opencti(self, entity: dict) -> dict:
-        """
-        This method allows you to find all the information associated with the entity ID in OpenCTI.
-
-        :param entity: A parameter that includes the entity_id
-        :return: A dict
-        """
-
-        opencti_entity = self.helper.api.stix_cyber_observable.read(
-            id=entity["entity_id"]
-        )
-        if opencti_entity is not None:
-            return opencti_entity
-
     def _extract_and_check_markings(self, opencti_entity: dict) -> bool:
         """
         Extract TLP, and we check if the variable "max_tlp" is less than


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Delete method "_get_entity_in_opencti()" not used after organization

### Related issues

* #1868
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
