### PR TITLE
[Import External Reference] Correct config variable name

### DIFF
--- a/internal-enrichment/import-external-reference/README.md
+++ b/internal-enrichment/import-external-reference/README.md
@@ -21,7 +21,7 @@ OpenCTI data is coming from *import* connectors.
 | `opencti_token`                              | `OPENCTI_TOKEN`                              | Yes       | The default admin token configured in the OpenCTI platform parameters file.              |
 | `connector_id`                               | `CONNECTOR_ID`                               | Yes       | A valid arbitrary `UUIDv4` that must be unique for this connector.                       |
 | `connector_name`                             | `CONNECTOR_NAME`                             | Yes       | Option `ImportExternalReference`                                                         |
-| `connector_auto`                             | `CONNCETOR_AUTO`                             | Yes       | `false` Enable/disable auto-import of external references                                |
+| `connector_auto`                             | `CONNECTOR_AUTO`                             | Yes       | `false` Enable/disable auto-import of external references                                |
 | `connector_scope`                            | `CONNECTOR_SCOPE`                            | Yes       | Supported file types: `'External-Reference'`                                             |
 | `connector_confidence_level`                 | `CONNECTOR_CONFIDENCE_LEVEL`                 | Yes       | The default confidence level for created sightings (a number between 1 and 100).         |
 | `connector_log_level`                        | `CONNECTOR_LOG_LEVEL`                        | Yes       | Connector logging verbosity, could be `debug`, `info`, `warn` or `error` (less verbose). |


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Correct config variable name from `CONNCETOR_AUTO` to `CONNECTOR_AUTO`

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
