### PR TITLE
[Sekoia] Retrieve the list of entity sources

### DIFF
--- a/external-import/sekoia/README.md
+++ b/external-import/sekoia/README.md
@@ -29,6 +29,7 @@ connector-sekoia:
       - SEKOIA_COLLECTION=d6092c37-d8d7-45c3-8aff-c4dc26030608
       - SEKOIA_START_DATE=2022-01-01    # Optional, the date to start consuming data from. Maybe in the formats YYYY-MM-DD or YYYY-MM-DDT00:00:00
       - SEKOIA_CREATE_OBSERVABLES=true  # Create observables from indicators
+      - SEKOIA_IMPORT_SOURCE_LIST=false # Create the list of sources observed by Sekoia as label
     restart: always
     depends_on:
       - opencti
@@ -75,13 +76,13 @@ On this page, you can find the following information:
 2. Navigate the Sekoia Intelligence Feed
 Here are the elements of the Sekoia feed that can be found on OpenCTI after export:
 
-| **OpenCTI**   |	**Sekoia.io**  |
-|---------------|----------------|
-| Reports       | Threat-reports |
-| Observables   | Sightings      |
-| Malwares	    | Malwares       |
-| Intrusion Set	| Intrusion-sets |
-| Indicators	  | Indicators     |
+| **OpenCTI**    | 	**Sekoia.io** |
+|----------------|----------------|
+| Reports        | Threat-reports |
+| Observables    | Sightings      |
+| Malwares	      | Malwares       |
+| Intrusion Set	 | Intrusion-sets |
+| Indicators	    | Indicators     |
 
 ## Troubleshoot
 

--- a/external-import/sekoia/docker-compose.yml
+++ b/external-import/sekoia/docker-compose.yml
@@ -13,3 +13,4 @@ services:
       - SEKOIA_COLLECTION=d6092c37-d8d7-45c3-8aff-c4dc26030608
       - SEKOIA_START_DATE=2022-01-01    # Optional, the date to start consuming data from. Maybe in the formats YYYY-MM-DD or YYYY-MM-DDT00:00:00
       - SEKOIA_CREATE_OBSERVABLES=true  # Create observables from indicators
+      - SEKOIA_IMPORT_SOURCE_LIST=false # Create the list of sources observed by Sekoia as label

--- a/external-import/sekoia/src/config.yml.sample
+++ b/external-import/sekoia/src/config.yml.sample
@@ -16,3 +16,4 @@ sekoia:
   api_key: 'ChangeMe'
   start_date: '2022-01-01'  # Optional, the date to start consuming data from. Maybe in the formats YYYY-MM-DD or YYYY-MM-DDT00:00:00
   create_observables: true  # Create observables from indicators
+  import_source_list: false # Create the list of sources observed by Sekoia as label

--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -91,9 +91,7 @@ class Sekoia(object):
         cursor = state.get("last_cursor", self.generate_first_cursor())
         self.helper.log_info(f"Starting with {cursor}")
 
