### PR TITLE
[Mandiant]  Handle multiple standard ID for a software when importing a report + fix state when entity use epoch time

### DIFF
--- a/external-import/mandiant/src/connector/base.py
+++ b/external-import/mandiant/src/connector/base.py
@@ -59,7 +59,7 @@ class Mandiant:
             ["mandiant", "import_period"],
             config,
             isNumber=True,
-            default=3,
+            default=2,
         )
         self.mandiant_create_notes = get_config_variable(
             "MANDIANT_CREATE_NOTES",
@@ -745,7 +745,7 @@ class Mandiant:
             state[collection][STATE_END] = (
                 next_end.iso_format
                 if next_end is not None
-                else next_start.delta(days=2).iso_format
+                else next_start.delta(days=self.mandiant_import_period).iso_format
             )
         state[collection][STATE_LAST_RUN] = before_process_now.iso_format
         self.helper.set_state(state)

--- a/external-import/mandiant/src/connector/base.py
+++ b/external-import/mandiant/src/connector/base.py
@@ -743,7 +743,9 @@ class Mandiant:
                 next_end = None
             state[collection][STATE_START] = next_start.iso_format
             state[collection][STATE_END] = (
-                next_end.iso_format if next_end is not None else None
+                next_end.iso_format
+                if next_end is not None
+                else next_start.delta(days=2).iso_format
             )
         state[collection][STATE_LAST_RUN] = before_process_now.iso_format
         self.helper.set_state(state)

--- a/external-import/mandiant/src/connector/reports.py
+++ b/external-import/mandiant/src/connector/reports.py
@@ -348,12 +348,30 @@ class Report:
                     yield item
 
     def update_software(self):
-        entries_to_remove = ("cpe", "version")
+        entries_to_remove = ("cpe", "version", "id")
+        tmp_software = []
 
         for bundle_obj in self.bundle["objects"]:
             if "software" in bundle_obj["type"]:
+                # Remove standard STIX ID, CPE and version
                 for key in entries_to_remove:
                     bundle_obj.pop(key)
+
+                tmp_software.append(bundle_obj)
+
+        # Remove all software from current bundle object
+        self.bundle["objects"] = [
+            obj for obj in self.bundle["objects"] if obj.get("type") != "software"
+        ]
+
+        # Remove all duplicates
+        final_software = [
+            software
+            for n, software in enumerate(tmp_software)
+            if software not in tmp_software[:n]
+        ]
+
+        self.bundle["objects"].extend(final_software)
 
     def create_relationships(self):
         # Get related objects

--- a/external-import/mandiant/src/connector/reports.py
+++ b/external-import/mandiant/src/connector/reports.py
@@ -348,16 +348,19 @@ class Report:
                     yield item
 
     def update_software(self):
-        entries_to_remove = ("cpe", "version", "id")
-        tmp_software = []
+        tmp_software_list = []
 
         for bundle_obj in self.bundle["objects"]:
             if "software" in bundle_obj["type"]:
-                # Remove standard STIX ID, CPE and version
-                for key in entries_to_remove:
-                    bundle_obj.pop(key)
 
-                tmp_software.append(bundle_obj)
+                # recreate Software STIX object with new generated ID
+                software = stix2.Software(
+                    name=bundle_obj["name"],
+                    vendor=bundle_obj["vendor"],
+                    object_marking_refs=bundle_obj["object_marking_refs"],
+                )
+
+                tmp_software_list.append(software)
 
         # Remove all software from current bundle object
         self.bundle["objects"] = [
@@ -367,8 +370,8 @@ class Report:
         # Remove all duplicates
         final_software = [
             software
-            for n, software in enumerate(tmp_software)
-            if software not in tmp_software[:n]
+            for n, software in enumerate(tmp_software_list)
+            if software not in tmp_software_list[:n]
         ]
 
         self.bundle["objects"].extend(final_software)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  Generate new ID when importing Software from a Report when `MANDIANT_VULNERABILITY_IMPORT_SOFTWARE_CPE` is configured to False 
*  Fix state when entity use epoch time: add a security for end_epoch => start_epoch + 2 days

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2492

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
