### PR TITLE
[Mandiant] Create 2 new environment variables for creating CPE or not for software and limit number of relationships 

### DIFF
--- a/external-import/mandiant/README.md
+++ b/external-import/mandiant/README.md
@@ -6,60 +6,62 @@ This connector connects to the Mandiant Advantage API V4 and gather all data fro
 
 The connector can be configured with the following variables:
 
-| Env var                                                  | Default                               | Description                                                                 |
-|----------------------------------------------------------|---------------------------------------|-----------------------------------------------------------------------------|
-| `MANDIANT_API_URL`                                       | https://api.intelligence.mandiant.com | URL for the Mandiant API                                                    |
-| `MANDIANT_API_V4_KEY_ID`                                 |                                       | Mandiant API Key ID                                                         |
-| `MANDIANT_API_V4_KEY_SECRET`                             |                                       | Mandiant API Key Secret                                                     |
-| `MANDIANT_IMPORT_START_DATE`                             | 2023-01-01                            | Date to start collect data                                                  |
-| `MANDIANT_INDICATOR_IMPORT_START_DATE`                   | 2023-01-01                            | Date to start collect indicators                                            |
-| `MANDIANT_IMPORT_PERIOD`                                 | 2                                     | Number of days to fetch in one round trip                                   |
-| `MANDIANT_INDICATOR_MINIMUM_SCORE`                       | 80                                    | Minimum score (based on mscore) that an indicator must have to be processed |
-| `MANDIANT_CREATE_NOTES`                                  | False                                 | Create notes                                                                |
-| `MANDIANT_REMOVE_STATEMENT_MARKING`                      | False                                 | Remove statement marking                                                    |
-| `MANDIANT_IMPORT_ACTORS`                                 | True                                  | Enable to collect actors                                                    |
-| `MANDIANT_IMPORT_ACTORS_INTERVAL`                        | 1                                     | Interval in hours to check and collect new actors                           |
-| `MANDIANT_IMPORT_ACTORS_ALIASES`                         | False                                 | Import actors aliases                                                       |
-| `MANDIANT_IMPORT_REPORTS`                                | True                                  | Enable to collect reports                                                   |
-| `MANDIANT_IMPORT_REPORTS_INTERVAL`                       | 1                                     | Interval in hours to check and collect new reports                          |
-| `MANDIANT_IMPORT_MALWARES`                               | True                                  | Enable to collect malwares                                                  |
-| `MANDIANT_IMPORT_MALWARES_INTERVAL`                      | 1                                     | Interval in hours to check and collect new malwares                         |
-| `MANDIANT_IMPORT_MALWARES_ALIASES`                       | False                                 | Import malware aliases                                                      |
-| `MANDIANT_IMPORT_CAMPAIGNS`                              | True                                  | Enable to collect campaigns                                                 |
-| `MANDIANT_IMPORT_CAMPAIGNS_INTERVAL`                     | 1                                     | Interval in hours to check and collect new campaigns                        |
-| `MANDIANT_IMPORT_INDICATORS`                             | False                                 | Enable to collect indicators                                                |
-| `MANDIANT_IMPORT_INDICATORS_INTERVAL`                    | 1                                     | Interval in hours to check and collect new indicators                       |
-| `MANDIANT_IMPORT_VULNERABILITIES`                        | False                                 | Enable to collect vulnerabilities                                           |
-| `MANDIANT_IMPORT_VULNERABILITIES_INTERVAL`               | 1                                     | Interval in hours to check and collect new vulnerabilities                  |
-| `MANDIANT_ACTOR_PROFILE_REPORT`                          | True                                  | Enable to collect report type actor profile                                 |
-| `MANDIANT_COUNTRY_PROFILE_REPORT`                        | True                                  | Enable to collect report type country_profile                               |
-| `MANDIANT_EVENT_COVERAGE_IMPLICATION_REPORT`             | True                                  | Enable to collect report type event_coverage_implication                    |
-| `MANDIANT_EXECUTIVE_PERSPECTIVE_REPORT`                  | True                                  | Enable to collect report type executive_perspective                         |
-| `MANDIANT_ICS_SECURITY_ROUNDUP_REPORT`                   | True                                  | Enable to collect report type ics_security_roundup                          |
-| `MANDIANT_INDUSTRY_REPORTING_REPORT`                     | True                                  | Enable to collect report type industry_reporting                            |
-| `MANDIANT_MALWARE_PROFILE_REPORT`                        | True                                  | Enable to collect report type malware_profile                               |
-| `MANDIANT_NETWORK_ACTIVITY_REPORT`                       | True                                  | Enable to collect report type network_activity_reports                      |
-| `MANDIANT_PATCH_REPORT`                                  | True                                  | Enable to collect report type patch_report                                  |
-| `MANDIANT_TTP_DEEP_DIVE_REPORT`                          | True                                  | Enable to collect report type ttp_deep_dive                                 |
-| `MANDIANT_THREAT_ACTIVITY_ALERT_REPORT`                  | True                                  | Enable to collect report type threat_activity_alert                         |
-| `MANDIANT_THREAT_ACTIVITY_REPORT`                        | True                                  | Enable to collect report type threat_activity_report                        |
-| `MANDIANT_TRENDS_AND_FORECASTING_REPORT`                 | True                                  | Enable to collect report type trends_and_forecasting                        |
-| `MANDIANT_VULNERABILITY_REPORT`                          | True                                  | Enable to collect report type vulnerability_report                          |
-| `MANDIANT_WEEKLY_VULNERABILITY_EXPLOITATION_REPORT`      | True                                  | Enable to collect report type weekly_vulnerability_exploitation_report      |
-| `MANDIANT_NEWS_ANALYSIS_REPORT`                          | True                                  | Enable to collect report type news_analysis                                 |
-| `MANDIANT_ACTOR_PROFILE_REPORT_TYPE`                     | actor-profile                         | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_COUNTRY_PROFILE_REPORT_TYPE`                   | country-profile                       | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_EVENT_COVERAGE_IMPLICATION_REPORT_TYPE`        | event-coverage                        | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_EXECUTIVE_PERSPECTIVE_REPORT_TYPE`             | executive-perspective                 | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_ICS_SECURITY_ROUNDUP_REPORT_TYPE`              | ics-security-roundup                  | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_INDUSTRY_REPORTING_REPORT_TYPE`                | industry                              | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_MALWARE_PROFILE_REPORT_TYPE`                   | malware-profile                       | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_NETWORK_ACTIVITY_REPORT_TYPE`                  | network-activity                      | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_PATCH_REPORT_TYPE`                             | patch                                 | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_TTP_DEEP_DIVE_REPORT_TYPE`                     | ttp-deep-dive                         | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_THREAT_ACTIVITY_ALERT_REPORT_TYPE`             | threat-alert                          | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_THREAT_ACTIVITY_REPORT_TYPE`                   | threat-activity                       | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_TRENDS_AND_FORECASTING_REPORT_TYPE`            | trends-forecasting                    | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_VULNERABILITY_REPORT_TYPE`                     | vulnerability                         | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_WEEKLY_VULNERABILITY_EXPLOITATION_REPORT_TYPE` | vulnerability-exploitation            | Report type on vocabulary `report_types_ov`                                 |
-| `MANDIANT_NEWS_ANALYSIS_REPORT_TYPE`                     | news-analysis                         | Report type on vocabulary `report_types_ov`                                 |
+| Env var                                                  | Default                               | Description                                                                    |
+|----------------------------------------------------------|---------------------------------------|--------------------------------------------------------------------------------|
+| `MANDIANT_API_URL`                                       | https://api.intelligence.mandiant.com | URL for the Mandiant API                                                       |
+| `MANDIANT_API_V4_KEY_ID`                                 |                                       | Mandiant API Key ID                                                            |
+| `MANDIANT_API_V4_KEY_SECRET`                             |                                       | Mandiant API Key Secret                                                        |
+| `MANDIANT_IMPORT_START_DATE`                             | 2023-01-01                            | Date to start collect data                                                     |
+| `MANDIANT_INDICATOR_IMPORT_START_DATE`                   | 2023-01-01                            | Date to start collect indicators                                               |
+| `MANDIANT_IMPORT_PERIOD`                                 | 2                                     | Number of days to fetch in one round trip                                      |
+| `MANDIANT_INDICATOR_MINIMUM_SCORE`                       | 80                                    | Minimum score (based on mscore) that an indicator must have to be processed    |
+| `MANDIANT_CREATE_NOTES`                                  | False                                 | Create notes                                                                   |
+| `MANDIANT_REMOVE_STATEMENT_MARKING`                      | False                                 | Remove statement marking                                                       |
+| `MANDIANT_IMPORT_ACTORS`                                 | True                                  | Enable to collect actors                                                       |
+| `MANDIANT_IMPORT_ACTORS_INTERVAL`                        | 1                                     | Interval in hours to check and collect new actors                              |
+| `MANDIANT_IMPORT_ACTORS_ALIASES`                         | False                                 | Import actors aliases                                                          |
+| `MANDIANT_IMPORT_REPORTS`                                | True                                  | Enable to collect reports                                                      |
+| `MANDIANT_IMPORT_REPORTS_INTERVAL`                       | 1                                     | Interval in hours to check and collect new reports                             |
+| `MANDIANT_IMPORT_MALWARES`                               | True                                  | Enable to collect malwares                                                     |
+| `MANDIANT_IMPORT_MALWARES_INTERVAL`                      | 1                                     | Interval in hours to check and collect new malwares                            |
+| `MANDIANT_IMPORT_MALWARES_ALIASES`                       | False                                 | Import malware aliases                                                         |
+| `MANDIANT_IMPORT_CAMPAIGNS`                              | True                                  | Enable to collect campaigns                                                    |
+| `MANDIANT_IMPORT_CAMPAIGNS_INTERVAL`                     | 1                                     | Interval in hours to check and collect new campaigns                           |
+| `MANDIANT_IMPORT_INDICATORS`                             | False                                 | Enable to collect indicators                                                   |
+| `MANDIANT_IMPORT_INDICATORS_INTERVAL`                    | 1                                     | Interval in hours to check and collect new indicators                          |
+| `MANDIANT_IMPORT_VULNERABILITIES`                        | False                                 | Enable to collect vulnerabilities                                              |
+| `MANDIANT_IMPORT_VULNERABILITIES_INTERVAL`               | 1                                     | Interval in hours to check and collect new vulnerabilities                     |
+| `MANDIANT_ACTOR_PROFILE_REPORT`                          | True                                  | Enable to collect report type actor profile                                    |
+| `MANDIANT_COUNTRY_PROFILE_REPORT`                        | True                                  | Enable to collect report type country_profile                                  |
+| `MANDIANT_EVENT_COVERAGE_IMPLICATION_REPORT`             | True                                  | Enable to collect report type event_coverage_implication                       |
+| `MANDIANT_EXECUTIVE_PERSPECTIVE_REPORT`                  | True                                  | Enable to collect report type executive_perspective                            |
+| `MANDIANT_ICS_SECURITY_ROUNDUP_REPORT`                   | True                                  | Enable to collect report type ics_security_roundup                             |
+| `MANDIANT_INDUSTRY_REPORTING_REPORT`                     | True                                  | Enable to collect report type industry_reporting                               |
+| `MANDIANT_MALWARE_PROFILE_REPORT`                        | True                                  | Enable to collect report type malware_profile                                  |
+| `MANDIANT_NETWORK_ACTIVITY_REPORT`                       | True                                  | Enable to collect report type network_activity_reports                         |
+| `MANDIANT_PATCH_REPORT`                                  | True                                  | Enable to collect report type patch_report                                     |
+| `MANDIANT_TTP_DEEP_DIVE_REPORT`                          | True                                  | Enable to collect report type ttp_deep_dive                                    |
+| `MANDIANT_THREAT_ACTIVITY_ALERT_REPORT`                  | True                                  | Enable to collect report type threat_activity_alert                            |
+| `MANDIANT_THREAT_ACTIVITY_REPORT`                        | True                                  | Enable to collect report type threat_activity_report                           |
+| `MANDIANT_TRENDS_AND_FORECASTING_REPORT`                 | True                                  | Enable to collect report type trends_and_forecasting                           |
+| `MANDIANT_VULNERABILITY_REPORT`                          | True                                  | Enable to collect report type vulnerability_report                             |
+| `MANDIANT_VULNERABILITY_IMPORT_SOFTWARE_CPE`                          | True                                  | Enable to import CPE and version or not                                        |
+| `MANDIANT_VULNERABILITY_MAX_CPE_RELATIONSHIP`                          | 200                                   | Enable to define a maximum number of relationships created for a vulnerability |
+| `MANDIANT_WEEKLY_VULNERABILITY_EXPLOITATION_REPORT`      | True                                  | Enable to collect report type weekly_vulnerability_exploitation_report         |
+| `MANDIANT_NEWS_ANALYSIS_REPORT`                          | True                                  | Enable to collect report type news_analysis                                    |
+| `MANDIANT_ACTOR_PROFILE_REPORT_TYPE`                     | actor-profile                         | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_COUNTRY_PROFILE_REPORT_TYPE`                   | country-profile                       | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_EVENT_COVERAGE_IMPLICATION_REPORT_TYPE`        | event-coverage                        | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_EXECUTIVE_PERSPECTIVE_REPORT_TYPE`             | executive-perspective                 | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_ICS_SECURITY_ROUNDUP_REPORT_TYPE`              | ics-security-roundup                  | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_INDUSTRY_REPORTING_REPORT_TYPE`                | industry                              | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_MALWARE_PROFILE_REPORT_TYPE`                   | malware-profile                       | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_NETWORK_ACTIVITY_REPORT_TYPE`                  | network-activity                      | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_PATCH_REPORT_TYPE`                             | patch                                 | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_TTP_DEEP_DIVE_REPORT_TYPE`                     | ttp-deep-dive                         | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_THREAT_ACTIVITY_ALERT_REPORT_TYPE`             | threat-alert                          | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_THREAT_ACTIVITY_REPORT_TYPE`                   | threat-activity                       | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_TRENDS_AND_FORECASTING_REPORT_TYPE`            | trends-forecasting                    | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_VULNERABILITY_REPORT_TYPE`                     | vulnerability                         | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_WEEKLY_VULNERABILITY_EXPLOITATION_REPORT_TYPE` | vulnerability-exploitation            | Report type on vocabulary `report_types_ov`                                    |
+| `MANDIANT_NEWS_ANALYSIS_REPORT_TYPE`                     | news-analysis                         | Report type on vocabulary `report_types_ov`                                    |

