### PR TITLE
[Sentinel-Intel] Fix missing init retries_builder

### DIFF
--- a/stream/sentinel-intel/docker-compose.yml
+++ b/stream/sentinel-intel/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - CONNECTOR_SCOPE=sentinel # MIME type or Stix Object - Not used
       - CONNECTOR_LOG_LEVEL=error
       - SENTINEL_INTEL_TENANT_ID=ChangeMe # Azure Tentant ID
-      - SENTINEL_INTEL_WORKSPACE_ID=ChangeMe # Sentinel Workspace ID (only for Azure Sentinel)
       - SENTINEL_INTEL_CLIENT_ID=ChangeMe # Azure App Client ID
       - SENTINEL_INTEL_CLIENT_SECRET=ChangeMe # Azure App Client Secret
       - "SENTINEL_INTEL_TARGET_PRODUCT=Azure Sentinel" # "Azure Sentinel" or "Microsoft Defender ATP"

--- a/stream/sentinel-intel/src/config.yml.sample
+++ b/stream/sentinel-intel/src/config.yml.sample
@@ -14,7 +14,6 @@ connector:
 
 sentinel_intel:
   tenant_id: 'ChangeMe'
-  workspace_id: 'ChangeMe' # Only for Sentinel
   client_id: 'ChangeMe' 
   client_secret: 'ChangeMe' 
   login_url: 'https://login.microsoft.com'

--- a/stream/sentinel-intel/src/sentinel_intel_connector/api_handler.py
+++ b/stream/sentinel-intel/src/sentinel_intel_connector/api_handler.py
@@ -31,6 +31,7 @@ class SentinelApiHandler:
 
         # Define headers in session and update when needed
         self.session = requests.Session()
+        self.retries_builder()
         self._expiration_token_date = None
 
     def _get_authorization_header(self):

--- a/stream/sentinel-intel/src/sentinel_intel_connector/api_handler.py
+++ b/stream/sentinel-intel/src/sentinel_intel_connector/api_handler.py
@@ -22,7 +22,7 @@ from .utils import (
 class SentinelApiHandler:
     def __init__(self, helper, config):
         """
-        Init Tanium API handler.
+        Init Sentinel Intel API handler.
         :param helper: PyCTI helper instance
         :param config: Connector config variables
         """


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added initialization of retries_builder() method to handle error 429
* Deletion of unused environment variable named “_SENTINEL_INTEL_WORKSPACE_ID_”.

### Related issues

* #3042 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
