### PR TITLE
[CrowdStrike-Endpoint-Security] Fixing severity map bug

### DIFF
--- a/stream/crowdstrike-endpoint-security/src/crowdstrike_services/constants.py
+++ b/stream/crowdstrike-endpoint-security/src/crowdstrike_services/constants.py
@@ -10,11 +10,11 @@ observable_type_mapper = {
 
 # Map OpenCTI IOC score to Crowdstrike IOC severity
 severity_mapper = {
-    range(0, 19): "informational",
-    range(20, 39): "low",
-    range(40, 59): "medium",
-    range(60, 79): "high",
-    range(80, 100): "critical",
+    range(0, 20): "informational",
+    range(20, 40): "low",
+    range(40, 60): "medium",
+    range(60, 80): "high",
+    range(80, 101): "critical",
 }
 
 # Map OpenCTI IOC platforms to Crowdstrike platforms


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change values used in `range()` function.

### Related issues

* 19, 39, 59, 79, and 100 were not taken into account when mapping thus returning `null` value.
* This resulted in an invalid input error when creating indicators with those scores.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
