### PR TITLE
[backend] Define file marking definitions (#opencti/5797-export)

### DIFF
--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -99,6 +99,7 @@ class ExportFileCsv:
         export_scope = data["export_scope"]  # query or selection or single
         export_type = data["export_type"]  # Simple or Full
         # max_marking = data["max_marking"]  # TODO Implement marking restriction
+        file_markings = data["file_markings"]
         entity_id = data.get("entity_id")
         entity_type = data["entity_type"]
 
@@ -220,15 +221,15 @@ class ExportFileCsv:
                 )
                 if entity_type == "Stix-Cyber-Observable":
                     self.helper.api.stix_cyber_observable.push_list_export(
-                        entity_id, entity_type, file_name, csv_data, list_filters
+                        entity_id, entity_type, file_name, file_markings, csv_data, list_filters
                     )
                 elif entity_type == "Stix-Core-Object":
                     self.helper.api.stix_core_object.push_list_export(
-                        entity_id, entity_type, file_name, csv_data, list_filters
+                        entity_id, entity_type, file_name, file_markings, csv_data, list_filters
                     )
                 else:
                     self.helper.api.stix_domain_object.push_list_export(
-                        entity_id, entity_type, file_name, csv_data, list_filters
+                        entity_id, entity_type, file_name, file_markings, csv_data, list_filters
                     )
                 self.helper.connector_logger.info(
                     "Export done",

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -145,10 +145,11 @@ class ExportFileCsv:
                     "entity_id": entity_id,
                     "export_type": export_type,
                     "file_name": file_name,
+                    "file_markings": file_markings,
                 },
             )
             self.helper.api.stix_domain_object.push_entity_export(
-                entity_id, file_name, csv_data
+                entity_id, file_name, file_markings, csv_data
             )
             self.helper.connector_logger.info(
                 "Export done",
@@ -157,6 +158,7 @@ class ExportFileCsv:
                     "entity_id": entity_id,
                     "export_type": export_type,
                     "file_name": file_name,
+                    "file_markings": file_markings,
                 },
             )
 

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -223,15 +223,30 @@ class ExportFileCsv:
                 )
                 if entity_type == "Stix-Cyber-Observable":
                     self.helper.api.stix_cyber_observable.push_list_export(
-                        entity_id, entity_type, file_name, file_markings, csv_data, list_filters
+                        entity_id,
+                        entity_type,
+                        file_name,
+                        file_markings,
+                        csv_data,
+                        list_filters,
                     )
                 elif entity_type == "Stix-Core-Object":
                     self.helper.api.stix_core_object.push_list_export(
-                        entity_id, entity_type, file_name, file_markings, csv_data, list_filters
+                        entity_id,
+                        entity_type,
+                        file_name,
+                        file_markings,
+                        csv_data,
+                        list_filters,
                     )
                 else:
                     self.helper.api.stix_domain_object.push_list_export(
-                        entity_id, entity_type, file_name, file_markings, csv_data, list_filters
+                        entity_id,
+                        entity_type,
+                        file_name,
+                        file_markings,
+                        csv_data,
+                        list_filters,
                     )
                 self.helper.connector_logger.info(
                     "Export done",

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -149,7 +149,7 @@ class ExportFileCsv:
                 },
             )
             self.helper.api.stix_domain_object.push_entity_export(
-                entity_id, file_name, file_markings, csv_data
+                entity_id, file_name, csv_data, file_markings
             )
             self.helper.connector_logger.info(
                 "Export done",

--- a/internal-export-file/export-file-stix/src/export-file-stix.py
+++ b/internal-export-file/export-file-stix/src/export-file-stix.py
@@ -22,7 +22,8 @@ class ExportFileStix:
         file_name = data["file_name"]
         export_scope = data["export_scope"]  # query or selection or single
         export_type = data["export_type"]  # Simple or Full
-        max_marking = data["max_marking"]
+        max_marking = data["content_max_markings"][0] # remove index on in chunk #2
+        file_markings = data["file_markings"]
 
         entity_id = data.get("entity_id")
         entity_type = data["entity_type"]
@@ -49,7 +50,7 @@ class ExportFileStix:
                 },
             )
             self.helper.api.stix_domain_object.push_entity_export(
-                entity_id, file_name, json_bundle
+                entity_id, file_name, json_bundle, file_markings
             )
             self.helper.connector_logger.info(
                 "Export done",

--- a/internal-export-file/export-file-stix/src/export-file-stix.py
+++ b/internal-export-file/export-file-stix/src/export-file-stix.py
@@ -22,7 +22,7 @@ class ExportFileStix:
         file_name = data["file_name"]
         export_scope = data["export_scope"]  # query or selection or single
         export_type = data["export_type"]  # Simple or Full
-        max_marking = data["content_max_markings"][0] # remove index on in chunk #2
+        max_marking = data["content_max_markings"][0]  # remove index on in chunk #2
         file_markings = data["file_markings"]
 
         entity_id = data.get("entity_id")
@@ -128,15 +128,30 @@ class ExportFileStix:
             )
             if entity_type == "Stix-Cyber-Observable":
                 self.helper.api.stix_cyber_observable.push_list_export(
-                    entity_id, entity_type, file_name, json_bundle, list_filters
+                    entity_id,
+                    entity_type,
+                    file_name,
+                    file_markings,
+                    json_bundle,
+                    list_filters,
                 )
             elif entity_type == "Stix-Core-Object":
                 self.helper.api.stix_core_object.push_list_export(
-                    entity_id, entity_type, file_name, json_bundle, list_filters
+                    entity_id,
+                    entity_type,
+                    file_name,
+                    file_markings,
+                    json_bundle,
+                    list_filters,
                 )
             else:
                 self.helper.api.stix_domain_object.push_list_export(
-                    entity_id, entity_type, file_name, json_bundle, list_filters
+                    entity_id,
+                    entity_type,
+                    file_name,
+                    file_markings,
+                    json_bundle,
+                    list_filters,
                 )
             self.helper.connector_logger.info(
                 "Export done",

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -21,6 +21,7 @@ class ExportFileTxt:
     def _process_message(self, data):
         file_name = data["file_name"]
         # max_marking = data["max_marking"]  # TODO Implement marking restriction
+        file_markings = data["file_markings"]
         entity_id = data.get("entity_id")
         entity_type = data["entity_type"]
         export_scope = data["export_scope"]
@@ -88,6 +89,7 @@ class ExportFileTxt:
                         entity_id,
                         entity_type,
                         file_name,
+                        file_markings,
                         observable_values_bytes,
                         list_filters,
                     )
