### PR TITLE
[Zvelo] Fix type error

### DIFF
--- a/external-import/zvelo/src/zvelo_connector/converter_to_stix.py
+++ b/external-import/zvelo/src/zvelo_connector/converter_to_stix.py
@@ -14,8 +14,8 @@ class ConverterError(Exception):
 
 
 def known_converter_error(
-    func: callable[["ConverterToStix", ...], stix2.v21._STIXBase21],
-) -> callable[["ConverterToStix", ...], stix2.v21._STIXBase21]:
+    func: callable([["ConverterToStix", ...], stix2.v21._STIXBase21]),
+) -> callable([["ConverterToStix", ...], stix2.v21._STIXBase21]):
     """
     Decorator to catch known conversion errors and raise custom exception.
     Args:

--- a/external-import/zvelo/src/zvelo_connector/converter_to_stix.py
+++ b/external-import/zvelo/src/zvelo_connector/converter_to_stix.py
@@ -1,5 +1,6 @@
 import functools
 import ipaddress
+from typing import Callable
 
 import stix2
 from dateutil.parser import parse
@@ -14,8 +15,8 @@ class ConverterError(Exception):
 
 
 def known_converter_error(
-    func: callable([["ConverterToStix", ...], stix2.v21._STIXBase21]),
-) -> callable([["ConverterToStix", ...], stix2.v21._STIXBase21]):
+    func: Callable[["ConverterToStix", ...], stix2.v21._STIXBase21],
+) -> Callable[["ConverterToStix", ...], stix2.v21._STIXBase21]:
     """
     Decorator to catch known conversion errors and raise custom exception.
     Args:


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix Type Error

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3409

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Error due to the typo between "c" and "C" leading to the use of `callable ` method rather than `Callable` type

```bash
def known_converter_error(
    func: Callable[["ConverterToStix", ...], stix2.v21._STIXBase21),
) -> Callable[["ConverterToStix", ...], stix2.v21._STIXBase21]:
```

Test by raising a ConverterError

![image](https://github.com/user-attachments/assets/ac57b8e6-f31a-46cf-8742-0c0db8cf74e2)


```{"timestamp": "2025-02-12T06:40:12.681908Z", "level": "ERROR", "name": "Zvelo CTI", "message": "[CONNECTOR] An error occurred while converting {'ip_info': [{'ip': '162.241.124.142'}], 'url': 'https://yaseui.net/Ik98ufh9FIV8FUV', 'discovered_date': '2025-02-12T05:54:58Z', 'brand': '1&1 ionos', 'confidence_level': 100, 'last_active_date': '2025-02-12T06:36:05.057148Z', 'status': 'active', 'last_verified_date': '2025-02-12T06:36:05.057148Z'} to stix, skipping entity.", "exc_info": "Traceback (most recent call last):\n  File \"C:\\Users\\helen\\IdeaProjects\\connectors\\external-import\\zvelo\\src\\zvelo_connector\\connector.py\", line 82, in _collect_intelligence\n    stix_objects.extend(converter_method(entity))\n                        ^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"C:\\Users\\helen\\IdeaProjects\\connectors\\external-import\\zvelo\\src\\zvelo_connector\\converter_to_stix.py\", line 30, in wrapper\n    return func(self, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"C:\\Users\\helen\\IdeaProjects\\connectors\\external-import\\zvelo\\src\\zvelo_connector\\converter_to_stix.py\", line 304, in convert_phish_to_stix\n    raise ConverterError(\"error\")\nzvelo_connector.converter_to_stix.ConverterError: error", "attributes": {"error": "error"}}```


![image](https://github.com/user-attachments/assets/388047d7-d4b5-47d0-86b0-a119b75a9a86)

In the exemple, it is well catched by decorator
