### PR TITLE
[ Webhook Stream ] - Correct CONNECTOR_SCOPE

### DIFF
--- a/stream/webhook/docker-compose.yml
+++ b/stream/webhook/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       CONNECTOR_LIVE_STREAM_LISTEN_DELETE: true
       CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES: true
       CONNECTOR_NAME: OpenCTI Webhook Stream Connector
-      CONNECTOR_SCOPE: wevhook
+      CONNECTOR_SCOPE: webhook
       CONNECTOR_CONFIDENCE_LEVEL: 80 # From 0 (Unknown) to 100 (Fully trusted)
       CONNECTOR_LOG_LEVEL: info
       WEBHOOK_TYPE: URL


### PR DESCRIPTION
CONNECTOR_SCOPE is incorrect based on documentation. This is the fix

Docker-compose.yml of the connector-webhook has the incorrect CONNECTOR_SCOPE

Documentation found in README states that the it is mandatory and 'Must be webhook'


