### PR TITLE
[internal-import] only add object_refs if entity context is a container

### DIFF
--- a/internal-import-file/import-file-misp/src/import-file-misp.py
+++ b/internal-import-file/import-file-misp/src/import-file-misp.py
@@ -2101,21 +2101,22 @@ class MispImportFile:
                 if "x_opencti_id" in object
                 and object["x_opencti_id"] == container["id"]
             ][0]
-            if self._contains_container(bundle):
-                self.helper.log_info("Bundle contains container.")
-                container_stix["object_refs"] = []
-                for elem in bundle:
-                    if self._is_container(elem.get("type")):
-                        container_stix["object_refs"].append(elem["id"])
-                        if "object_refs" in elem:
-                            for object_id in elem.get("object_refs"):
-                                container_stix["object_refs"].append(object_id)
-            else:
-                self.helper.log_info(
-                    "No container in Stix file. Updating current container"
-                )
-                container_stix["object_refs"] = [object["id"] for object in bundle]
-            bundle.append(container_stix)
+            if self._is_container(container_stix.get("type")):
+                if self._contains_container(bundle):
+                    self.helper.log_info("Bundle contains container.")
+                    container_stix["object_refs"] = []
+                    for elem in bundle:
+                        if self._is_container(elem.get("type")):
+                            container_stix["object_refs"].append(elem["id"])
+                            if "object_refs" in elem:
+                                for object_id in elem.get("object_refs"):
+                                    container_stix["object_refs"].append(object_id)
+                else:
+                    self.helper.log_info(
+                        "No container in Stix file. Updating current container"
+                    )
+                    container_stix["object_refs"] = [object["id"] for object in bundle]
+                bundle.append(container_stix)
         return bundle
 
 

--- a/internal-import-file/import-file-stix/src/import-file-stix.py
+++ b/internal-import-file/import-file-stix/src/import-file-stix.py
@@ -86,21 +86,22 @@ class ImportFileStix:
                 if "x_opencti_id" in object
                 and object["x_opencti_id"] == container["id"]
             ][0]
-            if self._contains_container(bundle):
-                self.helper.log_info("Bundle contains container.")
-                container_stix["object_refs"] = []
-                for elem in bundle:
-                    if self._is_container(elem.get("type")):
-                        container_stix["object_refs"].append(elem["id"])
-                        if "object_refs" in elem:
-                            for object_id in elem.get("object_refs"):
-                                container_stix["object_refs"].append(object_id)
-            else:
-                self.helper.log_info(
-                    "No container in Stix file. Updating current container"
-                )
-                container_stix["object_refs"] = [object["id"] for object in bundle]
-            bundle.append(container_stix)
+            if self._is_container(container_stix.get("type")):
+                if self._contains_container(bundle):
+                    self.helper.log_info("Bundle contains container.")
+                    container_stix["object_refs"] = []
+                    for elem in bundle:
+                        if self._is_container(elem.get("type")):
+                            container_stix["object_refs"].append(elem["id"])
+                            if "object_refs" in elem:
+                                for object_id in elem.get("object_refs"):
+                                    container_stix["object_refs"].append(object_id)
+                else:
+                    self.helper.log_info(
+                        "No container in Stix file. Updating current container"
+                    )
+                    container_stix["object_refs"] = [object["id"] for object in bundle]
+                bundle.append(container_stix)
         return bundle
 
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* we were adding objects_refs to all enties in the context of an import within an entity. We now check if the entity context is a container before adding object refs. This caused the splitter to incorrectly skip the relationships linked to the entity context

### Related issues

* closes #2918
* original opencti issue https://github.com/OpenCTI-Platform/opencti/issues/8818

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