--- a/external-import/mandiant/README.md
+++ b/external-import/mandiant/README.md
@@ -45,8 +45,8 @@ The connector can be configured with the following variables:
 | `MANDIANT_THREAT_ACTIVITY_REPORT`                        | True                                  | Enable to collect report type threat_activity_report                           |
 | `MANDIANT_TRENDS_AND_FORECASTING_REPORT`                 | True                                  | Enable to collect report type trends_and_forecasting                           |
 | `MANDIANT_VULNERABILITY_REPORT`                          | True                                  | Enable to collect report type vulnerability_report                             |
-| `MANDIANT_VULNERABILITY_IMPORT_SOFTWARE_CPE`                          | True                                  | Enable to import CPE and version or not                                        |
-| `MANDIANT_VULNERABILITY_MAX_CPE_RELATIONSHIP`                          | 200                                   | Enable to define a maximum number of relationships created for a vulnerability |
+| `MANDIANT_VULNERABILITY_IMPORT_SOFTWARE_CPE`             | True                                  | Enable to import CPE and version or not                                        |
+| `MANDIANT_VULNERABILITY_MAX_CPE_RELATIONSHIP`            | 200                                   | Enable to define a maximum number of relationships created for a vulnerability |
 | `MANDIANT_WEEKLY_VULNERABILITY_EXPLOITATION_REPORT`      | True                                  | Enable to collect report type weekly_vulnerability_exploitation_report         |
 | `MANDIANT_NEWS_ANALYSIS_REPORT`                          | True                                  | Enable to collect report type news_analysis                                    |
 | `MANDIANT_ACTOR_PROFILE_REPORT_TYPE`                     | actor-profile                         | Report type on vocabulary `report_types_ov`                                    |

