### PR TITLE
[CISA KEV]: Do not republish all the content at each execution

### DIFF
--- a/external-import/cisa-known-exploited-vulnerabilities/src/main.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/main.py
@@ -259,39 +259,39 @@ class Cisa:
             # Get the current timestamp and check
             timestamp = int(time.time())
             current_state = self.helper.get_state()
-            if current_state is not None and "last_run" in current_state:
-                last_run = current_state["last_run"]
-                self.helper.log_info(
-                    "Connector last run: "
-                    + datetime.datetime.utcfromtimestamp(last_run).strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    )
-                )
+            last_update = None
+            if current_state is not None and "last_update" in current_state:
+                last_update = current_state["last_update"]
+                self.helper.log_info(f"CISA KEV last catalog update: {last_update}")
             else:
-                self.helper.log_info("Connector has never run")
+                self.helper.log_info("CISA KEV connector has never run")
 
-            self.helper.log_info("Connector will run!")
             now = datetime.datetime.utcfromtimestamp(timestamp)
             friendly_name = "CISA run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
-            work_id = self.helper.api.work.initiate_work(
-                self.helper.connect_id, friendly_name
-            )
             if self.cisa_catalog_url is not None and len(self.cisa_catalog_url) > 0:
+                work_id = self.helper.api.work.initiate_work(
+                    self.helper.connect_id, friendly_name
+                )
                 cisa_data = self.retrieve_data(self.cisa_catalog_url)
-                self.set_created_by_stix(org=self.org)
-                self.set_tlp_marking(tlp_mark=self.tlp)
                 cisa_data = json.loads(cisa_data)
-                for vuln in cisa_data["vulnerabilities"]:
-                    bundle = self.build_bundle(vuln)
-                    self.send_bundle(work_id, bundle)
-
-            # Store the current timestamp as a last run
-            message = "Connector successfully run, storing last_run as " + str(
-                timestamp
-            )
-            self.helper.log_info(message)
-            self.helper.set_state({"last_run": timestamp})
-            self.helper.api.work.to_processed(work_id, message)
+                if cisa_data.get("dateReleased") != last_update:
+                    self.set_created_by_stix(org=self.org)
+                    self.set_tlp_marking(tlp_mark=self.tlp)
+                    for vuln in cisa_data["vulnerabilities"]:
+                        bundle = self.build_bundle(vuln)
+                        self.send_bundle(work_id, bundle)
+                    # Store the current timestamp as a last run
+                    message = "Connector successfully run, storing last_update as " + str(
+                        cisa_data.get("dateReleased")
+                    )
+                    self.helper.log_info(message)
+                    self.helper.set_state({"last_update": cisa_data.get("dateReleased")})
+                    self.helper.api.work.to_processed(work_id, message)
+                else:
+                    # Store the current timestamp as a last run
+                    message = "Connector successfully run, nothing to do"
+                    self.helper.log_info(message)
+                    self.helper.api.work.to_processed(work_id, message)
 
         except (KeyboardInterrupt, SystemExit):
             self.helper.log_info("Connector stop")

--- a/external-import/cisa-known-exploited-vulnerabilities/src/main.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/main.py
@@ -281,11 +281,14 @@ class Cisa:
                         bundle = self.build_bundle(vuln)
                         self.send_bundle(work_id, bundle)
                     # Store the current timestamp as a last run
-                    message = "Connector successfully run, storing last_update as " + str(
-                        cisa_data.get("dateReleased")
+                    message = (
+                        "Connector successfully run, storing last_update as "
+                        + str(cisa_data.get("dateReleased"))
                     )
                     self.helper.log_info(message)
-                    self.helper.set_state({"last_update": cisa_data.get("dateReleased")})
+                    self.helper.set_state(
+                        {"last_update": cisa_data.get("dateReleased")}
+                    )
                     self.helper.api.work.to_processed(work_id, message)
                 else:
                     # Store the current timestamp as a last run


### PR DESCRIPTION
### Proposed changes

Instead of storing the "execution date", use the provided "dateReleased" as the state and republish content only if the "dateReleased" is updated since last execution.
https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities_schema.json

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2720

