### PR TITLE
Fix Tagger Connector entity type comparison and safe attribute access"

### DIFF
--- a/internal-enrichment/tagger/src/connector.py
+++ b/internal-enrichment/tagger/src/connector.py
@@ -34,15 +34,17 @@ class TaggerConnector:
                 entity_type = scope.lower()
 
                 #  Check if enrichment entity is supported
-                if enrichment_entity["entity_type"] != entity_type:
+                if enrichment_entity["entity_type"].lower() != entity_type:
                     continue
 
                 for rule in definition["rules"]:
                     flags = load_re_flags(rule)
 
                     for attribute in rule["attributes"]:
-                        self.helper.log_debug(enrichment_entity)
-                        attr = enrichment_entity[attribute]
+                        attr = enrichment_entity.get(attribute)
+                        if attr is None:
+                            continue
+
                         if attribute.lower() == "objectlabel":
                             for el in attr:
                                 if not re.search(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fixed the issue in TaggerConnector where entity type comparisons were case-sensitive, causing mismatches.
* Ensured safe access to entity attributes to prevent runtime errors when attributes are missing.


### Related issues

* This fix addresses an unreported issue where reports were not being tagged correctly due to case-sensitive entity type checks and missing attributes.


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

These changes ensure that the 'Tagger' connector correctly tags entities by using case-insensitive comparisons and handling missing attributes gracefully. This improves the robustness and accuracy of the tagging process.