### PR TITLE
add campaign,infrastructure,relationship in CONNECTOR_SCOPE

### DIFF
--- a/external-import/sekoia/docker-compose.yml
+++ b/external-import/sekoia/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
       - CONNECTOR_NAME=SEKOIA.IO
-      - CONNECTOR_SCOPE=identity,attack-pattern,course-of-action,intrusion-set,malware,tool,report,location,vulnerability,indicator
+      - CONNECTOR_SCOPE=identity,attack-pattern,course-of-action,intrusion-set,malware,tool,report,location,vulnerability,indicator,campaign,infrastructure,relationship
       - CONNECTOR_CONFIDENCE_LEVEL=50 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_LOG_LEVEL=error
       - SEKOIA_API_KEY=ChangeMe


### PR DESCRIPTION
### Proposed changes

* add campaign,infrastructure,relationship in CONNECTOR_SCOPE in accordance to [our documentation](https://docs.sekoia.io/cti/features/integrations/opencti/)

### Related issues
* Users were not able to have the relationship between objects

### Checklist
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality