### PR TITLE
[CISA KEV] Fix for updating existing vulnerabilities

### DIFF
--- a/external-import/cisa-known-exploited-vulnerabilities/src/config.yml.sample
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/config.yml.sample
@@ -15,3 +15,4 @@ cisa:
   catalog_url: 'https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json'
   create_infrastructures: false
   tlp: 'TLP:CLEAR'
+  update_existing: true

--- a/external-import/cisa-known-exploited-vulnerabilities/src/main.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/main.py
@@ -156,7 +156,7 @@ class Cisa:
             description=f"{description}",
             created_by_ref=self.created_by_stix["id"],
             created=f"{created}",
-            confidence=80 if description is not None and len(description) > 0 else 50,
+            confidence=100 if description is not None and len(description) > 0 else 50,
             object_marking_refs=[f"{marking_id}"],
             custom_properties={"x_opencti_cisa_kev": True},
         )
@@ -320,6 +320,7 @@ class Cisa:
             self.helper.send_stix2_bundle(
                 serialized_bundle,
                 work_id=work_id,
+                update=True
             )
         except Exception as e:
             self.helper.log_error(f"Error while sending bundle: {e}")

--- a/external-import/cisa-known-exploited-vulnerabilities/src/main.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/main.py
@@ -61,7 +61,9 @@ class Cisa:
         self.cisa_interval = get_config_variable(
             "CISA_INTERVAL", ["cisa", "interval"], config, default=7
         )
-
+        self.update_exisiting = get_config_variable(
+            "CISA_UPDATE_EXISTING", ["cisa", "update_exisiting"], config, default=True
+        )
         self.created_by_stix = None
         self.tlp_marking = None
         self.org = "Cybersecurity and Infrastructure Security Agency"
@@ -318,9 +320,7 @@ class Cisa:
     def send_bundle(self, work_id: str, serialized_bundle: str) -> None:
         try:
             self.helper.send_stix2_bundle(
-                serialized_bundle,
-                work_id=work_id,
-                update=True
+                serialized_bundle, work_id=work_id, update=self.update_exisiting
             )
         except Exception as e:
             self.helper.log_error(f"Error while sending bundle: {e}")


### PR DESCRIPTION
80 and 100 are the same confidence level (1- Confirmed by other sources) but if the score is already at 100 the hardcoded 80 prevents the object being updated.

Passing the update=True is also required to update existing vulnerabilities, otherwise this connector has to create the vulnerability and won't update exisiting vulnerabilities.

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change the hardcoded 80 confidence value to 100 to ensure all existing entries can be updated.
* Added update=True so that exisiting vulnerabilities will be updated

### Related issues

* Issue: Fix for https://github.com/OpenCTI-Platform/connectors/issues/3315
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ x] I consider the submitted work as finished
- [ x] I tested the code for its functionality using different use cases
- [x ] I added/update the relevant documentation (either on github or on notion)
- [ x] Where necessary I refactored code to improve the overall quality

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
