### PR TITLE
Update sentinel-incidents docker-compose.yml

### DIFF
--- a/external-import/sentinel-incidents/docker-compose.yml
+++ b/external-import/sentinel-incidents/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "CONNECTOR_NAME=Microsoft Sentinel"
       - CONNECTOR_SCOPE=sentinel # MIME type or Stix Object - Not used
       - CONNECTOR_LOG_LEVEL=error
+      - CONNECTOR_DURATION_PERIOD=PT1H
+      
       # Connector's definition parameters OPTIONAL
       # - CONNECTOR_QUEUE_THRESHOLD=500 # Default 500Mo, Float accepted
       # - CONNECTOR_RUN_AND_TERMINATE=False # Default False, True run connector once


### PR DESCRIPTION
Update sentinel-incidents docker-compose.yml to include the mandatory "CONNECTOR_DURATION_PERIOD"
