### PR TITLE
[Mandiant] Remove report creation while importing indicators

### DIFF
--- a/external-import/mandiant/src/connector/indicators.py
+++ b/external-import/mandiant/src/connector/indicators.py
@@ -160,23 +160,6 @@ def process(connector, indicator):
             )
         )
 
-    for report in indicator.get("reports", []):
-        # {
-        # "report_id": "20-00015687",
-        # "type": "Vulnerability Report",
-        # "title": "Title - 1afddaa7 3bf50d632cd9fa2e-1605910297",
-        # "published_date": "2020-11-20T22:11:45.213Z"
-        # }
-        stix_report = stix2.Report(
-            id=Report.generate_id(report["title"], report["published_date"]),
-            name=report["title"],
-            published=report["published_date"],
-            object_refs=list(map(lambda item: item["id"], items)),
-            created_by_ref=connector.identity.get("standard_id"),
-            allow_custom=True,
-        )
-        items.append(stix_report)
-
     bundle = stix2.Bundle(objects=items, allow_custom=True)
 
     if bundle is None:

--- a/external-import/mandiant/src/connector/indicators.py
+++ b/external-import/mandiant/src/connector/indicators.py
@@ -1,5 +1,5 @@
 import stix2
-from pycti import Indicator, Report
+from pycti import Indicator
 
 from . import utils
 from .common import create_stix_relationship


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove report creation loop while importing indicators

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2170

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
