### PR TITLE
[Mitre] Add default for interval, as the documentation states.

### DIFF
--- a/external-import/mitre/src/connector.py
+++ b/external-import/mitre/src/connector.py
@@ -21,6 +21,7 @@ STATEMENT_MARKINGS = [
     "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168",
     "marking-definition--17d82bb2-eeeb-4898-bda5-3ddbcd2b799d",
 ]
+MITRE_INTERVAL = 7
 
 
 def time_from_unixtime(timestamp):
@@ -73,7 +74,11 @@ class Mitre:
             default=False,
         )
         self.mitre_interval = get_config_variable(
-            "MITRE_INTERVAL", ["mitre", "interval"], config, isNumber=True
+            "MITRE_INTERVAL",
+            ["mitre", "interval"],
+            config,
+            isNumber=True,
+            default=MITRE_INTERVAL,
         )
         urls = [
             get_config_variable(

--- a/external-import/mitre/src/connector.py
+++ b/external-import/mitre/src/connector.py
@@ -21,7 +21,6 @@ STATEMENT_MARKINGS = [
     "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168",
     "marking-definition--17d82bb2-eeeb-4898-bda5-3ddbcd2b799d",
 ]
-MITRE_INTERVAL = 7
 
 
 def time_from_unixtime(timestamp):
@@ -78,7 +77,7 @@ class Mitre:
             ["mitre", "interval"],
             config,
             isNumber=True,
-            default=MITRE_INTERVAL,
+            default=7,
         )
         urls = [
             get_config_variable(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added a default value of 7 for the MITRE_INTERVAL, as expected per documentation.

### Related issues

* N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

No big change, just a minor thing I stumbled on during my first deployment.  If the misp.interval setting is not explicitly defined, the worker will crash with a type error, while the documentation states there is a default value of 7.
