### PR TITLE
[Recorded Future] handle exception raised when no attachment and no object_refs to report

### DIFF
--- a/external-import/recorded-future/src/rflib/rf_client.py
+++ b/external-import/recorded-future/src/rflib/rf_client.py
@@ -77,8 +77,12 @@ class RFClient:
             if pull_signatures and "attachment" in attributes:
                 try:
                     result = self.get_attachment(note["id"])
-                    attributes["attachment_content"] = result["rules"][0]["content"]
-                    attributes["attachment_type"] = result["type"]
+                    if result:
+                        attributes["attachment_content"] = result["rules"][0]["content"]
+                        attributes["attachment_type"] = result["type"]
+                    else:
+                        msg = "[ANALYST NOTES] No attachment found"
+                        self.helper.log_error(msg)
                 except requests.exceptions.HTTPError as err:
                     if "403" in str(err):
                         msg = "[ANALYST NOTES] Your API token does not have permission to pull Detection Rules"
@@ -123,7 +127,7 @@ class RFClient:
 
         res = self.session.post(DETECTION_SEARCH, json=query)
         res.raise_for_status()
-        return res.json()["result"][0]
+        return res.json()["result"][0] if len(res.json()["result"]) > 0 else None
 
     def get_fusion_file(self, path: str) -> str:
         """Gets a fusion file provided a path

--- a/external-import/recorded-future/src/rflib/rf_to_stix2.py
+++ b/external-import/recorded-future/src/rflib/rf_to_stix2.py
@@ -1104,6 +1104,7 @@ class StixNote:
         return list(ret)
 
     def to_stix_objects(self):
+        """Returns a list of STIX objects"""
         report_object_refs = [obj.id for obj in self.objects]
         # Report in STIX lib must have at least one object_refs even if there is no object_refs
         if len(report_object_refs) == 0:
@@ -1112,7 +1113,6 @@ class StixNote:
                 "intrusion-set--fc5ee88d-7987-4c00-991e-a863e9aa8a0e"
             )
 
-        """Returns a list of STIX objects"""
         report = stix2.Report(
             id=pycti.Report.generate_id(self.name, self.published),
             name=self.name,

--- a/external-import/recorded-future/src/rflib/rf_to_stix2.py
+++ b/external-import/recorded-future/src/rflib/rf_to_stix2.py
@@ -1104,6 +1104,14 @@ class StixNote:
         return list(ret)
 
     def to_stix_objects(self):
+        report_object_refs = [obj.id for obj in self.objects]
+        # Report in STIX lib must have at least one object_refs even if there is no object_refs
+        if len(report_object_refs) == 0:
+            # Put a fake ID in the report
+            report_object_refs.append(
+                "intrusion-set--fc5ee88d-7987-4c00-991e-a863e9aa8a0e"
+            )
+
         """Returns a list of STIX objects"""
         report = stix2.Report(
             id=pycti.Report.generate_id(self.name, self.published),
@@ -1113,7 +1121,7 @@ class StixNote:
             created_by_ref=self.author.id,
             labels=self.labels,
             report_types=self.report_types,
-            object_refs=[obj.id for obj in self.objects],
+            object_refs=report_object_refs,
             external_references=self.external_references,
             object_marking_refs=self.tlp,
         )


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* handle case when no attachement found
* Add a fake ID in the report as STIX2 doesn’t allowed that a report have no object references and it raise an error when no object_refs exists and we still want to create the report ❌
* Solution preferred:  Create a subclass of Report to have optional object_refs and not required

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/2938

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
