### PR TITLE
[CrowdStrike] Fix KeyError in CrowdStrike processing

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_services/utils/__init__.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_services/utils/__init__.py
@@ -868,7 +868,7 @@ def create_stix2_report_from_report(
     report_tags = report["tags"]
     if report_tags is not None:
         for tag in report_tags:
-            value = tag["value"]
+            value = tag.get("value")
             if value is None or not value:
                 continue
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

The CrowdStike Connector was failing when encountering a specific report from CrowdStrike that had an undefined tag. This PR uses the more resilient `get` method to obtain a key that may be missing.

Here is a log showing the error:

> `"level": "ERROR", "name": "Crowdstrike", "message": "CrowdStrike connector internal error: 'value'", "exc_info": "Traceback (most recent call last):\n  File \"/opt/opencti-connector-crowdstrike/crowdstrike_feeds_connector/core.py\", line 284, in process_message\n    importer_state = importer.start(work_id, new_state)\n                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/opencti-connector-crowdstrike/crowdstrike_feeds_connector/importer.py\", line 40, in start\n    return self.run(state)\n           ^^^^^^^^^^^^^^^\n  File \"/opt/opencti-connector-crowdstrike/crowdstrike_feeds_connector/rule/yara_master_importer.py\", line 121, in run\n    failed = self._process_yara_rule_group(yara_rule_group)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/opencti-connector-crowdstrike/crowdstrike_feeds_connector/rule/yara_master_importer.py\", line 262, in _process_yara_rule_group\n    yara_rule_bundle = self._create_yara_rule_bundle(yara_rule, fetched_reports)\n                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/opencti-connector-crowdstrike/crowdstrike_feeds_connector/rule/yara_master_importer.py\", line 396, in _create_yara_rule_bundle\n    return bundle_builder.build()\n           ^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/opencti-connector-crowdstrike/crowdstrike_feeds_connector/rule/yara_master_builder.py\", line 109, in build\n    reports = self._create_reports(object_refs)\n              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/opencti-connector-crowdstrike/crowdstrike_feeds_connector/rule/yara_master_builder.py\", line 185, in _create_reports\n    report = self._create_report(\n             ^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/opencti-connector-crowdstrike/crowdstrike_feeds_connector/rule/yara_master_builder.py\", line 200, in _create_report\n    return create_stix2_report_from_report(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/opencti-connector-crowdstrike/crowdstrike_feeds_services/utils/__init__.py\", line 871, in create_stix2_report_from_report\n    value = tag[\"value\"]\n            ~~~^^^^^^^^^\nKeyError: 'value'"}`

### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
