### PR TITLE
[greynoise-feed] fix feed queries to match documentation

### DIFF
--- a/external-import/greynoise-feed/src/main.py
+++ b/external-import/greynoise-feed/src/main.py
@@ -105,9 +105,7 @@ class GreyNoiseFeed:
         elif feed_type.lower() == "malicious":
             query = "last_seen:1d classification:malicious"
         elif feed_type.lower() == "benign+malicious":
-            query = (
-                "last_seen:1d (classification:malicious OR classification:benign)"
-            )
+            query = "last_seen:1d (classification:malicious OR classification:benign)"
         elif feed_type.lower() == "all":
             query = "last_seen:1d"
 

--- a/external-import/greynoise-feed/src/main.py
+++ b/external-import/greynoise-feed/src/main.py
@@ -1,4 +1,3 @@
-import math
 import os
 import time
 from datetime import datetime, timedelta

--- a/external-import/greynoise-feed/src/main.py
+++ b/external-import/greynoise-feed/src/main.py
@@ -93,7 +93,7 @@ class GreyNoiseFeed:
         # Cache for label
         self.labels_cache = {}
 
-    def get_feed_query(self, feed_type, last_seen):
+    def get_feed_query(self, feed_type):
         query = ""
         if feed_type.lower() not in ["benign", "malicious", "benign+malicious", "all"]:
             self.helper.log_error(
@@ -101,17 +101,15 @@ class GreyNoiseFeed:
             )
             exit(1)
         elif feed_type.lower() == "benign":
-            query = "last_seen:" + last_seen + " classification:benign"
+            query = "last_seen:1d classification:benign"
         elif feed_type.lower() == "malicious":
-            query = "last_seen:" + last_seen + " classification:malicious"
+            query = "last_seen:1d classification:malicious"
         elif feed_type.lower() == "benign+malicious":
             query = (
-                "last_seen:"
-                + last_seen
-                + " (classification:malicious OR classification:benign)"
+                "last_seen:1d (classification:malicious OR classification:benign)"
             )
         elif feed_type.lower() == "all":
-            query = "last_seen:" + last_seen
+            query = "last_seen:1d"
 
         return query
 
@@ -598,10 +596,8 @@ class GreyNoiseFeed:
                     session = GreyNoise(
                         api_key=self.api_key, integration_name="opencti-feed-v2.3"
                     )
-                    delta = now - last_run_timestamp
-                    days = math.ceil(delta.total_seconds() / 3600 / 24)
 
-                    query = self.get_feed_query(self.feed_type, str(days) + "d")
+                    query = self.get_feed_query(self.feed_type)
                     self.helper.log_info(
                         "Querying GreyNoise API - First Results Page (" + query + ")"
                     )


### PR DESCRIPTION
### Proposed changes

* Modifies the query the feed uses to match the restrictions documented: https://docs.greynoise.io/docs/using-greynoise-as-an-indicator-feed#how-to-build-a-script-to-pull-a-greynoise-feed
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
