### PR TITLE
[ThreatFox] Fix mapping of malware aliases

### DIFF
--- a/external-import/threatfox/src/main.py
+++ b/external-import/threatfox/src/main.py
@@ -144,7 +144,17 @@ class ThreatFox:
                             "r",
                             encoding="utf-8",
                         )
-                        rdr = csv.reader(filter(lambda row: row[0] != "#", fp))
+                        csv.register_dialect(
+                            "custom",
+                            delimiter=",",
+                            quotechar='"',
+                            skipinitialspace=True,
+                        )
+                        rdr = csv.reader(
+                            (line for line in fp if not line.startswith("#")),
+                            dialect="custom",
+                        )
+                        # rdr = csv.reader(filter(lambda row: row[0] != "#", fp))
                         bundle_objects = []
                         # the csv-file has the following columns:
                         # first_seen_utc, ioc_id, ioc_value, ioc_type, threat_type, fk_malware, malware_alias,
@@ -174,9 +184,42 @@ class ThreatFox:
                             wanted_ioc.append("all_types")
 
                         for i, row in enumerate(rdr):
+
+                            data_object = {
+                                "first_seen_utc": row[0],
+                                "ioc_id": row[1],
+                                "ioc_value": row[2],
+                                "ioc_type": row[3],
+                                "threat_type": row[4],
+                                "fk_malware": row[5] if row[5] != "unknown" else "",
+                                "malware_alias": row[6].split(","),
+                                "malware_printable": (
+                                    row[7] if row[7] != "Unknown malware" else ""
+                                ),
+                                "last_seen_utc": row[8],
+                                "confidence_level": row[9],
+                                "reference": row[10],
+                                "tags": row[11].split(","),
+                                "anonymous": row[12],
+                                "reporter": row[13],
+                            }
+
                             # Pre-process row data for efficiency
-                            ioc_value = row[2].strip().replace('"', "")
-                            ioc_type = row[3].strip().strip('"')
+                            ioc_value = data_object["ioc_value"]
+                            ioc_type = data_object["ioc_type"]
+                            data_object["malware_alias"].insert(
+                                0, data_object["fk_malware"]
+                            )
+                            ioc_aliases = [
+                                x
+                                for x in data_object["malware_alias"]
+                                if x not in {"None", ""}
+                            ]
+                            data_object["tags"].insert(0, data_object["threat_type"])
+                            ioc_labels = [
+                                x for x in data_object["tags"] if x not in {"None", ""}
+                            ]
+
                             self.helper.log_info(f"ioc_type: '{ioc_type}'")
 
                             # Skip unwanted IOC types
