### PR TITLE
[Taxii2] Option to pull data from custom property and put in a label

### DIFF
--- a/external-import/taxii2/README.md
+++ b/external-import/taxii2/README.md
@@ -28,6 +28,8 @@ There are a number of configuration options, which are set either in `docker-com
 | TAXII2_CUSTOM_LABEL | string | String to use for custom label. Requires TAXII2_ADD_CUSTOM_LABEL to be configured.
 | TAXII2_FORCE_PATTERN_AS_NAME | false | Boolean statement on whether to force name to be contents of pattern. Default to False
 | TAXII2_FORCE_MULTIPLE_PATTERN_NAME | string | String to use for indicators that contain multiple indicators in a single pattern. Requires TAXII2_FORCE_PATTERN_AS_NAME to be configured.
+| TAXII2_STIX_CUSTOM_PROPERTY_TO_LABEL | false | Boolean statement on whether to create a label from a stix custom property.
+| TAXII2_STIX_CUSTOM_PROPERTY | string | String to match the stix custom property you wish to add as a label e.g. x_foo. Requires TAXII2_STIX_CUSTOM_PROPERTY_TO_LABEL to be configured.
 
 ### Collections and API roots
 TAXII 2.0 introduced a new concept into the TAXII standard called an "API Root." API Roots are logical groupings of TAXII Collections and Channels that allow for better organization and federated access. More information can be found in the [TAXII2 standard](https://docs.oasis-open.org/cti/taxii/v2.1/csprd01/taxii-v2.1-csprd01.pdf)

--- a/external-import/taxii2/src/config.yml.sample
+++ b/external-import/taxii2/src/config.yml.sample
@@ -29,3 +29,5 @@ taxii2:
   custom_label: ChangeMe
   force_pattern_as_name: false
   force_multiple_pattern_name: 'Multiple Indicators'
+  stix_custom_property_to_label: false
+  stix_custom_property: 'x_foo'

--- a/external-import/taxii2/src/taxii2.py
+++ b/external-import/taxii2/src/taxii2.py
@@ -146,6 +146,17 @@ class Taxii2Connector:
             ["taxii2", "force_multiple_pattern_name"],
             config,
         )
+        self.stix_custom_property_to_label = get_config_variable(
+            "TAXII2_STIX_CUSTOM_PROPERTY_TO_LABEL",
+            ["taxii2", "stix_custom_property_to_label"],
+            config,
+            default=False,
+        )
+        self.stix_custom_property = get_config_variable(
+            "TAXII2_STIX_CUSTOM_PROPERTY",
+            ["taxii2", "stix_custom_property"],
+            config,
+        )
 
     @staticmethod
     def _init_collection_table(colls):
@@ -287,6 +298,12 @@ class Taxii2Connector:
                     new_labels = object["labels"]
                 if self.add_custom_label == True:
                     new_labels.append(self.custom_label)
+                    object["labels"] = new_labels
+                if (
+                    self.stix_custom_property_to_label == True
+                    and self.stix_custom_property in object
+                ):
+                    new_labels.append(object[self.stix_custom_property])
                     object["labels"] = new_labels
                 # Enumerate main observable type
                 if object["type"] == "indicator":


### PR DESCRIPTION
### Proposed changes

I have a taxii 2.0 feed that is pushing interesting data in a stix custom property. Currently it is being dropped by OpenCTI. I've added some code (disabled by default) that will allow a user to define the custom property as a variable and save the data as a label. I wasn't sure if there was a better way to do this.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

I did pop the question into slack, just in case I get any interesting responses there.. https://filigran-community.slack.com/archives/C06CC3T5Z37/p1716258546130119