### PR TITLE
[RST CLOUD] May 2024: Bug Fixes 

### DIFF
--- a/external-import/rst-report-hub/src/main.py
+++ b/external-import/rst-report-hub/src/main.py
@@ -54,7 +54,7 @@ class ReportHub:
     def get_config(name: str, config, default=None):
         env_name = "RST_REPORT_HUB_{}".format(name.upper())
         # usually this connector gets its config from variables
-        # but if these are not defined, then it 
+        # but if these are not defined, then it
         # reads 'rst-report-hub' property in the file config.yml
         result = get_config_variable(env_name, ["rst-report-hub", name], config)
         return result or default

--- a/external-import/rst-report-hub/src/main.py
+++ b/external-import/rst-report-hub/src/main.py
@@ -53,7 +53,10 @@ class ReportHub:
     @staticmethod
     def get_config(name: str, config, default=None):
         env_name = "RST_REPORT_HUB_{}".format(name.upper())
-        result = get_config_variable(env_name, ["rst_report_hub", name], config)
+        # usually this connector gets its config from variables
+        # but if these are not defined, then it 
+        # reads 'rst-report-hub' property in the file config.yml
+        result = get_config_variable(env_name, ["rst-report-hub", name], config)
         return result or default
 
     def _combine_report_and_send(self, stix_bundle, x_opencti_file, report_id):
@@ -62,8 +65,8 @@ class ReportHub:
         stix_bundle_main = []
         for entry in parsed_bundle.get("objects", []):
             stix_bundle_main.append(entry)
-            # attach a pdf
-            if x_opencti_file:
+            # attach PDFs only to the Report object
+            if x_opencti_file and entry.get("type", "") == "report":
                 entry["x_opencti_files"] = [x_opencti_file]
 
         message = "Importing " + report_id.replace("_", " ")


### PR DESCRIPTION
### Related issues

* A PDF copy of the original webpages (where the TI reports come from) is copied to all objects in the bundle. Fixed by attaching PDFs only to a Report stix object
* If connector is run manually, the config file needs another stanza as there is a type in the code. Fixed by changing the property name from "rst_report_hub" to "rst-report-hub" to align with this connector name and the folder name for it.

### Checklist

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality using different use cases
- [X] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

### Further comments
