### PR TITLE
fix(Sekoia): Prevent adding multiple times Sekoia.io as reference

### DIFF
--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -212,16 +212,21 @@ class Sekoia(object):
         Remove empty values from external references and add link to original object in Sekoia.io platform
         """
         for item in items:
-            item["external_references"] = [
-                {k: v for k, v in ref.items() if v}
-                for ref in item.get("external_references", [])
-            ]
-            item["external_references"].append(
-                {
-                    "source_name": "Sekoia.io",
-                    "url": f"https://app.sekoia.io/intelligence/objects/{item['id']}",
-                }
-            )
+            has_sekoia_source = False
+            external_references = item.setdefault("external_references", [])
+            for ref in external_references:
+                if ref.get("source_name") == "Sekoia.io":
+                    has_sekoia_source = True
+                for key in list(ref.keys()):
+                    if not ref[key]:
+                        del ref[key]
+            if not has_sekoia_source:
+                external_references.append(
+                    {
+                        "source_name": "Sekoia.io",
+                        "url": f"https://app.sekoia.io/intelligence/objects/{item['id']}",
+                    }
+                )
 
     def _clean_ic_fields(self, items: List[Dict]) -> List[Dict]:
         """


### PR DESCRIPTION

### Proposed changes

* Avoid to add multiple time the Sekoia.io source in objects

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
