### PR TITLE
[import-document] Initialize file before import (opencti/6999)

### DIFF
--- a/internal-import-file/import-document/src/reportimporter/core.py
+++ b/internal-import-file/import-document/src/reportimporter/core.py
@@ -67,6 +67,7 @@ class ReportImporter:
 
     def _process_message(self, data: Dict) -> str:
         self.helper.log_info("Processing new message")
+        self.file = None
         file_name = self._download_import_file(data)
         entity_id = data.get("entity_id", None)
         bypass_validation = data.get("bypass_validation", False)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Initialize file to None before import, otherwise we might add the previous file imported (global import) to a report when creating a workbench directly from a report

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2144

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

To reproduce the issue, you need to import globally a file that will create a workbench, no need to validate this workbench, just create a new report, import in this report another file, then validate the workbench and it will take the last imported file and add it to the report.
