### PR TITLE
[Diode-Import] Fix directory entrypoint.sh

### DIFF
--- a/external-import/diode-import/entrypoint.sh
+++ b/external-import/diode-import/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Correct working directory
-cd /opt/opencti-connector-diode-bundle-import
+cd /opt/opencti-connector-diode-import
 
 # Start the connector
 python3 diode-import.py


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix directory entrypoint.sh
 It should be : `cd /opt/opencti-connector-diode-import` instead `cd /opt/opencti-connector-diode-bundle-import`.

### Related issues

* #2152 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
