### PR TITLE
[eset] Bug: Fix entities and SCOs created with no author

### DIFF
--- a/external-import/eset/src/eset.py
+++ b/external-import/eset/src/eset.py
@@ -196,6 +196,10 @@ class Eset:
                     parsed_content = json.loads(item.content)
                     objects = []
                     for object in parsed_content["objects"]:
+                        # If no author provided in the entity, then default to set
+                        # author to ESET
+                        if not "created_by_ref" in object:
+                            object["created_by_ref"] = self.identity["standard_id"]
                         if "confidence" in object_types_with_confidence:
                             if "confidence" not in object:
                                 object["confidence"] = int(


### PR DESCRIPTION
### Proposed changes
* When a STIX object is encountered which has no `created_by_ref` then add one referencing the ESET author

### Checklist
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The ESET connector is creating a lot of objects with no listed author, when ingesting from a collection. The connector properly sets authors in reports, but not in entities ingested from collections. This change will add ESET as the author, if the STIX in the TAXII feed doesn't already list another author, so that none of these entities are author-less.