### PR TITLE
Sets 100% as the maximum width of images when converting to html before to be exported in PDF

### DIFF
--- a/internal-export-file/export-report-pdf/src/resources/case.css.template
+++ b/internal-export-file/export-report-pdf/src/resources/case.css.template
@@ -207,6 +207,10 @@ h4 {
   float: right;
 }
 
+#content img {
+  max-width: 100%;
+}
+
 section {
   padding-top: 1cm;
 }

--- a/internal-export-file/export-report-pdf/src/resources/intrusion-set.css.template
+++ b/internal-export-file/export-report-pdf/src/resources/intrusion-set.css.template
@@ -214,6 +214,10 @@ h4 {
   float: right;
 }
 
+#content img {
+  max-width: 100%;
+}
+
 #columns section p {
   text-align: left;
 }

--- a/internal-export-file/export-report-pdf/src/resources/report.css.template
+++ b/internal-export-file/export-report-pdf/src/resources/report.css.template
@@ -207,6 +207,10 @@ h4 {
   float: right;
 }
 
+#content img {
+  max-width: 100%;
+}
+
 section {
   padding-top: 1cm;
 }

--- a/internal-export-file/export-report-pdf/src/resources/threat-actor.css.template
+++ b/internal-export-file/export-report-pdf/src/resources/threat-actor.css.template
@@ -214,6 +214,10 @@ h4 {
   float: right;
 }
 
+#content img {
+  max-width: 100%;
+}
+
 #columns section p {
   text-align: left;
 }


### PR DESCRIPTION
### Proposed changes

Sets 100% as the maximum width of images when converting to html before to be exported in PDF.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2587

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality