### PR TITLE
[eset] Bug: Fix cases where ESET randomly-generates STIX ids, creating infinite aliases

### DIFF
--- a/external-import/eset/src/eset.py
+++ b/external-import/eset/src/eset.py
@@ -212,7 +212,7 @@ class Eset:
                             object["type"] == "identity"
                             and "name" in object
                             and object["name"] == "customer"
-                        ):
+                        ) or object["type"] == "observed-data":
                             removed_ids.add(object["id"])
                             continue
 

--- a/external-import/eset/src/eset.py
+++ b/external-import/eset/src/eset.py
@@ -11,7 +11,13 @@ import pytz
 import stix2
 import yaml
 from dateutil.parser import parse
-from pycti import Malware, OpenCTIConnectorHelper, Report, get_config_variable
+from pycti import (
+    Indicator,
+    Malware,
+    OpenCTIConnectorHelper,
+    Report,
+    get_config_variable,
+)
 
 TMP_DIR = "TMP"
 
@@ -252,6 +258,12 @@ class Eset:
                                 .replace("SHA1", "'SHA-1'")
                                 .replace("SHA256", "'SHA-256'")
                             )
+                            new_id = Indicator.generate_id(object["pattern"])
+                            if object["id"] in id_remaps:
+                                new_id = id_remaps[object["id"]]
+                            else:
+                                id_remaps[object["id"]] = new_id
+                            object["id"] = new_id
                             if self.eset_create_observables:
                                 object["x_opencti_create_observables"] = (
                                     self.eset_create_observables


### PR DESCRIPTION
### Proposed changes

The STIX2 malware entities from ESET's data stream appear to have their IDs randomly generated each time they appear in a new object. This results in many thousands of STIX IDs being generated for the same malware signature. To correct this, the STIX ID provided by ESET is overridden by the deterministic id generator available in pycti, before the entity is ingested. This is contributing to redis memory consumption, as well as unnecessary backlogging of the ESET connector's ingest queue.

Additionally, I discovered a similar bug exists where ESET attempts to communicate country-targeting information by using an Identity named `"customer"` with country codes in the `contact_information` field. The way this is formatted causes similar problems as the Malware entities above, but in this case I have chosen to simply remove these (and their respective relationships) from the ingest altogether, because the de-duplication process destroys the information ESET is trying to preserve with these. A preferable option would be to create new Location/Country entities from these, and new relationships to connect those to the other entities where they were related to the identity originally. I have left a "TODO" comment in the connector for this.

The re-generated STIX ids also appear on the Indicator entities as well, so I also perform the same normalization there.

Finally, similar to the way Identities are being de-duped and consolidated as described above, so are Observed Data entities, which also exhibit the increasing number of STIX id aliases on each instance. Additionally, this seems to be more an attempt at representing "sightings". I observed that the distinct counts in the Observed Data would be overwritten by future occurrences. Additionally, there's an attempt to report TCP/UDP port numbers using the Network Traffic data type, but the implementation after ingestion is confusing. There are a lot of these and their informational value is limited, at best, due to the platform behavior on ingest. I am also proposing we remove these (and their associated relationships) from the bundle until/unless a more elegant solution can be made to replace it.

### Related issues

* Probably fixes #1834 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Someone should take a closer look at ESETs data stream to see if any of the other entity types that get ingested exhibit the same anomalous behavior.

**For Observed Data + "customer" Identities** - my personal recommendation is that we should be reporting these as sightings within the relevant Observable, which grants the ability to record the occurrence count, whether it was FP or not, the temporal data, and also reflects a native relationship type between an observable and a location (how Identities are being used above). That is beyond the scope of this PR, though.