### PR TITLE
[Crowdstrike] Handle IOCs to be added in the report while importing the report

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/core.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/core.py
@@ -184,6 +184,20 @@ class CrowdStrike:
             importers.append(actor_importer)
 
         if self._CONFIG_SCOPE_REPORT in scopes:
+            indicator_config = {
+                "default_latest_timestamp": indicator_start_timestamp,
+                "create_observables": create_observables,
+                "create_indicators": create_indicators,
+                "exclude_types": indicator_exclude_types,
+                "default_x_opencti_score": default_x_opencti_score,
+                "indicator_low_score": indicator_low_score,
+                "indicator_low_score_labels": set(indicator_low_score_labels),
+                "indicator_medium_score": indicator_medium_score,
+                "indicator_medium_score_labels": set(indicator_medium_score_labels),
+                "indicator_high_score": indicator_high_score,
+                "indicator_high_score_labels": set(indicator_high_score_labels),
+                "indicator_unwanted_labels": set(indicator_unwanted_labels),
+            }
             report_importer = ReportImporter(
                 self.helper,
                 author,
@@ -193,6 +207,7 @@ class CrowdStrike:
                 report_status,
                 report_type,
                 report_guess_malware,
+                indicator_config,
             )
 
             importers.append(report_importer)

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
@@ -201,9 +201,7 @@ class IndicatorImporter(BaseImporter):
     def _process_indicator(self, indicator: dict) -> bool:
         self._info("Processing indicator {0}...", indicator["id"])
 
-        indicator_reports = self._get_reports_by_code(indicator["reports"])
-
-        indicator_bundle = self._create_indicator_bundle(indicator, indicator_reports)
+        indicator_bundle = self._create_indicator_bundle(indicator)
         if indicator_bundle is None:
             self._error("Discarding indicator {0} bundle", indicator["id"])
             return False
@@ -218,9 +216,7 @@ class IndicatorImporter(BaseImporter):
     def _get_reports_by_code(self, codes: List[str]) -> List[FetchedReport]:
         return self.report_fetcher.get_by_codes(codes)
 
-    def _create_indicator_bundle(
-        self, indicator: dict, indicator_reports: List[FetchedReport]
-    ) -> Optional[Bundle]:
+    def _create_indicator_bundle(self, indicator: dict) -> Optional[Bundle]:
         bundle_builder_config = IndicatorBundleBuilderConfig(
             indicator=indicator,
             author=self.author,
@@ -229,9 +225,6 @@ class IndicatorImporter(BaseImporter):
             confidence_level=self._confidence_level(),
             create_observables=self.create_observables,
             create_indicators=self.create_indicators,
-            indicator_report_status=self.report_status,
-            indicator_report_type=self.report_type,
-            indicator_reports=indicator_reports,
             default_x_opencti_score=self.default_x_opencti_score,
             indicator_low_score=self.indicator_low_score,
             indicator_low_score_labels=self.indicator_low_score_labels,
@@ -244,7 +237,8 @@ class IndicatorImporter(BaseImporter):
 
         try:
             bundle_builder = IndicatorBundleBuilder(bundle_builder_config)
-            return bundle_builder.build()
+            indicator_bundle_built = bundle_builder.build()
+            return indicator_bundle_built["indicator_bundle"]
         except TypeError as te:
             self._error(
                 "Failed to build indicator bundle for '{0}': {1}",

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/builder.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/builder.py
@@ -50,6 +50,7 @@ class ReportBundleBuilder:
         confidence_level: int,
         guessed_malwares: Mapping[str, str],
         report_file: Optional[Mapping[str, str]] = None,
+        related_indicators: Optional = None,
     ) -> None:
         """Initialize report bundle builder."""
         self.report = report
@@ -61,6 +62,7 @@ class ReportBundleBuilder:
         self.report_type = report_type
         self.report_file = report_file
         self.guessed_malwares = guessed_malwares
+        self.related_indicators = related_indicators
 
         # Use report dates for start time and stop time.
         start_time = timestamp_to_datetime(self.report["created_date"])
@@ -279,6 +281,10 @@ class ReportBundleBuilder:
         )
         bundle_objects.extend(malwares_target_countries)
 
