### PR TITLE
[Misp] Fix error of relation having same ref for source and target

### DIFF
--- a/external-import/misp-feed/src/misp-feed.py
+++ b/external-import/misp-feed/src/misp-feed.py
@@ -1369,26 +1369,35 @@ class MispFeed:
                         allow_custom=True,
                     )
                 )
-            ### Create relationship between MISP attribute (indicator or observable) and MISP object (observable)
-            if object_observable is not None and (
-                indicator is not None or observable is not None
-            ):
-                relationships.append(
-                    stix2.Relationship(
-                        id=StixCoreRelationship.generate_id(
-                            "related-to",
-                            object_observable.id,
-                            observable.id if observable is not None else indicator.id,
-                        ),
-                        relationship_type="related-to",
-                        created_by_ref=author["id"],
-                        source_ref=object_observable.id,
-                        target_ref=(
-                            observable.id if (observable is not None) else indicator.id
-                        ),
-                        allow_custom=True,
-                    )
+
+            # Create relationship between MISP attribute (indicator or observable) and MISP object (observable)
+            if object_observable is not None:
+
+                indicator_id = indicator.get("id") if indicator else None
+                observable_id = observable.get("id") if observable else None
+                source_id = object_observable.get("id")
+                target_id = (
+                    observable_id
+                    if observable_id is not None and observable_id != source_id
+                    else indicator_id
                 )
+
+                if target_id is not None:
+                    relationships.append(
+                        stix2.Relationship(
+                            id=StixCoreRelationship.generate_id(
+                                "related-to",
+                                source_id,
+                                target_id,
+                            ),
+                            relationship_type="related-to",
+                            created_by_ref=author["id"],
+                            source_ref=source_id,
+                            target_ref=target_id,
+                            allow_custom=True,
+                        )
+                    )
+
             # Event threats
             threat_names = {}
             for threat in (

--- a/external-import/misp/src/misp.py
+++ b/external-import/misp/src/misp.py
@@ -1429,26 +1429,35 @@ class Misp:
                         allow_custom=True,
                     )
                 )
-            ### Create relationship between MISP attribute (indicator or observable) and MISP object (observable)
-            if object_observable is not None and (
-                indicator is not None or observable is not None
-            ):
-                relationships.append(
-                    stix2.Relationship(
-                        id=StixCoreRelationship.generate_id(
-                            "related-to",
-                            object_observable.id,
-                            observable.id if observable is not None else indicator.id,
-                        ),
-                        relationship_type="related-to",
-                        created_by_ref=author["id"],
-                        source_ref=object_observable.id,
-                        target_ref=(
-                            observable.id if (observable is not None) else indicator.id
-                        ),
-                        allow_custom=True,
-                    )
+
+            # Create relationship between MISP attribute (indicator or observable) and MISP object (observable)
+            if object_observable is not None:
+
+                indicator_id = indicator.get("id") if indicator else None
+                observable_id = observable.get("id") if observable else None
+                source_id = object_observable.get("id")
+                target_id = (
+                    observable_id
+                    if observable_id is not None and observable_id != source_id
+                    else indicator_id
                 )
+
+                if target_id is not None:
+                    relationships.append(
+                        stix2.Relationship(
+                            id=StixCoreRelationship.generate_id(
+                                "related-to",
+                                source_id,
+                                target_id,
+                            ),
+                            relationship_type="related-to",
+                            created_by_ref=author["id"],
+                            source_ref=source_id,
+                            target_ref=target_id,
+                            allow_custom=True,
+                        )
+                    )
+
             # Event threats
             threat_names = {}
             for threat in (


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- Implementation of a check when creating a relationship: if `object_observable` id is different from `observable` id, then the relationship can be created; otherwise, it cannot be created.
Initially, when creating the relationship, we could have had an identical ref for `source_ref `and `target_ref`, which would have caused the error: `UNSUPPORTED ERROR (Relation cant be created with the same source and target)`

- Changes made to `MISP` & `MISP-FEED` connectors

### Related issues

* #2868

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
