### PR TITLE
[ExportReportPdf] Convert entity's description from markdown to HTML

### DIFF
--- a/internal-export-file/export-report-pdf/src/export-report-pdf.py
+++ b/internal-export-file/export-report-pdf/src/export-report-pdf.py
@@ -7,14 +7,19 @@ import sys
 import time
 
 import cairosvg
-import markdown
+import cmarkgfm
 import yaml
+from cmarkgfm.cmark import Options as cmarkgfmOptions
 from jinja2 import Environment, FileSystemLoader
 from pycti import OpenCTIConnectorHelper, get_config_variable
 from pycti.utils.constants import StixCyberObservableTypes
 from pygal_maps_world.i18n import COUNTRIES
 from pygal_maps_world.maps import World
 from weasyprint import HTML
+
+CMARKGFM_OPTIONS = (
+    cmarkgfmOptions.CMARK_OPT_GITHUB_PRE_LANG | cmarkgfmOptions.CMARK_OPT_FOOTNOTES
+)
 
 
 class ExportReportPdf:
@@ -726,7 +731,9 @@ class ExportReportPdf:
         # Extract values for inclusion in output pdf
         case_name = case_dict["name"]
         case_description = case_dict.get("description") or "No description available."
-        case_description = markdown.markdown(case_description, output_format="html")
+        case_description = cmarkgfm.github_flavored_markdown_to_html(
+            case_description, CMARKGFM_OPTIONS
+        )
         case_content = case_dict["content"]
         case_marking = case_dict.get("objectMarking", None)
         if case_marking:

--- a/internal-export-file/export-report-pdf/src/export-report-pdf.py
+++ b/internal-export-file/export-report-pdf/src/export-report-pdf.py
@@ -18,7 +18,9 @@ from pygal_maps_world.maps import World
 from weasyprint import HTML
 
 CMARKGFM_OPTIONS = (
-    cmarkgfmOptions.CMARK_OPT_GITHUB_PRE_LANG | cmarkgfmOptions.CMARK_OPT_FOOTNOTES
+    cmarkgfmOptions.CMARK_OPT_GITHUB_PRE_LANG  # Use GitHub-style tags for code blocks
+    | cmarkgfmOptions.CMARK_OPT_FOOTNOTES  # Parse footnotes
+    | cmarkgfmOptions.CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES  # Use style attributes to align table cells
 )
 
 

--- a/internal-export-file/export-report-pdf/src/export-report-pdf.py
+++ b/internal-export-file/export-report-pdf/src/export-report-pdf.py
@@ -7,6 +7,7 @@ import sys
 import time
 
 import cairosvg
+import markdown
 import yaml
 from jinja2 import Environment, FileSystemLoader
 from pycti import OpenCTIConnectorHelper, get_config_variable
@@ -724,6 +725,8 @@ class ExportReportPdf:
 
         # Extract values for inclusion in output pdf
         case_name = case_dict["name"]
+        case_description = case_dict.get("description") or "No description available."
+        case_description = markdown.markdown(case_description, output_format="html")
         case_content = case_dict["content"]
         case_marking = case_dict.get("objectMarking", None)
         if case_marking:
@@ -743,9 +746,7 @@ class ExportReportPdf:
         # Store context for usage in html template
         context = {
             "case_name": case_name,
-            "case_description": case_dict.get(
-                "description", "No description available."
-            ),
+            "case_description": case_description,
             "case_content": case_content,
             "case_marking": case_marking,
             "case_confidence": case_confidence,

--- a/internal-export-file/export-report-pdf/src/export-report-pdf.py
+++ b/internal-export-file/export-report-pdf/src/export-report-pdf.py
@@ -311,7 +311,12 @@ class ExportReportPdf:
         if report_marking:
             report_marking = report_marking[-1]["definition"]
         report_name = report_dict["name"]
-        report_description = report_dict.get("description", "No description available.")
+        report_description = (
+            report_dict.get("description") or "No description available."
+        )
+        report_description = cmarkgfm.github_flavored_markdown_to_html(
+            report_description, CMARKGFM_OPTIONS
+        )
         report_content = report_dict["content"]
         report_confidence = report_dict["confidence"]
         report_id = report_dict["id"]

--- a/internal-export-file/export-report-pdf/src/requirements.txt
+++ b/internal-export-file/export-report-pdf/src/requirements.txt
@@ -5,4 +5,4 @@ pygal==3.0.5
 wheel==0.45.0
 CairoSVG==2.7.1
 pygal_maps_world==1.0.2
-Markdown==3.7
+cmarkgfm==2024.1.14

--- a/internal-export-file/export-report-pdf/src/requirements.txt
+++ b/internal-export-file/export-report-pdf/src/requirements.txt
@@ -5,3 +5,4 @@ pygal==3.0.5
 wheel==0.45.0
 CairoSVG==2.7.1
 pygal_maps_world==1.0.2
+Markdown==3.7

--- a/internal-export-file/export-report-pdf/src/resources/case.html
+++ b/internal-export-file/export-report-pdf/src/resources/case.html
@@ -87,7 +87,7 @@
             </section>
             <section>
                 <h3 id="description-title">Description</h3>
-                <p>{{ case_description }}</p>
+                <div>{{ case_description }}</div>
             </section>
             <section>
                 <h3 id="confidence-title">Confidence</h3>

--- a/internal-export-file/export-report-pdf/src/resources/report.css.template
+++ b/internal-export-file/export-report-pdf/src/resources/report.css.template
@@ -235,7 +235,7 @@ table {
 }
 tr,
 td {
-  word-break: break-all;
+  word-break: break-word;
 }
 td {
   padding: 15px;

--- a/internal-export-file/export-report-pdf/src/resources/report.html
+++ b/internal-export-file/export-report-pdf/src/resources/report.html
@@ -67,9 +67,9 @@
         <h3 id="description-title">
           Description
         </h3>
-        <p>
+        <div>
           {{ report_description }}
-        </p>
+        </div>
       </section>
       <section>
         <h3 id="confidence-title">


### PR DESCRIPTION
### Proposed changes

- add `cmarkgfm` library
- convert entity `description` field to HTML before injecting it into template
- replace `<p>` tag by `<div>` in case’s template to ensure consistent display

### Related issues

* #2735 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases  
    - run `bandit` on `markdown` lib's code
    - run `pip-audit` on connector's requirements
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Incident response's description used for tests:
```
**Incident from Harfanglab Incidents**  
1. first item  
    first description
2. second item  
    second desc  

### GFM

#### Autolink literals

www.example.com, https://example.com, and contact@example.com.

#### Footnote

A note[^1]

[^1]: Big note.

#### Strikethrough

~one~ or ~~two~~ tildes.

#### Table

| a | b  |  c |  d  |
| - | :- | -: | :-: |

#### Tasklist

* [ ] to do
* [x] done
``` 

output:
![image](https://github.com/user-attachments/assets/d578be77-2ae8-4411-a473-fe05f9a6b605)


### Useful resources

cmarkgfm lib doc: [https://pypi.org/project/pycmarkgfm/](https://pypi.org/project/pycmarkgfm/)
