### PR TITLE
[Crowdstrike] Replace latest modified report date filter instead of created date

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
@@ -73,25 +73,25 @@ class ReportImporter(BaseImporter):
 
         new_state = state.copy()
 
-        latest_report_created_timestamp = None
+        latest_report_modified_timestamp = None
 
         for reports_batch in self._fetch_reports(fetch_timestamp):
             if not reports_batch:
                 break
 
-            latest_report_created_datetime = self._process_reports(reports_batch)
+            latest_report_modified_datetime = self._process_reports(reports_batch)
 
-            if latest_report_created_datetime is not None:
-                latest_report_created_timestamp = datetime_to_timestamp(
-                    latest_report_created_datetime
+            if latest_report_modified_datetime is not None:
+                latest_report_modified_timestamp = datetime_to_timestamp(
+                    latest_report_modified_datetime
                 )
 
                 new_state[self._LATEST_REPORT_TIMESTAMP] = (
-                    latest_report_created_timestamp
+                    latest_report_modified_timestamp
                 )
                 self._set_state(new_state)
 
-        latest_report_timestamp = latest_report_created_timestamp or fetch_timestamp
+        latest_report_timestamp = latest_report_modified_timestamp or fetch_timestamp
 
         self._info(
             "Report importer completed, latest fetch {0}.",
@@ -105,10 +105,10 @@ class ReportImporter(BaseImporter):
 
     def _fetch_reports(self, start_timestamp: int) -> Generator[List, None, None]:
         limit = 30
-        sort = "created_date|asc"
+        sort = "last_modified_date|asc"
         fields = ["__full__"]
 
-        fql_filter = f"created_date:>{start_timestamp}"
+        fql_filter = f"last_modified_date:>{start_timestamp}"
 
         if self.include_types:
             fql_filter = f"{fql_filter}+type:{self.include_types}"
@@ -145,33 +145,33 @@ class ReportImporter(BaseImporter):
         report_count = len(reports)
         self._info("Processing {0} reports...", report_count)
 
-        latest_created_datetime = None
+        latest_modified_datetime = None
 
         for report in reports:
             self._process_report(report)
 
-            created_date = report["created_date"]
-            if created_date is None:
+            last_modified_date = report["last_modified_date"]
+            if last_modified_date is None:
                 self._error(
-                    "Missing created date for report {0} ({1})",
+                    "Missing last modified date for report {0} ({1})",
                     report["name"],
                     report["id"],
                 )
                 continue
 
             if (
-                latest_created_datetime is None
-                or created_date > latest_created_datetime
+                latest_modified_datetime is None
+                or last_modified_date > latest_modified_datetime
             ):
-                latest_created_datetime = created_date
+                latest_modified_datetime = last_modified_date
 
         self._info(
             "Processing reports completed (imported: {0}, latest: {1})",
             report_count,
-            latest_created_datetime,
+            latest_modified_datetime,
         )
 
-        return timestamp_to_datetime(latest_created_datetime)
+        return timestamp_to_datetime(latest_modified_datetime)
 
     def _process_report(self, report) -> None:
         self._info("Processing report {0} ({1})...", report["name"], report["id"])


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  Replace latest modified report date filter instead of created date to update the report with the latest modification from Crowdstrike source

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2756

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
