### PR TITLE
[Hunt IO] Connector for importing C2 feed into OpenCTI

### DIFF
--- a/external-import/hunt-io/.docker-compose.yml
+++ b/external-import/hunt-io/.docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  connector-hunt-io:
+    image: opencti/connector-hunt-io:6.3.13
+    environment:
+      - OPENCTI_URL=http://opencti:8080
+      - OPENCTI_TOKEN=${OPENCTI_TOKEN}
+      - CONNECTOR_ID=${CONNECTOR_ID}
+      - CONNECTOR_NAME=Hunt IO
+      - CONNECTOR_SCOPE=ipv4-addr,ipv6-addr,vulnerability,domain,url,StixFile
+      - CONNECTOR_LOG_LEVEL=error
+      - CONNECTOR_DURATION_PERIOD=PT24H
+
+      # Connector's custom execution parameters
+      - CONNECTOR_HUNT_UI_API_BASE_URL=${CONNECTOR_HUNT_UI_API_BASE_URL}
+      - CONNECTOR_HUNT_UI_API_KEY=${CONNECTOR_HUNT_UI_API_KEY}
+    restart: always

--- a/external-import/hunt-io/.dockerignore
+++ b/external-import/hunt-io/.dockerignore
@@ -1,0 +1,5 @@
+src/config.yml
+src/__pycache__
+src/logs
+src/*.gql
+src/.venv

--- a/external-import/hunt-io/Dockerfile
+++ b/external-import/hunt-io/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-alpine
+ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
+
+# Copy the connector
+COPY src /opt/opencti-connector-hunt-io
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk update && apk upgrade && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN cd /opt/opencti-connector-hunt-io && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/hunt-io/README.md
+++ b/external-import/hunt-io/README.md
@@ -1,0 +1,153 @@
+# OpenCTI External Ingestion Connector Hunt IO
+
+<!--
+General description of the connector
+* What it does
+* How it works
+* Special requirements
+* Use case description
+* ...
+-->
+
+Table of Contents
+
+- [OpenCTI External Ingestion Connector Hunt IO](#opencti-external-ingestion-connector-hunt-io)
+  - [Introduction](#introduction)
+  - [Installation](#installation)
+    - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenCTI environment variables](#opencti-environment-variables)
+    - [Base connector environment variables](#base-connector-environment-variables)
+    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
+
+## Introduction
+
+## Installation
+
+### Requirements
+
+- OpenCTI Platform >= 6...
+
+## Configuration variables
+
+There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
+in `config.yml` (for manual deployment).
+
+### OpenCTI environment variables
+
+Below are the parameters you'll need to set for OpenCTI:
+
+| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
+|---------------|------------|-----------------------------|-----------|------------------------------------------------------|
+| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
+| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+
+### Base connector environment variables
+
+Below are the parameters you'll need to set for running the connector properly:
+
+| Parameter       | config.yml | Docker environment variable | Default         | Mandatory | Description                                                                              |
+|-----------------|------------|-----------------------------|-----------------|-----------|------------------------------------------------------------------------------------------|
+| Connector ID    | id         | `CONNECTOR_ID`              | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
+| Connector Type  | type       | `CONNECTOR_TYPE`            | EXTERNAL_IMPORT | Yes       | Should always be set to `EXTERNAL_IMPORT` for this connector.                            |
+| Connector Name  | name       | `CONNECTOR_NAME`            |                 | Yes       | Name of the connector.                                                                   |
+| Connector Scope | scope      | `CONNECTOR_SCOPE`           |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
+| Log Level       | log_level  | `CONNECTOR_LOG_LEVEL`       | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
+
+### Connector extra parameters environment variables
+
+Below are the parameters you'll need to set for the connector:
+
+| Parameter    | config.yml   | Docker environment variable | Default | Mandatory | Description |
+|--------------|--------------|-----------------------------|---------|-----------|-------------|
+| API base URL | api_base_url |                             |         | Yes       |             |
+| API key      | api_key      |                             |         | Yes       |             |
+
+## Deployment
+
+### Docker Deployment
+
+Before building the Docker container, you need to set the version of pycti in `requirements.txt` equal to whatever
+version of OpenCTI you're running. Example, `pycti==5.12.20`. If you don't, it will take the latest version, but
+sometimes the OpenCTI SDK fails to initialize.
+
+Build a Docker Image using the provided `Dockerfile`.
+
+Example:
+
+```shell
+# Replace the IMAGE NAME with the appropriate value
+docker build . -t [IMAGE NAME]:latest
+```
+
+Make sure to replace the environment variables in `docker-compose.yml` with the appropriate configurations for your
+environment. Then, start the docker container with the provided docker-compose.yml
+
+```shell
+docker compose up -d
+# -d for detached
+```
+
+### Manual Deployment
+
+Create a file `config.yml` based on the provided `config.yml.sample`.
+
+Replace the configuration variables (especially the "**ChangeMe**" variables) with the appropriate configurations for
+you environment.
+
+Install the required python dependencies (preferably in a virtual environment):
+
+```shell
+pip3 install -r requirements.txt
+```
+
+Then, start the connector from recorded-future/src:
+
+```shell
+python3 main.py
+```
+
+## Usage
+
+After Installation, the connector should require minimal interaction to use, and should update automatically at a regular interval specified in your `docker-compose.yml` or `config.yml` in `duration_period`.
+
+However, if you would like to force an immediate download of a new batch of entities, navigate to:
+
+`Data management` -> `Ingestion` -> `Connectors` in the OpenCTI platform.
+
+Find the connector, and click on the refresh button to reset the connector's state and force a new
+download of data by re-running the connector.
+
+## Behavior
+
+<!--
+Describe how the connector functions:
+* What data is ingested, updated, or modified
+* Important considerations for users when utilizing this connector
+* Additional relevant details
+-->
+
+
+## Debugging
+
+The connector can be debugged by setting the appropiate log level.
+Note that logging messages can be added using `self.helper.connector_logger,{LOG_LEVEL}("Sample message")`, i.
+e., `self.helper.connector_logger.error("An error message")`.
+
+<!-- Any additional information to help future users debug and report detailed issues concerning this connector -->
+
+## Additional information
+
+<!--
+Any additional information about this connector
+* What information is ingested/updated/changed
+* What should the user take into account when using this connector
+* ...
+-->

--- a/external-import/hunt-io/entrypoint.sh
+++ b/external-import/hunt-io/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Go to the right directory
+cd /opt/opencti-connector-hunt-io
+
+# Launch the worker
+python3 main.py

--- a/external-import/hunt-io/src/config.yml.sample
+++ b/external-import/hunt-io/src/config.yml.sample
@@ -1,0 +1,24 @@
+opencti:
+  url: 'http://opencti:8080'
+  token: 'ChangeMe'
+
+connector:
+  id: 'ChangeMe'
+  type: 'EXTERNAL_IMPORT'
+  name: 'Hunt IO'
+  scope: 'ChangeMe'
+  log_level: 'info'
+  duration_period: 'PT5M' # Interval given for scheduler process in ISO-8601 format
+  #============================================#
+  # Optional connector's definition parameters #
+  #============================================#
+  #queue_threshold: 500
+  #run_and_terminate: 'False'
+  #send_to_queue: 'True'
+  #send_to_directory: 'False'
+  #send_to_directory_path: 'ChangeMe'
+  #send_to_directory_retention: 7
+
+connector_hunt_io:
+  api_base_url: 'https://api.hunt.io/v1/feeds/c2'
+  api_key: 'ChangeMe'

--- a/external-import/hunt-io/src/external_import_connector/__init__.py
+++ b/external-import/hunt-io/src/external_import_connector/__init__.py
@@ -1,0 +1,3 @@
+from .connector import ConnectorHuntIo
+
+__all__ = ["ConnectorHuntIo"]

--- a/external-import/hunt-io/src/external_import_connector/client_api.py
+++ b/external-import/hunt-io/src/external_import_connector/client_api.py
@@ -1,0 +1,126 @@
+import gzip
+import json
+from io import BytesIO
+from typing import List, Optional
+
+import requests
+from requests.exceptions import HTTPError, RequestException
+
+from .models import C2
+
+
+class ConnectorClient:
+    """
+    A client for interacting with an API.
+
+    This class handles making HTTP requests to an API, including authentication
+    and error handling, and processes the API responses.
+
+    Attributes:
+        helper: A helper object for logging and utilities.
+        config: A configuration object containing API details.
+        session: An HTTP session for making requests with pre-configured headers.
+    """
+
+    def __init__(self, helper, config):
+        """
+        Initialize the ConnectorClient with necessary configurations.
+        """
+        self.helper = helper
+        self.config = config
+
+        # Set up session with default headers
+        self.session = requests.Session()
+        self.session.headers.update({"token": self.config.api_key})
+
+    def _request_data(
+        self, api_url: str, params: Optional[dict] = None
+    ) -> requests.Response:
+        """
+        Sends a GET request to the specified API URL.
+
+        Args:
+            api_url (str): The URL to send the request to.
+            params (dict, optional): Query parameters for the request.
+
+        Returns:
+            requests.Response: The HTTP response object.
+
+        Raises:
+            HTTPError: If an HTTP error occurs.
+            RequestException: If a request-related error occurs.
+        """
+
+        try:
+            response = self.session.get(api_url, params=params)
+
+            self.helper.connector_logger.info(
+                "[API] HTTP GET Request to endpoint", {"url_path": api_url}
+            )
+
+            response.raise_for_status()
+            return response
+
+        except HTTPError as http_err:
+            self.helper.connector_logger.error(
+                "[API] HTTP error occurred",
+                {"url_path": api_url, "error": str(http_err)},
+            )
+            raise
+        except RequestException as req_err:
+            self.helper.connector_logger.error(
+                "[API] Request error occurred",
+                {"url_path": api_url, "error": str(req_err)},
+            )
+            raise
+        except Exception as err:
+            self.helper.connector_logger.error(
+                "[API] Unexpected error occurred",
+                {"url_path": api_url, "error": str(err)},
+            )
+            raise
+
+    def get_entities(self, params: Optional[dict] = None) -> Optional[List[C2]]:
+        """
+        Fetches and processes entities from the API.
+
+        Args:
+            params (dict, optional): Query parameters for the API request.
+
+        Returns:
+            list[dict] or None: A list of entities if successful, or None if an error occurs.
+        """
+        try:
+            response = self._request_data(self.config.api_base_url, params=params)
+
+            # Decompress and decode the response content
+            with gzip.GzipFile(fileobj=BytesIO(response.content)) as gzipped_file:
+                raw_data = gzipped_file.read().decode("utf-8")
+
+            # Parse each line of the raw data as JSON
+            entities: List[C2] = []
+            for line in raw_data.splitlines():
+                if line.strip():
+                    try:
+                        entities.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        self.helper.connector_logger.warning(
+                            "Skipping invalid JSON line: %s", line
+                        )
+
+            return entities
+
+        except HTTPError as http_err:
+            self.helper.connector_logger.error(
+                "HTTP error while retrieving entities: %s", http_err
+            )
+        except RequestException as req_err:
+            self.helper.connector_logger.error(
+                "Request error while retrieving entities: %s", req_err
+            )
+        except Exception as err:
+            self.helper.connector_logger.error(
+                "Unexpected error while retrieving entities: %s", err
+            )
+
+        return None

--- a/external-import/hunt-io/src/external_import_connector/config_variables.py
+++ b/external-import/hunt-io/src/external_import_connector/config_variables.py
@@ -1,0 +1,56 @@
+import os
+from pathlib import Path
+
+import yaml
+from pycti import get_config_variable
+
+
+class ConfigConnector:
+    def __init__(self):
+        """
+        Initialize the connector with necessary configurations
+        """
+
+        # Load configuration file
+        self.load = self._load_config()
+        self._initialize_configurations()
+
+    @staticmethod
+    def _load_config() -> dict:
+        """
+        Load the configuration from the YAML file
+        :return: Configuration dictionary
+        """
+        config_file_path = Path(__file__).parents[1].joinpath("config.yml")
+        config = (
+            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
+            if os.path.isfile(config_file_path)
+            else {}
+        )
+
+        return config
+
+    def _initialize_configurations(self) -> None:
+        """
+        Connector configuration variables
+        :return: None
+        """
+        # OpenCTI configurations
+        self.duration_period = get_config_variable(
+            "CONNECTOR_DURATION_PERIOD",
+            ["connector", "duration_period"],
+            self.load,
+        )
+
+        # Connector extra parameters
+        self.api_base_url = get_config_variable(
+            "CONNECTOR_HUNT_UI_API_BASE_URL",
+            ["connector_hunt-io", "api_base_url"],
+            self.load,
+        )
+
+        self.api_key = get_config_variable(
+            "CONNECTOR_HUNT_UI_API_KEY",
+            ["connector_hunt-io", "api_key"],
+            self.load,
+        )

--- a/external-import/hunt-io/src/external_import_connector/config_variables.py
+++ b/external-import/hunt-io/src/external_import_connector/config_variables.py
@@ -45,12 +45,12 @@ class ConfigConnector:
         # Connector extra parameters
         self.api_base_url = get_config_variable(
             "CONNECTOR_HUNT_UI_API_BASE_URL",
-            ["connector_hunt-io", "api_base_url"],
+            ["connector_hunt_io", "api_base_url"],
             self.load,
         )
 
         self.api_key = get_config_variable(
             "CONNECTOR_HUNT_UI_API_KEY",
-            ["connector_hunt-io", "api_key"],
+            ["connector_hunt_io", "api_key"],
             self.load,
         )

--- a/external-import/hunt-io/src/external_import_connector/connector.py
+++ b/external-import/hunt-io/src/external_import_connector/connector.py
@@ -1,0 +1,291 @@
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from typing import List
+
+import stix2
+from pycti import ObservedData as PyCTIObservedData
+from pycti import OpenCTIConnectorHelper
+
+from .client_api import ConnectorClient
+from .config_variables import ConfigConnector
+from .converter_to_stix import ConverterToStix
+from .models import C2, C2ScanResult
+from .utils import convert_timestamp_to_iso_format
+
+
+class ConnectorHuntIo:
+    """
+    Specifications of the external import connector
+    """
+
+    def __init__(self):
+        """
+        Initialize the Connector with necessary configurations
+        """
+
+        # Load configuration file and connection helper
+        self.config = ConfigConnector()
+        self.helper = OpenCTIConnectorHelper(self.config.load)
+        self.client = ConnectorClient(self.helper, self.config)
+        self.converter_to_stix = ConverterToStix(self.helper)
+
+    def _collect_intelligence_and_ingest(self) -> None:
+        """
+        Collect intelligence from the source, convert into STIX objects and send
+          incrementally to OpenCTI.
+        """
+
+        def process_entity(entity: C2ScanResult):
+            """
+            Process a single entity into STIX objects and send it to OpenCTI.
+            """
+            try:
+                relationships = []
+                confidence = int(entity.confidence)
+
+                timestamp = convert_timestamp_to_iso_format(entity.timestamp)
+
+                ipv4_object = self.converter_to_stix.create_ipv4_observable(entity.ip)
+
+                malware_object = self.converter_to_stix.create_malware_object(
+                    entity.malware_name, entity.malware_subsystem
+                )
+
+                url_indicator = self.converter_to_stix.create_url_indicator(
+                    entity.scan_uri, timestamp
+                )
+
+                domain_object = self.converter_to_stix.create_domain_observable(
+                    entity.hostname
+                )
+
+                c2_infrastructure = self.converter_to_stix.create_c2_infrastructure(
+                    entity.malware_name, "command-and-control", timestamp
+                )
+
+                if ipv4_object:
+                    network_traffic_object = (
+                        self.converter_to_stix.create_network_traffic(
+                            entity.port, ipv4_object.id
+                        )
+                    )
+
+                    if c2_infrastructure.id and malware_object:
+                        c2_infrastructure_malware_relationship = (
+                            self.converter_to_stix.create_relationship(
+                                "controls",
+                                timestamp,
+                                c2_infrastructure.id,
+                                malware_object.id,
+                                confidence,
+                            )
+                        )
+
+                        relationships.append(
+                            c2_infrastructure_malware_relationship.stix2_object
+                        )
+
+                    if c2_infrastructure.id and ipv4_object:
+                        c2_infrastructure_ipv4_relationship = (
+                            self.converter_to_stix.create_relationship(
+                                "consists-of",
+                                timestamp,
+                                c2_infrastructure.id,
+                                ipv4_object.id,
+                                confidence,
+                            )
+                        )
+
+                        relationships.append(
+                            c2_infrastructure_ipv4_relationship.stix2_object
+                        )
+
+                    if c2_infrastructure.id and domain_object:
+                        c2_infrastructure_domain_relationship = (
+                            self.converter_to_stix.create_relationship(
+                                "consists-of",
+                                timestamp,
+                                c2_infrastructure.id,
+                                domain_object.id,
+                                confidence,
+                            )
+                        )
+
+                        relationships.append(
+                            c2_infrastructure_domain_relationship.stix2_object
+                        )
+
+                    if url_indicator.id and malware_object:
+                        c2_infrastructure_url_malware_relationship = (
+                            self.converter_to_stix.create_relationship(
+                                "indicates",
+                                timestamp,
+                                url_indicator.id,
+                                malware_object.id,
+                                confidence,
+                            )
+                        )
+
+                        relationships.append(
+                            c2_infrastructure_url_malware_relationship.stix2_object
+                        )
+
+                # Create ObservedData with only valid objects
+                observed_data_refs = [
+                    obj
+                    for obj in [
+                        ipv4_object.stix2_object,
+                        domain_object.stix2_object,
+                        network_traffic_object.stix2_object,
+                    ]
+                    if obj
+                ]
+
+                if observed_data_refs:
+                    observed_data = stix2.ObservedData(
+                        id=PyCTIObservedData.generate_id("observed-data"),
+                        first_observed=timestamp,
+                        last_observed=timestamp,
+                        number_observed=1,
+                        object_refs=observed_data_refs,
+                    )
+                else:
+                    observed_data = None
+
+                # Collect all STIX objects and filter None
+                stix_objects = [
+                    obj
+                    for obj in [
+                        ipv4_object.stix2_object,
+                        domain_object.stix2_object,
+                        url_indicator.stix2_object,
+                        c2_infrastructure.stix2_object,
+                        malware_object.stix2_object,
+                        network_traffic_object.stix2_object,
+                        observed_data,
+                    ]
+                    if obj
+                ]
+                stix_objects.extend(relationships)
+
+                # Create STIX bundle
+                if stix_objects:
+                    stix_bundle = stix2.Bundle(objects=stix_objects, allow_custom=True)
+
+                    # Send the STIX bundle to OpenCTI incrementally
+                    self.helper.send_stix2_bundle(stix_bundle.serialize(), update=True)
+
+            except Exception as e:
+                self.helper.connector_logger.error(
+                    f"Error processing entity {entity}: {e}"
+                )
+
+        # Fetch entities from the external source
+        entities: List[C2] = self.client.get_entities() or []
+
+        # Use ThreadPoolExecutor to process entities concurrently
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = {
+                executor.submit(process_entity, C2ScanResult(entity)): entity
+                for entity in entities
+            }
+            for future in as_completed(futures):
+                future.result()
+
+    def process_message(self) -> None:
+        """
+        Connector main process to collect intelligence
+        :return: None
+        """
+        self.helper.connector_logger.info(
+            "[CONNECTOR] Starting connector...",
+            {"connector_name": self.helper.connect_name},
+        )
+
+        try:
+            # Get the current state
+            now = datetime.now()
+            current_timestamp = int(datetime.timestamp(now))
+            current_state = self.helper.get_state()
+
+            if current_state is not None and "last_run" in current_state:
+                last_run = current_state["last_run"]
+
+                self.helper.connector_logger.info(
+                    "[CONNECTOR] Connector last run",
+                    {"last_run_datetime": last_run},
+                )
+            else:
+                self.helper.connector_logger.info(
+                    "[CONNECTOR] Connector has never run..."
+                )
+
+            # Friendly name will be displayed on OpenCTI platform
+            friendly_name = "Connector Hunt IO feed"
+
+            # Initiate a new work
+            work_id = self.helper.api.work.initiate_work(
+                self.helper.connect_id, friendly_name
+            )
+
+            self.helper.connector_logger.info(
+                "[CONNECTOR] Running connector...",
+                {"connector_name": self.helper.connect_name},
+            )
+
+            # Performing the collection of intelligence
+            self._collect_intelligence_and_ingest()
+
+            # Store the current timestamp as a last run of the connector
+            self.helper.connector_logger.debug(
+                "Getting current state and update it with last run of the connector",
+                {"current_timestamp": current_timestamp},
+            )
+            current_state = self.helper.get_state()
+            current_state_datetime = now.strftime("%Y-%m-%d %H:%M:%S")
+            last_run_datetime = datetime.utcfromtimestamp(current_timestamp).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+            if current_state:
+                current_state["last_run"] = current_state_datetime
+            else:
+                current_state = {"last_run": current_state_datetime}
+            self.helper.set_state(current_state)
+
+            message = (
+                f"{self.helper.connect_name} connector successfully run, storing last_run as "
+                + str(last_run_datetime)
+            )
+
+            self.helper.api.work.to_processed(work_id, message)
+            self.helper.connector_logger.info(message)
+
+        except (KeyboardInterrupt, SystemExit):
+            self.helper.connector_logger.info(
+                "[CONNECTOR] Connector stopped...",
+                {"connector_name": self.helper.connect_name},
+            )
+            sys.exit(0)
+        except Exception as err:
+            self.helper.connector_logger.error(str(err))
+
+    def run(self) -> None:
+        """
+        Run the main process encapsulated in a scheduler
+        It allows you to schedule the process to run at a certain intervals
+        This specific scheduler from the pycti connector helper will also check the queue size
+          of a connector
+        If `CONNECTOR_QUEUE_THRESHOLD` is set, if the connector's queue size exceeds the queue
+          threshold,
+        the connector's main process will not run until the queue is ingested and reduced
+          sufficiently,
+        allowing it to restart during the next scheduler check. (default is 500MB)
+        It requires the `duration_period` connector variable in ISO-8601 standard format
+        Example: `CONNECTOR_DURATION_PERIOD=PT5M` => Will run the process every 5 minutes
+        :return: None
+        """
+        self.helper.schedule_iso(
+            message_callback=self.process_message,
+            duration_period=self.config.duration_period,
+        )

--- a/external-import/hunt-io/src/external_import_connector/converter_to_stix.py
+++ b/external-import/hunt-io/src/external_import_connector/converter_to_stix.py
@@ -1,0 +1,126 @@
+from datetime import datetime
+
+import stix2
+
+from .models import (
+    URL,
+    Author,
+    DomainName,
+    Infrastructure,
+    IPv4Address,
+    Malware,
+    NetworkTraffic,
+    Relationship,
+)
+
+
+class ConverterToStix:
+    """
+    Provides methods for converting various types of input data into STIX 2.1 objects.
+
+    REQUIREMENTS:
+    - generate_id() for each entity from OpenCTI pycti library except observables to create
+    """
+
+    def __init__(self, helper):
+        self.helper = helper
+        self.author = self.create_author()
+        self.external_reference = self.create_external_reference()
+
+    @staticmethod
+    def create_external_reference() -> list:
+        """
+        Create external reference
+        :return: External reference STIX2 list
+        """
+        external_reference = stix2.ExternalReference(
+            source_name="Hunt IO",
+            url="https://hunt.io",
+            description="Hunt IO",
+        )
+        return [external_reference]
+
+    @staticmethod
+    def create_author() -> dict:
+        """
+        Create Author
+        :return: Author in Stix2 object
+        """
+        author = Author("Hunt IO", "Hunt IO").stix2_object
+        assert author is not None
+
+        return author
+
+    def create_c2_infrastructure(
+        self,
+        name: str,
+        infrastructure_types: str,
+        created: datetime | None = None,
+    ):
+        """
+        Creates a Command and Control (C2) infrastructure object.
+        """
+        infrastructure = Infrastructure(
+            name, infrastructure_types, self.author["id"], created
+        )
+        return infrastructure
+
+    def create_ipv4_observable(self, ip: str) -> IPv4Address:
+        """
+        Creates an IPv4 address observable.
+        """
+        ipv4 = IPv4Address(ip)
+        return ipv4
+
+    def create_domain_observable(self, hostname: str) -> DomainName:
+        """
+        Creates an domain name observable.
+        """
+        domain = DomainName(hostname)
+        return domain
+
+    def create_url_indicator(self, scan_uri: str, timestamp: datetime) -> URL:
+        """
+        Creates an URL indicator.
+        """
+        indicator = URL(scan_uri, timestamp, self.author["id"])
+        return indicator
+
+    def create_malware_object(
+        self, malware_name: str, malware_subsystem: str
+    ) -> Malware:
+        """
+        Creates a malware object.
+        """
+        malware = Malware(malware_name, malware_subsystem)
+        return malware
+
+    def create_network_traffic(
+        self, port: int | None, src_ref: str | None
+    ) -> NetworkTraffic:
+        """
+        Creates a network traffic object.
+        """
+        network_traffic = NetworkTraffic(port, src_ref)
+        return network_traffic
+
+    def create_relationship(
+        self,
+        relationship_type: str,
+        created: datetime,
+        source_id: str,
+        target_id: str | None,
+        confidence: int,
+    ) -> Relationship:
+        """
+        Creates a relationship object.
+        """
+        relationship = Relationship(
+            relationship_type,
+            created,
+            source_id,
+            target_id,
+            self.author["id"],
+            confidence,
+        )
+        return relationship

--- a/external-import/hunt-io/src/external_import_connector/models.py
+++ b/external-import/hunt-io/src/external_import_connector/models.py
@@ -1,0 +1,371 @@
+"""OpenCTI Hunt models module."""
+
+from abc import abstractmethod
+from datetime import datetime
+from typing import Any, TypedDict
+
+import pycti
+import stix2
+from pycti import Identity as PyCTIIdentity
+from pycti import Infrastructure as PyCTIInfrastructure
+from pycti import Malware as PyCTIMalware
+
+
+class BaseModel:
+    """
+    Base class for OpenCTI models/observables.
+    """
+
+    _stix2_object: dict | None = None
+    _id: str | None = None
+
+    def __post_init__(self):
+        self._stix2_object = self.to_stix2_object()
+        self._id = self._stix2_object.get("id") if self._stix2_object else None
+
+    @property
+    def id(self):
+        """
+        Retrieves the ID of the object.
+        """
+        return self._id
+
+    @property
+    def stix2_object(self):
+        """
+        Retrieves the STIX2 object representation of the instance.
+        """
+        if self._stix2_object is None:
+            self._stix2_object = self.to_stix2_object()
+        return self._stix2_object
+
+    @abstractmethod
+    def to_stix2_object(self) -> Any:
+        """Construct STIX 2.1 object"""
+
+
+class C2(TypedDict):
+    """
+    Represents the structure of a Command and Control (C2) scan result.
+
+    This TypedDict defines the expected fields for C2 scan data, including details
+    about the IP address, port, hostname, and malware information.
+
+    Attributes:
+        ip (str): The IP address associated with the C2 scan.
+        port (int): The port number used by the C2 server.
+        hostname (str): The hostname or domain associated with the C2 server.
+        timestamp (str): The timestamp of the scan in ISO 8601 format.
+        scan_uri (str): The URI used to access the C2 server.
+        confidence (float): A confidence score (0-100) indicating the reliability of the scan data.
+        malware_name (str): The name of the detected malware.
+        malware_subsystem (str): The subsystem or type of malware (e.g., "Phishing", "Ransomware").
+        extra (dict): Additional metadata or context about the scan, such as geographical
+                    or ASN (Autonomous System Number) information.
+
+    Example:
+        ```python
+        from typing import TypedDict
+
+        class C2(TypedDict):
+            ip: str
+            port: int
+            hostname: str
+            timestamp: str
+            scan_uri: str
+            confidence: float
+            malware_name: str
+            malware_subsystem: str
+            extra: dict
+
+        c2_data: C2 = {
+            "ip": "192.168.1.1",
+            "port": 8080,
+            "hostname": "example.com",
+            "timestamp": "2024-11-25T12:00:00",
+            "scan_uri": "http://example.com",
+            "confidence": 95.0,
+            "malware_name": "ExampleMalware",
+            "malware_subsystem": "Phishing",
+            "extra": {
+                "geoip_city": "New York",
+                "geoip_country": "USA",
+            },
+        }
+        print(c2_data["ip"])  # Output: 192.168.1.1
+        ```
+    """
+
+    ip: str
+    port: int
+    hostname: str
+    timestamp: str
+    scan_uri: str
+    confidence: float
+    malware_name: str
+    malware_subsystem: str
+    extra: dict
+
+
+class C2ScanResult:
+    """
+    Represents the results of a Command and Control (C2) scan.
+
+    This class is used to parse and store information about a C2 scan result,
+    including details about the IP address, port, hostname, and associated malware.
+
+    Attributes:
+        ip (str): The IP address associated with the C2 scan.
+        port (int): The port number used in the C2 connection.
+        hostname (str): The hostname or domain associated with the C2 scan.
+        timestamp (str): The timestamp of the scan.
+        scan_uri (str): The URI of the scan target.
+        confidence (float): The confidence score of the scan result.
+        malware_name (str): The name of the malware detected during the scan.
+        malware_subsystem (str): The subsystem of malware detected.
+
+    Methods:
+        None (this class only stores data and does not provide additional methods).
+
+    Example:
+        ```python
+        from c2_scan_result import C2ScanResult
+
+        # Example C2 scan data
+        scan_data = {
+            "ip": "192.168.1.1",
+            "port": 8080,
+            "hostname": "example.com",
+            "timestamp": "2024-11-24T12:00:00",
+            "scan_uri": "http://example.com/login",
+            "confidence": 95.0,
+            "malware_name": "ExampleMalware",
+            "malware_subsystem": "Ransomware",
+        }
+
+        result = C2ScanResult(scan_data)
+        print(result.ip)  # Output: 192.168.1.1
+        print(result.confidence)  # Output: 95.0
+        ```
+    """
+
+    def __init__(self, data: C2) -> None:
+        self.ip = data.get("ip", "")
+        self.port = data.get("port", 1111)
+        self.hostname = data.get("hostname", "")
+        self.timestamp = data.get("timestamp", "")
+        self.scan_uri = data.get("scan_uri", "")
+        self.confidence = data.get("confidence", 50.0)
+        self.malware_name = data.get("malware_name", "")
+        self.malware_subsystem = data.get("malware_subsystem", "")
+
+
+class IPv4Address(BaseModel):
+    """
+    IPv4 observable.
+    """
+
+    def __init__(
+        self,
+        value: str,
+    ):
+        self.value = value
+        self.__post_init__()
+
+    def to_stix2_object(self) -> stix2.v21.observables.IPv4Address:
+        return stix2.IPv4Address(
+            value=self.value,
+        )
+
+
+class DomainName(BaseModel):
+    """
+    DomainName observable.
+    """
+
+    def __init__(
+        self,
+        value: str,
+    ):
+        self.value = value
+        self.__post_init__()
+
+    def to_stix2_object(self) -> stix2.v21.observables.DomainName:
+        return stix2.DomainName(
+            value=self.value,
+        )
+
+
+class Malware(BaseModel):
+    """
+    Malware object.
+    """
+
+    def __init__(self, malware_name: str, malware_subsystem: str):
+        self.name = malware_name
+        self.malware_subsystem = malware_subsystem
+        self.is_family = False
+        self.__post_init__()
+
+    def to_stix2_object(self) -> stix2.v21.Malware:
+        return stix2.Malware(
+            id=PyCTIMalware.generate_id(self.name),
+            name=self.name,
+            is_family=self.is_family,
+            malware_types=self.malware_subsystem,
+        )
+
+
+class URL(BaseModel):
+    """
+    URL indicator.
+    """
+
+    def __init__(
+        self, scan_uri: str, valid_from: datetime, author_id: str, description: str = ""
+    ):
+        self.scan_uri = scan_uri
+        self.description = description
+        self.valid_from = valid_from
+        self.author_id = author_id
+        self.__post_init__()
+
+    def to_stix2_object(self) -> stix2.v21.observables.URL:
+        return stix2.Indicator(
+            id=pycti.Indicator.generate_id(f"[url:value = '{self.scan_uri}']"),
+            name=self.scan_uri,
+            description=self.description,
+            pattern_type="stix",
+            valid_from=self.valid_from,
+            pattern=f"[url:value = '{self.scan_uri}']",
+            created_by_ref=self.author_id,
+        )
+
+
+class Author(BaseModel):
+    """
+    Author organization.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+    ):
+        identity_class = "organization"
+        self.name = name
+        self.description = description
+        self.identity_class = identity_class
+        self.__post_init__()
+
+    def to_stix2_object(self) -> stix2.Identity:
+        return stix2.Identity(
+            id=PyCTIIdentity.generate_id(self.name, self.identity_class),
+            name=self.name,
+            identity_class=self.identity_class,
+            description=self.description,
+        )
+
+
+class Infrastructure(BaseModel):
+    """
+    Infrastructure
+    """
+
+    def __init__(
+        self,
+        name: str,
+        infrastructure_types: str,
+        author: str,
+        created: datetime | None = None,
+    ):
+        self.name = name
+        self.infrastructure_types = infrastructure_types
+        self.created = created
+        self.author = author
+        self.__post_init__()
+
+    def to_stix2_object(self) -> stix2.Infrastructure:
+        return stix2.Infrastructure(
+            id=PyCTIInfrastructure.generate_id(name=self.name),
+            created=self.created,
+            name=self.name,
+            created_by_ref=self.author,
+            infrastructure_types=self.infrastructure_types,
+        )
+
+
+class NetworkTraffic(BaseModel):
+    """
+    Creates a STIX NetworkTraffic observable that links a C2 server's IP address to its
+      actively listening port.
+
+    This function creates a relationship between a C2 server IP (src_ref) and its detected
+      open port.
+    The relationship is represented as a STIX NetworkTraffic object with TCP protocol, indicating
+    a potential active C2 communication channel.
+
+    Args:
+        port (int | None): The open port number detected during C2 infrastructure scanning.
+                        For example: 11111
+        src_ref (str | None): STIX ID reference to an existing IPv4 address object that
+                            represents the C2 server's IP address.
+                            For example: "ipv4-addr--1234"
+
+    Returns:
+        stix2.v21.observables.NetworkTraffic | None: A STIX NetworkTraffic object if both port and
+            src_ref are provided, None if either argument is None.
+
+    Example:
+        >>> port = 11111  # C2 server's open port
+        >>> src_ref = "ipv4-addr--1234"  # Reference to the C2 IP
+        >>> traffic = create_network_traffic(port, src_ref)
+    """
+
+    def __init__(self, port: int | None, src_ref: str | None):
+        self.port = port
+        self.src_ref = src_ref
+        self.__post_init__()
+
+    def to_stix2_object(self) -> stix2.NetworkTraffic:
+        return stix2.NetworkTraffic(
+            src_ref=self.src_ref,
+            dst_port=self.port,
+            protocols=["tcp"],
+        )
+
+
+class Relationship(BaseModel):
+    """
+    Creates Relationship object
+    """
+
+    def __init__(
+        self,
+        relationship_type: str,
+        created: datetime,
+        source_id: str,
+        target_id: str | None,
+        author: str,
+        confidence: int,
+    ):
+        self.relationship_type = relationship_type
+        self.created = created
+        self.source_id = source_id
+        self.target_id = target_id
+        self.author = author
+        self.confidence = confidence
+        self.__post_init__()
+
+    def to_stix2_object(self) -> stix2.Relationship:
+        return stix2.Relationship(
+            id=pycti.StixCoreRelationship.generate_id(
+                self.relationship_type, self.source_id, self.target_id
+            ),
+            relationship_type=self.relationship_type,
+            created=self.created,
+            source_ref=self.source_id,
+            target_ref=self.target_id,
+            created_by_ref=self.author,
+            confidence=self.confidence,
+        )

--- a/external-import/hunt-io/src/external_import_connector/utils.py
+++ b/external-import/hunt-io/src/external_import_connector/utils.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+
+from validators import domain, hashes, ip_address, url  # type: ignore
+
+
+def is_ipv4(value: str) -> bool:
+    """
+    Return whether given value is a valid IPv4 address.
+    """
+    return ip_address.ipv4(value) is True
+
+
+def is_ipv6(value: str) -> bool:
+    """
+    Return whether given value is a valid IPv6 address.
+    """
+    return ip_address.ipv6(value) is True
+
+
+def is_domain(value: str) -> bool:
+    """
+    Return whether given value is a valid Domain name.
+    """
+    return domain(value) is True
+
+
+def is_url(value: str) -> bool:
+    """
+    Valid url
+    :param value: Value in string
+    :return: A boolean
+    """
+    is_valid_url = url(value)
+
+    if is_valid_url:
+        return True
+    else:
+        return False
+
+
+def is_md5(value: str) -> bool:
+    """
+    Return whether given value is a valid MD5 hash.
+    """
+    return hashes.md5(value) is True
+
+
+def is_sha1(value: str) -> bool:
+    """
+    Return whether given value is a valid SHA-1 hash.
+    """
+    return hashes.sha1(value) is True
+
+
+def is_sha256(value: str) -> bool:
+    """
+    Return whether given value is a valid SHA-256 hash.
+    """
+    return hashes.sha256(value) is True
+
+
+def is_sha512(value: str) -> bool:
+    """
+    Return whether given value is a valid SHA-512 hash.
+    """
+    return hashes.sha512(value) is True
+
+
+def create_indicator_pattern(value: str) -> str:
+    """
+    Create indicator pattern
+    :param value: Value in string
+    :return: String of the pattern
+    """
+    if is_ipv6(value) is True:
+        return f"[ipv6-addr:value = '{value}']"
+    elif is_ipv4(value) is True:
+        return f"[ipv4-addr:value = '{value}']"
+    elif is_domain(value) is True:
+        return f"[domain-name:value = '{value}']"
+    elif is_url(value) is True:
+        return f"[url:value = '{value}']"
+    else:
+        raise ValueError(
+            f"This pattern value {value} is not a valid IPv4 or IPv6 address or Domain name nor URL"
+        )
+
+
+def convert_timestamp_to_iso_format(timestamp: str) -> datetime:
+    """
+    Convert timestamp to ISO format
+    """
+    return datetime.fromisoformat(timestamp)

--- a/external-import/hunt-io/src/main.py
+++ b/external-import/hunt-io/src/main.py
@@ -1,0 +1,20 @@
+import traceback
+
+from external_import_connector import ConnectorHuntIo
+
+if __name__ == "__main__":
+    """
+    Entry point of the script
+
+    - traceback.print_exc(): This function prints the traceback of the exception to the standard error (stderr).
+    The traceback includes information about the point in the program where the exception occurred,
+    which is very useful for debugging purposes.
+    - exit(1): effective way to terminate a Python program when an error is encountered.
+    It signals to the operating system and any calling processes that the program did not complete successfully.
+    """
+    try:
+        connector = ConnectorHuntIo()
+        connector.run()
+    except Exception:
+        traceback.print_exc()
+        exit(1)

--- a/external-import/hunt-io/src/requirements.txt
+++ b/external-import/hunt-io/src/requirements.txt
@@ -1,0 +1,3 @@
+pycti==6.3.13
+validators==0.33.0
+ruff==0.4.8

--- a/external-import/hunt-io/tests/common_fixtures.py
+++ b/external-import/hunt-io/tests/common_fixtures.py
@@ -1,0 +1,14 @@
+from unittest.mock import Mock
+
+import pytest  # type: ignore
+
+
+@pytest.fixture(scope="class")
+def setup_config(request):
+    """
+    Setup configuration for class method
+    Create fake pycti OpenCTI helper
+    """
+    request.cls.mock_helper = Mock()
+
+    yield

--- a/external-import/hunt-io/tests/test-requirements.txt
+++ b/external-import/hunt-io/tests/test-requirements.txt
@@ -1,0 +1,4 @@
+# Main dependencies needs to be installed
+-r ../src/requirements.txt
+pytest
+pytest-mock

--- a/external-import/hunt-io/tests/test_template_connector.py
+++ b/external-import/hunt-io/tests/test_template_connector.py
@@ -1,0 +1,17 @@
+# import pytest
+
+# from .common_fixtures import setup_config # noqa: F401
+
+
+# @pytest.mark.usefixtures("setup_config")
+class TestHuntIoConnector(object):
+    def test_to_do(self) -> None:
+        """
+        Check if running test works
+        """
+        # Use the helper
+        # self.mock_helper()
+        value_received = "Value is True"
+        expected_result = "Value is True"
+
+        assert value_received == expected_result


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This PR introduces a new connector to integrate Hunt.io’s C2 (Command and Control) feed with OpenCTI. The connector retrieves, processes, and maps threat intelligence data into STIX-compliant objects and relationships to enhance threat visibility in OpenCTI.

#### Features

- API Integration: The connector fetches C2 feeds from the [Hunt.io API](https://apidocs.hunt.io/reference/download-c2-feed) in zip format.
- Response Handling: The compressed payload is unzipped, and its contents are processed into actionable threat intelligence.
- STIX Object Creation: Each entity in the feed is mapped to corresponding STIX objects/observables.
- Concurrency: To efficiently handle the large datasets, the connector spawns up to 4 worker threads, processing entities concurrently to mitigate buffer overflow risks.

#### Field Mapping

| **C2 Feed Fields**           | **STIX2.1**                                                   |
|------------------------------|-----------------------------------------------------------|
| `ip` - The IP address associated with the C2 scan | `IPv4Address` observable                               |
| `port` - The port number used in the C2 connection | `NetworkTraffic` object that maps IP to a specific port |
| `hostname` - The hostname or domain associated with the C2 scan | `DomainName` observable                              |
| `timestamp` - The timestamp of the scan          | Used as a timestamp for different objects and observables |
| `scan_uri` - The URI of the scan target          | `Indicator` with `url:value` pattern                     |
| `confidence` - The confidence score of the scan result | Used as confidence score for different objects and observables |
| `malware_name` - The name of the malware detected during the scan | `Malware` object                                      |
| `malware_subsystem` - The subsystem of malware detected | Used for `Malware` object to represent a malware type  |

#### Relationships

| **Source**                     | **Relationship**   | **Target**                      |
|--------------------------------|--------------------|----------------------------------|
| `Infrastructure` (`malware_name`) | `controls`         | `Malware` (`malware_name`)        |
| `Infrastructure` (`malware_name`) | `consist-of`       | `IPv4Address` (`ip`)              |
| `Infrastructure` (`malware_name`) | `consist-of`       | `DomainName` (`hostname`)         |
| `Indicator` (`scan_uri`)          | `indicates`        | `Malware` (`malware_name`)        |

#### Note
- For more details about Hunt’s C2 feed, visit the official documentation at https://apidocs.hunt.io/docs/c2-feed.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3286

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
