### PR TITLE
[Shodan] Created config to use ISP name for ASN name.

### DIFF
--- a/internal-enrichment/shodan/README.md
+++ b/internal-enrichment/shodan/README.md
@@ -77,6 +77,8 @@ Below are the parameters you'll need to set for Shodan Connector:
 | max_tlp               | `max_tlp`               | `SHODAN_MAX_TLP`               | `TLP:AMBER` | No        | The maximal TLP of the observable being enriched.                                               |
 | default_score         | `default_score`         | `SHODAN_DEFAULT_SCORE`         | `50`        | No        | Default_score allows you to add a default score for an indicator and its observable             |
 | import_search_results | `import_search_results` | `SHODAN_IMPORT_SEARCH_RESULTS` | `True`      | No        | Returns the results of the search against the enriched indicator (Search the SHODAN database). |
+| create_note | `create_note` | `SHODAN_CREATE_NOTE` | `True` | Adds Shodan results to a note, otherwise it is saved in the description. |
+| use_isp_name_for_asn | `use_isp_name_for_asn` | `SHODAN_USE_ISP_NAME_FOR_ASN` | `False` | Use the ISP name for ASN name rather than AS+Number. |
 
 ## Deployment
 

--- a/internal-enrichment/shodan/docker-compose.yml
+++ b/internal-enrichment/shodan/docker-compose.yml
@@ -15,4 +15,5 @@ services:
       - SHODAN_DEFAULT_SCORE=50
       - SHODAN_IMPORT_SEARCH_RESULTS=true
       - SHODAN_CREATE_NOTE=true # Add results to note rather than description
+      - SHODAN_USE_ISP_NAME_FOR_ASN=false
     restart: always

--- a/internal-enrichment/shodan/src/config.yml.sample
+++ b/internal-enrichment/shodan/src/config.yml.sample
@@ -16,3 +16,4 @@ shodan:
   default_score: 50
   import_search_results: true
   create_note: true
+  use_isp_name_for_asn: false

--- a/internal-enrichment/shodan/src/shodanImport.py
+++ b/internal-enrichment/shodan/src/shodanImport.py
@@ -69,7 +69,12 @@ class ShodanConnector:
             config,
             default=True,
         )
-
+        self.use_isp_name_for_asn = get_config_variable(
+            "SHODAN_USE_ISP_NAME_FOR_ASN",
+            ["shodan", "use_isp_name_for_asn"],
+            config,
+            default=False,
+        )
         # Shodan Identity
         self.shodan_identity = self.helper.api.identity.create(
             type="Organization",
@@ -211,7 +216,7 @@ class ShodanConnector:
     def _generate_stix_asn(self, data):
         if "asn" in data and data["asn"] is not None and len(data["asn"]) > 0:
             # Generate Asn
-            entity_asn = data["asn"]
+            entity_asn = data["isp"] if self.use_isp_name_for_asn else data["asn"]
             asn_number = int(data["asn"].replace("AS", ""))
             stix_asn = stix2.AutonomousSystem(
                 type="autonomous-system",


### PR DESCRIPTION
### Proposed changes

* Created config to use ISP name for ASN name. I wasn't sure if this was a bug or intended by the original author, but other enrichment connectors use a name, so this change allows you to align with that.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Screenshot

<img width="208" alt="image" src="https://github.com/user-attachments/assets/ccca1428-f36d-48ca-a5e0-30dd1562daa0">
