### PR TITLE
[Recorded Future] Fix risk rules criticality score, handle empty string

### DIFF
--- a/external-import/recorded-future/entrypoint.sh
+++ b/external-import/recorded-future/entrypoint.sh
@@ -4,4 +4,4 @@
 cd /opt/opencti-connector-recorded-future
 
 # Start the connector
-python main.py
+python3 main.py

--- a/external-import/recorded-future/src/rflib/constants.py
+++ b/external-import/recorded-future/src/rflib/constants.py
@@ -16,6 +16,7 @@ THREAT_MAP_TYPE_MAPPER = {
 }
 
 RISK_RULES_MAPPER = [
+    {"rule_score": 0, "severity": "No current evidence of risk", "risk_score": "0"},
     {"rule_score": 1, "severity": "Unusual", "risk_score": "5-24"},
     {"rule_score": 2, "severity": "Suspicious", "risk_score": "25-64"},
     {"rule_score": 3, "severity": "Malicious", "risk_score": "65-89"},

--- a/external-import/recorded-future/src/rflib/risk_list.py
+++ b/external-import/recorded-future/src/rflib/risk_list.py
@@ -73,7 +73,12 @@ class RiskList(threading.Thread):
                     )
 
                     for index, criticality in enumerate(rule_criticality_list):
+                        # If criticality comes with empty string, replace value at 0
+                        if not criticality:
+                            criticality = 0
+
                         criticality_score = int(criticality)
+
                         for corresponding_rule in RISK_RULES_MAPPER:
                             if criticality_score == corresponding_rule["rule_score"]:
                                 description += (


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix criticality score mapper and handle empty string to be replaced with score at 0 and add corresponding security level to be aligned with Recorded Future severity level

![image](https://github.com/OpenCTI-Platform/connectors/assets/75518128/a5500f89-73fb-4723-96f7-7a9a3a3288cd)

* Fix entrypoint to align with all connectors


### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/6358

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
