### PR TITLE
[RiskIQ] Add support for import start date

### DIFF
--- a/external-import/riskiq/src/config.yml.sample
+++ b/external-import/riskiq/src/config.yml.sample
@@ -18,3 +18,4 @@ riskiq:
   password: 'ChangeMe'
   create_observables: true
   interval_sec: 86400
+  import_from_timestamp: 1712929994

--- a/external-import/riskiq/src/riskiq/riskiq.py
+++ b/external-import/riskiq/src/riskiq/riskiq.py
@@ -43,12 +43,12 @@ class RiskIQConnector:
         self.interval_sec = get_config_variable(
             "RISKIQ_INTERVAL_SEC", ["riskiq", "interval_sec"], config
         )
-        self.import_from_timestamp= get_config_variable(
+        self.import_from_timestamp = get_config_variable(
             "RISKIQ_IMPORT_FROM_TIMESTAMP",
-             ["riskiq", "import_from_timestamp"],
-             config,
-             True,
-             default=None,
+            ["riskiq", "import_from_timestamp"],
+            config,
+            True,
+            default=None,
         )
         user = get_config_variable("RISKIQ_USER", ["riskiq", "user"], config)
         password = get_config_variable(
@@ -148,7 +148,7 @@ class RiskIQConnector:
                     self.helper.metric.state("running")
                     work_id = self._initiate_work(timestamp)
                     new_state = current_state.copy()
-                    
+
                     last_article = self._get_state_value(
                         current_state, ArticleImporter._LATEST_ARTICLE_TIMESTAMP
                     )
@@ -161,7 +161,9 @@ class RiskIQConnector:
                     # if the last_article_date is None (first run), we check if IMPORT_FROM_TIMESTAMP is set
                     if last_article_date is None:
                         if self.import_from_timestamp is not None:
-                            last_article_date = timestamp_to_datetime(self.import_from_timestamp).date()
+                            last_article_date = timestamp_to_datetime(
+                                self.import_from_timestamp
+                            ).date()
                             self.helper.log_debug(
                                 f"[RiskIQ] Import from date configured, articles will be fetch from date: {last_article_date}"
                             )
@@ -178,7 +180,9 @@ class RiskIQConnector:
                     response = self.client.get_articles(last_article_date)
 
                     if self.client.is_correct(response):
-                        self.helper.log_debug(f"[RiskIQ] The response contains {len(response['articles'])} articles to process")
+                        self.helper.log_debug(
+                            f"[RiskIQ] The response contains {len(response['articles'])} articles to process"
+                        )
 
                         for article in response["articles"]:
                             importer = ArticleImporter(


### PR DESCRIPTION
### Proposed changes

* We want to be able to set a starting date for importing RiskIQ items.
* A new environment variable can now be used to configure this behavior (RISKIQ_IMPORT_FROM_TIMESTAMP); if it's not set, the behavior remains the same (all articles are fetched).

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
