### PR TITLE
[import-external-reference] Change distribution to bookworm as playrwright cannot be used with alpine

### DIFF
--- a/internal-enrichment/import-external-reference/Dockerfile
+++ b/internal-enrichment/import-external-reference/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.12-bookworm
 ENV CONNECTOR_TYPE=INTERNAL_ENRICHMENT
 
 # Copy the connector
@@ -6,12 +6,11 @@ COPY src /opt/opencti-connector-import-external-reference
 
 # Install Python modules
 # hadolint ignore=DL3003
-RUN apk update && apk upgrade && \
-    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev cargo libsm-dev libxrender libxext-dev && \
+RUN apt-get update && \
+    apt-get install -y git build-essential libmagic-dev libffi-dev libxml2-dev libxslt-dev libssl-dev cargo libjpeg-dev zlib1g-dev libxkbcommon0 libgbm1 libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libatspi2.0-0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libasound2 && \
     cd /opt/opencti-connector-import-external-reference && \
     pip3 install --no-cache-dir -r requirements.txt && \
-    playwright install --with-deps && \
-    apk del git build-base
+    playwright install
 
 # Expose and entrypoint
 COPY entrypoint.sh /


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change distribution to bookworm as playrwright cannot be used with alpine

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2848

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
