### PR TITLE
[opencti] Fix interval bug

### DIFF
--- a/external-import/opencti/src/connector.py
+++ b/external-import/opencti/src/connector.py
@@ -113,10 +113,8 @@ class OpenCTI:
             else:
                 last_run = None
                 self.helper.log_info("Connector has never run")
-            # If the last_run is more than interval-1 day
-            if last_run is None or (
-                (timestamp - last_run) > (int(self.interval) - 60 * 60 * 24)
-            ):
+            # If the last_run is more than interval seconds
+            if last_run is None or ((timestamp - last_run) > self.interval):
                 now = datetime.utcfromtimestamp(timestamp)
                 friendly_name = "OpenCTI datasets run @ " + now.strftime(
                     "%Y-%m-%d %H:%M:%S"

--- a/external-import/opencti/src/connector.py
+++ b/external-import/opencti/src/connector.py
@@ -115,7 +115,7 @@ class OpenCTI:
                 self.helper.log_info("Connector has never run")
             # If the last_run is more than interval-1 day
             if last_run is None or (
-                (timestamp - last_run) > ((int(self.interval) - 1) * 60 * 60 * 24)
+                (timestamp - last_run) > (int(self.interval) - 60 * 60 * 24)
             ):
                 now = datetime.utcfromtimestamp(timestamp)
                 friendly_name = "OpenCTI datasets run @ " + now.strftime(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- Fix the interval check in the OpenCTI connector.

`self.interval` is already converted to seconds [here](https://github.com/OpenCTI-Platform/connectors/blob/master/external-import/opencti/src/connector.py#L63)
So the current calculation takes a seconds value, subtracts 1 second, then multiplies, turning it into something inbetween millis/nanos.

Relevant log:
```
{
    "timestamp": "2024-07-08T18:20:42.200433Z",
    "level": "INFO",
    "name": "OpenCTI",
    "message": "Connector will not run, next run in: -122.06 days"
}
```

Relevant state:
```
{'last_run': 1709246449}
last_run.isoformat()='2024-02-29T22:40:49+00:00'
```

Broken since [here](https://github.com/OpenCTI-Platform/connectors/commit/038869f327b01c455fca22191ccf150e5e92e5f9#diff-ba1788a6c5f0f2c6a513a1165e4289377d127e7b17bf69fcfd7d88f0d22e26a6R62)

### Related issues

* n/a

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
