### PR TITLE
[Threatfox] rework, improvements

### DIFF
--- a/external-import/threatfox/README.md
+++ b/external-import/threatfox/README.md
@@ -12,15 +12,18 @@ General description of the connector
 This connector imports data from the [Threat Fox Recent Feed](https://threatfox.abuse.ch/)
 
 The connector adds data for the following OpenCTI observable/indicator types:
-* file-md5
-* file-sha1
-* file-sha256
-* ipv4-addr
-* domain-name
-* url
+
+- file-md5
+- file-sha1
+- file-sha256
+- ipv4-addr
+- domain-name
+- url
 
 The connector adds the following Entities:
-* Malware
+
+- Malware
+
 ## Installation
 
 ### Requirements
@@ -30,18 +33,17 @@ The connector adds the following Entities:
 ### Configuration
 
 | Parameter              | Docker envvar                    | Mandatory | Description                                                                                                             |
-|------------------------|----------------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------|
+| ---------------------- | -------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `opencti_url`          | `OPENCTI_URL`                    | Yes       | The URL of the OpenCTI platform.                                                                                        |
 | `opencti_token`        | `OPENCTI_TOKEN`                  | Yes       | The default admin token configured in the OpenCTI platform parameters file.                                             |
 | `connector_id`         | `CONNECTOR_ID`                   | Yes       | A valid arbitrary `UUIDv4` that must be unique for this connector.                                                      |
 | `connector_name`       | `CONNECTOR_NAME`                 | Yes       | Option `ZeroFox`                                                                                                        |
 | `connector_scope`      | `CONNECTOR_SCOPE`                | Yes       | Supported scope: Template Scope (MIME Type or Stix Object)                                                              |
 | `confidence_level`     | `CONNECTOR_CONFIDENCE_LEVEL`     | Yes       | Set the confidence level for this data                                                                                  |
-| `update_existing_data` | `CONNECTOR_UPDATE_EXISTING_DATA` | Yes       | Update data alrerady in the platform based on the Threat Fox data pull                                                  |
-| `log_level`            | `CONNECTOR_LOG_LEVEL`            | Yes       | Log output for the connector                                                                                            |
-| `csv_url`              | `THREATFOX_CSV_URL`              | Yes       |                                                                                                                         |
-| `import_offline`       | `THREATFOX_IMPORT_OFFLINE`       | Yes       |                                                                                                                         |
-| `create_indicators`    | `THREATFOX_CREATE_INDICATORS`    | Yes       |                                                                                                                         |
-| `threats_from_labels`  | `THREATFOX_THREATS_FROM_LABELS`  | Yes       |                                                                                                                         | 
-| `interval`             | `THREATFOX_INTERVAL`             | Yes       |                                                                                                                         |
-| `ioc_types`            | `THREATFOX_IOC_TYPES`            | Yes       | List of IOC types to retrieve, available parameter: `all_types, ip:port, domain, url, md5_hash, sha1_hash, sha256_hash` |
+| `update_existing_data` | `CONNECTOR_UPDATE_EXISTING_DATA` | No        | Update data alrerady in the platform based on the Threat Fox data pull                                                  |
+| `log_level`            | `CONNECTOR_LOG_LEVEL`            | No        | Log output for the connector. Defaults to `INFO`                                                                                            |
+| `csv_url`              | `THREATFOX_CSV_URL`              | No        | Defaults to `https://threatfox.abuse.ch/export/csv/recent/`                                                                                                                        |
+| `import_offline`       | `THREATFOX_IMPORT_OFFLINE`       | No        | Create records for indicators that are offline. Defaults to `True`                                                                                                                        |
+| `create_indicators`    | `THREATFOX_CREATE_INDICATORS`    | No        | Create indicators in addition to observables. Defaults to `True`                                                                                                                        |
+| `interval`             | `THREATFOX_INTERVAL`             | No        | Run interval. Defaults to `3`                                                                                                                        |
+| `ioc_types`            | `THREATFOX_IOC_TYPES`            | No        | List of IOC types to retrieve, available parameter: `all_types, ip:port, domain, url, md5_hash, sha1_hash, sha256_hash` |

--- a/external-import/threatfox/docker-compose.yml
+++ b/external-import/threatfox/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   connector-threatfox:
     image: opencti/connector-threatfox:6.0.7
@@ -13,7 +13,6 @@ services:
       - THREATFOX_CSV_URL=https://threatfox.abuse.ch/export/csv/recent/
       - THREATFOX_IMPORT_OFFLINE=true
       - THREATFOX_CREATE_INDICATORS=true
-      - THREATFOX_THREATS_FROM_LABELS=true
       - THREATFOX_INTERVAL=3 # In days, must be strictly greater than 1
       - THREATFOX_IOC_TO_IMPORT=ip:port,domain,url # List of IOC types to import
     restart: always

--- a/external-import/threatfox/src/config.yml.sample
+++ b/external-import/threatfox/src/config.yml.sample
@@ -15,6 +15,5 @@ threatfox:
   csv_url: 'https://threatfox.abuse.ch/export/csv/full/'
   import_offline: true
   create_indicators: true
-  threats_from_labels: true
   interval: 3 # In days, must be strictly greater than 1
   ioc_to_import:'ip:port,domain,url' # List of IOC types to import

--- a/external-import/threatfox/src/main.py
+++ b/external-import/threatfox/src/main.py
@@ -438,13 +438,13 @@ class ThreatFox:
 
         # Create the malware object
         stix_malware = stix2.Malware(
-            id=Malware.generate_id(ioc.malware_printable),
-            name=ioc.malware_printable,
+            id=Malware.generate_id(ioc.fk_malware),
+            name=ioc.fk_malware,
             aliases=ioc.malware_aliases,
             created_by_ref=self.identity["standard_id"],
             object_marking_refs=[stix2.TLP_WHITE],
             confidence=ioc.confidence_level,
-            description=f"Threat: {ioc.fk_malware} - Reporter: {ioc.reporter}",
+            description=f"Threat: {ioc.fk_malware}\nReporter: {ioc.reporter}",
             is_family=False,
             labels=ioc.tags,
             malware_types=malware_types,
@@ -514,11 +514,11 @@ class FeedRow:
 
         if self.fk_malware == "unknown":
             self.fk_malware = ""
-        else:
-            self.malware_aliases.insert(0, self.fk_malware)
 
         if self.malware_printable == "Unknown malware":
             self.malware_printable = ""
+        else:
+            self.malware_aliases.insert(0, self.malware_printable)
 
         last_seen = row[8]
         if last_seen:

--- a/external-import/threatfox/src/main.py
+++ b/external-import/threatfox/src/main.py
@@ -185,7 +185,6 @@ class ThreatFox:
 
             for i, row in enumerate(csv_reader):
                 ioc = FeedRow(row)
-                print(f"{ioc=}")
 
                 # skip unwanted IOC types
                 if ALL_TYPES not in self.ioc_to_import:

--- a/external-import/threatfox/src/main.py
+++ b/external-import/threatfox/src/main.py
@@ -1,5 +1,8 @@
+"""ThreatFox connector"""
+
+from __future__ import annotations
+
 import csv
-import datetime
 import io
 import os
 import ssl
@@ -8,6 +11,9 @@ import time
 import traceback
 import urllib.request
 import zipfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import stix2
 import validators
@@ -19,422 +25,95 @@ from pycti import (
     StixCoreRelationship,
     get_config_variable,
 )
+from stix2.base import _Observable as Observable
+
+ALL_TYPES = "all_types"
+BASE_PATH = os.path.dirname(os.path.abspath(__file__))
+CSV_PATH = f"{BASE_PATH}/data.csv"
 
 
+# pylint:disable=too-many-instance-attributes
 class ThreatFox:
+    """ThreatFox connector"""
+
     def __init__(self):
+        """Initializer"""
+
         # Instantiate the connector helper from config
-        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
+        config_file_path = f"{BASE_PATH}/config.yml"
         config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
+            yaml.load(open(config_file_path, encoding="utf-8"), Loader=yaml.FullLoader)
             if os.path.isfile(config_file_path)
             else {}
         )
         self.helper = OpenCTIConnectorHelper(config)
+
         # Extra config
-        self.threatfox_csv_url = get_config_variable(
-            "THREATFOX_CSV_URL", ["threatfox", "csv_url"], config
+        self.threatfox_csv_url: str = get_config_variable(
+            "THREATFOX_CSV_URL",
+            ["threatfox", "csv_url"],
+            config,
+            default="https://threatfox.abuse.ch/export/csv/recent/",
         )
-        self.threatfox_import_offline = get_config_variable(
+        self.threatfox_import_offline: bool = get_config_variable(
             "THREATFOX_IMPORT_OFFLINE",
             ["threatfox", "import_offline"],
             config,
-            False,
-            True,
+            default=True,
         )
-        self.threatfox_interval = get_config_variable(
-            "THREATFOX_INTERVAL", ["threatfox", "interval"], config, False
+        self.threatfox_interval: int = get_config_variable(
+            "THREATFOX_INTERVAL",
+            ["threatfox", "interval"],
+            config,
+            isNumber=True,
+            default=3,
         )
-        self.create_indicators = get_config_variable(
+        self.create_indicators: bool = get_config_variable(
             "THREATFOX_CREATE_INDICATORS",
             ["threatfox", "create_indicators"],
             config,
-            False,
-            True,
+            default=True,
         )
-        self.threats_from_labels = get_config_variable(
-            "THREATFOX_THREATS_FROM_LABELS",
-            ["threatfox", "threats_from_labels"],
-            config,
-            False,
-            True,
-        )
-        self.ioc_to_import = get_config_variable(
+        self.ioc_to_import: list[str] = get_config_variable(
             "THREATFOX_IOC_TO_IMPORT",
             ["threatfox", "ioc_to_import"],
             config,
-            False,
-            "all_types",
-        )
-        self.update_existing_data = get_config_variable(
+            default=ALL_TYPES,
+        ).split(",")
+        self.ioc_to_import = [ioc.strip() for ioc in self.ioc_to_import]
+        if len(self.ioc_to_import) == 0:
+            self.ioc_to_import = [ALL_TYPES]
+
+        self.update_existing_data: bool = get_config_variable(
             "CONNECTOR_UPDATE_EXISTING_DATA",
             ["connector", "update_existing_data"],
             config,
+            default=False,
         )
 
-        self.identity = self.helper.api.identity.create(
+        self.identity: str = self.helper.api.identity.create(
             type="Organization",
             name="Threat Fox | Abuse.ch",
-            description="abuse.ch is operated by a random swiss guy fighting malware for non-profit, running a couple "
-            "of projects helping internet service providers and network operators protecting their "
-            "infrastructure from malware.",
+            description="abuse.ch is operated by a random swiss guy fighting malware for "
+            "non-profit, running a couple of projects helping internet service providers "
+            "and network operators protecting their infrastructure from malware.",
         )
 
-    def get_interval(self, offset=0):
-        return (float(self.threatfox_interval) * 60 * 60 * 24) + offset
+    def get_interval(self) -> float:
+        """Convert the threatfox_interval from days to millis"""
 
-    def next_run(self, seconds):
-        return
+        return float(self.threatfox_interval) * 60 * 60 * 24
 
     def run(self):
-        self.helper.log_info("Fetching Threat Fox dataset...")
+        """Run the connector"""
+
         while True:
             try:
-                # Get the current timestamp and check
-                timestamp = int(time.time())
-                current_state = self.helper.get_state()
-                if current_state is not None and "last_run" in current_state:
-                    last_run = current_state["last_run"]
-                    self.helper.log_info(
-                        "Connector last run: "
-                        + datetime.datetime.utcfromtimestamp(last_run).strftime(
-                            "%Y-%m-%d %H:%M:%S"
-                        )
-                    )
-                else:
-                    last_run = None
-                    self.helper.log_info("Connector has never run")
-                # If the last_run is more than interval-1 day
-                if last_run is None or (
-                    (timestamp - last_run) > self.get_interval(offset=-1)
-                ):
-                    self.helper.log_info("Connector will run!")
-                    now = datetime.datetime.utcfromtimestamp(timestamp)
-                    friendly_name = "Threat Fox run @ " + now.strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    )
-                    work_id = self.helper.api.work.initiate_work(
-                        self.helper.connect_id, friendly_name
-                    )
-
-                    last_processed_entry_running_max = 0
-
-                    try:
-                        response = urllib.request.urlopen(
-                            self.threatfox_csv_url,
-                            context=ssl.create_default_context(),
-                        )
-                        data = response.read()
-                        try:
-                            zipped_file = io.BytesIO(data)
-                            with zipfile.ZipFile(zipped_file, "r") as zip_ref:
-                                with zip_ref.open("full.csv") as full_file:
-                                    csv_data = full_file.read()
-                        except zipfile.BadZipFile:
-                            # Treat as an unzipped CSV from /recent/
-                            csv_data = data
-
-                        with open(
-                            os.path.dirname(os.path.abspath(__file__)) + "/data.csv",
-                            "wb",
-                        ) as file:
-                            file.write(csv_data)
-                        fp = open(
-                            os.path.dirname(os.path.abspath(__file__)) + "/data.csv",
-                            "r",
-                            encoding="utf-8",
-                        )
-                        csv.register_dialect(
-                            "custom",
-                            delimiter=",",
-                            quotechar='"',
-                            skipinitialspace=True,
-                        )
-                        csv_reader = csv.reader(
-                            (line for line in fp if not line.startswith("#")),
-                            dialect="custom",
-                        )
-
-                        bundle_objects = []
-                        # the csv-file has the following columns:
-                        # first_seen_utc, ioc_id, ioc_value, ioc_type, threat_type, fk_malware, malware_alias,
-                        # malware_printable, last_seen_utc, reference, tags, anonymous, reporter
-
-                        if (
-                            current_state is not None
-                            and "last_processed_entry" in current_state
-                        ):
-                            last_processed_entry = current_state[
-                                "last_processed_entry"
-                            ]  # epoch time format
-                        else:
-                            self.helper.log_info(
-                                "'last_processed_entry' state not found, setting it to epoch start."
-                            )
-                            last_processed_entry = 0  # start of the epoch
-
-                        last_processed_entry_running_max = last_processed_entry
-
-                        # If importing a subset of IOCs
-                        wanted_ioc = []
-                        if self.ioc_to_import:
-                            for ioc in self.ioc_to_import.split(","):
-                                wanted_ioc.append(ioc.strip())
-                        else:
-                            wanted_ioc.append("all_types")
-
-                        for i, row in enumerate(csv_reader):
-                            ioc_object = {
-                                "first_seen_utc": row[0],
-                                "ioc_id": row[1],
-                                "ioc_value": row[2],
-                                "ioc_type": row[3],
-                                "threat_type": row[4],
-                                "fk_malware": row[5] if row[5] != "unknown" else "",
-                                "malware_alias": row[6].split(","),
-                                "malware_printable": (
-                                    row[7] if row[7] != "Unknown malware" else ""
-                                ),
-                                "last_seen_utc": row[8],
-                                "confidence_level": row[9],
-                                "reference": row[10],
-                                "tags": row[11].split(","),
-                                "anonymous": row[12],
-                                "reporter": row[13],
-                            }
-
-                            # Pre-process row data for efficiency
-                            ioc_value = ioc_object["ioc_value"]
-                            ioc_type = ioc_object["ioc_type"]
-                            ioc_object["malware_alias"].insert(
-                                0, ioc_object["fk_malware"]
-                            )
-                            ioc_aliases = [
-                                x
-                                for x in ioc_object["malware_alias"]
-                                if x not in {"None", ""}
-                            ]
-                            ioc_object["tags"].insert(0, ioc_object["threat_type"])
-                            ioc_labels = [
-                                x for x in ioc_object["tags"] if x not in {"None", ""}
-                            ]
-
-                            self.helper.log_info(f"ioc_type: '{ioc_type}'")
-
-                            # Skip unwanted IOC types
-                            if not (ioc_type in wanted_ioc):
-                                self.helper.log_info(
-                                    f"Unwanted ioc_type skipped: {ioc_type}"
-                                )
-                                continue
-
-                            entry_date = datetime.datetime.strptime(
-                                ioc_object["first_seen_utc"], "%Y-%m-%d %H:%M:%S"
-                            )
-                            if i % 5000 == 0:
-                                self.helper.log_info(
-                                    f"Process entry {i} with dateadded='{entry_date.strftime('%Y-%m-%d %H:%M:%S')}'"
-                                )
-
-                            # skip entry if newer events already processed in the past
-                            if last_processed_entry > entry_date.timestamp():
-                                continue
-                            last_processed_entry_running_max = max(
-                                entry_date.timestamp(), last_processed_entry_running_max
-                            )
-
-                            if ioc_type == "ip:port":
-                                pattern_value = (
-                                    "[ipv4-addr:value = '"
-                                    + ioc_value.split(":")[0]
-                                    + "']"
-                                )
-                                indicator_type = "ipv4"
-                                observable_type = "IPv4-Addr"
-                            elif ioc_type == "domain":
-                                pattern_value = (
-                                    "[domain-name:value = '" + ioc_value + "']"
-                                )
-                                indicator_type = "domain"
-                                observable_type = "Domain-Name"
-                            elif ioc_type == "url":
-                                pattern_value = "[url:value = '" + ioc_value + "']"
-                                indicator_type = "url"
-                                observable_type = "Url"
-                            elif ioc_type == "md5_hash":
-                                pattern_value = (
-                                    "[file:hashes.MD5 = '" + ioc_value + "']"
-                                )
-                                indicator_type = "md5"
-                                observable_type = "StixFile"
-                            elif ioc_type == "sha1_hash":
-                                pattern_value = (
-                                    "[file:hashes.SHA1 = '" + ioc_value + "']"
-                                )
-                                indicator_type = "sha1"
-                                observable_type = "StixFile"
-                            elif ioc_type == "sha256_hash":
-                                pattern_value = (
-                                    "[file:hashes.'SHA-256' = '" + ioc_value + "']"
-                                )
-                                indicator_type = "sha256"
-                                observable_type = "StixFile"
-                            else:
-                                self.helper.log_warning(
-                                    f"Unrecognized ioc_type: {ioc_type}"
-                                )
-                                continue
-
-                            # Check if we have an external reference
-                            if validators.url(ioc_object["reference"]):
-                                indicator_external_reference = [
-                                    stix2.ExternalReference(
-                                        source_name="ThreatFox source reference",
-                                        url=ioc_object["reference"],
-                                    )
-                                ]
-
-                                stix_indicator = stix2.Indicator(
-                                    name=ioc_value,
-                                    id=Indicator.generate_id(pattern_value),
-                                    indicator_types=[indicator_type],
-                                    pattern_type="stix",
-                                    pattern=pattern_value,
-                                    valid_from=datetime.datetime.utcnow().strftime(
-                                        "%Y-%m-%dT%H:%M:%S.%fZ"
-                                    ),
-                                    labels=ioc_labels,
-                                    object_marking_refs=[stix2.TLP_WHITE],
-                                    created_by_ref=self.identity["standard_id"],
-                                    external_references=indicator_external_reference,
-                                    custom_properties={
-                                        "x_opencti_main_observable_type": observable_type
-                                    },
-                                )
-
-                            else:
-                                stix_indicator = stix2.Indicator(
-                                    name=ioc_value,
-                                    id=Indicator.generate_id(pattern_value),
-                                    indicator_types=[indicator_type],
-                                    pattern_type="stix",
-                                    pattern=pattern_value,
-                                    valid_from=datetime.datetime.utcnow().strftime(
-                                        "%Y-%m-%dT%H:%M:%S.%fZ"
-                                    ),
-                                    labels=ioc_labels,
-                                    object_marking_refs=[stix2.TLP_WHITE],
-                                    created_by_ref=self.identity["standard_id"],
-                                    custom_properties={
-                                        "x_opencti_main_observable_type": observable_type
-                                    },
-                                )
-
-                            self.helper.log_info(
-                                "Indicator created: " + str(stix_indicator)
-                            )
-
-                            bundle_objects.append(stix_indicator)
-
-                            if not ioc_object["malware_printable"]:
-                                continue
-
-                            if ioc_object["threat_type"] == "botnet_cc":
-                                malware_type = "Bot"
-                            elif ioc_object["threat_type"] == "payload_delivery":
-                                malware_type = "dropper"
-                            else:
-                                malware_type = ""
-
-                            # Create the malware object
-                            self.helper.log_info("Creating Malware object...")
-                            malware_object = stix2.Malware(
-                                id=Malware.generate_id(ioc_object["malware_printable"]),
-                                name=ioc_object["malware_printable"],
-                                aliases=ioc_aliases,
-                                created_by_ref=self.identity["standard_id"],
-                                object_marking_refs=[stix2.TLP_WHITE],
-                                description="Threat: "
-                                + ioc_object["fk_malware"]
-                                + " - Reporter: "
-                                + ioc_object["reporter"],
-                                is_family="false",
-                                labels=ioc_labels,
-                                malware_types=[malware_type] if malware_type else None,
-                            )
-                            self.helper.log_info(
-                                "Malware object created: " + str(malware_object)
-                            )
-                            bundle_objects.append(malware_object)
-
-                            # Create a relationship between the indicator and the malware object
-                            self.helper.log_info("Creating Relationship...")
-                            relationship = stix2.Relationship(
-                                id=StixCoreRelationship.generate_id(
-                                    "indicates",
-                                    stix_indicator.id,
-                                    malware_object.id,
-                                ),
-                                source_ref=stix_indicator.id,
-                                target_ref=malware_object.id,
-                                relationship_type="indicates",
-                                created_by_ref=self.identity["standard_id"],
-                                object_marking_refs=[stix2.TLP_WHITE],
-                                description="Indicates relationship between indicator and malware",
-                            )
-                            self.helper.log_info(
-                                "Relationship created: " + str(relationship)
-                            )
-                            bundle_objects.append(relationship)
-
-                        fp.close()
-                        bundle = stix2.Bundle(
-                            objects=bundle_objects, allow_custom=True
-                        ).serialize()
-                        self.helper.send_stix2_bundle(
-                            bundle,
-                            update=self.update_existing_data,
-                            work_id=work_id,
-                        )
-                        print(bundle)
-                        if os.path.exists(
-                            os.path.dirname(os.path.abspath(__file__)) + "/data.csv"
-                        ):
-                            os.remove(
-                                os.path.dirname(os.path.abspath(__file__)) + "/data.csv"
-                            )
-                    except Exception:
-                        self.helper.log_error(traceback.format_exc())
-
-                    # Store the current timestamp as a last run
-                    message = "Connector successfully run, storing last_run as " + str(
-                        timestamp
-                    )
-                    self.helper.log_info(message)
-                    self.helper.set_state(
-                        {
-                            "last_run": timestamp,
-                            "last_processed_entry": last_processed_entry_running_max,
-                        }
-                    )
-                    self.helper.api.work.to_processed(work_id, message)
-                    self.helper.log_info(
-                        "Last_run stored, next run in: "
-                        + str(round(self.get_interval() / 60 / 60 / 24, 2))
-                        + " days"
-                    )
-                else:
-                    new_interval = self.get_interval() - (timestamp - last_run)
-                    self.helper.log_info(
-                        "Connector will not run, next run in: "
-                        + str(round(new_interval / 60 / 60 / 24, 2))
-                        + " days"
-                    )
-
+                self.loop()
             except (KeyboardInterrupt, SystemExit):
                 self.helper.log_info("Connector stop")
                 sys.exit(0)
-            except Exception:
+            except Exception:  # pylint:disable=broad-exception-caught
                 self.helper.log_error(traceback.format_exc())
 
             if self.helper.connect_run_and_terminate:
@@ -444,12 +123,431 @@ class ThreatFox:
 
             time.sleep(60)
 
+    def loop(self) -> None:
+        """Main connector loop"""
+
+        # Get the current timestamp and check
+        now_dt = datetime.now(UTC)
+        now_ts = now_dt.timestamp()
+        state = self.helper.get_state()
+        if state is None:
+            state = {}
+
+        last_run_ts = state.get("last_run")
+        if last_run_ts is None:
+            self.helper.log_info("Connector has never run")
+            last_run_ts = 0
+        else:
+            last_run_dt = datetime.fromtimestamp(last_run_ts, UTC)
+            self.helper.log_info(f"Connector last run: {last_run_dt}")
+
+        next_dt = datetime.fromtimestamp(now_ts + self.get_interval(), UTC)
+        if (now_ts - last_run_ts) >= self.get_interval():
+            self.helper.log_info("Connector will run!")
+            self.import_data(state, now_dt, now_ts)
+            self.helper.log_info(f"Last_run stored, next run in: {next_dt - now_dt}")
+        else:
+            self.helper.log_info(
+                f"Connector will not run, next run in: {next_dt - now_dt}"
+            )
+
+    def import_data(self, state: Dict, now_dt: datetime, now_ts: int) -> None:
+        """Pull and import ThreatFox data"""
+
+        work_id = self.helper.api.work.initiate_work(
+            self.helper.connect_id,
+            "Threat Fox run @ " + now_dt.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+
+        csv.register_dialect(
+            "custom",
+            delimiter=",",
+            quotechar='"',
+            skipinitialspace=True,
+        )
+
+        last_processed_entry_running_max = 0
+
+        try:
+            lines = self.download_csv()
+            csv_reader = csv.reader(lines, dialect="custom")
+
+            bundle_objects = []
+
+            last_processed_entry = state.get("last_processed_entry")  # epoch
+            if last_processed_entry is None:
+                self.helper.log_info(
+                    "'last_processed_entry' state not found, setting it to epoch start."
+                )
+                last_processed_entry = 0
+
+            last_processed_entry_running_max = last_processed_entry
+
+            for i, row in enumerate(csv_reader):
+                ioc = FeedRow(row)
+                print(f"{ioc=}")
+
+                # skip unwanted IOC types
+                if ALL_TYPES not in self.ioc_to_import:
+                    if ioc.type not in self.ioc_to_import:
+                        self.helper.log_info(f"Unwanted ioc_type skipped: {ioc.type}")
+                        continue
+
+                # occasional logging
+                if i % 5000 == 0:
+                    self.helper.log_info(
+                        f"Processing entry {i} with dateadded='{ioc.first_seen}'"
+                    )
+
+                # skip entry if newer events already processed in the past
+                if last_processed_entry > ioc.first_seen.timestamp():
+                    continue
+
+                # update the running max
+                last_processed_entry_running_max = max(
+                    ioc.first_seen.timestamp(),
+                    last_processed_entry_running_max,
+                )
+
+                if not self.threatfox_import_offline:
+                    if not ioc.last_seen or ioc.last_seen < now_dt:
+                        self.helper.log_info(f"Skipping offline IOC: {ioc.value}")
+                        continue
+
+                bundle_objects.extend(self.process_row(ioc))
+
+            bundle = stix2.Bundle(
+                objects=bundle_objects,
+                allow_custom=True,
+            ).serialize()
+            self.helper.send_stix2_bundle(
+                bundle,
+                update=self.update_existing_data,
+                work_id=work_id,
+            )
+            self.helper.log_debug(bundle)
+
+            if os.path.exists(CSV_PATH):
+                os.remove(CSV_PATH)
+
+        except Exception:  # pylint:disable=broad-exception-caught
+            self.helper.log_error(traceback.format_exc())
+
+        # Store the current timestamp as a last run
+        message = f"Connector successfully run, storing last_run as {now_ts}"
+        self.helper.log_info(message)
+        self.helper.set_state(
+            {
+                "last_run": now_ts,
+                "last_processed_entry": last_processed_entry_running_max,
+            }
+        )
+        self.helper.api.work.to_processed(work_id, message)
+
+    def download_csv(self) -> Iterable[str]:
+        """
+        Download the csv_url, and if zipped, extract `full.csv` otherwise
+        treat the response as the csv itself. Return the non-commented lines
+        as a generator.
+        """
+
+        self.helper.log_info("Fetching Threat Fox dataset")
+        with urllib.request.urlopen(
+            self.threatfox_csv_url,
+            context=ssl.create_default_context(),
+        ) as response:
+            data: bytes = response.read()
+
+        try:
+            zipped_file = io.BytesIO(data)
+            with zipfile.ZipFile(zipped_file, "r") as zip_ref:
+                with zip_ref.open("full.csv") as full_file:
+                    csv_data = full_file.read()
+        except zipfile.BadZipFile:
+            # Treat as an unzipped CSV from /recent/
+            csv_data = data
+
+        with open(CSV_PATH, "wb") as fd:
+            fd.write(csv_data)
+
+        with open(CSV_PATH, "r", encoding="utf-8") as fd:
+            yield from (line for line in fd if not line.startswith("#"))
+
+    def process_row(self, ioc: FeedRow) -> Iterable[Dict]:
+        """Process the IOC record and generate SCO/SDO/SRO objects."""
+
+        stix_observable, stix_indicator = self.process_row_observable(ioc)
+        if stix_observable:
+            yield stix_observable
+        if stix_indicator:
+            yield stix_indicator
+
+        # Don't create malware if the source doesn't exists
+        if stix_observable is None:
+            return
+
+        stix_malware = self.process_row_malware(ioc)
+        if stix_malware:
+            yield stix_malware
+
+        if stix_indicator and stix_observable:
+            yield self.create_relationship(stix_indicator, "based-on", stix_observable)
+
+        if stix_indicator and stix_malware:
+            yield self.create_relationship(stix_indicator, "indicates", stix_malware)
+
+    def process_row_observable(
+        self, ioc: FeedRow
+    ) -> Tuple[Optional[Observable], Optional[stix2.Indicator]]:
+        """Process the IOC record and return an observable and indicator"""
+
+        description = None
+        if ioc.type == "ip:port":
+            ioc.value, port = ioc.value.split(":", maxsplit=1)
+            description = f"Traffic seen on port {port}"
+            pattern_value = f"[ipv4-addr:value = '{ioc.value}']"
+            indicator_type = "ipv4"
+            observable_type = "IPv4-Addr"
+            stix_observable = stix2.IPv4Address(
+                value=ioc.value,
+                object_marking_refs=[stix2.TLP_WHITE],
+                custom_properties={
+                    "created_by_ref": self.identity["standard_id"],
+                    "x_opencti_description": description,
+                    "x_opencti_labels": ioc.tags,
+                },
+            )
+        elif ioc.type == "domain":
+            pattern_value = f"[domain-name:value = '{ioc.value}']"
+            indicator_type = "domain"
+            observable_type = "Domain-Name"
+            stix_observable = stix2.DomainName(
+                value=ioc.value,
+                object_marking_refs=[stix2.TLP_WHITE],
+                custom_properties={
+                    "created_by_ref": self.identity["standard_id"],
+                    "x_opencti_description": description,
+                    "x_opencti_labels": ioc.tags,
+                },
+            )
+        elif ioc.type == "url":
+            pattern_value = f"[url:value = '{ioc.value}']"
+            indicator_type = "url"
+            observable_type = "Url"
+            stix_observable = stix2.URL(
+                value=ioc.value,
+                object_marking_refs=[stix2.TLP_WHITE],
+                custom_properties={
+                    "created_by_ref": self.identity["standard_id"],
+                    "x_opencti_description": description,
+                    "x_opencti_labels": ioc.tags,
+                },
+            )
+        elif ioc.type == "md5_hash":
+            pattern_value = f"[file:hashes.MD5 = '{ioc.value}']"
+            indicator_type = "md5"
+            observable_type = "StixFile"
+            stix_observable = stix2.File(
+                name=ioc.value,
+                hashes={"MD5": ioc.value},
+                object_marking_refs=[stix2.TLP_WHITE],
+                custom_properties={
+                    "created_by_ref": self.identity["standard_id"],
+                    "x_opencti_description": description,
+                    "x_opencti_labels": ioc.tags,
+                },
+            )
+        elif ioc.type == "sha1_hash":
+            pattern_value = f"[file:hashes.SHA1 = '{ioc.value}']"
+            indicator_type = "sha1"
+            observable_type = "StixFile"
+            stix_observable = stix2.File(
+                name=ioc.value,
+                hashes={"SHA-1": ioc.value},
+                object_marking_refs=[stix2.TLP_WHITE],
+                custom_properties={
+                    "created_by_ref": self.identity["standard_id"],
+                    "x_opencti_description": description,
+                    "x_opencti_labels": ioc.tags,
+                },
+            )
+        elif ioc.type == "sha256_hash":
+            pattern_value = f"[file:hashes.'SHA-256' = '{ioc.value}']"
+            indicator_type = "sha256"
+            observable_type = "StixFile"
+            stix_observable = stix2.File(
+                name=ioc.value,
+                hashes={"SHA-256": ioc.value},
+                object_marking_refs=[stix2.TLP_WHITE],
+                custom_properties={
+                    "created_by_ref": self.identity["standard_id"],
+                    "x_opencti_description": description,
+                    "x_opencti_labels": ioc.tags,
+                },
+            )
+        else:
+            self.helper.log_warning(f"Unrecognized ioc_type: {ioc.type}")
+            return None
+
+        # Check if we have an external reference
+        if validators.url(ioc.reference):
+            ext_refs = [
+                stix2.ExternalReference(
+                    source_name="ThreatFox source reference",
+                    url=ioc.reference,
+                )
+            ]
+        else:
+            ext_refs = []
+
+        if self.create_indicators:
+            stix_indicator = stix2.Indicator(
+                name=ioc.value,
+                description=description,
+                id=Indicator.generate_id(pattern_value),
+                indicator_types=[indicator_type],
+                pattern_type="stix",
+                pattern=pattern_value,
+                valid_from=datetime.now(UTC),
+                labels=ioc.tags,
+                object_marking_refs=[stix2.TLP_WHITE],
+                created_by_ref=self.identity["standard_id"],
+                confidence=ioc.confidence_level,
+                external_references=ext_refs,
+                custom_properties={
+                    "x_opencti_main_observable_type": observable_type,
+                },
+            )
+            self.helper.log_debug(f"Indicator created: {stix_indicator}")
+        else:
+            stix_indicator = None
+
+        return stix_observable, stix_indicator
+
+    def process_row_malware(self, ioc: FeedRow) -> stix2.Malware:
+        """Process the IOC record and generate a malware SDO"""
+
+        if not ioc.malware_printable:
+            return None
+
+        if ioc.threat_type == "botnet_cc":
+            malware_types = ["Bot"]
+        elif ioc.threat_type == "payload_delivery":
+            malware_types = ["dropper"]
+        else:
+            malware_types = None
+
+        # Create the malware object
+        stix_malware = stix2.Malware(
+            id=Malware.generate_id(ioc.malware_printable),
+            name=ioc.malware_printable,
+            aliases=ioc.malware_aliases,
+            created_by_ref=self.identity["standard_id"],
+            object_marking_refs=[stix2.TLP_WHITE],
+            confidence=ioc.confidence_level,
+            description=f"Threat: {ioc.fk_malware} - Reporter: {ioc.reporter}",
+            is_family=False,
+            labels=ioc.tags,
+            malware_types=malware_types,
+        )
+        self.helper.log_debug(f"Malware object created: {stix_malware}")
+
+        return stix_malware
+
+    def create_relationship(
+        self,
+        source: Observable,
+        rel_type: str,
+        target: Observable,
+    ) -> stix2.Relationship:
+        """Create a relationship between two objects"""
+
+        stix_rel = stix2.Relationship(
+            id=StixCoreRelationship.generate_id(rel_type, source.id, target.id),
+            source_ref=source.id,
+            target_ref=target.id,
+            relationship_type=rel_type,
+            created_by_ref=self.identity["standard_id"],
+            object_marking_refs=[stix2.TLP_WHITE],
+        )
+        self.helper.log_debug(f"Relationship created: {source.id} -> {target.id}")
+
+        return stix_rel
+
+
+# pylint:disable=too-many-instance-attributes
+@dataclass(init=False)
+class FeedRow:
+    """ThreatFox csv row"""
+
+    first_seen: datetime
+    id: str
+    value: str
+    type: str
+    threat_type: str
+    fk_malware: str
+    malware_aliases: List[str]
+    malware_printable: str
+    last_seen: Union[datetime, None]
+    confidence_level: int
+    reference: str
+    tags: List[str]
+    anonymous: bool
+    reporter: str
+
+    def __init__(self, row: Tuple) -> None:
+        """Initializer"""
+
+        first_seen = row[0]
+        self.first_seen = datetime.strptime(first_seen, "%Y-%m-%d %H:%M:%S")
+        self.first_seen = self.first_seen.replace(tzinfo=UTC)
+
+        self.id = row[1]
+        self.value = row[2]
+        self.type = row[3]
+        self.threat_type = row[4]
+        self.fk_malware = row[5]
+        self.malware_aliases = list(filter(None, row[6].split(",")))
+        self.malware_printable = row[7]
+
+        if self.malware_aliases == ["None"]:
+            self.malware_aliases = []
+
+        if self.fk_malware == "unknown":
+            self.fk_malware = ""
+        else:
+            self.malware_aliases.insert(0, self.fk_malware)
+
+        if self.malware_printable == "Unknown malware":
+            self.malware_printable = ""
+
+        last_seen = row[8]
+        if last_seen:
+            self.last_seen = datetime.strptime(last_seen, "%Y-%m-%d %H:%M:%S")
+            self.last_seen = self.last_seen.replace(tzinfo=UTC)
+        else:
+            self.last_seen = None
+
+        self.confidence_level = int(row[9])
+        self.reference = row[10]
+
+        if self.reference == "None":
+            self.reference = ""
+
+        self.tags = list(filter(None, row[11].split(",")))
+
+        if self.threat_type:
+            self.tags.insert(0, self.threat_type)
+
+        self.anonymous = bool(int(row[12]))
+        self.reporter = row[13]
+
 
 if __name__ == "__main__":
     try:
         ThreatFoxConnector = ThreatFox()
         ThreatFoxConnector.run()
-    except Exception:
+    except Exception:  # pylint:disable=broad-exception-caught
         print(traceback.format_exc())
         time.sleep(10)
         sys.exit(0)


### PR DESCRIPTION
### Proposed changes

- In the nature of so many connectors, this was previously one giant function. Now it has several and looks somewhat organized.
- Changed the stix2.Malware to use the `fk_malware` field instead of `malware_printable` from the feed. Whichever connector made my Malware/alias records tends to use the fk_malware instead. This was causing ref not found errors when importing the releationships. For example: change from using `WikiLoader` to `win.wikiloader` as the malware name.
    - Discussion: This could be considered a breaking change, add a toggle-able option?
- The Elasticsearch [integration](https://github.com/elastic/integrations/tree/main/packages/ti_opencti) expects the indicator name to be a valid ip, domain-name, or hash. Previously, this connector added them with the port included in the name. The port annotation has been moved to the indicator description now.
    - Discussion: Another potentially breaking change, toggle option? 
- Create observables in addition to indicators and the appropriate relationship. 
- The `THREATS_FROM_LABELS` config option was never implemented before, it has been removed.

### Related issues

* n/a

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Been running this in prod for about two weeks so far. Everything works as intended.
