### PR TITLE
[Mandiant] Add log when exception is caught outside of running connector process

### DIFF
--- a/external-import/mandiant/src/connector/__main__.py
+++ b/external-import/mandiant/src/connector/__main__.py
@@ -9,4 +9,3 @@ try:
 except Exception:
     traceback.print_exc()
     exit(1)
-

--- a/external-import/mandiant/src/connector/__main__.py
+++ b/external-import/mandiant/src/connector/__main__.py
@@ -7,6 +7,7 @@ try:
     mandiantConnector = Mandiant()
     while True:
         mandiantConnector.run()
-except Exception:
+except Exception as err:
+    print(err)
     time.sleep(10)
     sys.exit(0)

--- a/external-import/mandiant/src/connector/__main__.py
+++ b/external-import/mandiant/src/connector/__main__.py
@@ -1,5 +1,4 @@
-import sys
-import time
+import traceback
 
 from connector.base import Mandiant
 
@@ -7,7 +6,7 @@ try:
     mandiantConnector = Mandiant()
     while True:
         mandiantConnector.run()
-except Exception as err:
-    print(err)
-    time.sleep(10)
-    sys.exit(0)
+except Exception:
+    traceback.print_exc()
+    exit(1)
+


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Catch exception outside running connector process by adding a print()

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2372

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