@@ -98,6 +100,7 @@ class ExportFileTxt:
                         entity_id,
                         entity_type,
                         file_name,
+                        file_markings,
                         entities_values_bytes,
                         list_filters,
                     )
@@ -111,6 +114,7 @@ class ExportFileTxt:
                         entity_id,
                         entity_type,
                         file_name,
+                        file_markings,
                         entities_values_bytes,
                         list_filters,
                     )

--- a/internal-export-file/export-report-pdf/src/export-report-pdf.py
+++ b/internal-export-file/export-report-pdf/src/export-report-pdf.py
@@ -99,20 +99,22 @@ class ExportReportPdf:
         entity_type = data["entity_type"]
         entity_id = data["entity_id"]
 
+        # Retrieve markings for export push
+        file_markings = data["file_markings"]
         if entity_type == "Report":
-            self._process_report(entity_id, file_name)
+            self._process_report(entity_id, file_name, file_markings)
         elif entity_type == "Case-Incident":
-            self._process_case(entity_id, file_name, entity_type)
+            self._process_case(entity_id, file_name, entity_type, file_markings)
         elif entity_type == "Case-Rfi":
-            self._process_case(entity_id, file_name, entity_type)
+            self._process_case(entity_id, file_name, entity_type, file_markings)
         elif entity_type == "Case-Rft":
-            self._process_case(entity_id, file_name, entity_type)
+            self._process_case(entity_id, file_name, entity_type, file_markings)
         elif entity_type == "Intrusion-Set":
-            self._process_intrusion_set(entity_id, file_name)
+            self._process_intrusion_set(entity_id, file_name, file_markings)
         elif entity_type == "Threat-Actor-Group":
-            self._process_threat_actor_group(entity_id, file_name)
+            self._process_threat_actor_group(entity_id, file_name, file_markings)
         elif entity_type == "Threat-Actor-Individual":
