### PR TITLE
[Zerofox] Add format changes to malware endpoint and country entities

### DIFF
--- a/external-import/zerofox/src/collectors/mappers/malwareToMalware.py
+++ b/external-import/zerofox/src/collectors/mappers/malwareToMalware.py
@@ -44,11 +44,12 @@ def malware_to_malware(
 
     indic = indicator(
         created_by=created_by,
-        name=f"Pattern for malware {entry.sha256}",
+        name=f"{entry.sha256}",
         pattern_type=PATTERN_TYPE_STIX,
         pattern=pattern_string,
         valid_from=entry.created_at,
         indicator_types=["malicious-activity"],
+        observable_type="StixFile",
     )
 
     file_indicator_rel = relationship(source=indic.id, target=file.id, type="based-on")

--- a/external-import/zerofox/src/collectors/mappers/ransomwareToMalware.py
+++ b/external-import/zerofox/src/collectors/mappers/ransomwareToMalware.py
@@ -69,6 +69,7 @@ def ransomware_to_malware(
         pattern_type=PATTERN_TYPE_STIX,
         valid_from=entry.created_at,
         indicator_types=["malicious-activity"],
+        observable_type="StixFile",
     )
 
     file_indicator_rel = Relationship(

--- a/external-import/zerofox/src/open_cti/domain_objects.py
+++ b/external-import/zerofox/src/open_cti/domain_objects.py
@@ -1,3 +1,4 @@
+import pycountry
 import pycti
 from stix2 import (
     TLP_AMBER,
@@ -10,6 +11,13 @@ from stix2 import (
     Tool,
     Vulnerability,
 )
+
+
+def _get_country_name(country_code: str) -> str:
+    try:
+        return pycountry.countries.get(alpha_2=country_code).name
+    except Exception:
+        return country_code
 
 
 def _additional_kwargs(created_by) -> dict:
@@ -26,6 +34,7 @@ def indicator(
     pattern: str,
     pattern_type: str,
     indicator_types: list,
+    observable_type: str,
 ):
     return Indicator(
         id=pycti.Indicator.generate_id(pattern=pattern),
@@ -35,6 +44,9 @@ def indicator(
         pattern_type=pattern_type,
         indicator_types=indicator_types,
         **_additional_kwargs(created_by),
+        custom_properties={
+            "x_opencti_main_observable_type": observable_type,
+        },
     )
 
 
@@ -65,7 +77,7 @@ def location(
     postal_code: str | None,
     created_by: str,
 ):
-    name = f"{country} - {postal_code}"
+    name = _get_country_name(country)
     return Location(
         id=pycti.Location.generate_id(name=name, x_opencti_location_type="Country"),
         name=name,

--- a/external-import/zerofox/src/requirements.txt
+++ b/external-import/zerofox/src/requirements.txt
@@ -1,4 +1,6 @@
-pydantic==2.8.2
-pytest==8.3.3
-pycti==6.4.4
-urllib3==2.2.2
+requests>=2.31.0,<3.0.0
+pydantic>=2.7.1,<3.0.0
+pycti>=6.4.4,<7.0.0
+urllib3>=2.2.1,<3.0.0
+stix2[semantic]>=3.0.1,<4.0.0
+pycountry>=24.6.1,<25.0.0


### PR DESCRIPTION
### Proposed changes

* Use pycountry to better annotate country codes
* add opencti_main_observable_type to indicators
* correct malware name to just be a file hash

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2828

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