@@ -187,7 +230,7 @@ class ThreatFox:
                                 continue
 
                             entry_date = datetime.datetime.strptime(
-                                row[0], "%Y-%m-%d %H:%M:%S"
+                                data_object["first_seen_utc"], "%Y-%m-%d %H:%M:%S"
                             )
                             if i % 5000 == 0:
                                 self.helper.log_info(
@@ -244,11 +287,11 @@ class ThreatFox:
                                 continue
 
                             # Check if we have an external reference
-                            if validators.url(row[10]):
+                            if validators.url(data_object["reference"]):
                                 indicator_external_reference = [
                                     stix2.ExternalReference(
                                         source_name="ThreatFox source reference",
-                                        url=row[10],
+                                        url=data_object["reference"],
                                     )
                                 ]
 
@@ -261,11 +304,7 @@ class ThreatFox:
                                     valid_from=datetime.datetime.utcnow().strftime(
                                         "%Y-%m-%dT%H:%M:%S.%fZ"
                                     ),
-                                    labels=[
-                                        row[i].replace('"', "")
-                                        for i in range(4, 9)
-                                        if row[i]
-                                    ],
+                                    labels=ioc_labels,
                                     object_marking_refs=[stix2.TLP_WHITE],
                                     created_by_ref=self.identity["standard_id"],
                                     external_references=indicator_external_reference,
@@ -284,11 +323,7 @@ class ThreatFox:
                                     valid_from=datetime.datetime.utcnow().strftime(
                                         "%Y-%m-%dT%H:%M:%S.%fZ"
                                     ),
-                                    labels=[
-                                        row[i].replace('"', "")
-                                        for i in range(4, 9)
-                                        if row[i]
-                                    ],
+                                    labels=ioc_labels,
                                     object_marking_refs=[stix2.TLP_WHITE],
                                     created_by_ref=self.identity["standard_id"],
                                     custom_properties={
@@ -302,9 +337,12 @@ class ThreatFox:
 
                             bundle_objects.append(stix_indicator)
 
-                            if row[4] == "botnet_cc":
+                            if not data_object["malware_printable"]:
+                                continue
+
+                            if data_object["threat_type"] == "botnet_cc":
                                 malware_type = "Bot"
-                            elif row[4] == "payload_delivery":
+                            elif data_object["threat_type"] == "payload_delivery":
                                 malware_type = "dropper"
                             else:
                                 malware_type = ""
@@ -312,25 +350,19 @@ class ThreatFox:
                             # Create the malware object
                             self.helper.log_info("Creating Malware object...")
                             malware_object = stix2.Malware(
-                                id=Malware.generate_id(row[5].replace('"', "")),
-                                name=row[5].replace('"', ""),
-                                aliases=[
-                                    row[i].replace('"', "")
-                                    for i in range(6, 8)
-                                    if row[i]
-                                ],
+                                id=Malware.generate_id(
+                                    data_object["malware_printable"]
+                                ),
+                                name=data_object["malware_printable"],
+                                aliases=ioc_aliases,
                                 created_by_ref=self.identity["standard_id"],
                                 object_marking_refs=[stix2.TLP_WHITE],
                                 description="Threat: "
-                                + row[5].replace('"', "")
+                                + data_object["fk_malware"]
                                 + " - Reporter: "
-                                + row[13].replace('"', ""),
+                                + data_object["reporter"],
                                 is_family="false",
-                                labels=[
-                                    row[i].replace('"', "")
-                                    for i in range(4, 9)
-                                    if row[i] != "None"
-                                ],
+                                labels=ioc_labels,
                                 malware_types=[malware_type] if malware_type else None,
                             )
                             self.helper.log_info(

--- a/external-import/threatfox/src/main.py
+++ b/external-import/threatfox/src/main.py
@@ -150,7 +150,7 @@ class ThreatFox:
                             quotechar='"',
                             skipinitialspace=True,
                         )
-                        rdr = csv.reader(
+                        csv_reader = csv.reader(
                             (line for line in fp if not line.startswith("#")),
                             dialect="custom",
                         )
@@ -183,7 +183,7 @@ class ThreatFox:
                         else:
                             wanted_ioc.append("all_types")
 
-                        for i, row in enumerate(rdr):
+                        for i, row in enumerate(csv_reader):
 
                             data_object = {
                                 "first_seen_utc": row[0],

--- a/external-import/threatfox/src/main.py
+++ b/external-import/threatfox/src/main.py
@@ -350,9 +350,7 @@ class ThreatFox:
                             # Create the malware object
                             self.helper.log_info("Creating Malware object...")
                             malware_object = stix2.Malware(
-                                id=Malware.generate_id(
-                                    ioc_object["malware_printable"]
-                                ),
+                                id=Malware.generate_id(ioc_object["malware_printable"]),
                                 name=ioc_object["malware_printable"],
                                 aliases=ioc_aliases,
                                 created_by_ref=self.identity["standard_id"],

--- a/external-import/threatfox/src/main.py
+++ b/external-import/threatfox/src/main.py
@@ -185,7 +185,7 @@ class ThreatFox:
 
                         for i, row in enumerate(csv_reader):
 
-                            data_object = {
+                            ioc_object = {
                                 "first_seen_utc": row[0],
                                 "ioc_id": row[1],
                                 "ioc_value": row[2],
@@ -205,19 +205,19 @@ class ThreatFox:
                             }
 
                             # Pre-process row data for efficiency
-                            ioc_value = data_object["ioc_value"]
-                            ioc_type = data_object["ioc_type"]
-                            data_object["malware_alias"].insert(
-                                0, data_object["fk_malware"]
+                            ioc_value = ioc_object["ioc_value"]
+                            ioc_type = ioc_object["ioc_type"]
+                            ioc_object["malware_alias"].insert(
+                                0, ioc_object["fk_malware"]
                             )
                             ioc_aliases = [
                                 x
-                                for x in data_object["malware_alias"]
+                                for x in ioc_object["malware_alias"]
                                 if x not in {"None", ""}
                             ]
-                            data_object["tags"].insert(0, data_object["threat_type"])
+                            ioc_object["tags"].insert(0, ioc_object["threat_type"])
                             ioc_labels = [
-                                x for x in data_object["tags"] if x not in {"None", ""}
+                                x for x in ioc_object["tags"] if x not in {"None", ""}
                             ]
 
                             self.helper.log_info(f"ioc_type: '{ioc_type}'")
@@ -230,7 +230,7 @@ class ThreatFox:
                                 continue
 
                             entry_date = datetime.datetime.strptime(
-                                data_object["first_seen_utc"], "%Y-%m-%d %H:%M:%S"
+                                ioc_object["first_seen_utc"], "%Y-%m-%d %H:%M:%S"
                             )
                             if i % 5000 == 0:
                                 self.helper.log_info(
@@ -287,11 +287,11 @@ class ThreatFox:
                                 continue
 
                             # Check if we have an external reference
-                            if validators.url(data_object["reference"]):
+                            if validators.url(ioc_object["reference"]):
                                 indicator_external_reference = [
                                     stix2.ExternalReference(
                                         source_name="ThreatFox source reference",
-                                        url=data_object["reference"],
+                                        url=ioc_object["reference"],
                                     )
                                 ]
 
@@ -337,12 +337,12 @@ class ThreatFox:
 
                             bundle_objects.append(stix_indicator)
 
-                            if not data_object["malware_printable"]:
+                            if not ioc_object["malware_printable"]:
                                 continue
 
-                            if data_object["threat_type"] == "botnet_cc":
+                            if ioc_object["threat_type"] == "botnet_cc":
                                 malware_type = "Bot"
-                            elif data_object["threat_type"] == "payload_delivery":
+                            elif ioc_object["threat_type"] == "payload_delivery":
                                 malware_type = "dropper"
                             else:
                                 malware_type = ""
@@ -351,16 +351,16 @@ class ThreatFox:
                             self.helper.log_info("Creating Malware object...")
                             malware_object = stix2.Malware(
                                 id=Malware.generate_id(
-                                    data_object["malware_printable"]
+                                    ioc_object["malware_printable"]
                                 ),
-                                name=data_object["malware_printable"],
+                                name=ioc_object["malware_printable"],
                                 aliases=ioc_aliases,
                                 created_by_ref=self.identity["standard_id"],
                                 object_marking_refs=[stix2.TLP_WHITE],
                                 description="Threat: "
-                                + data_object["fk_malware"]
+                                + ioc_object["fk_malware"]
                                 + " - Reporter: "
-                                + data_object["reporter"],
+                                + ioc_object["reporter"],
                                 is_family="false",
                                 labels=ioc_labels,
                                 malware_types=[malware_type] if malware_type else None,

--- a/external-import/threatfox/src/main.py
+++ b/external-import/threatfox/src/main.py
@@ -154,7 +154,7 @@ class ThreatFox:
                             (line for line in fp if not line.startswith("#")),
                             dialect="custom",
                         )
-                        # rdr = csv.reader(filter(lambda row: row[0] != "#", fp))
+
                         bundle_objects = []
                         # the csv-file has the following columns:
                         # first_seen_utc, ioc_id, ioc_value, ioc_type, threat_type, fk_malware, malware_alias,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Improved csv reader configuration parameters
* Setting a block for malware creation and its relationship with the indicator when it is "unknown" (only indicator creation)
* Creation of a new object for better reading of columns
* Sort and remove null values (“None”, “”) for aliases and labels

### Related issues

* #1891

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
