### PR TITLE
[Crowdstrike] Fix "'FetchedReport' not subscriptable" errors

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/builder.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/builder.py
@@ -422,7 +422,7 @@ class IndicatorBundleBuilder:
 
         for indicator_report in self.indicator_reports:
             report = self._create_report(
-                indicator_report["report"], indicator_report["files"], objects
+                indicator_report.report, indicator_report.files, objects
             )
             reports.append(report)
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* use dot notation to access properties of FetchedReport instances, as bracket notation can't be used in this case

### Related issues

* #2603 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

