### PR TITLE
[Connectors] Remove non-existing arguments for generate_id

### DIFF
--- a/external-import/crits/src/crits.py
+++ b/external-import/crits/src/crits.py
@@ -109,9 +109,7 @@ class CRITsConnector:
             dynamic_params["created_by_ref"] = custom_properties["created_by_ref"]
 
         return stix2.ThreatActor(
-            id=ThreatActor.generate_id(
-                name=crits_obj["name"], opencti_type="Threat-Actor-Group"
-            ),
+            id=ThreatActor.generate_id(name=crits_obj["name"]),
             name=crits_obj["name"],
             labels=crits_obj.get("bucket_list", []),
             object_marking_refs=[self.default_marking],

--- a/external-import/group-ib/src/data_to_stix2.py
+++ b/external-import/group-ib/src/data_to_stix2.py
@@ -577,7 +577,7 @@ class ThreatActor(_BaseSDO):
 
     def _generate_sdo(self):
         self.stix_main_object = stix2.ThreatActor(
-            id=pycti.ThreatActor.generate_id(self.name, "Threat-Actor-Group"),
+            id=pycti.ThreatActor.generate_id(self.name),
             name=self.name,
             description=self.description,
             aliases=self.aliases,

--- a/external-import/ransomwarelive/src/lib/ransom_conn.py
+++ b/external-import/ransomwarelive/src/lib/ransom_conn.py
@@ -380,7 +380,7 @@ class RansomwareAPIConnector:
         # Creating Threat Actor object
         threat_actor_name = item.get("group_name")
         threat_actor = ThreatActor(
-            id=pycti.ThreatActor.generate_id(threat_actor_name, "Threat-Actor-Group"),
+            id=pycti.ThreatActor.generate_id(threat_actor_name),
             name=threat_actor_name,
             labels=["ransomware"],
             created_by_ref=self.author.get("id"),

--- a/external-import/recorded-future/src/rflib/rf_to_stix2.py
+++ b/external-import/recorded-future/src/rflib/rf_to_stix2.py
@@ -381,7 +381,7 @@ class ThreatActor(RFStixEntity):
     def create_stix_objects(self):
         """Creates STIX objects from object attributes"""
         self.stix_obj = stix2.ThreatActor(
-            id=pycti.ThreatActor.generate_id(self.name, "Threat-Actor-Group"),
+            id=pycti.ThreatActor.generate_id(self.name),
             name=self.name,
             resource_level="individual" if self.type == "Person" else None,
             created_by_ref=self.author.id,

--- a/internal-enrichment/greynoise/src/main.py
+++ b/internal-enrichment/greynoise/src/main.py
@@ -624,7 +624,7 @@ class GreyNoiseConnector:
         ):
             # Generate Threat Actor
             stix_threat_actor = stix2.ThreatActor(
-                id=ThreatActor.generate_id(data["actor"], "Threat-Actor-Group"),
+                id=ThreatActor.generate_id(data["actor"]),
                 name=data["actor"],
                 created_by_ref=self.greynoise_identity["id"],
             )

--- a/internal-enrichment/hybrid-analysis-sandbox/src/hybrid-analysis-sandbox.py
+++ b/internal-enrichment/hybrid-analysis-sandbox/src/hybrid-analysis-sandbox.py
@@ -248,7 +248,7 @@ class HybridAnalysis:
             )
         )
         malware_analysis = stix2.MalwareAnalysis(
-            id=MalwareAnalysis.generate_id(result_name, "HybridAnalysis", None),
+            id=MalwareAnalysis.generate_id(result_name),
             product="HybridAnalysis",
             result_name=result_name,
             analysis_started=analysis_started,

--- a/internal-enrichment/orion-malware/src/main.py
+++ b/internal-enrichment/orion-malware/src/main.py
@@ -628,9 +628,7 @@ class OrionMalwareConnector:
             json_report.get("overview").get("submissions").get("first_date")
         )
         malware_analysis = stix2.MalwareAnalysis(
-            id=pycti.MalwareAnalysis.generate_id(
-                analysis_result_name, "Orion Malware", analysis_submitted
-            ),
+            id=pycti.MalwareAnalysis.generate_id(analysis_result_name),
             product="Orion Malware",
             result_name=analysis_result_name,
             created_by_ref=self.identity["standard_id"],

--- a/internal-enrichment/recordedfuture-enrichment/src/rflib/rf_to_stix2.py
+++ b/internal-enrichment/recordedfuture-enrichment/src/rflib/rf_to_stix2.py
@@ -333,7 +333,7 @@ class RfThreatActor(RFStixEntity):
         """Creates STIX objects from object attributes"""
         self.helper.log_debug("Add Threat Actor.")
         self.stix_obj = stix2.ThreatActor(
-            id=pycti.ThreatActor.generate_id(self.name, "Threat-Actor-Group"),
+            id=pycti.ThreatActor.generate_id(self.name),
             name=self.name,
             created_by_ref=self.author.id,
         )


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  Remove non-existing arguments for generate_id for following connectors
   * crits
   * group ib
   * ransomware live
   * recorded future
   * greynoise
   * hybrid analysis sandbox
   * orion malware
   * recorded future enrichment

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2908

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
