### PR TITLE
[greynoise_enricher] change API key validation to use local state file

### DIFF
--- a/internal-enrichment/greynoise/src/main.py
+++ b/internal-enrichment/greynoise/src/main.py
@@ -60,49 +60,70 @@ class GreyNoiseConnector:
         self.tlp = None
         self.stix_objects = []
 
-        # Validate GreyNoise API Key
-        session = GreyNoise(
-            api_key=self.greynoise_key, integration_name="opencti-enricher-v3.1"
-        )
-        try:
-            key_check = session.test_connection()
+        self.check_api_key(force_recheck=True)
 
+    def check_api_key(self, force_recheck=False):
+        # Validate GreyNoise API Key
+        self.helper.log_debug("Validating GreyNoise API Key...")
+        try:
             today = datetime.today().strftime("%Y-%m-%d")
 
-            key_state = {
-                "offering": key_check.get("offering"),
-                "expiration": key_check.get("expiration"),
-                "last_checked": today
-            }
+            if os.path.exists("KEY_INFO"):
+                with open("KEY_INFO") as text_file:
+                    key_info = text_file.read()
+                key_state = json.loads(key_info)
+            else:
+                empty_key_state = {"offering": "", "expiration": "", "last_checked": ""}
+                with open("KEY_INFO", "w") as text_file:
+                    empty_key_state = json.dumps(empty_key_state)
+                    print(f"{empty_key_state}", file=text_file)
+                key_state = json.loads(empty_key_state)
 
