### PR TITLE
[urlscan-enrichment] Return empty array instead of None when no ASN found

### DIFF
--- a/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/converter_to_stix2.py
+++ b/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/converter_to_stix2.py
@@ -316,7 +316,7 @@ class UrlscanConverter:
             )
             stix_asn_with_relationship.append(ip_to_asn)
 
-            return stix_asn_with_relationship
+        return stix_asn_with_relationship
 
     def generate_stix_hostname_with_relationship(
         self,


### PR DESCRIPTION
When no ASN was found, generate_stix_asn_with_relationship returned None, causing extend(stix_obs_asn) to fail, returning empty array instead fixes the issue

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix error in urlscan-enrichment when no ASN is found

Error I got:

```
connector-urlscan-enrichment-1  | {"timestamp": "2024-11-14T11:01:57.762977Z", "level": "ERROR", "name": "Urlscan", "message": "Error in message processing, reporting error to API", "exc_info": "Traceback (most recent call last):\n  File \"/opt/opencti-connector-urlscan-enrichment/main.py\", line 318, in _process_message\n    stix_bundle = self._generate_stix_bundle(\n                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/opencti-connector-urlscan-enrichment/main.py\", line 196, in _generate_stix_bundle\n    self.stix_objects.extend(stix_obs_asn)\nTypeError: 'NoneType' object is not iterable\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.12/site-packages/pycti/connector/opencti_connector_helper.py\", line 352, in _data_handler\n    message = self.callback(event_data)\n              ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/opencti-connector-urlscan-enrichment/main.py\", line 351, in _process_message\n    raise ValueError(str(e))\nValueError: 'NoneType' object is not iterable", "taskName": null}
```

I suspect the change I did is what was actually intended initially.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
