### PR TITLE
[internal-export-file-stix] fix incomplete JSON export of reports  (#2004)

### DIFF
--- a/internal-export-file/export-file-stix/src/export-file-stix.py
+++ b/internal-export-file/export-file-stix/src/export-file-stix.py
@@ -68,9 +68,34 @@ class ExportFileStix:
                 entities_list = []
 
                 for selected_id in selected_ids:
-                    entity_data = self.helper.api_impersonate.stix_domain_object.read(
-                        id=selected_id, withFiles=True
+                    custom_attributes = """
+                        ... on StixCoreObject {
+                          id
+                          entity_type
+                        }
+                        ... on StixCoreRelationship {
+                          id
+                          entity_type
+                        }
+                        ... on StixSightingRelationship {
+                          id
+                          entity_type
+                        }
+                    """
+                    stix_object_result = (
+                        self.helper.api_impersonate.opencti_stix_object_or_stix_relationship.read(id=selected_id, customAttributes=custom_attributes)
                     )
+                    if stix_object_result is not None:
+                        entity_type = stix_object_result["entity_type"]
+                        # Reader
+                        do_read = self.helper.api.stix2.get_reader(entity_type)
+                        entity_data = do_read(id=selected_id)
+
+                    else:
+                        entity_data = self.helper.api_impersonate.stix_domain_object.read(
+                            id=selected_id, withFiles=True
+                        )
+
                     if entity_data is None:
                         entity_data = (
                             self.helper.api_impersonate.stix_cyber_observable.read(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* use `get_reade`r method created in `client python` to allow get reader from a specific `entity_type`


### Related issues

* [issue/2004](https://github.com/OpenCTI-Platform/connectors/issues/2004)
* [issue/305](https://github.com/OpenCTI-Platform/client-python/issues/605)
* [opencti/6499](https://github.com/OpenCTI-Platform/opencti/issues/6499)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