-            if "offering" in key_check:
-                self.helper.log_info(
-                    "GreyNoise API Key Status: "
-                    + str(key_check.get("offering", ""))
-                    + "/"
-                    + str(key_check.get("expiration", ""))
+            if key_state.get("last_checked") != today or force_recheck:
+                session = GreyNoise(
+                    api_key=self.greynoise_key, integration_name="opencti-enricher-v3.1"
                 )
-                if key_check.get("offering") == "community_trial":
-                    key_state["valid"] = True
-                    self.helper.log_info("GreyNoise API key is valid!")
-                elif key_check.get("offering") == "community":
-                    key_state["valid"] = False
-                    self.helper.log_info("GreyNoise API key NOT valid! Update to use connector!")
-                elif (
+                key_check = session.test_connection()
+
+                key_state = {
+                    "offering": key_check.get("offering"),
+                    "expiration": key_check.get("expiration"),
+                    "last_checked": today,
+                }
+
+                if "offering" in key_check:
+                    self.helper.log_info(
+                        "GreyNoise API Key Status: "
+                        + str(key_check.get("offering", ""))
+                        + "/"
+                        + str(key_check.get("expiration", ""))
+                    )
+                    if key_check.get("offering") == "community_trial":
+                        key_state["valid"] = True
+                        self.helper.log_info("GreyNoise API key is valid!")
+                    elif key_check.get("offering") == "community":
+                        key_state["valid"] = False
+                        self.helper.log_info(
+                            "GreyNoise API key NOT valid! Update to use connector!"
+                        )
+                    elif (
                         key_check.get("offering") != "community"
                         and key_check.get("expiration") > today
-                ):
-                    key_state["valid"] = True
-                    self.helper.log_info("GreyNoise API key is valid!")
-                elif (
+                    ):
+                        key_state["valid"] = True
+                        self.helper.log_info("GreyNoise API key is valid!")
+                    elif (
                         key_check.get("offering") != "community"
                         and key_check.get("expiration") < today
-                ):
-                    key_state["valid"] = False
+                    ):
+                        key_state["valid"] = False
 
-            with open("KEY_INFO", "w") as text_file:
-                key_state = json.dumps(key_state)
-                print(f"{key_state}", file=text_file)
+                with open("KEY_INFO", "w") as text_file:
+                    key_state = json.dumps(key_state)
+                    print(f"{key_state}", file=text_file)
+                key_state = json.loads(key_state)
+
+            return key_state.get("valid", False)
 
         except Exception as e:
             self.helper.log_error(
@@ -134,12 +155,12 @@ class GreyNoiseConnector:
         return is_valid_max_tlp
 
     def _generate_stix_relationship(
-            self,
-            source_ref: str,
-            stix_core_relationship_type: str,
-            target_ref: str,
-            start_time: str | None = None,
-            stop_time: str | None = None,
+        self,
+        source_ref: str,
+        stix_core_relationship_type: str,
+        target_ref: str,
+        start_time: str | None = None,
+        stop_time: str | None = None,
     ) -> dict:
         """
         This method allows you to create a relationship in Stix2 format.
@@ -254,8 +275,8 @@ class GreyNoiseConnector:
 
             # If category is malicious and activity, prepare malware object
             elif (
-                    tag_details["intention"] == "malicious"
-                    and tag_details["category"] == "activity"
+                tag_details["intention"] == "malicious"
+                and tag_details["category"] == "activity"
             ):
                 malware_malicious_activity = {
                     "name": f"{tag}",
@@ -272,7 +293,7 @@ class GreyNoiseConnector:
         return self.all_labels, all_malwares
 
     def _generate_stix_external_reference(
-            self, data: dict, sighting_not_seen: bool = False
+        self, data: dict, sighting_not_seen: bool = False
     ) -> list:
         """
         This method allows you to create an external reference in Stix2 format.
@@ -479,10 +500,10 @@ class GreyNoiseConnector:
             self.stix_objects.append(observable_to_tool)
 
     def _generate_stix_sighting(
-            self,
-            external_reference: list,
-            stix_indicator: dict,
-            sighting_not_seen: bool = False,
+        self,
+        external_reference: list,
+        stix_indicator: dict,
+        sighting_not_seen: bool = False,
     ):
         """
         This method creates a sighting.
@@ -570,9 +591,9 @@ class GreyNoiseConnector:
 
         # Create threat actor for non-benign when known
         if (
-                data["actor"]
-                and data["actor"] != "unknown"
-                and data["classification"] != "benign"
+            data["actor"]
+            and data["actor"] != "unknown"
+            and data["classification"] != "benign"
         ):
             # Generate Threat Actor
             stix_threat_actor = stix2.ThreatActor(
@@ -593,7 +614,7 @@ class GreyNoiseConnector:
             self.stix_objects.append(observable_to_threat_actor)
 
     def _generate_stix_indicator_with_relationship(
-            self, data: dict, detection: bool, external_reference: list, labels: list = None
+        self, data: dict, detection: bool, external_reference: list, labels: list = None
     ) -> dict:
         """
         This method creates and adds a bundle to "self.stix_objects" the IPv4 associated "Indicator"
@@ -636,7 +657,7 @@ class GreyNoiseConnector:
         return stix_indicator
 
     def _generate_stix_observable(
-            self, detection: bool, external_reference: list, labels: list = None
+        self, detection: bool, external_reference: list, labels: list = None
     ):
         """
         This method creates and adds a bundle to "self.stix_objects" the IPv4 associated "Observable"
@@ -662,7 +683,7 @@ class GreyNoiseConnector:
         self.stix_objects.append(stix_observable)
 
     def _generate_stix_bundle(
-            self, data: dict, data_tags: dict, stix_entity: dict
+        self, data: dict, data_tags: dict, stix_entity: dict
     ) -> str:
         """
         This method create a bundle in Stix2 format.
@@ -746,20 +767,15 @@ class GreyNoiseConnector:
         entity_splited = data["entity_id"].split("--")
         entity_type = entity_splited[0].lower()
 
-        with open("KEY_INFO") as text_file:
-            key_info = text_file.read()
-
-        key_state = json.loads(key_info)
-
-        if not key_state.get("valid"):
-            self.helper.log_error(f"Current GreyNoise API is NOT VALID: {key_state}")
+        if not self.check_api_key():
+            self.helper.log_error(
+                "GreyNoise API Key is NOT valid. Update to Enterprise API key to use this connector."
+            )
             raise ValueError(
                 "GreyNoise API Key is NOT valid. Update to Enterprise API key to use this connector."
             )
 
         if entity_type in scopes:
-            print(scopes)
-            print(data)
             # OpenCTI entity information retrieval
             stix_entity = data["stix_entity"]
             opencti_entity = data["enrichment_entity"]
@@ -785,9 +801,9 @@ class GreyNoiseConnector:
                 json_data = session.ip(opencti_entity_value)
 
                 if (
-                        "seen" in json_data
-                        and json_data["seen"] is False
-                        and self.sighting_not_seen is False
+                    "seen" in json_data
+                    and json_data["seen"] is False
+                    and self.sighting_not_seen is False
                 ):
                     raise ValueError(
                         "[API] This IP has not yet been identified by GreyNoise"
@@ -806,9 +822,9 @@ class GreyNoiseConnector:
                 # Send stix2 bundle
                 bundles_sent = self.helper.send_stix2_bundle(stix_bundle)
                 return (
-                        "[CONNECTOR] Sent "
-                        + str(len(bundles_sent))
-                        + " stix bundle(s) for worker import"
+                    "[CONNECTOR] Sent "
+                    + str(len(bundles_sent))
+                    + " stix bundle(s) for worker import"
                 )
 
             except Exception as e:


### PR DESCRIPTION
### Proposed changes

* The previous update for API checking was causing container restarts every few minutes
* Adds a local state file for the API key, which the container can then use

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
