### PR TITLE
Fix for mistake in indent.

### DIFF
--- a/external-import/misp/src/misp.py
+++ b/external-import/misp/src/misp.py
@@ -1654,15 +1654,15 @@ class Misp:
                             allow_custom=True,
                         )
                     )
-            return {
-                "indicator": indicator,
-                "observable": observable,
-                "relationships": relationships,
-                "attribute_elements": attribute_elements,
-                "markings": attribute_markings,
-                "identities": identities,
-                "sightings": sightings,
-            }
+        return {
+            "indicator": indicator,
+            "observable": observable,
+            "relationships": relationships,
+            "attribute_elements": attribute_elements,
+            "markings": attribute_markings,
+            "identities": identities,
+            "sightings": sightings,
+        }
 
     def prepare_elements(self, galaxies, tags, author, markings):
         elements = {


### PR DESCRIPTION
The return was in a loop, when the indicator was composed, there was an exit too early. This resulted in the failure to create two indices for the filename|md5 type, for example.