--- a/external-import/mandiant/src/connector/base.py
+++ b/external-import/mandiant/src/connector/base.py
@@ -421,7 +421,7 @@ class Mandiant:
                 default=True,
             )
 
-            self.mandiant_import_software_cpe = get_config_variable(
+            self.vulnerability_max_cpe_relationship = get_config_variable(
                 "MANDIANT_VULNERABILITY_MAX_CPE_RELATIONSHIP",
                 ["mandiant", "vulnerability_max_cpe_relationship"],
                 config,

--- a/external-import/mandiant/src/connector/base.py
+++ b/external-import/mandiant/src/connector/base.py
@@ -414,6 +414,20 @@ class Mandiant:
                 vulnerability_report_type
             )
 
+            self.mandiant_import_software_cpe = get_config_variable(
+                "MANDIANT_VULNERABILITY_IMPORT_SOFTWARE_CPE",
+                ["mandiant", "vulnerability_import_software_cpe"],
+                config,
+                default=True,
+            )
+
+            self.mandiant_import_software_cpe = get_config_variable(
+                "MANDIANT_VULNERABILITY_MAX_CPE_RELATIONSHIP",
+                ["mandiant", "vulnerability_max_cpe_relationship"],
+                config,
+                default=200,
+            )
+
         if get_config_variable(
             "MANDIANT_WEEKLY_VULNERABILITY_EXPLOITATION_REPORT",
             ["mandiant", "weekly_vulnerability_exploitation_report"],

--- a/external-import/mandiant/src/connector/reports.py
+++ b/external-import/mandiant/src/connector/reports.py
@@ -478,8 +478,8 @@ class Report:
 
         if len(vulnerabilities) > 0:
 
-            if self.connector.mandiant_import_software_cpe and len(softwares) < int(
-                self.connector.mandiant_import_software_cpe
+            if self.connector.vulnerability_max_cpe_relationship and len(softwares) < int(
+                self.connector.vulnerability_max_cpe_relationship
             ):
                 definitions += [
                     {

--- a/external-import/mandiant/src/connector/reports.py
+++ b/external-import/mandiant/src/connector/reports.py
@@ -478,9 +478,9 @@ class Report:
 
         if len(vulnerabilities) > 0:
 
-            if self.connector.vulnerability_max_cpe_relationship and len(softwares) < int(
-                self.connector.vulnerability_max_cpe_relationship
-            ):
+            if self.connector.vulnerability_max_cpe_relationship and len(
+                softwares
+            ) < int(self.connector.vulnerability_max_cpe_relationship):
                 definitions += [
                     {
                         "type": "has",

--- a/external-import/mandiant/src/connector/reports.py
+++ b/external-import/mandiant/src/connector/reports.py
@@ -84,6 +84,8 @@ class Report:
         self.update_country()
         self.update_report()
         self.update_vulnerability()
+        if self.connector.mandiant_import_software_cpe:
+            self.update_software()
         self.create_relationships()
         if self.create_notes:
             self.create_note()
@@ -345,6 +347,14 @@ class Report:
                 if tag == item.get("name"):
                     yield item
 
+    def update_software(self):
+        entries_to_remove = ("cpe", "version")
+
+        for bundle_obj in self.bundle["objects"]:
+            if "software" in bundle_obj["type"]:
+                for key in entries_to_remove:
+                    bundle_obj.pop(key)
+
     def create_relationships(self):
         # Get related objects
         identities = list(utils.retrieve_all(self.bundle, "type", "identity"))
@@ -466,13 +476,20 @@ class Report:
                 },
             ]
 
-        if len(vulnerabilities) > 0:
+        if len(vulnerabilities) == 1:
+
+            if self.connector.mandiant_import_software_cpe and len(softwares) < int(
+                self.connector.mandiant_import_software_cpe
+            ):
+                definitions += [
+                    {
+                        "type": "has",
+                        "sources": softwares,
+                        "destinations": vulnerabilities,
+                    },
+                ]
+
             definitions += [
-                {
-                    "type": "has",
-                    "sources": softwares,
-                    "destinations": vulnerabilities,
-                },
                 {
                     "type": "mitigates",
                     "sources": course_actions,
@@ -505,6 +522,8 @@ class Report:
                 relationships.append(relationship)
                 relationships_ids.append(relationship.id)
 
+        # Remove duplicates relationships
+        relationships_ids = list(dict.fromkeys(relationships_ids))
         report = utils.retrieve(self.bundle, "type", "report")
         report["object_refs"] += relationships_ids
         self.bundle["objects"] += relationships

--- a/external-import/mandiant/src/connector/reports.py
+++ b/external-import/mandiant/src/connector/reports.py
@@ -476,7 +476,7 @@ class Report:
                 },
             ]
 
-        if len(vulnerabilities) == 1:
+        if len(vulnerabilities) > 0:
 
             if self.connector.mandiant_import_software_cpe and len(softwares) < int(
                 self.connector.mandiant_import_software_cpe

--- a/external-import/mandiant/src/connector/reports.py
+++ b/external-import/mandiant/src/connector/reports.py
@@ -84,7 +84,7 @@ class Report:
         self.update_country()
         self.update_report()
         self.update_vulnerability()
-        if self.connector.mandiant_import_software_cpe:
+        if not self.connector.mandiant_import_software_cpe:
             self.update_software()
         self.create_relationships()
         if self.create_notes:


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add new environment variable to add CPE for a Software or not => `MANDIANT_VULNERABILITY_IMPORT_SOFTWARE_CPE`
* Add new environment variable to limit the number of relationships created for a vulnerability => `MANDIANT_VULNERABILITY_MAX_CPE_RELATIONSHIP`

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2467

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
