### PR TITLE
[VirusTotal] Fix updating score

### DIFF
--- a/internal-enrichment/virustotal/src/virustotal/builder.py
+++ b/internal-enrichment/virustotal/src/virustotal/builder.py
@@ -86,18 +86,20 @@ class VirusTotalBuilder:
             raise ValueError(
                 "Cannot compute score. VirusTotal may have no record of the observable or it is currently being processed"
             ) from err
-        opencti_score = (
-            self.stix_entity["x_opencti_score"]
-            if "x_opencti_score" in self.stix_entity
-            else self.helper.api.get_attribute_in_extension("score", self.stix_entity)
+
+        observable = self.helper.api.stix_cyber_observable.read(
+            id=self.stix_entity["id"]
         )
-        if opencti_score is not None and not self.replace_with_lower_score:
-            if vt_score < opencti_score:
-                self.create_note(
-                    "VirusTotal Score",
-                    f"```\n{vt_score}\n```",
-                )
-                return opencti_score
+        if observable is not None:
+            if "x_opencti_score" in observable:
+                opencti_score = observable["x_opencti_score"]
+
+                if vt_score < opencti_score and not self.replace_with_lower_score:
+                    self.create_note(
+                        "VirusTotal Score",
+                        f"```\n{vt_score}\n```",
+                    )
+                    return opencti_score
         return vt_score
 
     def create_asn_belongs_to(self):


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Correct recovery and updating of the score
* In the case where the virustotal score is lower than the opencti score and the environment variable is set to false, we correctly create a note instead of changing the score in opencti.

### Related issues

* #2091 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
