### PR TITLE
[Mandiant]: Invalid "originates-from" relationships

### DIFF
--- a/external-import/mandiant/src/connector/reports.py
+++ b/external-import/mandiant/src/connector/reports.py
@@ -413,6 +413,7 @@ class MandiantReport:
 
         if len(intrusion_sets) > 0:
             definitions += [
+                # https://github.com/OpenCTI-Platform/connectors/compare/issue/3129
                 # {
                 #    "type": "originates-from",
                 #    "sources": intrusion_sets,
@@ -457,6 +458,7 @@ class MandiantReport:
 
         if len(malwares) > 0:
             definitions += [
+                # https://github.com/OpenCTI-Platform/connectors/compare/issue/3129
                 # {
                 #    "type": "originates-from",
                 #    "sources": malwares,

--- a/external-import/mandiant/src/connector/reports.py
+++ b/external-import/mandiant/src/connector/reports.py
@@ -398,7 +398,7 @@ class MandiantReport:
         ]
 
         # Get objects from tags
-        source_geographies = list(self._get_objects_from_tags("source_geographies"))
+        # source_geographies = list(self._get_objects_from_tags("source_geographies"))
         target_geographies = list(self._get_objects_from_tags("target_geographies"))
         affected_industries = list(self._get_objects_from_tags("affected_industries"))
         affected_systems = list(self._get_objects_from_tags("affected_systems"))

--- a/external-import/mandiant/src/connector/reports.py
+++ b/external-import/mandiant/src/connector/reports.py
@@ -413,11 +413,11 @@ class MandiantReport:
 
         if len(intrusion_sets) > 0:
             definitions += [
-                {
-                    "type": "originates-from",
-                    "sources": intrusion_sets,
-                    "destinations": source_geographies,
-                },
+                # {
+                #    "type": "originates-from",
+                #    "sources": intrusion_sets,
+                #    "destinations": source_geographies,
+                # },
                 {
                     "type": "targets",
                     "sources": intrusion_sets,
@@ -457,11 +457,11 @@ class MandiantReport:
 
         if len(malwares) > 0:
             definitions += [
-                {
-                    "type": "originates-from",
-                    "sources": malwares,
-                    "destinations": source_geographies,
-                },
+                # {
+                #    "type": "originates-from",
+                #    "sources": malwares,
+                #    "destinations": source_geographies,
+                # },
                 {
                     "type": "targets",
                     "sources": malwares,


### PR DESCRIPTION
### Proposed changes

Comment codes that generate invalid "originates-from" relationships between some countries  and malwares/intrusion-sets mentionned in Mandiant reports

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3129