### PR TITLE
[Urlscan] Fix import environment variable from docker

### DIFF
--- a/internal-enrichment/urlscan-enrichment/src/main.py
+++ b/internal-enrichment/urlscan-enrichment/src/main.py
@@ -18,7 +18,7 @@ class UrlscanConnector:
         self.helper = OpenCTIConnectorHelper(self.config.load, True)
         self.client = UrlscanClient(self.helper)
         self.converter = UrlscanConverter(self.helper)
-        self.constants = UrlscanConstants()
+        self.constants = UrlscanConstants
         self.utils = UrlscanUtils
 
         # Define variables

--- a/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/converter_to_stix2.py
+++ b/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/converter_to_stix2.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import stix2
 from pycti import CustomObservableHostname, Identity, Indicator, StixCoreRelationship
 
+from .config_variables import UrlscanConfig
 from .constants import UrlscanConstants
 from .utils import UrlscanUtils
 
@@ -14,7 +15,7 @@ class UrlscanConverter:
 
     def __init__(self, helper):
         self.helper = helper
-        self.config = self.helper.config["urlscan_enrichment"]
+        self.config = UrlscanConfig()
         self.identity = self.generate_urlscan_stix_identity()
         self.constants = UrlscanConstants
         self.utils = UrlscanUtils
@@ -104,7 +105,7 @@ class UrlscanConverter:
                     + search_entity_type
                     + entity_value
                     + " AND date:"
-                    + self.config["search_filtered_by_date"]
+                    + self.config.search_filtered_by_date
                 )
             else:
                 return []


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix import environment variable in converter_to_stix from docker
* Remove unnecessary instantiation of UrlscanConstants in main.py

### Related issues

* #2194 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