+        # Indicators linked to the report and add to bundle
+        indicators_linked = self.related_indicators
+        bundle_objects.extend(indicators_linked)
+
         # Create object references for the report.
         object_refs = create_object_refs(
             intrusion_sets,
@@ -302,6 +308,9 @@ class ReportBundleBuilder:
 
             bundle_objects.append(dummy_object)
             object_refs.append(dummy_object)
+
+        # Add related indicator to object refs for report
+        object_refs.extend(indicators_linked)
 
         report = self._create_report(object_refs)
         bundle_objects.append(report)

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
@@ -4,6 +4,7 @@
 from datetime import datetime
 from typing import Any, Dict, Generator, List, Mapping, Optional
 
+from crowdstrike_feeds_services.client.indicators import IndicatorsAPI
 from crowdstrike_feeds_services.client.reports import ReportsAPI
 from crowdstrike_feeds_services.utils import (
     create_file_from_download,
@@ -17,6 +18,7 @@ from pycti.connector.opencti_connector_helper import (  # type: ignore  # noqa: 
 from stix2 import Bundle, Identity, MarkingDefinition  # type: ignore
 
 from ..importer import BaseImporter
+from ..indicator.importer import IndicatorBundleBuilder, IndicatorBundleBuilderConfig
 from .builder import ReportBundleBuilder
 
 
@@ -39,6 +41,7 @@ class ReportImporter(BaseImporter):
         report_status: int,
         report_type: str,
         guess_malware: bool,
+        indicator_config: dict,
     ) -> None:
         """Initialize CrowdStrike report importer."""
         super().__init__(helper, author, tlp_marking)
@@ -49,6 +52,8 @@ class ReportImporter(BaseImporter):
         self.report_status = report_status
         self.report_type = report_type
         self.guess_malware = guess_malware
+        self.indicators_api_cs = IndicatorsAPI(helper)
+        self.indicator_config = indicator_config
 
         self.malware_guess_cache: Dict[str, str] = {}
 
@@ -201,10 +206,63 @@ class ReportImporter(BaseImporter):
         report_type = self.report_type
         confidence_level = self._confidence_level()
         guessed_malwares: Mapping[str, str] = {}
+        related_indicators = []
+        related_indicators_with_related_entities = []
 
         tags = report["tags"]
         if tags is not None:
             guessed_malwares = self._guess_malwares_from_tags(tags)
+
+        report_slug = report["slug"]
+        if report_slug is not None:
+            report_slug = report_slug.upper()
+            _limit = 1000
+            _sort = "last_updated|asc"
+            _fql_filter = f"reports:['{report_slug}']"
+
+            # Getting IOCs linked and based on report name
+            response = self.indicators_api_cs.get_combined_indicator_entities(
+                limit=_limit, sort=_sort, fql_filter=_fql_filter, deep_pagination=True
+            )
+            related_indicators.extend(response["resources"])
+
+        if related_indicators is not None:
+            for indicator in related_indicators:
+                bundle_builder_config = IndicatorBundleBuilderConfig(
+                    indicator=indicator,
+                    author=self.author,
+                    source_name=self._source_name(),
+                    object_markings=[self.tlp_marking],
+                    confidence_level=self._confidence_level(),
+                    create_observables=self.indicator_config["create_observables"],
+                    create_indicators=self.indicator_config["create_indicators"],
+                    default_x_opencti_score=self.indicator_config[
+                        "default_x_opencti_score"
+                    ],
+                    indicator_low_score=self.indicator_config["indicator_low_score"],
+                    indicator_low_score_labels=self.indicator_config[
+                        "indicator_low_score_labels"
+                    ],
+                    indicator_medium_score=self.indicator_config[
+                        "indicator_medium_score"
+                    ],
+                    indicator_medium_score_labels=self.indicator_config[
+                        "indicator_medium_score_labels"
+                    ],
+                    indicator_high_score=self.indicator_config["indicator_high_score"],
+                    indicator_high_score_labels=self.indicator_config[
+                        "indicator_high_score_labels"
+                    ],
+                    indicator_unwanted_labels=self.indicator_config[
+                        "indicator_unwanted_labels"
+                    ],
+                )
+                bundle_builder = IndicatorBundleBuilder(bundle_builder_config)
+                indicator_bundle_built = bundle_builder.build()
+                indicator_with_related_entities = indicator_bundle_built["object_refs"]
+                related_indicators_with_related_entities.extend(
+                    indicator_with_related_entities
+                )
 
         bundle_builder = ReportBundleBuilder(
             report,
@@ -216,6 +274,7 @@ class ReportImporter(BaseImporter):
             confidence_level,
             guessed_malwares,
             report_file,
+            related_indicators_with_related_entities,
         )
         return bundle_builder.build()
 

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
@@ -199,7 +199,7 @@ class ReportImporter(BaseImporter):
     def _get_related_iocs(self, report_name):
         related_indicators = []
         related_indicators_with_related_entities = []
-        _limit = 1000
+        _limit = 10000
         _sort = "last_updated|asc"
         _fql_filter = f"reports:['{report_name}']"
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove report creation when importing Indicators due to volume of data
* Add query when importing report to add IOCs at the same time

These changes avoid to have the report with some entities at a certain moment and avoid to wait days to have complete report with IOCs.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2765

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
