### PR TITLE
[ExportReportPdf] list params fixed (#9082)

### DIFF
--- a/internal-export-file/export-report-pdf/src/export-report-pdf.py
+++ b/internal-export-file/export-report-pdf/src/export-report-pdf.py
@@ -193,8 +193,8 @@ class ExportReportPdf:
 
         if entities_list is not None:
             list_marking = None
-            if file_markings:
-                list_marking = file_markings[-1]["definition"]
+            if len(file_markings) != 0:
+                list_marking = file_markings
             list_report_date = datetime.datetime.now().strftime("%b %d %Y")
             # Store context for usage in html template
 

--- a/internal-export-file/export-report-pdf/src/export-report-pdf.py
+++ b/internal-export-file/export-report-pdf/src/export-report-pdf.py
@@ -197,9 +197,15 @@ class ExportReportPdf:
                 list_marking = file_markings[-1]["definition"]
             list_report_date = datetime.datetime.now().strftime("%b %d %Y")
             # Store context for usage in html template
+
+            if list_params is not None:
+                list_search = list_params.get("search", "No search keyword")
+            else:
+                list_search = "No search keyword"
+
             context = {
                 "list_name": "Export of " + entity_type,
-                "list_search": list_params.get("search", "No search keyword"),
+                "list_search": list_search,
                 "list_filters": str(main_filter),
                 "list_marking": list_marking,
                 "list_report_date": list_report_date,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* fix list search in case of list params equal None
* fix file markings on selection 

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/9082

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

It crashed when we tried to export a selection of entities with file_markings.
Then another case was fixed: it would also crash when list_params was empty. 
ask Nino for more infos if needed