### PR TITLE
[taxii2] Added work_id to send_stix2_bundle

### DIFF
--- a/external-import/taxii2/src/taxii2.py
+++ b/external-import/taxii2/src/taxii2.py
@@ -6,7 +6,7 @@ import re
 import sys
 import time
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict
 
 import taxii2client.v20 as tx20
@@ -188,7 +188,7 @@ class Taxii2Connector:
             if self.first_run:
                 self.helper.log_info("Connector has never run")
             else:
-                last_run = datetime.utcfromtimestamp(
+                last_run = datetime.fromtimestamp(
                     self.helper.get_state()["last_run"]
                 ).strftime("%Y-%m-%d %H:%M:%S")
                 self.helper.log_info("Connector last run: " + last_run)
@@ -383,7 +383,7 @@ class Taxii2Connector:
                 "spec_version": version,
                 "objects": objects,
             }
-            self.send_to_server(new_bundle)
+            self.send_to_server(new_bundle,collection)
         else:
             self.helper.log_info("No objects found in request.")
 
@@ -396,7 +396,7 @@ class Taxii2Connector:
                 obj["x_opencti_create_indicators"] = self.create_indicators
         return stix_bundle
 
-    def send_to_server(self, bundle):
+    def send_to_server(self, bundle, collection):
         """
         Sends a STIX2 bundle to OpenCTI Server
         Args:
@@ -407,10 +407,16 @@ class Taxii2Connector:
             f"Sending Bundle to server with '{len(bundle.get('objects', []))}' objects"
         )
 
+        # Create work id
+        now = datetime.now(timezone.utc)
+        friendly_name = f"{self.helper.connect_name} - {collection.title} run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
+        work_id = self.helper.api.work.initiate_work(self.helper.connect_id, friendly_name)
+
         try:
             self.helper.send_stix2_bundle(
                 json.dumps(self._process_objects(bundle)),
                 update=self.update_existing_data,
+                work_id=work_id,
             )
 
         except Exception as e:

--- a/external-import/taxii2/src/taxii2.py
+++ b/external-import/taxii2/src/taxii2.py
@@ -383,7 +383,7 @@ class Taxii2Connector:
                 "spec_version": version,
                 "objects": objects,
             }
-            self.send_to_server(new_bundle,collection)
+            self.send_to_server(new_bundle, collection)
         else:
             self.helper.log_info("No objects found in request.")
 
@@ -409,8 +409,13 @@ class Taxii2Connector:
 
         # Create work id
         now = datetime.now(timezone.utc)
-        friendly_name = f"{self.helper.connect_name} - {collection.title} run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
-        work_id = self.helper.api.work.initiate_work(self.helper.connect_id, friendly_name)
+        friendly_name = (
+            f"{self.helper.connect_name} - {collection.title} run @ "
+            + now.strftime("%Y-%m-%d %H:%M:%S")
+        )
+        work_id = self.helper.api.work.initiate_work(
+            self.helper.connect_id, friendly_name
+        )
 
         try:
             self.helper.send_stix2_bundle(


### PR DESCRIPTION
### Proposed changes

* Added code to generate a work_id and modified send_stix2_bundle to send the work_id with the bundle.
* My IDE was complaining that utcfromtimestamp was depreciated, changed this to fromtimestamp. 

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/977

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments
I have tested this code against taxii 2.0 and 2.1 servers.
