### PR TITLE
Update Virustotal builder

### DIFF
--- a/internal-enrichment/virustotal/src/virustotal/builder.py
+++ b/internal-enrichment/virustotal/src/virustotal/builder.py
@@ -103,26 +103,27 @@ class VirusTotalBuilder:
 
     def create_asn_belongs_to(self):
         """Create AutonomousSystem and Relationship between the observable."""
-        self.helper.log_debug(f'[VirusTotal] creating asn {self.attributes["asn"]}')
-        as_stix = stix2.AutonomousSystem(
-            number=self.attributes["asn"],
-            name=self.attributes["as_owner"],
-            rir=self.attributes["regional_internet_registry"],
-        )
-        relationship = stix2.Relationship(
-            id=StixCoreRelationship.generate_id(
-                "belongs-to",
-                self.stix_entity["id"],
-                as_stix.id,
-            ),
-            relationship_type="belongs-to",
-            created_by_ref=self.author,
-            source_ref=self.stix_entity["id"],
-            target_ref=as_stix.id,
-            confidence=self.helper.connect_confidence_level,
-            allow_custom=True,
-        )
-        self.bundle += [as_stix, relationship]
+        if self.attributes.get("asn") is not None:
+            self.helper.log_debug(f'[VirusTotal] creating asn {self.attributes["asn"]}')
+            as_stix = stix2.AutonomousSystem(
+                number=self.attributes["asn"],
+                name=self.attributes["as_owner"],
+                rir=self.attributes["regional_internet_registry"],
+            )
+            relationship = stix2.Relationship(
+                id=StixCoreRelationship.generate_id(
+                    "belongs-to",
+                    self.stix_entity["id"],
+                    as_stix.id,
+                ),
+                relationship_type="belongs-to",
+                created_by_ref=self.author,
+                source_ref=self.stix_entity["id"],
+                target_ref=as_stix.id,
+                confidence=self.helper.connect_confidence_level,
+                allow_custom=True,
+            )
+            self.bundle += [as_stix, relationship]
 
     def _create_external_reference(
         self,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* added a check, to verify if the key "asn" is being returned, which doesn't cause the enrichment to fail completely.
*

### Related issues
Got the error:
``` json
"Error in message processing, reporting error to API", "exc_info": "Traceback (most recent call last):
 File \"/usr/local/lib/python3.11/site-packages/pycti/connector/opencti_connector_helper.py\", line 349, in _data_handler
    message = self.callback(event_data)
    ^^^^^^^^^^^^^^^^^^^^^^^^^
	  File \"/opt/opencti-connector-virustotal/virustotal/virustotal.py\", line 371, in _process_message
	      return self._process_ip(stix_objects, stix_entity, opencti_entity)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File \"/opt/opencti-connector-virustotal/virustotal/virustotal.py\", line 247, in _process_ip
          builder.create_asn_belongs_to()\n  File \"/opt/opencti-connector-virustotal/virustotal/builder.py\", line 106, in create_asn_belongs_to
              self.helper.log_debug(f'[VirusTotal] creating asn {self.attributes["asn"]}')\n       ~~~~~~~~~~~~~~~^^^^^^^\nKeyError: 'asn'"
```
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
