### PR TITLE
[Malpedia] Adding variable default_marking, and schedule_unit

### DIFF
--- a/external-import/malpedia/README.md
+++ b/external-import/malpedia/README.md
@@ -26,31 +26,34 @@ We provide an example of [`docker-compose.yml`](docker-compose.yml) file that co
 
 Below are the parameters you'll need to set for OpenCTI:
 
-| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
-|---------------|------------|-----------------------------|-----------|------------------------------------------------------|
-| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
-| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+| Parameter `OpenCTI` | config.yml    | Docker environment variable | Mandatory | Description                                          |
+|---------------------|---------------|-----------------------------|-----------|------------------------------------------------------|
+| URL                 | `url`         | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
+| Token               | `token`       | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
 
 Below are the parameters you'll need to set for running the connector properly:
 
-| Parameter                      | config.yml           | Docker environment variable      | Default    | Mandatory | Description                                                                            |
-|--------------------------------|----------------------|----------------------------------|------------|-----------|----------------------------------------------------------------------------------------|
-| Connector ID                   | id                   | `CONNECTOR_ID`                   | /          | Yes       | A unique `UUIDv4` identifier for this connector instance.                              |
-| Connector Name                 | name                 | `CONNECTOR_NAME`                 | `Malpedia` | Yes       | Name of the connector.                                                                 |
-| Connector Scope                | scope                | `CONNECTOR_SCOPE`                | `malpedia` | Yes       | Must be `malpedia`, not used in this connector.                                        |
-| Connector Log Level            | log_level            | `CONNECTOR_LOG_LEVEL`            | /          | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`. |
-| Connector Expose Metrics       | expose_metrics       | `CONNECTOR_EXPOSE_METRICS`       | `false`    | Yes       | If `True` use metrics.                                                                 |
+| Parameter `Connector` | config.yml        | Docker environment variable | Default    | Mandatory | Description                                                                                      |
+|-----------------------|-------------------|-----------------------------|------------|-----------|--------------------------------------------------------------------------------------------------|
+| ID                    | `id`              | `CONNECTOR_ID`              | /          | Yes       | A unique `UUIDv4` identifier for this connector instance.                                        |
+| Name                  | `name`            | `CONNECTOR_NAME`            | `Malpedia` | Yes       | Name of the connector.                                                                           |
+| Scope                 | `scope`           | `CONNECTOR_SCOPE`           | `malpedia` | Yes       | Must be `malpedia`, not used in this connector.                                                  |
+| Log Level             | `log_level`       | `CONNECTOR_LOG_LEVEL`       | /          | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.           |
+| Expose Metrics        | `expose_metrics`  | `CONNECTOR_EXPOSE_METRICS`  | `False`    | Yes       | If `True` use metrics.                                                                           |
+| Duration Period       | `duration_period` | `CONNECTOR_DURATION_PERIOD` | /          | No        | Determines the time interval between each launch of the connector (current use `interval_sec`).  |
+| Queue Threshold       | `queue_threshold` | `CONNECTOR_QUEUE_THRESHOLD` | `500`      | No        | Used to determine the limit (RabbitMQ) in MB at which the connector must go into buffering mode. |
 
 Below are the parameters you'll need to set for Malpedia connector:
 
-| Parameter                      | config.yml            | Docker environment variable      | Default | Mandatory | Description                                                             |
-|--------------------------------|-----------------------|----------------------------------|---------|-----------|-------------------------------------------------------------------------|
-| Malpedia Auth Key              | auth_key              | `MALPEDIA_AUTH_KEY`              | /       | Yes       | API authentication key                                                  |
-| Malpedia Interval Sec          | internal_sec          | `MALPEDIA_INTERVAL_SEC`          | `86400` | Yes       | Interval in seconds before a new import is considered                   |
-| Malpedia Import Intrusion Sets | import_intrusion_sets | `MALPEDIA_IMPORT_INTRUSION_SETS` | `true`  | Yes       | Choose if you want to import Intrusion-Sets from Malpedia               |
-| Malpedia Import Yara           | import_yara           | `MALPEDIA_IMPORT_YARA`           | `true`  | Yes       | Choose if you want to import Yara rules from Malpedia                   |
-| Malpedia Create Indicators     | create_indicators     | `MALPEDIA_CREATE_INDICATORS`     | `true`  | Yes       | Choose if you want to create Indicators Sample (File) from Malpedia     |
-| Malpedia Create Observables    | create_observables    | `MALPEDIA_CREATE_OBSERVABLES`    | `true`  | Yes       | Choose if you want to create Observables Sample (File) from Malpedia    |
+| Parameter `Malpedia`  | config.yml              | Docker environment variable      | Default     | Mandatory | Description                                                                                |
+|-----------------------|-------------------------|----------------------------------|-------------|-----------|--------------------------------------------------------------------------------------------|
+| Auth Key              | `auth_key`              | `MALPEDIA_AUTH_KEY`              | /           | Yes       | API authentication key                                                                     |
+| Interval Sec          | `internal_sec`          | `MALPEDIA_INTERVAL_SEC`          | `86400`     | Yes       | Interval in seconds before a new import is considered                                      |
+| Import Intrusion Sets | `import_intrusion_sets` | `MALPEDIA_IMPORT_INTRUSION_SETS` | `true`      | Yes       | Choose if you want to import Intrusion-Sets from Malpedia                                  |
+| Import Yara           | `import_yara`           | `MALPEDIA_IMPORT_YARA`           | `true`      | Yes       | Choose if you want to import Yara rules from Malpedia                                      |
+| Create Indicators     | `create_indicators`     | `MALPEDIA_CREATE_INDICATORS`     | `true`      | Yes       | Choose if you want to create Indicators Sample (File) from Malpedia                        |
+| Create Observables    | `create_observables`    | `MALPEDIA_CREATE_OBSERVABLES`    | `true`      | Yes       | Choose if you want to create Observables Sample (File) from Malpedia                       |
+| Default Marking       | `default_marking`       | `MALPEDIA_DEFAULT_MARKING`       | `TLP:CLEAR` | No        | If not defined in config, an authenticated user will have TLP:AMBER, otherwise TLP:CLEAR   |
 
 
 ## Notes
@@ -72,7 +75,3 @@ If you are not authenticated, by leaving this variable (auth_key) undefined or o
 
 If you choose to set environment variables such as import_intrusion_sets, import_yara, create_indicators, create_observables to false, the connector will simply skip the bundle creation steps for the selected category.
 
----
-**Caution**
-
-You should only enable update_existing_data for connectors that you consider a knowledge priority for specific entities. Entities created by other connectors might be overwritten.

--- a/external-import/malpedia/src/config.yml.sample
+++ b/external-import/malpedia/src/config.yml.sample
@@ -7,7 +7,6 @@ connector:
   type: 'EXTERNAL_IMPORT'
   name: 'Malpedia'
   scope: 'malpedia'
-  update_existing_data: false
   log_level: 'info'
   expose_metrics: false
 
@@ -18,3 +17,4 @@ malpedia:
   import_yara: true
   create_indicators: true # Required, create indicators for hashes
   create_observables: true # Required, create observables for hashes
+  default_marking: "TLP:CLEAR"

--- a/external-import/malpedia/src/main.py
+++ b/external-import/malpedia/src/main.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 """OpenCTI Malpedia connector main module."""
-import time
+import sys
+import traceback
 
 from malpedia_connector import MalpediaConnector
 
 if __name__ == "__main__":
     try:
         connector = MalpediaConnector()
-        connector.start()
-    except Exception as err:
-        print(err)
-        time.sleep(10)
-        exit(0)
+        connector.run()
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)

--- a/external-import/malpedia/src/malpedia_connector/malpedia.py
+++ b/external-import/malpedia/src/malpedia_connector/malpedia.py
@@ -35,122 +35,144 @@ class MalpediaConnector:
         self.helper.metric.state("idle")
 
         """
-        If we run without API key we can assume all data is TLP:WHITE 
+        If the default_marking environment variable does not exist,
+        then if we run without API key we can assume all data is TLP:WHITE 
         else we default to TLP:AMBER to be safe.
         """
-        self.default_marking = (
-            stix2.TLP_WHITE if self.api_client.unauthenticated else stix2.TLP_AMBER
-        )
+        TLP_MAPPING = {
+            "TLP:CLEAR": stix2.TLP_WHITE,
+            "TLP:WHITE": stix2.TLP_WHITE,
+            "TLP:GREEN": stix2.TLP_GREEN,
+            "TLP:AMBER": stix2.TLP_AMBER,
+            "TLP:RED": stix2.TLP_RED,
+        }
+        self.default_marking = self.config.load["malpedia"].get("default_marking", None)
+
+        if self.default_marking is not None:
+            default_marking_normalized = self.default_marking.strip().upper()
+            # Convert Markings for Stix2
+            if default_marking_normalized in TLP_MAPPING:
+                self.default_marking = TLP_MAPPING[default_marking_normalized]
+            else:
+                self.helper.connector_logger.info(
+                    "[INFO] Default marking defined in config is not supported by stix2, "
+                    "TLP marking will be defined by default TLP:CLEAR",
+                    {
+                        "default_marking_in_config": self.default_marking,
+                        "TLP_availables": "TLP:CLEAR, TLP:GREEN, TLP:AMBER, TLP:RED",
+                    },
+                )
+                self.default_marking = stix2.TLP_WHITE
+        else:
+            self.default_marking = (
+                stix2.TLP_WHITE if self.api_client.unauthenticated else stix2.TLP_AMBER
+            )
 
         self.models = MalpediaModels()
         self.utils = MalpediaUtils(self.helper, self.config.interval_sec)
         self.converter = MalpediaConverter(self.helper, self.default_marking)
-        self.update_existing_data = self.config.update_existing_data
 
         self.work_id = None
         self.stix_objects = []
         self.stix_relationships = []
 
+    def run(self):
+        self.helper.schedule_unit(
+            message_callback=self.start,
+            duration_period=self.config.interval_sec,
+            time_unit=self.helper.TimeUnit.SECONDS,
+        )
+
     def start(self):
         """Malpedia Connector execution"""
         self.helper.connector_logger.info("[CONNECTOR] Starting Malpedia connector...")
 
-        while True:
-            try:
-                current_malpedia_version = self.api_client.current_version()
+        try:
+            current_malpedia_version = self.api_client.current_version()
+            self.helper.connector_logger.info(
+                "[CONNECTOR] Current Malpedia version",
+                {"version": current_malpedia_version},
+            )
+            timestamp = self.utils.current_unix_timestamp()
+            current_state = self.utils.load_state()
+            self.helper.connector_logger.info(
+                "[CONNECTOR] Loaded state",
+                {
+                    "current_state": (
+                        "First run" if current_state == {} else str(current_state)
+                    )
+                },
+            )
+
+            last_run = self.utils.get_state_value(current_state, LAST_RUN)
+            last_version = self.utils.get_state_value(current_state, LAST_VERSION)
+
+            """
+            Only run the connector if:
+            1. It is scheduled to run per interval
+            2. The global Malpedia version from the API is newer than our last stored version.
+            """
+            if self.utils.is_scheduled(
+                last_run, timestamp
+            ) and self.utils.check_version(last_version, current_malpedia_version):
+                self.helper.connector_logger.info("[CONNECTOR] Running importers")
+                self.helper.metric.inc("run_count")
+                self.helper.metric.state("running")
+                self.work_id = self.utils.initiate_work_id(timestamp)
+
                 self.helper.connector_logger.info(
-                    "[CONNECTOR] Current Malpedia version",
-                    {"version": current_malpedia_version},
-                )
-                timestamp = self.utils.current_unix_timestamp()
-                current_state = self.utils.load_state()
-                self.helper.connector_logger.info(
-                    "[CONNECTOR] Loaded state",
+                    "[CONNECTOR] Running Malpedia process...",
                     {
-                        "current_state": (
+                        "state": (
                             "First run" if current_state == {} else str(current_state)
                         )
                     },
                 )
+                self._run_malpedia_process()
 
-                last_run = self.utils.get_state_value(current_state, LAST_RUN)
-                last_version = self.utils.get_state_value(current_state, LAST_VERSION)
+                new_state = current_state.copy()
+                new_state[LAST_RUN] = self.utils.current_unix_timestamp()
+                new_state[LAST_VERSION] = current_malpedia_version
 
-                """
-                Only run the connector if:
-                1. It is scheduled to run per interval
-                2. The global Malpedia version from the API is newer than our last stored version.
-                """
-                if self.utils.is_scheduled(
-                    last_run, timestamp
-                ) and self.utils.check_version(last_version, current_malpedia_version):
-                    self.helper.connector_logger.info("[CONNECTOR] Running importers")
-                    self.helper.metric.inc("run_count")
-                    self.helper.metric.state("running")
-                    self.work_id = self.utils.initiate_work_id(timestamp)
+                msg = "[CONNECTOR] Connector successfully run, storing the new state..."
+                self.helper.connector_logger.info(msg, {"new_state": new_state})
+                self.helper.api.work.to_processed(self.work_id, msg)
 
-                    self.helper.connector_logger.info(
-                        "[CONNECTOR] Running Malpedia process...",
-                        {
-                            "state": (
-                                "First run"
-                                if current_state == {}
-                                else str(current_state)
-                            )
-                        },
-                    )
-                    self._run_malpedia_process()
-
-                    new_state = current_state.copy()
-                    new_state[LAST_RUN] = self.utils.current_unix_timestamp()
-                    new_state[LAST_VERSION] = current_malpedia_version
-
-                    msg = "[CONNECTOR] Connector successfully run, storing the new state..."
-                    self.helper.connector_logger.info(msg, {"new_state": new_state})
-                    self.helper.api.work.to_processed(self.work_id, msg)
-
-                    self.helper.set_state(new_state)
-                    new_interval_in_hours = round(self.config.interval_sec / 60 / 60, 2)
-                    self.helper.connector_logger.info(
-                        "[CONNECTOR] State stored, next run in hours.",
-                        {"next_run": new_interval_in_hours},
-                    )
-
-                else:
-                    new_interval = self.config.interval_sec - (timestamp - last_run)
-                    if new_interval < 0:
-                        next_run = "waiting for a new version"
-                    else:
-                        next_run = round(new_interval / 60 / 60, 2)
-
-                    self.helper.connector_logger.info(
-                        "[CONNECTOR] The connector will not run, next run in hours.",
-                        {
-                            "config_interval_sec": self.config.interval_sec,
-                            "next_run": str(next_run),
-                        },
-                    )
-
-            except (KeyboardInterrupt, SystemExit):
-                self.helper.connector_logger.info("[CONNECTOR] Connector stop...")
-                self.helper.metric.state("stopped")
-                sys.exit(0)
-
-            except Exception as e:
-                self.helper.connector_logger.error(
-                    "[CONNECTOR] Error while processing data:", {"error": str(e)}
+                self.helper.set_state(new_state)
+                new_interval_in_hours = round(self.config.interval_sec / 60 / 60, 2)
+                self.helper.connector_logger.info(
+                    "[CONNECTOR] State stored, next run in hours.",
+                    {"next_run": new_interval_in_hours},
                 )
-                self.helper.metric.state("stopped")
-                sys.exit(0)
 
-            if self.helper.connect_run_and_terminate:
-                self.helper.connector_logger.info("[CONNECTOR] Connector stop...")
-                self.helper.metric.state("stopped")
-                self.helper.force_ping()
-                sys.exit(0)
+            else:
+                new_interval = self.config.interval_sec - (timestamp - last_run)
+                if new_interval < 0:
+                    next_run = "waiting for a new version"
+                else:
+                    next_run = round(new_interval / 60 / 60, 2)
 
-            self.helper.metric.state("idle")
-            time.sleep(60)
+                self.helper.connector_logger.info(
+                    "[CONNECTOR] The connector will not run, next run in hours.",
+                    {
+                        "config_interval_sec": self.config.interval_sec,
+                        "next_run": str(next_run),
+                    },
+                )
+
+        except (KeyboardInterrupt, SystemExit):
+            self.helper.connector_logger.info("[CONNECTOR] Connector stop...")
+            self.helper.metric.state("stopped")
+            sys.exit(0)
+
+        except Exception as e:
+            self.helper.connector_logger.error(
+                "[CONNECTOR] Error while processing data:", {"error": str(e)}
+            )
+            self.helper.metric.state("stopped")
+            sys.exit(0)
+
+        self.helper.metric.state("idle")
 
     def _run_malpedia_process(self):
 
@@ -174,7 +196,6 @@ class MalpediaConnector:
         self.helper.send_stix2_bundle(
             stix2_bundle,
             work_id=self.work_id,
-            update=self.config.update_existing_data,
         )
 
         self.helper.metric.inc("record_send", len(final_stix_objects))

--- a/external-import/malpedia/src/malpedia_connector/malpedia.py
+++ b/external-import/malpedia/src/malpedia_connector/malpedia.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """OpenCTI Malpedia Knowledge importer module."""
 import sys
-import time
 from datetime import datetime
 from typing import Any
 

--- a/external-import/malpedia/src/malpedia_services/config_variables.py
+++ b/external-import/malpedia/src/malpedia_services/config_variables.py
@@ -32,12 +32,6 @@ class MalpediaConfig:
         """
         Extra config
         """
-        self.update_existing_data = get_config_variable(
-            "CONNECTOR_UPDATE_EXISTING_DATA",
-            ["connector", "update_existing_data"],
-            self.load,
-        )
-
         self.auth_key = get_config_variable(
             "MALPEDIA_AUTH_KEY",
             ["malpedia", "auth_key"],
@@ -70,5 +64,11 @@ class MalpediaConfig:
         self.create_observables = get_config_variable(
             "MALPEDIA_CREATE_OBSERVABLES",
             ["malpedia", "create_observables"],
+            self.load,
+        )
+
+        self.default_marking = get_config_variable(
+            "MALPEDIA_DEFAULT_MARKING",
+            ["malpedia", "default_marking"],
             self.load,
         )

--- a/external-import/malpedia/src/malpedia_services/converter_to_stix.py
+++ b/external-import/malpedia/src/malpedia_services/converter_to_stix.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Union
 
 import stix2
 from pycti import (
@@ -17,9 +16,7 @@ class MalpediaConverter:
     def __init__(
         self,
         helper: OpenCTIConnectorHelper,
-        default_marking: Union[
-            stix2.TLP_WHITE, stix2.TLP_GREEN, stix2.TLP_AMBER, stix2.TLP_RED
-        ],
+        default_marking: stix2.MarkingDefinition,
     ):
         self.helper = helper
         self.default_marking = default_marking

--- a/external-import/malpedia/src/malpedia_services/converter_to_stix.py
+++ b/external-import/malpedia/src/malpedia_services/converter_to_stix.py
@@ -17,7 +17,7 @@ class MalpediaConverter:
     def __init__(
         self,
         helper: OpenCTIConnectorHelper,
-        default_marking: Union[stix2.TLP_WHITE, stix2.TLP_AMBER],
+        default_marking: Union[stix2.TLP_WHITE, stix2.TLP_GREEN, stix2.TLP_AMBER, stix2.TLP_RED],
     ):
         self.helper = helper
         self.default_marking = default_marking

--- a/external-import/malpedia/src/malpedia_services/converter_to_stix.py
+++ b/external-import/malpedia/src/malpedia_services/converter_to_stix.py
@@ -17,7 +17,9 @@ class MalpediaConverter:
     def __init__(
         self,
         helper: OpenCTIConnectorHelper,
-        default_marking: Union[stix2.TLP_WHITE, stix2.TLP_GREEN, stix2.TLP_AMBER, stix2.TLP_RED],
+        default_marking: Union[
+            stix2.TLP_WHITE, stix2.TLP_GREEN, stix2.TLP_AMBER, stix2.TLP_RED
+        ],
     ):
         self.helper = helper
         self.default_marking = default_marking


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Set a new environment variable to define the `default_marking`.
* Set up scheduler without breaking changes (using `schedule_unit`)
* Added traceback
* Updated Readme and config.yml.sample
* Removed `update_existing_data` usage


### Related issues

* #2460 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