-            self._process_threat_actor_individual(entity_id, file_name)
+            self._process_threat_actor_individual(entity_id, file_name, file_markings)
         else:
             raise ValueError(
                 f'This connector currently only handles the entity types: "Report", "Intrusion-Set", "Threat-Actor-Group", "Threat-Actor-Individual", "Case-Incident", "Case-Rfi", "Case-Rft", not "{entity_type}".'
@@ -120,7 +122,7 @@ class ExportReportPdf:
 
         return "Export done"
 
-    def _process_report(self, entity_id, file_name):
+    def _process_report(self, entity_id, file_name, file_markings):
         """
         Process a Report entity and upload as pdf.
         """
@@ -172,7 +174,7 @@ class ExportReportPdf:
 
             # Handle StixCyberObservables entities
             if obj_entity_type == "StixFile" or StixCyberObservableTypes.has_value(
-                obj_entity_type
+                    obj_entity_type
             ):
                 observable_dict = (
                     self.helper.api_impersonate.stix_cyber_observable.read(id=obj_id)
@@ -227,10 +229,10 @@ class ExportReportPdf:
         # Upload the output pdf
         self.helper.log_info(f"Uploading: {file_name}")
         self.helper.api.stix_domain_object.push_entity_export(
-            report_id, file_name, pdf_contents, "application/pdf"
+            report_id, file_name, pdf_contents, file_markings, "application/pdf"
         )
 
-    def _process_intrusion_set(self, entity_id, file_name):
+    def _process_intrusion_set(self, entity_id, file_name, file_markings):
         """
         Process an Intrusion Set entity and upload as pdf.
         """
@@ -284,9 +286,9 @@ class ExportReportPdf:
             targeted_countries = []
             for relationship in context["entities"]["relationship"]:
                 if (
-                    relationship["entity_type"] == "targets"
-                    and relationship["relationship_type"] == "targets"
-                    and relationship["to"]["entity_type"] == "Country"
+                        relationship["entity_type"] == "targets"
+                        and relationship["relationship_type"] == "targets"
+                        and relationship["to"]["entity_type"] == "Country"
                 ):
                     country_code = relationship["to"]["name"].lower()
                     if not self._validate_country_code(country_code):
@@ -322,10 +324,10 @@ class ExportReportPdf:
         # Upload the output pdf
         self.helper.log_info(f"Uploading: {file_name}")
         self.helper.api.stix_domain_object.push_entity_export(
-            entity_id, file_name, pdf_contents, "application/pdf"
+            entity_id, file_name, pdf_contents, file_markings, "application/pdf"
         )
 
-    def _process_threat_actor_group(self, entity_id, file_name):
+    def _process_threat_actor_group(self, entity_id, file_name, file_markings):
         """
         Process a Threat Actor Group entity and upload as pdf.
         """
@@ -379,9 +381,9 @@ class ExportReportPdf:
             targeted_countries = []
             for relationship in context["entities"]["relationship"]:
                 if (
-                    relationship["entity_type"] == "targets"
-                    and relationship["relationship_type"] == "targets"
-                    and relationship["to"]["entity_type"] == "Country"
+                        relationship["entity_type"] == "targets"
+                        and relationship["relationship_type"] == "targets"
+                        and relationship["to"]["entity_type"] == "Country"
                 ):
                     country_code = relationship["to"]["name"].lower()
                     if not self._validate_country_code(country_code):
@@ -417,10 +419,10 @@ class ExportReportPdf:
         # Upload the output pdf
         self.helper.log_info(f"Uploading: {file_name}")
         self.helper.api.stix_domain_object.push_entity_export(
-            entity_id, file_name, pdf_contents, "application/pdf"
+            entity_id, file_name, pdf_contents, file_markings, "application/pdf"
         )
 
-    def _process_threat_actor_individual(self, entity_id, file_name):
+    def _process_threat_actor_individual(self, entity_id, file_name, file_markings):
         """
         Process a Threat Actor Individual entity and upload as pdf.
         """
@@ -474,9 +476,9 @@ class ExportReportPdf:
             targeted_countries = []
             for relationship in context["entities"]["relationship"]:
                 if (
-                    relationship["entity_type"] == "targets"
-                    and relationship["relationship_type"] == "targets"
-                    and relationship["to"]["entity_type"] == "Country"
+                        relationship["entity_type"] == "targets"
+                        and relationship["relationship_type"] == "targets"
+                        and relationship["to"]["entity_type"] == "Country"
                 ):
                     country_code = relationship["to"]["name"].lower()
                     if not self._validate_country_code(country_code):
@@ -512,10 +514,10 @@ class ExportReportPdf:
         # Upload the output pdf
         self.helper.log_info(f"Uploading: {file_name}")
         self.helper.api.stix_domain_object.push_entity_export(
-            entity_id, file_name, pdf_contents, "application/pdf"
+            entity_id, file_name, pdf_contents, file_markings, "application/pdf"
         )
 
-    def _process_case(self, entity_id, file_name, entity_type):
+    def _process_case(self, entity_id, file_name, entity_type, file_markings):
         """
         Process a Case container and upload as pdf.
         """
@@ -584,7 +586,7 @@ class ExportReportPdf:
             obj_id = case_obj["standard_id"]
             # Handle StixCyberObservables entities
             if obj_entity_type == "StixFile" or StixCyberObservableTypes.has_value(
-                obj_entity_type
+                    obj_entity_type
             ):
                 observable_dict = (
                     self.helper.api_impersonate.stix_cyber_observable.read(id=obj_id)
@@ -640,7 +642,7 @@ class ExportReportPdf:
         # Upload the output pdf
         self.helper.log_info(f"Uploading: {file_name}")
         self.helper.api.stix_domain_object.push_entity_export(
-            entity_id, file_name, pdf_contents, "application/pdf"
+            entity_id, file_name, pdf_contents, file_markings, "application/pdf"
         )
 
     def _set_colors(self):

--- a/internal-export-file/export-report-pdf/src/export-report-pdf.py
+++ b/internal-export-file/export-report-pdf/src/export-report-pdf.py
@@ -174,7 +174,7 @@ class ExportReportPdf:
 
             # Handle StixCyberObservables entities
             if obj_entity_type == "StixFile" or StixCyberObservableTypes.has_value(
-                    obj_entity_type
+                obj_entity_type
             ):
                 observable_dict = (
                     self.helper.api_impersonate.stix_cyber_observable.read(id=obj_id)
@@ -286,9 +286,9 @@ class ExportReportPdf:
             targeted_countries = []
             for relationship in context["entities"]["relationship"]:
                 if (
-                        relationship["entity_type"] == "targets"
-                        and relationship["relationship_type"] == "targets"
-                        and relationship["to"]["entity_type"] == "Country"
+                    relationship["entity_type"] == "targets"
+                    and relationship["relationship_type"] == "targets"
+                    and relationship["to"]["entity_type"] == "Country"
                 ):
                     country_code = relationship["to"]["name"].lower()
                     if not self._validate_country_code(country_code):
@@ -381,9 +381,9 @@ class ExportReportPdf:
             targeted_countries = []
             for relationship in context["entities"]["relationship"]:
                 if (
-                        relationship["entity_type"] == "targets"
-                        and relationship["relationship_type"] == "targets"
-                        and relationship["to"]["entity_type"] == "Country"
+                    relationship["entity_type"] == "targets"
+                    and relationship["relationship_type"] == "targets"
+                    and relationship["to"]["entity_type"] == "Country"
                 ):
                     country_code = relationship["to"]["name"].lower()
                     if not self._validate_country_code(country_code):
@@ -476,9 +476,9 @@ class ExportReportPdf:
             targeted_countries = []
             for relationship in context["entities"]["relationship"]:
                 if (
-                        relationship["entity_type"] == "targets"
-                        and relationship["relationship_type"] == "targets"
-                        and relationship["to"]["entity_type"] == "Country"
+                    relationship["entity_type"] == "targets"
+                    and relationship["relationship_type"] == "targets"
+                    and relationship["to"]["entity_type"] == "Country"
                 ):
                     country_code = relationship["to"]["name"].lower()
                     if not self._validate_country_code(country_code):
@@ -586,7 +586,7 @@ class ExportReportPdf:
             obj_id = case_obj["standard_id"]
             # Handle StixCyberObservables entities
             if obj_entity_type == "StixFile" or StixCyberObservableTypes.has_value(
-                    obj_entity_type
+                obj_entity_type
             ):
                 observable_dict = (
                     self.helper.api_impersonate.stix_cyber_observable.read(id=obj_id)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Pass markings through export connectors : report pdf, csv, txt, stix

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/5797

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

This pull request is related to the ones in the `Client-Python` and `Open-CTI` :
* https://github.com/OpenCTI-Platform/client-python/pull/613
* https://github.com/OpenCTI-Platform/opencti/pull/6030