-        timestamp = int(time.time())
-        now = datetime.fromtimestamp(timestamp, timezone.utc)
-        friendly_name = "SEKOIA run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
+        friendly_name = "SEKOIA run @ " + datetime.now(timezone.utc).isoformat()
         try:
             work_id = self.helper.api.work.initiate_work(
                 self.helper.connect_id, friendly_name

--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -174,7 +174,7 @@ class Sekoia(object):
 
     def _run(self, cursor, work_id):
 
-        current_time = f"{datetime.now(timezone.utc).isoformat()}Z"
+        current_time = f"{datetime.now(timezone.utc).isoformat()}"
         current_cursor = base64.b64encode(current_time.encode("utf-8")).decode("utf-8")
 
         params = {"limit": self.limit, "cursor": cursor}

--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -554,8 +554,7 @@ class Sekoia(object):
             for source in self._retrieve_by_ids(
                 item.get("x_inthreat_sources_refs", []), self.get_object_url
             ):
-                label_name = "source:" + str(source["name"])
-                label_name = label_name.lower()
+                label_name = f'source:{source["name"]}'.lower()
                 if label_name not in self.all_labels:
                     self._create_custom_label(label_name, "#f8c167")
 

--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -11,8 +11,7 @@ from typing import Any, Dict, Iterable, List, Set
 import requests
 import yaml
 from dateutil.parser import ParserError, parse
-from pycti import (OpenCTIConnectorHelper, OpenCTIStix2Utils,
-                   get_config_variable)
+from pycti import OpenCTIConnectorHelper, OpenCTIStix2Utils, get_config_variable
 from requests import RequestException
 
 ## MODIFICATION BY CYRILYXE (OPENCTI 6.0.5, the 2022-08-12)

--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -172,7 +172,7 @@ class Sekoia(object):
         Yield successive n-sized chunks from items.
         """
         for i in range(0, len(items), chunk_size):
-            yield items[i: i + chunk_size]
+            yield items[i : i + chunk_size]
 
     def _run(self, cursor, work_id):
 
@@ -264,9 +264,9 @@ class Sekoia(object):
             "x_ic_impacted_sectors",
         ]
         return (
-                       (field.startswith("x_ic") or field.startswith("x_inthreat"))
-                       and (field.endswith("ref") or field.endswith("refs"))
-               ) or field in to_ignore
+            (field.startswith("x_ic") or field.startswith("x_inthreat"))
+            and (field.endswith("ref") or field.endswith("refs"))
+        ) or field in to_ignore
 
     def _retrieve_related_objects_and_relationships(self, indicators: List[Dict]):
         all_related_objects = []
@@ -311,9 +311,9 @@ class Sekoia(object):
     def _add_main_observable_type_to_indicators(items: List[Dict]):
         for item in items:
             if (
-                    item.get("type") == "indicator"
-                    and item.get("x_ic_observable_types") is not None
-                    and len(item.get("x_ic_observable_types")) > 0
+                item.get("type") == "indicator"
+                and item.get("x_ic_observable_types") is not None
+                and len(item.get("x_ic_observable_types")) > 0
             ):
                 stix_type = item.get("x_ic_observable_types")[0]
                 item["x_opencti_main_observable_type"] = (
@@ -321,7 +321,7 @@ class Sekoia(object):
                 )
 
     def _retrieve_references(
-            self, items: List[Dict], current_depth: int = 0
+        self, items: List[Dict], current_depth: int = 0
     ) -> List[Dict]:
         """
         Retrieve the references that appears in the given items.
@@ -385,8 +385,8 @@ class Sekoia(object):
         Whether or not the reference is a mapped one.
         """
         return (
-                ref in self._geography_mapping.values()
-                or ref in self._sectors_mapping.values()
+            ref in self._geography_mapping.values()
+            or ref in self._sectors_mapping.values()
         )
 
     def _update_mapped_refs(self, items: List[Dict]):
@@ -444,7 +444,7 @@ class Sekoia(object):
         Add item to the cache only if it is an identity or a marking definition
         """
         if item["id"].startswith("marking-definition--") or item["id"].startswith(
-                "identity--"
+            "identity--"
         ):
             if item["id"].startswith("marking-definition--"):
                 item.pop("object_marking_refs", None)
@@ -555,7 +555,9 @@ class Sekoia(object):
                 continue
 
             labels = []
-            sources = self._retrieve_by_ids(item.get("x_inthreat_sources_refs", []), self.get_object_url)
+            sources = self._retrieve_by_ids(
+                item.get("x_inthreat_sources_refs", []), self.get_object_url
+            )
             for source in sources:
                 label_name = "source:" + str(source["name"])
                 label_name = label_name.lower()

--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -557,20 +557,18 @@ class Sekoia(object):
             labels = []
             sources = self._retrieve_by_ids(item.get("x_inthreat_sources_refs", []), self.get_object_url)
             for source in sources:
-                label_name = "source:" + source["name"]
+                label_name = "source:" + str(source["name"])
+                label_name = label_name.lower()
                 if label_name not in self.all_labels:
                     self._create_custom_label(label_name, "#f8c167")
 
                 labels.append(label_name)
 
             if labels:
-                if item.get("custom_properties", []):
-                    if item["custom_properties"].get("x_opencti_labels", []):
-                        item["custom_properties"]["x_opencti_labels"].extend(labels)
-                    else:
-                        item["custom_properties"]["x_opencti_labels"] = labels
+                if item.get("x_opencti_labels", []):
+                    item["x_opencti_labels"].extend(labels)
                 else:
-                    item["custom_properties"] = {"x_opencti_labels": labels}
+                    item["x_opencti_labels"] = labels
             object_list.append(item)
 
         return object_list

--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -11,7 +11,8 @@ from typing import Any, Dict, Iterable, List, Set
 import requests
 import yaml
 from dateutil.parser import ParserError, parse
-from pycti import OpenCTIConnectorHelper, OpenCTIStix2Utils, get_config_variable
+from pycti import (OpenCTIConnectorHelper, OpenCTIStix2Utils,
+                   get_config_variable)
 from requests import RequestException
 
 ## MODIFICATION BY CYRILYXE (OPENCTI 6.0.5, the 2022-08-12)

--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -549,14 +549,11 @@ class Sekoia(object):
     def _add_sources_to_items(self, items: List[Dict]):
         object_list = []
         for item in items:
-            if not item.get("x_inthreat_sources_refs"):
-                continue
 
             labels = []
-            sources = self._retrieve_by_ids(
+            for source in self._retrieve_by_ids(
                 item.get("x_inthreat_sources_refs", []), self.get_object_url
-            )
-            for source in sources:
+            ):
                 label_name = "source:" + str(source["name"])
                 label_name = label_name.lower()
                 if label_name not in self.all_labels:


### PR DESCRIPTION
Sekoia provides a list of sources who have reported the information. The information is contained in a custom Sekoia field, named "x_inthreat_sources_refs".

The various sources would have to be imported into the platform. 

### Proposed changes

* Since STIX does not allow multiple “Author”, we record them in labels, e.g. “source:Name1”, “source:Name2”, ...

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3176

### Checklist

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality using different use cases
- [X] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality


