### PR TITLE
[Mandiant] Fix fail to parse if end_epoch is None

### DIFF
--- a/external-import/mandiant/src/connector/base.py
+++ b/external-import/mandiant/src/connector/base.py
@@ -551,8 +551,8 @@ class Mandiant:
             else:
                 # Fix problem when end state is in the future
                 if (
-                        Timestamp.from_iso(state[collection][STATE_END]).value
-                        > Timestamp.now().value
+                    Timestamp.from_iso(state[collection][STATE_END]).value
+                    > Timestamp.now().value
                 ):
                     state[collection][STATE_END] = None
                 end_short_format = Timestamp.from_iso(
@@ -694,8 +694,8 @@ class Mandiant:
         else:
             # Fix problem when end state is in the future
             if (
-                    Timestamp.from_iso(state[collection][STATE_END]).value
-                    > Timestamp.now().value
+                Timestamp.from_iso(state[collection][STATE_END]).value
+                > Timestamp.now().value
             ):
                 state[collection][STATE_END] = None
             end = Timestamp.from_iso(state[collection][STATE_END])

--- a/external-import/mandiant/src/connector/base.py
+++ b/external-import/mandiant/src/connector/base.py
@@ -541,13 +541,6 @@ class Mandiant:
             start_date = Timestamp.from_iso(state[collection][STATE_START])
             start_short_format = start_date.short_format
 
-            # Fix problem when end state is in the future
-            if (
-                Timestamp.from_iso(state[collection][STATE_END]).value
-                > Timestamp.now().value
-            ):
-                state[collection][STATE_END] = None
-
             # If no end date, put the proper period using delta
             if state[collection][STATE_END] is None:
                 next_end = start_date.delta(days=self.mandiant_import_period)
@@ -556,6 +549,12 @@ class Mandiant:
                     next_end = Timestamp.now()
                 end_short_format = next_end.short_format
             else:
+                # Fix problem when end state is in the future
+                if (
+                        Timestamp.from_iso(state[collection][STATE_END]).value
+                        > Timestamp.now().value
+                ):
+                    state[collection][STATE_END] = None
                 end_short_format = Timestamp.from_iso(
                     state[collection][STATE_END]
                 ).short_format
@@ -686,13 +685,6 @@ class Mandiant:
 
         start = Timestamp.from_iso(state[collection][STATE_START])
 
-        # Fix problem when end state is in the future
-        if (
-            Timestamp.from_iso(state[collection][STATE_END]).value
-            > Timestamp.now().value
-        ):
-            state[collection][STATE_END] = None
-
         # If no end date, put the proper period using delta
         if state[collection][STATE_END] is None:
             end = start.delta(days=self.mandiant_import_period)
@@ -700,6 +692,12 @@ class Mandiant:
             if end.value > Timestamp.now().value:
                 end = Timestamp.now()
         else:
+            # Fix problem when end state is in the future
+            if (
+                    Timestamp.from_iso(state[collection][STATE_END]).value
+                    > Timestamp.now().value
+            ):
+                state[collection][STATE_END] = None
             end = Timestamp.from_iso(state[collection][STATE_END])
 
         offset = state[collection][STATE_OFFSET]


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix fail to parse if end_epoch is None (Moving the condition when end_epoch is different from None)

### Related issues

* #2580 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
