### PR TITLE
Fix anyrun_feed.py

### DIFF
--- a/external-import/anyrun-feed/src/anyrun_feed.py
+++ b/external-import/anyrun-feed/src/anyrun_feed.py
@@ -15,7 +15,7 @@ class AnyrunFeed(ExternalImportConnector):
 
     def get_feed(self):
         response = requests.get(
-            self.ti_url, headers={"Authorization": "Basic {}".format(self.token)}
+            self.ti_url, headers={"Authorization": "API-Key {}".format(self.token)}
         )
         if response.status_code != 200:
             raise ValueError(


### PR DESCRIPTION
According to the [API manual](https://intelligence.any.run/Threat%20Intelligence%20Feeds%20Documentation.pdf), with 'TI token', the Header should start with API-Key.

### Proposed changes

* `Header: Basic <TI Token>` -> `Header: API-Key <TI Token>`

### Related issues

* Wrong way of using 'TI token'

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

