### PR TITLE
fix: revert to 3.11 for CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           webhook_url: $MS_TEAMS_WEBHOOK_URL
   test:
     docker:
-      - image: cimg/python:3.12
+      - image: cimg/python:3.11
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
### Proposed changes

* Revert python test image to 3..11 version as some dependencies do not support 3.12


### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2978
*

### Checklist
- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

