### PR TITLE
[feedly] Use content for reports intsead of creating notes

### DIFF
--- a/external-import/feedly/src/feedly/opencti_connector/connector.py
+++ b/external-import/feedly/src/feedly/opencti_connector/connector.py
@@ -3,8 +3,8 @@ from datetime import datetime
 
 from feedly.api_client.enterprise.indicators_of_compromise import StixIoCDownloader
 from feedly.api_client.session import FeedlySession
+from markdown import markdown
 from pycti import OpenCTIConnectorHelper, OpenCTIStix2Utils
-from stix2 import Note
 
 FEEDLY_AI_UUID = "identity--477866fd-8784-46f9-ab40-5592ed4eddd7"
 
@@ -26,7 +26,7 @@ class FeedlyConnector:
         bundle = StixIoCDownloader(
             self.feedly_session, newer_than, stream_id
         ).download_all()
-        _replace_description_with_note(bundle)
+        _make_reports_content_instead_of_descriptions(bundle)
         _add_main_observable_type_to_indicators(bundle)
         _transform_threat_actors_to_intrusion_sets(bundle)
         self.cti_helper.log_info(f"Found {_count_reports(bundle)} new reports")
@@ -37,18 +37,14 @@ def _count_reports(bundle: dict) -> int:
     return sum(1 for o in bundle["objects"] if o["type"] == "report")
 
 
-def _replace_description_with_note(bundle: dict) -> None:
+def _make_reports_content_instead_of_descriptions(bundle: dict) -> None:
     notes = []
     for o in bundle["objects"]:
         if o["type"] == "report":
-            notes.append(
-                Note(
-                    content=o["description"],
-                    object_refs=[o["id"]],
-                    created_by_ref=FEEDLY_AI_UUID,
-                )
+            o["content"], o["description"] = (
+                markdown(o["description"]),
+                o["name"],
             )
-            o["description"] = ""
     bundle["objects"].extend([json.loads(note.serialize()) for note in notes])
 
 

--- a/external-import/feedly/src/requirements.txt
+++ b/external-import/feedly/src/requirements.txt
@@ -1,3 +1,4 @@
 pycti==6.2.18
 feedly-client==0.26
 schedule==1.2.2
+Markdown==3.7


### PR DESCRIPTION

### Proposed changes

* Using report contents instead of creating a note in the feedly connector

### Related issues

* N/A

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
