### PR TITLE
[RF Enrichment] Make RF enrichment connector playbook compliant

### DIFF
--- a/internal-enrichment/recordedfuture-enrichment/docker-compose.yml
+++ b/internal-enrichment/recordedfuture-enrichment/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - CONNECTOR_NAME=Recorded Future Enrichment
       - CONNECTOR_SCOPE=ipv4-addr,ipv6-addr,domain-name,url,stixfile
       - CONNECTOR_AUTO=false
-      - CONNECTOR_CONFIDENCE_LEVEL=20
       - CONNECTOR_LOG_LEVEL=error
       - RECORDED_FUTURE_TOKEN=CHANGEME #required
       - RECORDED_FUTURE_INFO_MAX_TLP=TLP:AMBER

--- a/internal-enrichment/recordedfuture-enrichment/src/config.yml.sample
+++ b/internal-enrichment/recordedfuture-enrichment/src/config.yml.sample
@@ -7,7 +7,6 @@ connector:
   type: 'INTERNAL_ENRICHMENT'
   name: 'Recorded Future Enrichment'
   scope: 'ipv4-addr,ipv6-addr,domain-name,url,stixfile'
-  confidence_level: 5
   update_existing_data: false
   log_level: 'info'
 

--- a/internal-enrichment/recordedfuture-enrichment/src/requirements.txt
+++ b/internal-enrichment/recordedfuture-enrichment/src/requirements.txt
@@ -5,7 +5,6 @@ idna
 pika
 pycti
 python-dateutil
-python-magic
 pytz
 PyYAML
 regex

--- a/internal-enrichment/recordedfuture-enrichment/src/rf_enrichment.py
+++ b/internal-enrichment/recordedfuture-enrichment/src/rf_enrichment.py
@@ -20,7 +20,7 @@ class RFEnrichmentConnector:
         )
 
         self.work_id = None
-        self.helper = OpenCTIConnectorHelper(config)
+        self.helper = OpenCTIConnectorHelper(config, playbook_compatible=True)
 
         self.token = get_config_variable(
             "RECORDED_FUTURE_TOKEN",


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Update RF enrichment connector to be playbook compatible
* Update related configuration files
* Remove confidence level in connector as it is deprecated since >= 6.0

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/1839

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
