### PR TITLE
[Connectors] Fix valid_from date in some connectors + format files + correct relationships direction

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/builder.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/builder.py
@@ -33,7 +33,10 @@ from crowdstrike_feeds_services.utils import (
     create_vulnerability_external_references,
     timestamp_to_datetime,
 )
-from stix2 import Bundle, Identity
+from stix2 import (
+    Bundle,
+    Identity,
+)
 from stix2 import Indicator as STIXIndicator  # type: ignore
 from stix2 import (
     IntrusionSet,

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/builder.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/builder.py
@@ -33,10 +33,7 @@ from crowdstrike_feeds_services.utils import (
     create_vulnerability_external_references,
     timestamp_to_datetime,
 )
-from stix2 import (
-    Bundle,
-    Identity,
-)
+from stix2 import Bundle, Identity
 from stix2 import Indicator as STIXIndicator  # type: ignore
 from stix2 import (
     IntrusionSet,

--- a/external-import/group-ib/src/data_to_stix2.py
+++ b/external-import/group-ib/src/data_to_stix2.py
@@ -132,7 +132,7 @@ class BaseEntity(_CommonUtils):
         self.is_ioc = False
         self.description = ""
 
-        self.valid_from: datetime = datetime.now()
+        self.valid_from = None
         self.valid_until: datetime = datetime.now()
 
         # defined in self._setup

--- a/external-import/malpedia/src/malpedia_services/converter_to_stix.py
+++ b/external-import/malpedia/src/malpedia_services/converter_to_stix.py
@@ -127,7 +127,6 @@ class MalpediaConverter:
         :return: stix2.Indicator
         """
 
-        now = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
         return stix2.Indicator(
             id=Indicator.generate_id(prepared_data.name),
             name=prepared_data.name,
@@ -136,7 +135,6 @@ class MalpediaConverter:
             pattern_type=prepared_data.pattern_type,
             object_marking_refs=prepared_data.object_marking_refs,
             created_by_ref=self.malpedia_identity["id"],
-            valid_from=now,
             custom_properties={
                 "x_opencti_main_observable_type": "StixFile",
             },

--- a/external-import/malpedia/src/malpedia_services/converter_to_stix.py
+++ b/external-import/malpedia/src/malpedia_services/converter_to_stix.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import stix2
 from pycti import (
     Identity,

--- a/external-import/proofpoint-tap/tests/test_domain/test_use_cases/test_ingest_incident.py
+++ b/external-import/proofpoint-tap/tests/test_domain/test_use_cases/test_ingest_incident.py
@@ -6,11 +6,7 @@ from datetime import datetime, timezone
 from typing import Literal, Optional
 
 from proofpoint_tap.domain.use_cases.ingest_incident import IncidentProcessor
-from proofpoint_tap.ports.event import (
-    ClickEventPort,
-    EventThreatPort,
-    MessageEventPort,
-)
+from proofpoint_tap.ports.event import ClickEventPort, EventThreatPort, MessageEventPort
 from stix2.v21.base import _STIXBase21
 
 

--- a/external-import/recorded-future/src/rflib/rf_alerts.py
+++ b/external-import/recorded-future/src/rflib/rf_alerts.py
@@ -292,7 +292,7 @@ class RecordedFutureAlertConnector(threading.Thread):
                         },
                     )
                     stix_relationship = self._generate_stix_relationship(
-                        stix_incident.id, "related-to", stix_url.id
+                        stix_url.id, "related-to", stix_incident.id
                     )
                     bundle_objects.append(stix_url)
                     bundle_objects.append(stix_relationship)
@@ -306,7 +306,7 @@ class RecordedFutureAlertConnector(threading.Thread):
                         },
                     )
                     stix_relationship = self._generate_stix_relationship(
-                        stix_incident.id, "related-to", stix_ipv4address.id
+                        stix_ipv4address.id, "related-to", stix_incident.id
                     )
                     bundle_objects.append(stix_ipv4address)
                     bundle_objects.append(stix_relationship)
@@ -319,7 +319,7 @@ class RecordedFutureAlertConnector(threading.Thread):
                         },
                     )
                     stix_relationship = self._generate_stix_relationship(
-                        stix_incident.id, "related-to", stix_emailaddress.id
+                        stix_emailaddress.id, "related-to", stix_incident.id
                     )
                     bundle_objects.append(stix_emailaddress)
                     bundle_objects.append(stix_relationship)
@@ -332,7 +332,7 @@ class RecordedFutureAlertConnector(threading.Thread):
                         },
                     )
                     stix_relationship = self._generate_stix_relationship(
-                        stix_incident.id, "related-to", stix_domain.id
+                        stix_domain.id, "related-to", stix_incident.id
                     )
                     bundle_objects.append(stix_domain)
                     bundle_objects.append(stix_relationship)
@@ -426,7 +426,7 @@ class RecordedFutureAlertConnector(threading.Thread):
                     },
                 )
                 stix_relationship = self._generate_stix_relationship(
-                    stix_incident.id, "related-to", stix_text.id
+                    stix_text.id, "related-to", stix_incident.id
                 )
                 bundle_objects.append(stix_text)
                 bundle_objects.append(stix_relationship)
@@ -438,7 +438,7 @@ class RecordedFutureAlertConnector(threading.Thread):
                     },
                 )
                 stix_relationship = self._generate_stix_relationship(
-                    stix_incident.id, "related-to", stix_url_doc.id
+                    stix_url_doc.id, "related-to", stix_incident.id
                 )
                 bundle_objects.append(stix_url_doc)
                 bundle_objects.append(stix_relationship)
@@ -467,7 +467,7 @@ class RecordedFutureAlertConnector(threading.Thread):
                     },
                 )
                 stix_relationship = self._generate_stix_relationship(
-                    stix_incident.id, "related-to", stix_user.id
+                    stix_user.id, "related-to", stix_incident.id
                 )
                 bundle_objects.append(stix_user)
                 bundle_objects.append(stix_relationship)

--- a/external-import/recorded-future/src/rflib/rf_playbook_alerts.py
+++ b/external-import/recorded-future/src/rflib/rf_playbook_alerts.py
@@ -462,11 +462,11 @@ class RecordedFuturePlaybookAlertConnector(threading.Thread):
                         )
                         stix_relationship = stix2.Relationship(
                             id=StixCoreRelationship.generate_id(
-                                "related-to", stix_incident.id, stix_ipv4address.id
+                                "related-to", stix_ipv4address.id, stix_incident.id
                             ),
                             relationship_type="related-to",
-                            source_ref=stix_incident.id,
-                            target_ref=stix_ipv4address.id,
+                            source_ref=stix_ipv4address.id,
+                            target_ref=stix_incident.id,
                             created_by_ref=self.author["id"],
                             object_marking_refs=self.tlp,
                         )
@@ -567,11 +567,11 @@ class RecordedFuturePlaybookAlertConnector(threading.Thread):
         )
         stix_relationship = stix2.Relationship(
             id=StixCoreRelationship.generate_id(
-                "related-to", stix_incident.id, stix_url.id
+                "related-to", stix_url.id, stix_incident.id
             ),
             relationship_type="related-to",
-            source_ref=stix_incident.id,
-            target_ref=stix_url.id,
+            source_ref=stix_url.id,
+            target_ref=stix_incident.id,
             created_by_ref=self.author["id"],
             object_marking_refs=self.tlp,
         )
@@ -624,11 +624,11 @@ class RecordedFuturePlaybookAlertConnector(threading.Thread):
                 )
                 stix_relationship = stix2.Relationship(
                     id=StixCoreRelationship.generate_id(
-                        "related-to", stix_incident.id, stix_ipv4address.id
+                        "related-to", stix_ipv4address.id, stix_incident.id
                     ),
                     relationship_type="related-to",
-                    source_ref=stix_incident.id,
-                    target_ref=stix_ipv4address.id,
+                    source_ref=stix_ipv4address.id,
+                    target_ref=stix_incident.id,
                     created_by_ref=self.author["id"],
                     object_marking_refs=self.tlp,
                 )
@@ -658,11 +658,11 @@ class RecordedFuturePlaybookAlertConnector(threading.Thread):
                 )
                 stix_relationship = stix2.Relationship(
                     id=StixCoreRelationship.generate_id(
-                        "related-to", stix_incident.id, stix_domain.id
+                        "related-to", stix_domain.id, stix_incident.id
                     ),
                     relationship_type="related-to",
-                    source_ref=stix_incident.id,
-                    target_ref=stix_domain.id,
+                    source_ref=stix_domain.id,
+                    target_ref=stix_incident.id,
                     created_by_ref=self.author["id"],
                     object_marking_refs=self.tlp,
                 )

--- a/external-import/recorded-future/src/rflib/risk_list.py
+++ b/external-import/recorded-future/src/rflib/risk_list.py
@@ -51,7 +51,10 @@ class RiskList(threading.Thread):
                         )
                         continue
                 # Convert into stix object
-                indicator = risk_list_type["class"](row["Name"], key, tlp=self.tlp)
+                first_seen = row["FirstSeen"] if row["FirstSeen"] else None
+                indicator = risk_list_type["class"](
+                    row["Name"], key, tlp=self.tlp, first_seen=first_seen
+                )
 
                 rule_criticality_list = row["RuleCriticality"].strip("][").split(",")
                 risk_rules_list_str = row["RiskRules"].strip("][")

--- a/external-import/threatfox/src/main.py
+++ b/external-import/threatfox/src/main.py
@@ -480,7 +480,6 @@ class ThreatFox:
                 indicator_types=[indicator_type],
                 pattern_type="stix",
                 pattern=pattern_value,
-                valid_from=datetime.now(UTC),
                 labels=ioc.tags,
                 object_marking_refs=[stix2.TLP_WHITE],
                 created_by_ref=self.identity["standard_id"],

--- a/internal-enrichment/greynoise/src/main.py
+++ b/internal-enrichment/greynoise/src/main.py
@@ -655,8 +655,6 @@ class GreyNoiseConnector:
         :return: dict
         """
 
-        now = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
-
         # Generate Indicator
         stix_indicator = stix2.Indicator(
             id=Indicator.generate_id(data["ip"]),
@@ -665,7 +663,6 @@ class GreyNoiseConnector:
             pattern=f"[ipv4-addr:value = '{data['ip']}']",
             created_by_ref=self.greynoise_identity["id"],
             external_references=external_reference,
-            valid_from=now,
             custom_properties={
                 "pattern_type": "stix",
                 "x_opencti_score": self.default_score,

--- a/internal-enrichment/ipqs/src/ipqs/builder.py
+++ b/internal-enrichment/ipqs/src/ipqs/builder.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """IPQS builder module."""
 
-from datetime import datetime
-
 import pycti
 from pycti import OpenCTIConnectorHelper, StixCoreRelationship
 from stix2 import (

--- a/internal-enrichment/ipqs/src/ipqs/builder.py
+++ b/internal-enrichment/ipqs/src/ipqs/builder.py
@@ -122,7 +122,6 @@ class IPQSBuilder:
         pattern : str
             Stix pattern for the indicator.
         """
-        now_time = datetime.utcnow()
 
         # Create an Indicator if positive hits >= ip_indicator_create_positives specified in config
 
@@ -136,7 +135,6 @@ class IPQSBuilder:
             confidence=self.helper.connect_confidence_level,
             pattern=pattern,
             pattern_type="stix",
-            valid_from=self.helper.api.stix2.format_date(now_time),
             # valid_until=self.helper.api.stix2.format_date(valid_until),
             custom_properties={
                 "x_opencti_score": self.score,

--- a/internal-enrichment/malbeacon/src/malbeacon_converter.py
+++ b/internal-enrichment/malbeacon/src/malbeacon_converter.py
@@ -207,7 +207,6 @@ class MalbeaconConverter:
             name=value,
             description=description,
             pattern_type="stix",
-            valid_from=datetime.now(),
             pattern=self.create_indicator_pattern(value),
             created_by_ref=self.author["id"],
             external_references=self.external_reference,

--- a/internal-enrichment/malbeacon/src/malbeacon_converter.py
+++ b/internal-enrichment/malbeacon/src/malbeacon_converter.py
@@ -1,5 +1,4 @@
 import ipaddress
-from datetime import datetime
 
 import stix2
 import validators

--- a/internal-enrichment/recordedfuture-enrichment/src/rflib/rf_to_stix2.py
+++ b/internal-enrichment/recordedfuture-enrichment/src/rflib/rf_to_stix2.py
@@ -112,7 +112,6 @@ class Indicator(RFStixEntity):
             id=pycti.Indicator.generate_id(self._create_pattern()),
             name=self.name,
             pattern_type="stix",
-            valid_from=datetime.now(),
             pattern=self._create_pattern(),
             created_by_ref=self.author.id,
             custom_properties={"x_opencti_score": self.risk_score or None},
@@ -410,7 +409,6 @@ class DetectionRule(RFStixEntity):
             name=self.name,
             pattern_type=self.type,
             pattern=self.content,
-            valid_from=datetime.now(),
             created_by_ref=self.author.id,
         )
 

--- a/internal-enrichment/reversinglabs-malware-presence/src/main.py
+++ b/internal-enrichment/reversinglabs-malware-presence/src/main.py
@@ -131,7 +131,6 @@ class ReversingLabsConnector(InternalEnrichmentConnector):
         self, data, indicator_name, indicator_pattern, main_observable_type
     ):
         stix_indicator_with_relationship = []
-        now = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
         rl_threat_platform = data["rl_threat_platform"]
 
         # Create indicator
@@ -142,7 +141,6 @@ class ReversingLabsConnector(InternalEnrichmentConnector):
             labels=data["labels"],
             pattern=indicator_pattern,
             created_by_ref=self.reversinglabs_identity["standard_id"],
-            valid_from=now,
             object_marking_refs=[stix2.TLP_AMBER],
             custom_properties={
                 "pattern_type": "stix",

--- a/internal-enrichment/reversinglabs-spectra-analyze/src/main.py
+++ b/internal-enrichment/reversinglabs-spectra-analyze/src/main.py
@@ -544,7 +544,6 @@ class ReversingLabsSpectraAnalyzeConnector(InternalEnrichmentConnector):
         relationship,
     ):
         stix_indicator_with_relationship = []
-        now = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
         rl_threat_platform = results["platform"]
 
         # Create indicator
@@ -555,7 +554,6 @@ class ReversingLabsSpectraAnalyzeConnector(InternalEnrichmentConnector):
             labels=results["labels"],
             pattern=indicator_pattern,
             created_by_ref=self.reversinglabs_identity["standard_id"],
-            valid_from=now,
             object_marking_refs=[stix2.TLP_AMBER],
             custom_properties={
                 "pattern_type": "stix",
@@ -629,7 +627,6 @@ class ReversingLabsSpectraAnalyzeConnector(InternalEnrichmentConnector):
                 name=sha1,
                 description=description,
                 labels=labels,
-                valid_from=now,
                 pattern=f"[file:hashes. 'SHA-1' = '{sha1}']",
                 created_by_ref=self.reversinglabs_identity["standard_id"],
                 object_marking_refs=[stix2.TLP_AMBER],
@@ -648,7 +645,6 @@ class ReversingLabsSpectraAnalyzeConnector(InternalEnrichmentConnector):
                 name=download_url,
                 description=description,
                 labels=labels,
-                valid_from=now,
                 pattern=f"[url:value = '{download_url}']",
                 created_by_ref=self.reversinglabs_identity["standard_id"],
                 object_marking_refs=[stix2.TLP_AMBER],
@@ -853,7 +849,6 @@ class ReversingLabsSpectraAnalyzeConnector(InternalEnrichmentConnector):
                 name=one_domain.get("requested_domain"),
                 description="Created from Spectra Analyze Domain report.",
                 labels=labels,
-                valid_from=now,
                 pattern=f"[domain-name:value = '{one_domain.get('requested_domain')}']",
                 created_by_ref=self.reversinglabs_identity["standard_id"],
                 object_marking_refs=[stix2.TLP_AMBER],
@@ -990,7 +985,6 @@ class ReversingLabsSpectraAnalyzeConnector(InternalEnrichmentConnector):
                 name=one_url.get("requested_url"),
                 description="Created from Spectra Analyze URL report.",
                 labels=labels,
-                valid_from=now,
                 pattern=f"[url:value = '{one_url.get('requested_url')}']",
                 created_by_ref=self.reversinglabs_identity["standard_id"],
                 object_marking_refs=[stix2.TLP_AMBER],
@@ -1118,7 +1112,6 @@ class ReversingLabsSpectraAnalyzeConnector(InternalEnrichmentConnector):
             name=self.domain_sample,
             description="Created from Spectra Analyze Domain report.",
             labels=labels,
-            valid_from=now,
             pattern=f"[domain-name:value = '{self.domain_sample}']",
             created_by_ref=self.reversinglabs_identity["standard_id"],
             object_marking_refs=[stix2.TLP_AMBER],
@@ -1249,7 +1242,6 @@ class ReversingLabsSpectraAnalyzeConnector(InternalEnrichmentConnector):
             name=self.url_sample,
             description="Created from Spectra Analyze URL report.",
             labels=labels,
-            valid_from=now,
             pattern=f"[url:value = '{self.url_sample}']",
             created_by_ref=self.reversinglabs_identity["standard_id"],
             object_marking_refs=[stix2.TLP_AMBER],

--- a/internal-enrichment/reversinglabs-spectra-intel-submission/src/main.py
+++ b/internal-enrichment/reversinglabs-spectra-intel-submission/src/main.py
@@ -134,7 +134,6 @@ class ReversingLabsSpectraIntelConnector(InternalEnrichmentConnector):
         relationship,
     ):
         stix_indicator_with_relationship = []
-        now = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
         rl_threat_platform = results["platform"]
 
         # Create indicator
@@ -145,7 +144,6 @@ class ReversingLabsSpectraIntelConnector(InternalEnrichmentConnector):
             labels=results["labels"],
             pattern=indicator_pattern,
             created_by_ref=self.reversinglabs_identity["standard_id"],
-            valid_from=now,
             object_marking_refs=[stix2.TLP_AMBER],
             custom_properties={
                 "pattern_type": "stix",

--- a/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/converter_to_stix2.py
+++ b/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/converter_to_stix2.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import stix2
 from pycti import CustomObservableHostname, Identity, Indicator, StixCoreRelationship
 

--- a/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/converter_to_stix2.py
+++ b/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/converter_to_stix2.py
@@ -199,7 +199,6 @@ class UrlscanConverter:
         """
 
         stix_indicator_with_relationship = []
-        now = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
         x_opencti_type = stix_entity.get("x_opencti_type", None)
 
         if stix_entity["type"] == "url":
@@ -224,7 +223,6 @@ class UrlscanConverter:
             labels=labels,
             created_by_ref=self.identity["id"],
             external_references=external_reference,
-            valid_from=now,
             pattern_type="stix",
             custom_properties={
                 "x_opencti_main_observable_type": x_opencti_type,

--- a/internal-enrichment/virustotal/src/virustotal/builder.py
+++ b/internal-enrichment/virustotal/src/virustotal/builder.py
@@ -213,7 +213,6 @@ class VirusTotalBuilder:
                 confidence=self.helper.connect_confidence_level,
                 pattern=pattern,
                 pattern_type="stix",
-                valid_from=self.helper.api.stix2.format_date(now_time),
                 valid_until=self.helper.api.stix2.format_date(valid_until),
                 external_references=(
                     [self.external_reference]

--- a/internal-import-file/import-file-yara/src/import-file-yara.py
+++ b/internal-import-file/import-file-yara/src/import-file-yara.py
@@ -78,9 +78,6 @@ class ImportFileYARA:
             object_marking_refs=[],
             external_references=external_references,
             created=datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            valid_from=datetime.datetime.now(datetime.UTC).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            ),
             custom_properties={
                 "x_opencti_main_observable_type": "StixFile",
                 "x_opencti_score": 100,

--- a/stream/tanium/src/sightings.py
+++ b/stream/tanium/src/sightings.py
@@ -176,7 +176,7 @@ class TaniumSightings(threading.Thread):
                                 stix_relation_observable = stix2.Relationship(
                                     id=StixCoreRelationship.generate_id(
                                         "related-to",
-                                        entity["standard_i"],
+                                        entity["standard_id"],
                                         stix_incident.id,
                                     ),
                                     relationship_type="related-to",


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

The `valid_from` and `valid_until` fields generated in Python within some connectors logic are not predictive, contrary to the expectations of OpenCTI platform's mechanisms. These fields, like IDs, must always be predictive. Otherwise, it is preferable to leave them empty, allowing the platform to populate them with its algorithms and rules.

Currently, using now for these fields when no data is provided disrupts the decay logic and other business processes implemented within OpenCTI. Moreover, this approach is redundant, as the platform already defaults to now when the fields are left empty.

* Remove now date from `valid_from` attributes and replace by original and immutable date OR remove the field

### Other changes

* Fix format for Crowdsrtike IOC builder file
* Fix format for Proofpoint TAP
* Fix relationships: The relationship between observables and "threats" or "incidents" (threat actor, intrusion set, campaign, incident, etc.) should always be "Observable" => related-to => "Threat".

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3245
* https://github.com/OpenCTI-Platform/connectors/issues/3263

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
