### PR TITLE
[Sentinel-intel] Fix directory name in Dockerfile

### DIFF
--- a/stream/sentinel-intel/Dockerfile
+++ b/stream/sentinel-intel/Dockerfile
@@ -7,7 +7,7 @@ COPY src /opt/opencti-connector-sentinel-intel
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev && \
-    cd /opt/opencti-connector-sentinel && \
+    cd /opt/opencti-connector-sentinel-intel && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 


### PR DESCRIPTION
Replace `opencti-connector-sentinel` with `opencti-connector-sentinel-intel`.