### PR TITLE
[Yara] Quick Fix for artefact recovery

### DIFF
--- a/internal-enrichment/yara/src/main.py
+++ b/internal-enrichment/yara/src/main.py
@@ -10,7 +10,7 @@ from pycti import (
     StixCoreRelationship,
     get_config_variable,
 )
-from stix2 import Bundle, Relationship, TLP_WHITE
+from stix2 import TLP_WHITE, Bundle, Relationship
 
 
 class YaraConnector:

--- a/internal-enrichment/yara/src/main.py
+++ b/internal-enrichment/yara/src/main.py
@@ -41,7 +41,9 @@ class YaraConnector:
         """
         self.helper.log_debug("Getting Artifact contents (bytes) from OpenCTI")
 
-        artifact_files_contents = artifact.get("importFiles") if artifact.get("importFiles") else []
+        artifact_files_contents = (
+            artifact.get("importFiles") if artifact.get("importFiles") else []
+        )
 
         files_contents = []
         if artifact_files_contents:
@@ -49,9 +51,7 @@ class YaraConnector:
                 file_name = artifact_file_content.get("name")
                 file_id = artifact_file_content.get("id")
                 file_url = self.octi_api_url + "/storage/get/" + file_id
-                file_content = self.helper.api.fetch_opencti_file(
-                    file_url, binary=True
-                )
+                file_content = self.helper.api.fetch_opencti_file(file_url, binary=True)
                 files_contents.append(file_content)
                 self.helper.log_debug(
                     f"Associated file found in Artifact with file_name :{file_name}"

--- a/internal-enrichment/yara/src/main.py
+++ b/internal-enrichment/yara/src/main.py
@@ -42,7 +42,7 @@ class YaraConnector:
         self.helper.log_debug("Getting Artifact contents (bytes) from OpenCTI")
 
         artifact_files_contents = (
-            artifact.get("importFiles") if artifact.get("importFiles") else []
+            artifact.get("importFiles", [])
         )
 
         files_contents = []

--- a/internal-enrichment/yara/src/main.py
+++ b/internal-enrichment/yara/src/main.py
@@ -41,9 +41,7 @@ class YaraConnector:
         """
         self.helper.log_debug("Getting Artifact contents (bytes) from OpenCTI")
 
-        artifact_files_contents = (
-            artifact.get("importFiles", [])
-        )
+        artifact_files_contents = artifact.get("importFiles", [])
 
         files_contents = []
         if artifact_files_contents:
@@ -100,7 +98,7 @@ class YaraConnector:
                     rule_content = indicator["pattern"]
                     rule = yara.compile(source=rule_content)
                 except yara.SyntaxError:
-                    self.helper.log_debug(
+                    self.helper.log_error(
                         f"Encountered YARA syntax error {indicator['name']}"
                     )
                     continue

--- a/internal-enrichment/yara/src/main.py
+++ b/internal-enrichment/yara/src/main.py
@@ -4,7 +4,12 @@ import time
 
 import yaml
 import yara
-from pycti import OpenCTIConnectorHelper, StixCoreRelationship, get_config_variable, OpenCTIApiClient
+from pycti import (
+    OpenCTIApiClient,
+    OpenCTIConnectorHelper,
+    StixCoreRelationship,
+    get_config_variable,
+)
 from stix2 import Bundle, Relationship
 
 
@@ -33,7 +38,9 @@ class YaraConnector:
             if artifact.get("importFiles"):
                 artifact_files_contents = artifact.get("importFiles")
             else:
-                artifact_entity = self.client.stix_cyber_observable.read(id=artifact.get("standard_id"))
+                artifact_entity = self.client.stix_cyber_observable.read(
+                    id=artifact.get("standard_id")
+                )
                 artifact_files_contents = artifact_entity.get("importFiles")
 
             files_contents = []
@@ -41,7 +48,9 @@ class YaraConnector:
                 for artifact_file_content in artifact_files_contents:
                     file_id = artifact_file_content.get("id")
                     file_url = self.octi_api_url + "/storage/get/" + file_id
-                    file_content = self.helper.api.fetch_opencti_file(file_url, binary=True)
+                    file_content = self.helper.api.fetch_opencti_file(
+                        file_url, binary=True
+                    )
                     files_contents.append(file_content)
                 return files_contents
 
@@ -103,7 +112,9 @@ class YaraConnector:
                 if results:
                     relationship = Relationship(
                         id=StixCoreRelationship.generate_id(
-                            "related-to", artifact["standard_id"], indicator["standard_id"]
+                            "related-to",
+                            artifact["standard_id"],
+                            indicator["standard_id"],
                         ),
                         relationship_type="related-to",
                         source_ref=artifact["standard_id"],


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

Following the discussion with @nino-filigran, we're going to go for a quick fix, which doesn't solve the problem in its entirety but does correct it on the connector. The main problem will be dealt with at a later date.

### Proposed changes

* ~(Quick Fix) Temporary solution to the artefact issue with the YARA connector. In automatic mode, when an artefact is created with a file (either through another connector or manually), the file is not immediately accessible to the YARA connector for data retrieval, leading to an error.~ `Will be resolved on another PR`

* The error when the artefact does not initially have a file has also been fixed.

* A strange behavior has also been fixed: although only one file can be associated with an artifact at the time of creation, it is possible to add others afterward. However, when manual enrichment was used, the YARA connector would only check the first file and ignore any additional ones. From now on, all added files will be taken into account during the scan.

**IMPORTANT:** Julien's directive on the real fix : (see https://github.com/OpenCTI-Platform/connectors/issues/2811#issuecomment-2437348224)
- _"Looks like we create the artifact and the upload the file. I think we need to modify the client python to use the createArtefact API containing directly the file upload."_

- _"we also need to check the artifact creation from the platform when using a standard observable instead of the Artifact."_
Details : When creating an observable of type "artifact", it is not necessary to link it to a file, unlike a full-fledged artifact which generates hashes from a file.

### Related issues

* #2546
* #2700
* #2811
* https://github.com/OpenCTI-Platform/opencti/issues/8794

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
