### PR TITLE
Add montysecurity C2-Tracker connector

### DIFF
--- a/external-import/montysecurity-c2-tracker/Dockerfile
+++ b/external-import/montysecurity-c2-tracker/Dockerfile
@@ -5,8 +5,8 @@ COPY src /opt/opencti-c2-tracker
 WORKDIR /opt/opencti-c2-tracker
 
 RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
-RUN pip install --upgrade pip
-RUN pip install requests pycti
+RUN pip install requests==2.32.3
+RUN pip install pycti==6.3.13
 
 # Expose and run entrypoint
 COPY entrypoint.sh /

--- a/external-import/montysecurity-c2-tracker/Dockerfile
+++ b/external-import/montysecurity-c2-tracker/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-alpine
+ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
+
+COPY src /opt/opencti-c2-tracker
+WORKDIR /opt/opencti-c2-tracker
+
+RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+RUN pip install --upgrade pip
+RUN pip install requests pycti
+
+# Expose and run entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/montysecurity-c2-tracker/README.md
+++ b/external-import/montysecurity-c2-tracker/README.md
@@ -1,0 +1,20 @@
+# OpenCTI montysecurity C2-Tracker Connector
+
+The connector uses [C2-Tracker](https://github.com/montysecurity/C2-Tracker) from montysecurity to import the latest IOCs.
+
+The intel feed collects IOCs weekly and it tracks various C2s, malware, botnets, etc. If the OpenCTI instance also has the [MITRE Connector](https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/mitre) installed, the C2-Tracker connector will map IOCs to tools/malware from MITRE where applicable.
+
+The connector will automatically deleted old IOCs as they age out of the IOC feed.
+
+## Installation
+
+### Requirements
+
+- OpenCTI Platform >= 6.4.8
+
+### Configuration
+
+| Docker envvar | Mandatory | Description |
+| ------------- | --------- | ----------- |
+| `opencti_url` | Yes       | The URL of the OpenCTI platform.|
+| `opencti_c2tracker_token` | Yes | A valid arbitrary `UUIDv4` that must be unique for this connector. |

--- a/external-import/montysecurity-c2-tracker/docker-compose.yml
+++ b/external-import/montysecurity-c2-tracker/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  connector-c2tracker:
+    image: montysecurity/opencti-c2-tracker:latest
+    environment:
+      - OPENCTI_URL=http://opencti:8080
+      - OPENCTI_C2TRACKER_TOKEN=${OPENCTI_C2TRACKER_TOKEN}
+    restart: always

--- a/external-import/montysecurity-c2-tracker/entrypoint.sh
+++ b/external-import/montysecurity-c2-tracker/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd /opt/opencti-c2-tracker
+python connector.py

--- a/external-import/montysecurity-c2-tracker/src/connector.py
+++ b/external-import/montysecurity-c2-tracker/src/connector.py
@@ -7,12 +7,6 @@ from datetime import date
 from stix2 import TLP_WHITE
 from time import sleep
 
-api_url = os.getenv("OPENCTI_URL")
-api_token = os.getenv("OPENCTI_C2TRACKER_TOKEN")
-print(f"[+] API Token: {api_token}")
-print(f"[+] API URL: {api_url}")
-opencti_api_client = OpenCTIApiClient(api_url, api_token)
-
 def get_current_c2_tracker_ips():
     print("[+] Getting Current IOCs...")
     all_ips = set()
@@ -255,6 +249,12 @@ def create_relationships(indicators, tools):
                         opencti_api_client.stix_core_relationship.add_label(id=relationship["id"], label_id=label["id"])
 
 def main():
+    api_url = os.getenv("OPENCTI_URL")
+    api_token = os.getenv("OPENCTI_C2TRACKER_TOKEN")
+    print(f"[+] API Token: {api_token}")
+    print(f"[+] API URL: {api_url}")
+    global opencti_api_client
+    opencti_api_client = OpenCTIApiClient(api_url, api_token)
     current_c2_tracker_ips = get_current_c2_tracker_ips()
     current_opencti_c2_tracker_indicators = opencti_indicator_loop(current_c2_tracker_ips, delete_old_iocs=False)
     opencti_indicator_loop(current_c2_tracker_ips, delete_old_iocs=True)

--- a/external-import/montysecurity-c2-tracker/src/connector.py
+++ b/external-import/montysecurity-c2-tracker/src/connector.py
@@ -1,0 +1,280 @@
+import requests
+import re
+from time import sleep
+from pycti import OpenCTIApiClient
+import os
+from datetime import date
+from stix2 import TLP_WHITE
+from time import sleep
+
+api_url = os.getenv("OPENCTI_URL")
+api_token = os.getenv("OPENCTI_C2TRACKER_TOKEN")
+print(f"[+] API Token: {api_token}")
+print(f"[+] API URL: {api_url}")
+opencti_api_client = OpenCTIApiClient(api_url, api_token)
+
+def get_current_c2_tracker_ips():
+    print("[+] Getting Current IOCs...")
+    all_ips = set()
+    url = "https://github.com/montysecurity/C2-Tracker/tree/main/data"
+    request = requests.get(url)
+    tools = list(set(re.findall("\"[\w|\s|\d|\.]+IPs\.txt\"", request.text)))
+    i = 0
+    for tool in tools:
+        tools[i] = str(tool).strip('"')
+        i += 1
+    for tool in tools:
+        print(f"[+] Looking at {tool}")
+        url = str("https://raw.githubusercontent.com/montysecurity/C2-Tracker/main/data/" + str(tool).replace(" ", "%20"))
+        request = requests.get(url)
+        # Get IPs for C2
+        ips = str(request.text).split("\n")
+        # Remote empty newline
+        ips.pop()
+        for ip in ips:
+            all_ips.add(ip)
+    return all_ips
+
+def add_indicator(c2, ip):
+    print(f"[+] Adding {c2} indicator", ip)
+    date_now = str(date.today().strftime("%Y-%m-%dT%H:%M:%SZ"))
+    # Create the tag (if not exists)
+    label = opencti_api_client.label.create(
+        value="c2-tracker",
+        color="#ffa500",
+    )
+
+    # Get TLP Clear ID
+    TLP_WHITE_CTI = opencti_api_client.marking_definition.read(id=TLP_WHITE["id"])
+    
+    # Create indicator
+    indicator = opencti_api_client.indicator.create(
+        name=f"{c2} IP - {ip}",
+        description=f"This IP is was recently seen hosting {c2}",
+        pattern=f"[ipv4-addr:value = '{str(ip)}']",
+        pattern_type="stix",
+        x_opencti_main_observable_type="IPv4-Addr",
+        valid_from=date_now,
+        update=True,
+        confidence=100,
+        markingDefinitions=[TLP_WHITE_CTI["id"]]
+    )
+
+    # Add label to indicator
+    opencti_api_client.stix_domain_object.add_label(id=indicator["id"], label_id=label["id"])
+
+def update_opencti(current_opencti_c2_tracker_indicators):
+    # Create variable to hold all IPs
+    # will be used to compare against current IPs in OpenCTI
+    # Will delete any IPs in OpenCTI and not in the all_ips variable
+    url = "https://github.com/montysecurity/C2-Tracker/tree/main/data"
+    request = requests.get(url)
+    # Get all file names ending in " IPs.txt"
+    tools = list(set(re.findall("\"[\w|\s|\d|\.]+IPs\.txt\"", request.text)))
+    # Strip quotes
+    i = 0
+    for tool in tools:
+        tools[i] = str(tool).strip('"')
+        i += 1
+    for tool in tools:
+        url = str("https://raw.githubusercontent.com/montysecurity/C2-Tracker/main/data/" + str(tool).replace(" ", "%20"))
+        request = requests.get(url)
+        # Remove " IPs.txt"
+        tool = str(tool)[:-8]
+        # Get IPs for C2
+        ips = str(request.text).split("\n")
+        # Remote empty newline
+        ips.pop()
+        for ip in ips:
+            if ip not in current_opencti_c2_tracker_indicators:
+                add_indicator(tool, ip)
+                # use break for testing 1 IP of all tools
+                #break
+            elif ip in current_opencti_c2_tracker_indicators:
+                print("[+] Skipping upload of", ip, "as it is already in OpenCTI")
+
+def opencti_indicator_loop(current_c2_tracker_ips, delete_old_iocs):
+    print("[+] Deleting old indicators")
+    final_indicators = []
+    data = {"pagination": {"hasNextPage": True, "endCursor": None}}
+    while data["pagination"]["hasNextPage"]:
+        after = data["pagination"]["endCursor"]
+        if after:
+            print("Listing indicators after " + after)
+        data = opencti_api_client.indicator.list(
+            first=50,
+            after=after,
+            withPagination=True,
+            orderBy="created_at",
+            orderMode="asc",
+        )
+        final_indicators += data["entities"]
+
+    current_opencti_c2_tracker_indicators = set()
+    for indicator in final_indicators:
+        for i in range(int(len(indicator["objectLabel"]))):
+            if str(indicator["objectLabel"][i]["value"]) == "c2-tracker":
+                ioc = str(indicator["name"]).split(" - ")[1]
+                if delete_old_iocs:
+                    if ioc not in current_c2_tracker_ips:
+                        print(f"[+] Deleting {ioc}")
+                        opencti_api_client.stix_domain_object.delete(id=indicator["id"])
+                elif not delete_old_iocs:
+                    current_opencti_c2_tracker_indicators.add(ioc)
+    
+    return current_opencti_c2_tracker_indicators
+
+def check_mitre():
+    mitre = False
+    data = {"pagination": {"hasNextPage": True, "endCursor": None}}
+    while data["pagination"]["hasNextPage"] and mitre == False:
+        after = data["pagination"]["endCursor"]
+        if after:
+            print("Listing indicators after " + after)
+        data = opencti_api_client.malware.list(
+            first=50,
+            after=after,
+            withPagination=True,
+            orderBy="created_at",
+            orderMode="asc",
+        )
+        for malware in data["entities"]:
+            if str(malware["createdBy"]["name"]) == "The MITRE Corporation":
+                mitre = True
+                print("MITRE is enabled")
+                break
+    return mitre
+
+def get_current_indicators():
+    final_indicators = []
+    data = {"pagination": {"hasNextPage": True, "endCursor": None}}
+    while data["pagination"]["hasNextPage"]:
+        after = data["pagination"]["endCursor"]
+        if after:
+            print("Listing indicators after " + after)
+        data = opencti_api_client.indicator.list(
+            first=50,
+            after=after,
+            withPagination=True,
+            orderBy="created_at",
+            orderMode="asc",
+        )
+        final_indicators += data["entities"]
+
+    for indicator in final_indicators:
+        for i in range(int(len(indicator["objectLabel"]))):
+            if str(indicator["objectLabel"][i]["value"]) == "c2-tracker":
+                print(indicator["name"] + " --- " + indicator["id"])
+    return final_indicators
+
+def get_malware():
+    final_malware = []
+    data = {"pagination": {"hasNextPage": True, "endCursor": None}}
+    while data["pagination"]["hasNextPage"]:
+        after = data["pagination"]["endCursor"]
+        if after:
+            print("Listing indicators after " + after)
+        data = opencti_api_client.malware.list(
+            first=50,
+            after=after,
+            withPagination=True,
+            orderBy="created_at",
+            orderMode="asc",
+        )
+        final_malware += data["entities"]
+    
+    return final_malware
+
+def get_tools():
+    final_tools = []
+    data = {"pagination": {"hasNextPage": True, "endCursor": None}}
+    while data["pagination"]["hasNextPage"]:
+        after = data["pagination"]["endCursor"]
+        if after:
+            print("Listing indicators after " + after)
+        data = opencti_api_client.tool.list(
+            first=50,
+            after=after,
+            withPagination=True,
+            orderBy="created_at",
+            orderMode="asc",
+        )
+        final_tools += data["entities"]
+    
+    return final_tools
+
+def create_relationships(indicators, tools):
+    # Create the tag (if not exists)
+    label = opencti_api_client.label.create(
+        value="c2-tracker",
+        color="#ffa500",
+    )
+    TLP_WHITE_CTI = opencti_api_client.marking_definition.read(id=TLP_WHITE["id"])
+
+
+    mapping = {
+        # MITRE: C2Tracker
+        "Mythic": "Mythic C2 IP",
+        "Cobalt Strike": "Cobalt Strike C2 IP",
+        "NanoCore": "NanoCore RAT Trojan IP",
+        "njRAT": "njRAT Trojan IP",
+        "ShadowPad": "ShadowPad IP",
+        "DarkComet": "DarkComet Trojan IP",
+        "AsyncRAT": "AsyncRAT IP",
+        "Brute Ratel C4": "Brute Ratel C4 IP",
+        "Empire": "Empire C2 IP",
+        "Sliver": "Sliver C2 IP",
+        "Remcos": "Remcos Pro RAT Trojan IP"
+    }
+    indicator_tool_malware_names = set()
+    for i in indicators:
+        indicator_tool_malware_names.add(str(i["name"]).split(" - ")[0])
+
+    tool_names = set()
+    for t in tools:
+        tool_names.add(str(t["name"]))
+    
+    for i in indicators:
+        n = str(i["name"]).split(" - ")[0]
+        for m in mapping:
+            if mapping[m] == n:
+                for t in tools:
+                    if t["name"] == m:
+                        relationship = opencti_api_client.stix_core_relationship.create(
+                            fromType=str(i["entity_type"]),
+                            fromId=str(i["id"]),
+                            toType=str(t["entity_type"]),
+                            toId=str(t["id"]),
+                            relationship_type="indicates",
+                            first_seen=str(date.today().strftime("%Y-%m-%dT%H:%M:%SZ")),
+                            last_seen=str(date.today().strftime("%Y-%m-%dT%H:%M:%SZ")),
+                            description="This is a server hosting the tool",
+                            markingDefinitions=[TLP_WHITE_CTI["id"]]
+                        )
+                        # Add label to relationship
+                        opencti_api_client.stix_core_relationship.add_label(id=relationship["id"], label_id=label["id"])
+
+def main():
+    current_c2_tracker_ips = get_current_c2_tracker_ips()
+    current_opencti_c2_tracker_indicators = opencti_indicator_loop(current_c2_tracker_ips, delete_old_iocs=False)
+    opencti_indicator_loop(current_c2_tracker_ips, delete_old_iocs=True)
+    update_opencti(current_opencti_c2_tracker_indicators)
+    mitre = check_mitre()
+    if mitre:
+        indicators = get_current_indicators()
+        malware = get_malware()
+        tools = get_tools()
+        create_relationships(indicators, tools=malware)
+        create_relationships(indicators, tools)
+
+def loop():
+    try:
+        main()
+    except Exception as e:
+        print("[+] Main Loop Failed. Restarting in 10 seconds.")
+        print(e)
+        sleep(10)
+        loop()
+
+if __name__ == "__main__":
+    loop()

--- a/external-import/montysecurity-c2-tracker/src/purge.py
+++ b/external-import/montysecurity-c2-tracker/src/purge.py
@@ -1,0 +1,32 @@
+from pycti import OpenCTIApiClient
+import os
+
+api_url = os.getenv("OPENCTI_URL")
+api_token = os.getenv("OPENCTI_C2TRACKER_TOKEN")
+opencti_api_client = OpenCTIApiClient(api_url, api_token)
+
+def delete_current_indicators():
+    final_indicators = []
+    data = {"pagination": {"hasNextPage": True, "endCursor": None}}
+    while data["pagination"]["hasNextPage"]:
+        after = data["pagination"]["endCursor"]
+        if after:
+            print("Listing indicators after " + after)
+        data = opencti_api_client.indicator.list(
+            first=50,
+            after=after,
+            withPagination=True,
+            orderBy="created_at",
+            orderMode="asc",
+        )
+        final_indicators += data["entities"]
+
+    for indicator in final_indicators:
+        for i in range(int(len(indicator["objectLabel"]))):
+            if str(indicator["objectLabel"][i]["value"]) == "c2-tracker":
+                opencti_api_client.stix_domain_object.delete(id=indicator["id"])
+
+def main():
+    delete_current_indicators()
+
+main()


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add montysecurity c2-tracker external-import connector



### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality using different use cases
- [X] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

This commit contains a purge.py script that is not automatically used under any circumstance but may be useful to the operator in order to delete all IOCs from this IOC feed.

The Dockerfile uses harcoded values for they pycti and request library versions. The current version of pycti breaks a part of this connector so it has been backdated for the docker image.

The IOCs are pulled from https://github.com/montysecurity/C2-Tracker

Connector.py automatically prunes IOCs, uses labels to prevent interfering with other IOCs.

Contains functionality to link IOCs to entities created by the [MITRE Connector](https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/mitre). This functionality does not require extra setup by the operator. 

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
