### PR TITLE
Ransomware.live connector : update to use API v2

### DIFF
--- a/external-import/ransomwarelive/src/lib/ransom_conn.py
+++ b/external-import/ransomwarelive/src/lib/ransom_conn.py
@@ -75,7 +75,7 @@ class RansomwareAPIConnector:
             identity_class="organization",
             type="identity",
             object_marking_refs=[self.marking.get("id")],
-            contact_information="https://www.ransomware.live/#/about?id=⚙️-integration-with-opencti",
+            contact_information="https://www.ransomware.live/about#data",
             x_opencti_reliability="A - Completely reliable",
             allow_custom=True,
         )
@@ -350,12 +350,12 @@ class RansomwareAPIConnector:
         if group_name in ("lockbit3", "lockbit2"):
             return ExternalReference(
                 source_name="Ransom Note",
-                url="https://www.ransomware.live/#/notes/lockbit",
+                url="https://www.ransomware.live/ransomnotes/lockbit",
                 description="Sample Ransom Note",
             )
         return ExternalReference(
             source_name="Ransom Note",
-            url=f"https://www.ransomware.live/#/notes/{group_name}",
+            url=f"https://www.ransomware.live/ransomnotes/{group_name}",
             description="Sample Ransom Note",
         )
 
@@ -397,7 +397,7 @@ class RansomwareAPIConnector:
         """Generates STIX objects from the ransomware.live API data"""
 
         # Creating Victim object
-        post_title = item.get("post_title")
+        post_title = item.get("victims")
         victim_name, identity_class = (
             (post_title, "organization")
             if len(post_title) > 2
@@ -413,12 +413,12 @@ class RansomwareAPIConnector:
         )
 
         # RansomNote External Reference
-        external_references_group = self.ransom_note_generator(item.get("group_name"))
+        external_references_group = self.ransom_note_generator(item.get("group"))
 
         # Creating Threat Actor object
         threat_actor = None
         if self.create_threat_actor:
-            threat_actor_name = item.get("group_name")
+            threat_actor_name = item.get("group")
             threat_actor = ThreatActor(
                 id=pycti.ThreatActorGroup.generate_id(threat_actor_name),
                 name=threat_actor_name,
@@ -438,8 +438,8 @@ class RansomwareAPIConnector:
         # Creating Intrusion Set object
         try:
             if (
-                item.get("group_name") == "lockbit3"
-                or item.get("group_name") == "lockbit2"
+                item.get("group") == "lockbit3"
+                or item.get("group") == "lockbit2"
             ):
                 intrusion_set = IntrusionSet(
                     id=pycti.IntrusionSet.generate_id("lockbit"),
@@ -454,14 +454,14 @@ class RansomwareAPIConnector:
                 )
 
             else:
-                intrusionset_name = item.get("group_name")
+                intrusionset_name = item.get("group")
                 intrusion_set = IntrusionSet(
                     id=pycti.IntrusionSet.generate_id(intrusionset_name),
                     name=intrusionset_name,
                     labels=["ransomware"],
                     created_by_ref=self.author.get("id"),
                     description=self.threat_description_generator(
-                        item.get("group_name"), group_data
+                        item.get("group"), group_data
                     ),
                     object_marking_refs=[self.marking.get("id")],
                     external_references=[external_references_group],
@@ -502,10 +502,10 @@ class RansomwareAPIConnector:
             object_refs.append(target_relation.get("id"))
             object_refs.append(relation_is_ta.get("id"))
         report_name = (
-            item.get("group_name") + " has published a new victim: " + post_title
+            item.get("group") + " has published a new victim: " + post_title
         )
         report_created = datetime.fromisoformat(item.get("discovered"))
-        report_published = datetime.fromisoformat(item.get("published"))
+        report_published = datetime.fromisoformat(item.get("attackdate"))
         report = Report(
             id=pycti.Report.generate_id(report_name, report_published),
             report_types=["Ransomware-report"],
@@ -560,15 +560,15 @@ class RansomwareAPIConnector:
             self.helper.log_error(str(e))
 
         # Creating Domain object
-        if self.is_domain(item.get("post_title")):
+        if self.is_domain(item.get("victim")):
 
-            domain_name = item.get("post_title")
+            domain_name = item.get("victim")
             # Extracting domain name
             domain_name = self.domain_extractor(domain_name)
             # Fetching domain description
             description = self.fetch_country_domain(domain_name)
 
-            domain = self.domain_generator(item.get("post_title"), description)
+            domain = self.domain_generator(item.get("victim"), description)
             relation_vi_do = self.relationship_generator(
                 domain.get("id"), victim.get("id"), "belongs-to"
             )
@@ -594,14 +594,14 @@ class RansomwareAPIConnector:
             bundle.append(relation_vi_do)
 
         elif (
-            item.get("website") != ""
-            and not self.is_domain(item.get("post_title"))
-            and item.get("website") is not None
+            item.get("domain") != ""
+            and not self.is_domain(item.get("victim"))
+            and item.get("domain") is not None
         ):
 
-            if self.domain_extractor(item.get("website")) is not None:
+            if self.domain_extractor(item.get("domain")) is not None:
 
-                domain_name = self.domain_extractor(item.get("website"))
+                domain_name = self.domain_extractor(item.get("domain"))
 
                 description = self.fetch_country_domain(domain_name)
                 try:
@@ -685,8 +685,8 @@ class RansomwareAPIConnector:
     # Collects historic intelligence from ransomware.live
     def collect_historic_intelligence(self):
         """Collects historic intelligence from ransomware.live"""
-        base_url = "https://api.ransomware.live/victims/"
-        groups_url = "https://api.ransomware.live/groups"
+        base_url = "https://api.ransomware.live/v2/victims/"
+        groups_url = "https://api.ransomware.live/v2/groups"
         headers = {"accept": "application/json", "User-Agent": "OpenCTI"}
 
         # fetching group information
@@ -725,7 +725,7 @@ class RansomwareAPIConnector:
                                 )
                             except Exception as e:
                                 self.helper.log_error(
-                                    f"Error creating STIX objects: {item.get('post_title')}"
+                                    f"Error creating STIX objects: {item.get('victim')}"
                                 )
                                 self.helper.log_error(str(e))
 
@@ -767,8 +767,8 @@ class RansomwareAPIConnector:
 
     def collect_intelligence(self, last_run) -> list:
 
-        url = "https://api.ransomware.live/recentvictims"
-        groups_url = "https://api.ransomware.live/groups"
+        url = "https://api.ransomware.live/v2/recentvictims"
+        groups_url = "https://api.ransomware.live/v2/groups"
         headers = {"accept": "application/json"}
 
         # fetching group information


### PR DESCRIPTION
### Proposed changes

* Update API connector to v2 --> https://api.ransomware.live/apidocs 
* Update API v2 field name (post_title --> victim, published --> attackdate, group_name --> group) 
* Update path for ransomnotes 
* Update contact_information url 

### Checklist

- [ x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments


