### PR TITLE
[attribution-tools] Install gfortran, openblas, xsimd

### DIFF
--- a/internal-enrichment/attribution-tools/Dockerfile
+++ b/internal-enrichment/attribution-tools/Dockerfile
@@ -6,7 +6,8 @@ COPY src /opt/opencti-connector-attribution-tools
 
 # Install dependencies
 RUN apk update && apk upgrade && \
-    apk --no-cache add gcc git build-base libmagic libffi-dev
+    apk --no-cache add gcc git build-base libmagic libffi-dev \
+    gfortran openblas openblas-dev xsimd xsimd-dev
 
 # Install Python modules
 RUN cd /opt/opencti-connector-attribution-tools && \


### PR DESCRIPTION
### Proposed changes

* Install `openblas`, `gfortran`, and `xsimd` in attribution-tools container

The build of the container for `attribution-tools` appears broken now, at least on ARM64 architecture. Not sure if it's also broken on x86-64 (I presume it is fine there?).

Installing dependencies OpenBLAS and gFortran seem to fix the breakage.

During fixing, I also noticed that some of the Python code will use `xsimd` if it is available. As this could potentially speed up analysis by leveraging streaming instructions, I figured I would add this as well to the container.

### Related issue
- https://github.com/OpenCTI-Platform/connectors/issues/3476

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality