### PR TITLE
[ZeroFox] add created_by_ref and opencti_observable_main_type to stix objects

### DIFF
--- a/external-import/zerofox/src/collectors/collector.py
+++ b/external-import/zerofox/src/collectors/collector.py
@@ -9,12 +9,14 @@ class Collector:
         self.mapper = mapper
         self.client = client
 
-    def collect_intelligence(self, now: datetime, last_run_date: datetime, logger):
+    def collect_intelligence(
+        self, created_by, now: datetime, last_run_date: datetime, logger
+    ):
         stix_objects = []
         missed_entries = 0
         for entry in self.client.fetch_feed(self.endpoint, last_run_date):
             try:
-                stix_data = self.mapper(now, entry)
+                stix_data = self.mapper(now, entry, created_by)
                 stix_objects += stix_data
             except Exception as ex:
                 logger.debug(

--- a/external-import/zerofox/src/collectors/mappers/botnetToInfrastructure.py
+++ b/external-import/zerofox/src/collectors/mappers/botnetToInfrastructure.py
@@ -6,7 +6,7 @@ from zerofox.domain.botnet import Botnet
 
 
 def botnet_to_infrastructure(
-    now: str, entry: Botnet
+    _, now: str, entry: Botnet
 ) -> List[Union[Infrastructure, Location, Relationship]]:
     """
     Creates a STIX Infrastructure/botnet object from a ZeroFOX Botnet object,

--- a/external-import/zerofox/src/collectors/mappers/c2DomainsToInfrastructure.py
+++ b/external-import/zerofox/src/collectors/mappers/c2DomainsToInfrastructure.py
@@ -1,7 +1,8 @@
 import ipaddress
 from typing import List, Tuple, Union
 
-from open_cti import build_observable
+from open_cti import observable
+from open_cti.domain_objects import domain_object
 from stix2 import Infrastructure, IPv4Address, IPv6Address, Relationship, Software
 from zerofox.domain.c2Domains import C2Domain
 
@@ -18,9 +19,10 @@ def c2_domains_to_infrastructure(
     entry_tags = entry.tags
     tags, tags_obtained_observables = _parse_tag_observables(entry_tags)
 
-    infrastructure = Infrastructure(
+    infrastructure = domain_object(
+        created_by=created_by,
+        cls=Infrastructure,
         name=f"{entry.domain}",
-        created_by_ref=created_by,
         labels=tags,
         created=now,
         first_seen=entry.created_at,
@@ -76,19 +78,19 @@ def _get_observables_relationships(
     return [
         Relationship(
             source_ref=infra.id,
-            target_ref=observable.id,
+            target_ref=obs.id,
             relationship_type="consists-of",
             start_time=entry.created_at,
         )
-        for observable in observables
+        for obs in observables
     ]
 
 
 def build_ip_stix_object(created_by, ip):
     version = ipaddress.ip_address(ip).version
     if version == 4:
-        return build_observable(created_by=created_by, cls=IPv4Address, value=ip)
+        return observable(created_by=created_by, cls=IPv4Address, value=ip)
     elif version == 6:
-        return build_observable(created_by=created_by, cls=IPv6Address, value=ip)
+        return observable(created_by=created_by, cls=IPv6Address, value=ip)
     else:
         raise ValueError(f"Invalid IP address: {ip}")

--- a/external-import/zerofox/src/collectors/mappers/c2DomainsToInfrastructure.py
+++ b/external-import/zerofox/src/collectors/mappers/c2DomainsToInfrastructure.py
@@ -2,19 +2,12 @@ import ipaddress
 from typing import List, Tuple, Union
 
 from open_cti import build_observable
-from stix2 import (
-    Identity,
-    Infrastructure,
-    IPv4Address,
-    IPv6Address,
-    Relationship,
-    Software,
-)
+from stix2 import Infrastructure, IPv4Address, IPv6Address, Relationship, Software
 from zerofox.domain.c2Domains import C2Domain
 
 
 def c2_domains_to_infrastructure(
-    created_by: Identity,
+    created_by: str,
     now: str,
     entry: C2Domain,
 ) -> List[Union[Infrastructure, Relationship, IPv4Address, IPv6Address]]:

--- a/external-import/zerofox/src/collectors/mappers/c2DomainsToInfrastructure.py
+++ b/external-import/zerofox/src/collectors/mappers/c2DomainsToInfrastructure.py
@@ -1,12 +1,22 @@
 import ipaddress
 from typing import List, Tuple, Union
 
-from stix2 import Infrastructure, IPv4Address, IPv6Address, Relationship, Software
+from open_cti import build_observable
+from stix2 import (
+    Identity,
+    Infrastructure,
+    IPv4Address,
+    IPv6Address,
+    Relationship,
+    Software,
+)
 from zerofox.domain.c2Domains import C2Domain
 
 
 def c2_domains_to_infrastructure(
-    now: str, entry: C2Domain
+    created_by: Identity,
+    now: str,
+    entry: C2Domain,
 ) -> List[Union[Infrastructure, Relationship, IPv4Address, IPv6Address]]:
     """
     Creates a STIX Infrastructure/command-and-conrtol object from a ZeroFOX C2Domain object, along with
@@ -17,6 +27,7 @@ def c2_domains_to_infrastructure(
 
     infrastructure = Infrastructure(
         name=f"{entry.domain}",
+        created_by_ref=created_by,
         labels=tags,
         created=now,
         first_seen=entry.created_at,
@@ -28,7 +39,7 @@ def c2_domains_to_infrastructure(
         entry, infrastructure, tags_obtained_observables
     )
     ip_addresses = (
-        [build_ip_stix_object(ip) for ip in entry.ip_addresses]
+        [build_ip_stix_object(created_by, ip) for ip in entry.ip_addresses]
         if entry.ip_addresses
         else []
     )
@@ -80,11 +91,11 @@ def _get_observables_relationships(
     ]
 
 
-def build_ip_stix_object(ip):
+def build_ip_stix_object(created_by, ip):
     version = ipaddress.ip_address(ip).version
     if version == 4:
-        return IPv4Address(value=ip)
+        return build_observable(created_by=created_by, cls=IPv4Address, value=ip)
     elif version == 6:
-        return IPv6Address(value=ip)
+        return build_observable(created_by=created_by, cls=IPv6Address, value=ip)
     else:
         raise ValueError(f"Invalid IP address: {ip}")

--- a/external-import/zerofox/src/collectors/mappers/exploitToTool.py
+++ b/external-import/zerofox/src/collectors/mappers/exploitToTool.py
@@ -1,5 +1,6 @@
 from typing import List, Union
 
+from open_cti import domain_object
 from stix2 import ExternalReference, Relationship, Tool, Vulnerability
 from zerofox.domain.exploits import Exploit
 
@@ -11,9 +12,10 @@ def exploit_to_tool(
     Creates a STIX Tool/exploitation object from a ZeroFOX Exploit object, along with
         - A Vulnerability object for the tagetted CVE
     """
-    tool = Tool(
+    tool = domain_object(
+        created_by=created_by,
+        cls=Tool,
         name=f"{entry.cve}",
-        created_by_ref=created_by,
         description=f"```{entry.exploit}```",
         created=now,
         external_references=[
@@ -21,7 +23,9 @@ def exploit_to_tool(
         ],
         tool_types=["exploitation"],
     )
-    vulnerability = Vulnerability(name=entry.cve)
+    vulnerability = domain_object(
+        created_by=created_by, cls=Vulnerability, name=entry.cve
+    )
 
     return [
         tool,

--- a/external-import/zerofox/src/collectors/mappers/exploitToTool.py
+++ b/external-import/zerofox/src/collectors/mappers/exploitToTool.py
@@ -5,7 +5,7 @@ from zerofox.domain.exploits import Exploit
 
 
 def exploit_to_tool(
-    now: str, entry: Exploit
+    created_by, now: str, entry: Exploit
 ) -> List[Union[Tool, Vulnerability, Relationship]]:
     """
     Creates a STIX Tool/exploitation object from a ZeroFOX Exploit object, along with
@@ -13,6 +13,7 @@ def exploit_to_tool(
     """
     tool = Tool(
         name=f"{entry.cve}",
+        created_by_ref=created_by,
         description=f"```{entry.exploit}```",
         created=now,
         external_references=[

--- a/external-import/zerofox/src/collectors/mappers/malwareToMalware.py
+++ b/external-import/zerofox/src/collectors/mappers/malwareToMalware.py
@@ -1,6 +1,6 @@
 from typing import List, Union
 
-from open_cti import build_observable
+from open_cti import domain_object, observable
 from stix2 import URL, File, Indicator
 from stix2 import Malware as stixMalware
 from stix2 import Relationship
@@ -19,13 +19,15 @@ def malware_to_malware(
         - An Indicator observable object pointing the file hash to each of the malware families it is based on
     """
     urls = (
-        [build_observable(created_by=created_by, cls=URL, value=c2) for c2 in entry.c2]
+        [observable(created_by=created_by, cls=URL, value=c2) for c2 in entry.c2]
         if entry.c2
         else []
     )
     malware_families = (
         [
-            stixMalware(name=family, is_family=True, created_by_ref=created_by)
+            domain_object(
+                created_by=created_by, cls=stixMalware, name=family, is_family=True
+            )
             for family in entry.family
         ]
         if entry.family
@@ -40,7 +42,7 @@ def malware_to_malware(
     if entry.md5:
         present_hashes["MD5"] = entry.md5
 
-    file = build_observable(
+    file = observable(
         created_by=created_by,
         cls=File,
         name=entry.sha256,
@@ -55,8 +57,9 @@ def malware_to_malware(
         pattern_string += f" OR file:hashes.'{k}' = '{v}'"
     pattern_string += "]"
 
-    indicator = Indicator(
-        created_by_ref=created_by,
+    indicator = domain_object(
+        created_by=created_by,
+        cls=Indicator,
         name=entry.sha256,
         pattern_type=PATTERN_TYPE_STIX,
         pattern=pattern_string,

--- a/external-import/zerofox/src/collectors/mappers/malwareToMalware.py
+++ b/external-import/zerofox/src/collectors/mappers/malwareToMalware.py
@@ -1,5 +1,6 @@
 from typing import List, Union
 
+from open_cti import build_observable
 from stix2 import URL, File, Indicator
 from stix2 import Malware as stixMalware
 from stix2 import Relationship
@@ -8,7 +9,7 @@ from zerofox.domain.malware import Malware
 
 
 def malware_to_malware(
-    now: str, entry: Malware
+    created_by, _: str, entry: Malware
 ) -> List[Union[URL, File, Indicator, Relationship, stixMalware]]:
     """
     Based on a ZeroFox Malware object, creates the following STIX objects:
@@ -17,9 +18,16 @@ def malware_to_malware(
         - A set of Malware family objects for each of the malware families associated with the malware entry
         - An Indicator observable object pointing the file hash to each of the malware families it is based on
     """
-    urls = [URL(value=c2) for c2 in entry.c2] if entry.c2 else []
+    urls = (
+        [build_observable(created_by=created_by, cls=URL, value=c2) for c2 in entry.c2]
+        if entry.c2
+        else []
+    )
     malware_families = (
-        [stixMalware(name=family, is_family=True) for family in entry.family]
+        [
+            stixMalware(name=family, is_family=True, created_by_ref=created_by)
+            for family in entry.family
+        ]
         if entry.family
         else []
     )
@@ -32,7 +40,9 @@ def malware_to_malware(
     if entry.md5:
         present_hashes["MD5"] = entry.md5
 
-    file = File(
+    file = build_observable(
+        created_by=created_by,
+        cls=File,
         name=entry.sha256,
         hashes={
             "SHA-256": entry.sha256,
@@ -46,6 +56,7 @@ def malware_to_malware(
     pattern_string += "]"
 
     indicator = Indicator(
+        created_by_ref=created_by,
         name=entry.sha256,
         pattern_type=PATTERN_TYPE_STIX,
         pattern=pattern_string,

--- a/external-import/zerofox/src/collectors/mappers/phishingToInfrastructure.py
+++ b/external-import/zerofox/src/collectors/mappers/phishingToInfrastructure.py
@@ -1,6 +1,6 @@
 from typing import List, Union
 
-from open_cti import build_observable
+from open_cti import domain_object, observable
 from stix2 import (
     URL,
     AutonomousSystem,
@@ -30,8 +30,9 @@ def phishing_to_infrastructure(created_by, now: str, entry: Phishing) -> List[
         - a X509Certificate object for the certificate authority and fingerprint, if present.
 
     """
-    phishing = Infrastructure(
-        created_by_ref=created_by,
+    phishing = domain_object(
+        created_by=created_by,
+        cls=Infrastructure,
         name=f"{entry.domain}",
         created=now,
         infrastructure_types=["phishing"],
@@ -40,7 +41,7 @@ def phishing_to_infrastructure(created_by, now: str, entry: Phishing) -> List[
     )
     certificate_objects = build_certificate_objects(created_by, entry, phishing)
 
-    url = build_observable(
+    url = observable(
         created_by=created_by,
         cls=URL,
         value=entry.url,
@@ -53,7 +54,7 @@ def phishing_to_infrastructure(created_by, now: str, entry: Phishing) -> List[
         start_time=entry.scanned,
     )
 
-    ip = build_observable(
+    ip = observable(
         created_by=created_by,
         cls=IPv4Address,
         value=entry.host.ip,
@@ -66,7 +67,7 @@ def phishing_to_infrastructure(created_by, now: str, entry: Phishing) -> List[
         start_time=entry.scanned,
     )
 
-    asn = build_observable(
+    asn = observable(
         created_by=created_by,
         cls=AutonomousSystem,
         number=entry.host.asn,
@@ -93,7 +94,7 @@ def phishing_to_infrastructure(created_by, now: str, entry: Phishing) -> List[
 def build_certificate_objects(created_by, entry: Phishing, stix_phishing):
     if not entry.cert or not entry.cert.authority:
         return []
-    certificate = build_observable(
+    certificate = observable(
         created_by=created_by,
         cls=X509Certificate,
         issuer=entry.cert.authority,

--- a/external-import/zerofox/src/collectors/mappers/ransomwareToMalware.py
+++ b/external-import/zerofox/src/collectors/mappers/ransomwareToMalware.py
@@ -1,6 +1,6 @@
 from typing import List, Union
 
-from open_cti import build_observable
+from open_cti import domain_object, observable
 from stix2 import File, Indicator
 from stix2 import Malware as stixMalware
 from stix2 import Relationship
@@ -26,9 +26,10 @@ def ransomware_to_malware(
     else:
         ransomware_name = entry.sha256
 
-    malware = stixMalware(
+    malware = domain_object(
+        created_by=created_by,
+        cls=stixMalware,
         name=f"{ransomware_name}",
-        created_by_ref=created_by,
         description=f"```{entry.ransom_note}```",
         labels=[tag for tag in entry.tags if not tag.startswith("family:")],
         first_seen=entry.created_at,
@@ -46,7 +47,7 @@ def ransomware_to_malware(
     if entry.md5:
         present_hashes["MD5"] = entry.md5
 
-    file = build_observable(
+    file = observable(
         created_by=created_by,
         cls=File,
         name=entry.sha256,
@@ -61,9 +62,10 @@ def ransomware_to_malware(
         pattern_string += f" OR file:hashes.'{k}' = '{v}'"
     pattern_string += "]"
 
-    indicator = Indicator(
+    indicator = domain_object(
+        created_by=created_by,
+        cls=Indicator,
         name=entry.sha256,
-        created_by_ref=created_by,
         pattern_type=PATTERN_TYPE_STIX,
         pattern=pattern_string,
     )

--- a/external-import/zerofox/src/collectors/mappers/ransomwareToMalware.py
+++ b/external-import/zerofox/src/collectors/mappers/ransomwareToMalware.py
@@ -1,5 +1,6 @@
 from typing import List, Union
 
+from open_cti import build_observable
 from stix2 import File, Indicator
 from stix2 import Malware as stixMalware
 from stix2 import Relationship
@@ -8,7 +9,7 @@ from zerofox.domain.ransomware import Ransomware
 
 
 def ransomware_to_malware(
-    now: str, entry: Ransomware
+    created_by, now: str, entry: Ransomware
 ) -> List[Union[Relationship, Indicator, File, stixMalware]]:
     """
     Based on a ZeroFox Ransomware object, creates the following STIX objects:
@@ -27,6 +28,7 @@ def ransomware_to_malware(
 
     malware = stixMalware(
         name=f"{ransomware_name}",
+        created_by_ref=created_by,
         description=f"```{entry.ransom_note}```",
         labels=[tag for tag in entry.tags if not tag.startswith("family:")],
         first_seen=entry.created_at,
@@ -44,7 +46,9 @@ def ransomware_to_malware(
     if entry.md5:
         present_hashes["MD5"] = entry.md5
 
-    file = File(
+    file = build_observable(
+        created_by=created_by,
+        cls=File,
         name=entry.sha256,
         hashes={
             "SHA-256": entry.sha256,
@@ -59,6 +63,7 @@ def ransomware_to_malware(
 
     indicator = Indicator(
         name=entry.sha256,
+        created_by_ref=created_by,
         pattern_type=PATTERN_TYPE_STIX,
         pattern=pattern_string,
     )

--- a/external-import/zerofox/src/collectors/mappers/vulnerabilityToVulnerability.py
+++ b/external-import/zerofox/src/collectors/mappers/vulnerabilityToVulnerability.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from open_cti import domain_object
 from stix2 import ExternalReference
 from stix2 import Vulnerability as StixVulnerability
 from zerofox.domain.vulnerabilities import Vulnerability
@@ -14,9 +15,10 @@ def vulnerability_to_vulnerability(
     summary = f"\n\nSummary: {entry.summary}" if entry.summary else ""
     remediation = f"\n\nRemediation: {entry.remediation}" if entry.remediation else ""
 
-    vulnerability = StixVulnerability(
+    vulnerability = domain_object(
+        created_by=created_by,
+        cls=StixVulnerability,
         name=entry.cve,
-        created_by_ref=created_by,
         description=f"{entry.description}{summary}{remediation}",
         external_references=[
             ExternalReference(source_name="cve", external_id=entry.cve)

--- a/external-import/zerofox/src/collectors/mappers/vulnerabilityToVulnerability.py
+++ b/external-import/zerofox/src/collectors/mappers/vulnerabilityToVulnerability.py
@@ -6,7 +6,7 @@ from zerofox.domain.vulnerabilities import Vulnerability
 
 
 def vulnerability_to_vulnerability(
-    now: str, entry: Vulnerability
+    created_by, now: str, entry: Vulnerability
 ) -> List[StixVulnerability]:
     """
     Based on a ZeroFox Vulnerability object, creates a STIX Vulnerability object.
@@ -16,6 +16,7 @@ def vulnerability_to_vulnerability(
 
     vulnerability = StixVulnerability(
         name=entry.cve,
+        created_by_ref=created_by,
         description=f"{entry.description}{summary}{remediation}",
         external_references=[
             ExternalReference(source_name="cve", external_id=entry.cve)

--- a/external-import/zerofox/src/main.py
+++ b/external-import/zerofox/src/main.py
@@ -7,7 +7,7 @@ from typing import Dict
 import stix2
 from collectors.builder import build_collectors
 from collectors.collector import Collector
-from pycti import OpenCTIConnectorHelper
+from pycti import Identity, OpenCTIConnectorHelper
 from time_.interval import delta_from_interval, seconds_from_interval
 from zerofox.app.zerofox import ZeroFox
 
@@ -16,6 +16,7 @@ ZEROFOX_REFERENCE = stix2.ExternalReference(
     url="https://www.zerofox.com/threat-intelligence/",
     description="ZeroFox provides comprehensive, accurate, and timely intelligence bundles through its API.",
 )
+ZEROFOX = "ZeroFox"
 
 
 class ZeroFoxConnector:
@@ -44,8 +45,10 @@ class ZeroFoxConnector:
             logger=self.helper.connector_logger,
         )
         self.author = stix2.Identity(
-            name="ZeroFox Connector",
+            id=Identity.generate_id(ZEROFOX, "organization"),
+            name=ZEROFOX,
             identity_class="organization",
+            object_marking_refs=[stix2.TLP_WHITE.id],
         )
 
     def _validate_interval(self, env_var, interval):
@@ -149,7 +152,7 @@ class ZeroFoxConnector:
             self.send_bundle(work_id=work_id, bundle_objects=[self.author])
             self.helper.log_info(f"Running collector: {collector_name}")
             missed_entries, bundle_objects = collector.collect_intelligence(
-                created_by=self.author,
+                created_by=self.author.id,
                 now=now,
                 last_run_date=datetime.fromtimestamp(last_run, UTC),
                 logger=self.helper.connector_logger,

--- a/external-import/zerofox/src/main.py
+++ b/external-import/zerofox/src/main.py
@@ -43,6 +43,10 @@ class ZeroFoxConnector:
             feeds=os.environ.get("ZEROFOX_COLLECTORS", None),
             logger=self.helper.connector_logger,
         )
+        self.author = stix2.Identity(
+            name="ZeroFox Connector",
+            identity_class="organization",
+        )
 
     def _validate_interval(self, env_var, interval):
         self.helper.log_info(
@@ -142,9 +146,13 @@ class ZeroFoxConnector:
             self.helper.log_debug(
                 f"{self.helper.connect_name} connector is starting the collection of objects..."
             )
+            self.send_bundle(work_id=work_id, bundle_objects=[self.author])
             self.helper.log_info(f"Running collector: {collector_name}")
             missed_entries, bundle_objects = collector.collect_intelligence(
-                now, datetime.fromtimestamp(last_run, UTC), self.helper.connector_logger
+                created_by=self.author,
+                now=now,
+                last_run_date=datetime.fromtimestamp(last_run, UTC),
+                logger=self.helper.connector_logger,
             )
             if missed_entries > 0:
                 self.helper.log_warning(
@@ -201,7 +209,10 @@ class ZeroFoxConnector:
                         )
 
                     self.collect_intelligence_for_endpoint(
-                        current_time, last_run, collector_name, collector
+                        current_time=current_time,
+                        last_run=last_run,
+                        collector_name=collector_name,
+                        collector=collector,
                     )
 
             except (KeyboardInterrupt, SystemExit):

--- a/external-import/zerofox/src/open_cti/__init__.py
+++ b/external-import/zerofox/src/open_cti/__init__.py
@@ -1,3 +1,4 @@
-from open_cti.observables import build_observable
+from open_cti.domain_objects import domain_object
+from open_cti.observables import observable
 
-__all__ = ["build_observable"]
+__all__ = ["observable", "domain_object"]

--- a/external-import/zerofox/src/open_cti/__init__.py
+++ b/external-import/zerofox/src/open_cti/__init__.py
@@ -1,0 +1,3 @@
+from open_cti.observables import build_observable
+
+__all__ = ["build_observable"]

--- a/external-import/zerofox/src/open_cti/domain_objects.py
+++ b/external-import/zerofox/src/open_cti/domain_objects.py
@@ -1,0 +1,14 @@
+from typing import Type
+
+from stix2 import TLP_AMBER
+from stix2.base import _DomainObject
+
+
+def domain_object(created_by: str, cls: Type[_DomainObject], **kwargs):
+
+    kwargs.pop("created_by_ref", None)
+    return cls(
+        **kwargs,
+        created_by_ref=created_by,
+        object_marking_refs=[TLP_AMBER.id],
+    )

--- a/external-import/zerofox/src/open_cti/observables.py
+++ b/external-import/zerofox/src/open_cti/observables.py
@@ -21,7 +21,7 @@ def _get_observable_type(cls: Type[_Observable]) -> str:
     return _type
 
 
-def build_observable(created_by: str, cls: Type[_Observable], **kwargs):
+def observable(created_by: str, cls: Type[_Observable], **kwargs):
     return cls(
         **kwargs,
         custom_properties={

--- a/external-import/zerofox/src/open_cti/observables.py
+++ b/external-import/zerofox/src/open_cti/observables.py
@@ -1,6 +1,6 @@
 from typing import Type
 
-from stix2 import Identity
+from stix2 import TLP_AMBER
 from stix2.base import _Observable
 
 main_observable_type = "x_opencti_main_observable_type"
@@ -21,11 +21,12 @@ def _get_observable_type(cls: Type[_Observable]) -> str:
     return _type
 
 
-def build_observable(created_by: Identity, cls: Type[_Observable], **kwargs):
+def build_observable(created_by: str, cls: Type[_Observable], **kwargs):
     return cls(
         **kwargs,
         custom_properties={
             main_observable_type: _get_observable_type(cls),
             created_by_ref: created_by,
         },
+        object_marking_refs=[TLP_AMBER.id],
     )

--- a/external-import/zerofox/src/open_cti/observables.py
+++ b/external-import/zerofox/src/open_cti/observables.py
@@ -1,0 +1,31 @@
+from typing import Type
+
+from stix2 import Identity
+from stix2.base import _Observable
+
+main_observable_type = "x_opencti_main_observable_type"
+created_by_ref = "x_opencti_created_by_ref"
+
+
+def _get_observable_type(cls: Type[_Observable]) -> str:
+    _type = {
+        "IPv4-Address": "IPv4-Addr",
+        "IPv6-Address": "IPv6-Addr",
+        "File": "StixFile",
+        "URL": "Url",
+        "AutonomousSystem": "Autonomous-System",
+        "X509Certificate": "X509-Certificate",
+    }.get(cls.__name__)
+    if not _type:
+        raise ValueError(f"Unsupported observable type: {cls.__name__}")
+    return _type
+
+
+def build_observable(created_by: Identity, cls: Type[_Observable], **kwargs):
+    return cls(
+        **kwargs,
+        custom_properties={
+            main_observable_type: _get_observable_type(cls),
+            created_by_ref: created_by,
+        },
+    )


### PR DESCRIPTION

### Proposed changes

* include the x_opencti_main_observable_type custom property on all observables
* add author as custom property  created_by_ref field on stix observables, normal one on other objects, based on a stix2 Identity object named ZeroFox




### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
