### PR TITLE
[Templates] Fix syntax error on entity_in_scope in template

### DIFF
--- a/templates/internal-enrichment/src/internal_enrichment_connector/connector.py
+++ b/templates/internal-enrichment/src/internal_enrichment_connector/connector.py
@@ -151,7 +151,7 @@ class ConnectorTemplate:
             )
             self.helper.connector_logger.info(info_msg, {"type": {obs_type}})
 
-            if self.entity_in_scope:
+            if self.entity_in_scope(data):
                 # Performing the collection of intelligence and enrich the entity
                 # ===========================
                 # === Add your code below ===


### PR DESCRIPTION
Fix syntax error making the test always true

`if self.entity_in_scope` was always true

### Proposed changes

* Add a parameter to entity_in_scope so it actually runs the function instead of testing if it exists

### Related issue
* https://github.com/OpenCTI-Platform/connectors/issues/3273