### PR TITLE
[Mandiant] Fix status complete on the progress bar for reports

### DIFF
--- a/external-import/mandiant/src/connector/base.py
+++ b/external-import/mandiant/src/connector/base.py
@@ -685,11 +685,9 @@ class Mandiant:
                 else:
                     first_run = start_offset == 0
 
-                """
-                We check that after each API call the collection respects the interval, 
-                either the default or the one specified in the config.
-                If it does not, we terminate the job and move on to the next collection.
-                """
+                # We check that after each API call the collection respects the interval,
+                # either the default or the one specified in the config.
+                # If it does not, we terminate the job and move on to the next collection.
 
                 if (
                     first_run is False
@@ -763,7 +761,7 @@ class Mandiant:
                     obj["object_marking_refs"] = new_markings
 
     def _process_batch_reports(
-        self, new_batch_reports: list, info_reports: dict[str, Any]
+        self, new_batch_reports: list[Any], info_reports: dict[str, Any]
     ) -> None:
         """
           Process a batch of reports by deduplicating, cleaning, and submitting them.
@@ -774,10 +772,6 @@ class Mandiant:
 
         Returns:
             None
-
-        Raises:
-            Exception: If an error occurs during the deduplicate, clean the bundle and report submission process.
-            The error will be logged.
         """
         try:
             bundles_objects_report = []
@@ -809,7 +803,7 @@ class Mandiant:
                 {"error": str(err), "info_reports": info_reports},
             )
 
-    def _deduplicate_and_clean_bundles(self, bundles_objects: list) -> list:
+    def _deduplicate_and_clean_bundles(self, bundles_objects: list[Any]) -> list:
         """
         Deduplicates and cleans STIX bundles.
 
@@ -822,10 +816,6 @@ class Mandiant:
 
         Returns:
             uniq_bundles_objects (list): A deduplicated and cleaned list of STIX objects in dictionary format.
-
-        Raises:
-            Exception: If an error occurs during the deduplicate and clean the bundle.
-            The error will be logged.
         """
         try:
             uniq_bundles_objects = list(
@@ -883,10 +873,6 @@ class Mandiant:
 
         Returns:
             None
-
-        Raises:
-            Exception: If an error occurs when initiating the job, creating the bundle or sending the data.
-            The error will be logged.
         """
         report_work_id = None
         try:
@@ -932,7 +918,6 @@ class Mandiant:
                 )
             module = importlib.import_module(f".{collection}", package=__package__)
             collection_api = getattr(self.api, collection)
-
 
             # If work in progress, then the new in progress will
             # be to start from the index until before_process_now. The current index

--- a/external-import/mandiant/src/connector/base.py
+++ b/external-import/mandiant/src/connector/base.py
@@ -933,11 +933,11 @@ class Mandiant:
             module = importlib.import_module(f".{collection}", package=__package__)
             collection_api = getattr(self.api, collection)
 
-            """
-            If work in progress, then the new in progress will
-            be to start from the index until before_process_now. The current index
-            will also be updated to before_process_now to be used as a marker.
-            """
+
+            # If work in progress, then the new in progress will
+            # be to start from the index until before_process_now. The current index
+            # will also be updated to before_process_now to be used as a marker.
+
             before_process_now = Timestamp.now()
 
             start = Timestamp.from_iso(

--- a/external-import/mandiant/src/connector/constants.py
+++ b/external-import/mandiant/src/connector/constants.py
@@ -17,3 +17,13 @@ MAPPING = {
     "Financial Theft": MOTIVATION_ORGANIZATIONAL_GAIN,
     "Disruption": MOTIVATION_ORGANIZATIONAL_GAIN,
 }
+
+STATE_START = "start_epoch"
+STATE_OFFSET = "offset"
+STATE_END = "end_epoch"
+STATE_LAST_RUN = "last_run"
+
+STATEMENT_MARKINGS = [
+    "marking-definition--ad2caa47-58fd-5491-8f67-255377927369",
+]
+BATCH_REPORT_SIZE = 10


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Moved constants like `STATE_START`, `STATE_OFFSET`, `STATE_END`, `STATE_LAST_RUN`, `STATEMENT_MARKINGS`, and `BATCH_REPORT_SIZE` to dedicated `constants.py` module.

* Refactored `remove_statement_marking `to be a static method 

* Moved work_id initiation and error handling for work_id from process_message to _run methods and Batch report. (Core PR)

  * Introduced **_new methods_** : 
    -  `_process_batch_reports` : This method is the overall process of handling a batch of reports by de-duplicating, cleansing and submitting them. It's used to implement batch processing of reports. The size is defined by BATCH_REPORT_SIZE and is set to 10 by default.
    - `_deduplicate_and_clean_bundles` : This method ensures that each object in the provided list of STIX bundles is unique based on its `id`. It also converts each STIX object to a dictionary format and optionally removes statement markings if the `mandiant_remove_statement_marking` variable environment is defined at true. _Created to refactor and simplify repeated portions of code._
    - `_process_submission_report` : Processes a submission report by creating a STIX bundle and marking the work as processed. This method initiates a work process, creates a STIX2 bundle from the provided data, sends the bundle, and marks the work as completed.

   * Why this solution ? 
     - Initially the work_id worked correctly for the other collections. However, for reports, the process repeated the call to send_stix_bundle for each report, resulting in a 'complete' status problem when ingested. Once the first report was ingested, the others used the same work_id, creating an inconsistency. The solution was to group the reports into batches and generate a unique work_id for each batch, which solved the problem. Here's what the work will look like in the future, with an indication of the position of the current batch
![image](https://github.com/user-attachments/assets/665c3f3a-09bb-4ec5-8392-aae7e3dec5ac)


### Related issues

* #2892
* https://github.com/OpenCTI-Platform/opencti/issues/8224
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments



