### PR TITLE
[Connectors] Downgrade Python version to 3.11 as stix-shifter is not compatible

### DIFF
--- a/stream/harfanglab/Dockerfile
+++ b/stream/harfanglab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.11-alpine
 ENV CONNECTOR_TYPE=STREAM
 
 # Copy the worker

--- a/stream/qradar/Dockerfile
+++ b/stream/qradar/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.11-alpine
 ENV CONNECTOR_TYPE=STREAM
 
 # Copy the worker

--- a/stream/sentinel-intel/Dockerfile
+++ b/stream/sentinel-intel/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.11-alpine
 ENV CONNECTOR_TYPE=STREAM
 
 # Copy the connector

--- a/stream/sentinel/Dockerfile
+++ b/stream/sentinel/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.11-alpine
 ENV CONNECTOR_TYPE=STREAM
 
 # Copy the connector

--- a/stream/splunk/Dockerfile
+++ b/stream/splunk/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.11-alpine
 ENV CONNECTOR_TYPE=STREAM
 
 # Copy the worker

--- a/stream/webhook/Dockerfile
+++ b/stream/webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.11-alpine
 ENV CONNECTOR_TYPE=STREAM
 
 # Copy the worker


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Downgrade Python version to 3.11 as stix-shifter is not compatible

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2848

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
