### PR TITLE
[urlscan] fix missing created_by_ref for indicators GH-2654

### DIFF
--- a/external-import/urlscan/src/urlscan/connector.py
+++ b/external-import/urlscan/src/urlscan/connector.py
@@ -307,6 +307,7 @@ class UrlscanConnector:
         """
         return stix2.Indicator(
             id=Indicator.generate_id(pattern.pattern),
+            created_by_ref=self._identity["standard_id"],
             pattern_type="stix",
             pattern=pattern.pattern,
             name=value,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Related issues

* Resolves GH-2654


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
