### PR TITLE
Fix path error

### DIFF
--- a/external-import/cisco-sma/entrypoint.sh
+++ b/external-import/cisco-sma/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Correct working directory
-cd /opt/opencti-connector-cisco_sma
+cd /opt/opencti-connector-cisco-sma
 
 # Start the connector
 python3 cisco_sma.py


### PR DESCRIPTION
### Error

/entrypoint.sh: cd: line 4: can't cd to /opt/opencti-connector-cisco_sma: No such file or directory
python3: can't open file '//cisco_sma.py': [Errno 2] No such file or directory

### Proposed changes

"/opt/opencti-connector-cisco_sma" -> "/opt/opencti-connector-cisco-sma"

### Checklist

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality using different use cases
- [X] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
