### PR TITLE
[Zvelo] hot fix: connector stops working if processed data is invalid or incorrectly formatted

### DIFF
--- a/external-import/zvelo/src/zvelo_connector/converter_to_stix.py
+++ b/external-import/zvelo/src/zvelo_connector/converter_to_stix.py
@@ -1,8 +1,41 @@
+import functools
 import ipaddress
 
 import stix2
 from dateutil.parser import parse
 from pycti import Identity, Indicator, Malware, StixCoreRelationship
+from stix2.exceptions import InvalidValueError
+
+
+class ConverterError(Exception):
+    """
+    Custom exception class for handling known conversion errors.
+    """
+
+
+def known_converter_error(
+    func: callable[["ConverterToStix", ...], stix2.v21._STIXBase21]
+) -> callable[["ConverterToStix", ...], stix2.v21._STIXBase21]:
+    """
+    Decorator to catch known conversion errors and raise custom exception.
+    Args:
+        func: Function to decorate
+    Returns:
+        Decorated function
+    """
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return func(self, *args, **kwargs)
+        except InvalidValueError as error:
+            msg = (
+                f"Invalid value while converting to stix object. data: {args}, {kwargs}"
+            )
+            self.helper.connector_logger.error(msg)
+            raise ConverterError(msg) from error
+
+    return wrapper
 
 
 class ConverterToStix:
@@ -119,6 +152,7 @@ class ConverterToStix:
         )
         return stix_relationship
 
+    @known_converter_error
     def convert_threat_to_stix(self, data) -> list[stix2.v21._STIXBase21]:
         """
         Convert threat IOC into STIX entities (indicator and related observables)
@@ -260,6 +294,7 @@ class ConverterToStix:
 
         return bundle_objects
 
+    @known_converter_error
     def convert_phish_to_stix(self, data) -> list[stix2.v21._STIXBase21]:
         """
         Convert phish IOC into STIX entities (indicator and related observables)
@@ -325,6 +360,7 @@ class ConverterToStix:
 
         return bundle_objects
 
+    @known_converter_error
     def convert_malicious_to_stix(self, data) -> list[stix2.v21._STIXBase21]:
         """
         Convert malicious IOC into STIX entities (indicator and related observables)

--- a/external-import/zvelo/src/zvelo_connector/converter_to_stix.py
+++ b/external-import/zvelo/src/zvelo_connector/converter_to_stix.py
@@ -14,7 +14,7 @@ class ConverterError(Exception):
 
 
 def known_converter_error(
-    func: callable[["ConverterToStix", ...], stix2.v21._STIXBase21]
+    func: callable[["ConverterToStix", ...], stix2.v21._STIXBase21],
 ) -> callable[["ConverterToStix", ...], stix2.v21._STIXBase21]:
     """
     Decorator to catch known conversion errors and raise custom exception.


### PR DESCRIPTION

### Proposed changes

* Implement a dedicated error in converter use case
* Hadle error in application layer to skip invalid conversion

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3372

### Checklist


- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


### Further comments
A Data Validation error raised while acquiring the data should be preferred to this hot fix directly inside the use case layer.

Notion investigation page: https://www.notion.so/filigran/Zvelo-Connector-stops-working-if-data-is-invalid-or-incorrectly-formatted-1928fce17f2a808fa051edf1224659ee
