### PR TITLE
fix: use title for obserable name

### DIFF
--- a/external-import/cpe/src/connector.py
+++ b/external-import/cpe/src/connector.py
@@ -320,6 +320,17 @@ class CPEConnector:
         return stix_objects
 
     def _get_cpe_title(self, cpe: dict) -> str:
+        """
+        Extracts the title from the cpe.
+
+        Args:
+            self
+            cpe (dict): The cpe where the title is extracted
+
+        Returns:
+            str: The title of the cpe.
+        """
+        
         cpe_title = ""
 
         for title in cpe["titles"]:

--- a/external-import/cpe/src/connector.py
+++ b/external-import/cpe/src/connector.py
@@ -330,7 +330,7 @@ class CPEConnector:
         Returns:
             str: The title of the cpe.
         """
-        
+
         cpe_title = ""
 
         for title in cpe["titles"]:
@@ -340,7 +340,7 @@ class CPEConnector:
         if cpe_title == "":
             cpe_title = self._get_cpe_infos(cpe["cpeName"])["name"]
 
-        return cpe_title    
+        return cpe_title
 
     def _import_all(self, work_id) -> None:
         """

--- a/external-import/cpe/src/connector.py
+++ b/external-import/cpe/src/connector.py
@@ -307,7 +307,7 @@ class CPEConnector:
                     type="software",
                     spec_version="2.1",
                     id=self._get_id("software"),
-                    name=cpe_infos["name"],
+                    name=self._get_cpe_title(json_objects["products"][i]["cpe"]),
                     cpe=json_objects["products"][i]["cpe"]["cpeName"],
                     languages=cpe_infos["language"],
                     vendor=cpe_infos["vendor"],
@@ -318,6 +318,18 @@ class CPEConnector:
         self.helper.log_info(f"{len(stix_objects)} STIX2 objects have been created!")
 
         return stix_objects
+
+    def _get_cpe_title(self, cpe: dict) -> str:
+        cpe_title = ""
+
+        for title in cpe["titles"]:
+            if title["lang"] == "en":
+                cpe_title = title["title"]
+
+        if cpe_title == "":
+            cpe_title = self._get_cpe_infos(cpe["cpeName"])["name"]
+
+        return cpe_title    
 
     def _import_all(self, work_id) -> None:
         """


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Use title instead of product name extract

### Related issues

* #1931 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ x] I consider the submitted work as finished
- [ x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion) NA
- [ x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments
It's a small change that improves the UX directly
