### PR TITLE
[eset] Bug: Fix the code to set default confidence level when not in STIX

### DIFF
--- a/external-import/eset/src/eset.py
+++ b/external-import/eset/src/eset.py
@@ -196,11 +196,12 @@ class Eset:
                     parsed_content = json.loads(item.content)
                     objects = []
                     for object in parsed_content["objects"]:
-                        if "confidence" in object_types_with_confidence:
+                        if object["type"] in object_types_with_confidence:
                             if "confidence" not in object:
-                                object["confidence"] = int(
+                                object["confidence"] = (
                                     self.helper.connect_confidence_level
                                 )
+
                         if object["type"] == "indicator":
                             object["name"] = object["pattern"]
                             object["pattern_type"] = "stix"


### PR DESCRIPTION
### Proposed changes
* Replace `if "confidence" in object_types_with_confidence:` with `if object["type"] in object_types_with_confidence:`

It appears that this if statement is supposed to be looking to see if the current object type is present in the `object_types_with_confidence` list before it tries to check for a `confidence` and assign a default one if none is present. Instead it is looking for the string `"confidence"` in that list, which is never in the list, and thus this test always fails.

### Checklist
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality