### PR TITLE
[import-document] added new exact_match_fields in configuration

### DIFF
--- a/internal-import-file/import-document/src/reportimporter/config/entity_config.ini
+++ b/internal-import-file/import-document/src/reportimporter/config/entity_config.ini
@@ -55,6 +55,8 @@ filter = { "mode": "and", "filterGroups": [], "filters": [{"key": "entity_type",
 fields =
     name
     x_opencti_aliases
+exact_match_fields =
+    x_opencti_aliases
 omit_match_in =
     Domain-Name.value
 custom_attributes =


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add a new configuration to only have exact match for some fields. 
* Add aliases of locations to exact match: when a country has a 'AND' alias for exemple, we do not want to match all lower cases 'and'

### Related issues

* opencti #7566

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
