### PR TITLE
[Mandiant] Add Mandiant score to IOC instead of confidence

### DIFF
--- a/external-import/mandiant/src/connector/indicators.py
+++ b/external-import/mandiant/src/connector/indicators.py
@@ -50,7 +50,7 @@ def create_indicator(connector, indicator):
     indicator_value = indicator["value"].replace("'", "%27")
     indicator_type = indicator["type"]
 
-    confidence = indicator.get("mscore", None)
+    indicator_score = indicator.get("mscore", None)
 
     mapping = MAPPING.get(indicator_type, None)
 
@@ -74,6 +74,7 @@ def create_indicator(connector, indicator):
     custom_properties = {
         "x_opencti_main_observable_type": observable_type,
         "x_opencti_create_observables": True,
+        "x_opencti_score": indicator_score,
     }
 
     return stix2.Indicator(
@@ -85,7 +86,6 @@ def create_indicator(connector, indicator):
         description=description,
         created=created,
         modified=modified,
-        confidence=confidence,
         created_by_ref=connector.identity["standard_id"],
         object_marking_refs=markings,
         custom_properties=custom_properties,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  Add Mandiant score to IOC instead of confidence level on OCTI

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2816

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
