### PR TITLE
[Taxii2] Handling Int in Config

### DIFF
--- a/external-import/taxii2/src/connector/connector.py
+++ b/external-import/taxii2/src/connector/connector.py
@@ -105,7 +105,7 @@ class Connector:
                 dt_format = dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
             if self.config.enable_url_query_limit and self.config.taxii2v21:
-                self.taxii2.filters["limit"] = self.config.url_query_limit
+                self.taxii2.filters["limit"] = int(self.config.url_query_limit)
             # Set added_after to either last run or initial history
             if current_state is not None and "last_run" in current_state:
                 self.taxii2.filters["added_after"] = dt_format

--- a/external-import/taxii2/src/connector/connector.py
+++ b/external-import/taxii2/src/connector/connector.py
@@ -111,7 +111,7 @@ class Connector:
                 self.taxii2.filters["added_after"] = dt_format
             else:
                 added_after = datetime.now() - timedelta(
-                    hours=self.config.initial_history
+                    hours=int(self.config.initial_history)
                 )
                 self.taxii2.filters["added_after"] = added_after
 

--- a/external-import/taxii2/src/connector/process_objects.py
+++ b/external-import/taxii2/src/connector/process_objects.py
@@ -126,13 +126,17 @@ class ProcessObjects:
                 if "x_opencti_score" not in obj:
                     for med_label in self.config.indicator_medium_score_labels:
                         if med_label.lower() in obj_labels_set:
-                            obj["x_opencti_score"] = int(self.config.indicator_medium_score)
+                            obj["x_opencti_score"] = int(
+                                self.config.indicator_medium_score
+                            )
                             break
                 # Low score labels (if neither high nor medium score assigned)
                 if "x_opencti_score" not in obj:
                     for low_label in self.config.indicator_low_score_labels:
                         if low_label.lower() in obj_labels_set:
-                            obj["x_opencti_score"] = int(self.config.indicator_low_score)
+                            obj["x_opencti_score"] = int(
+                                self.config.indicator_low_score
+                            )
                             break
                 # Default score if no match found
                 if "x_opencti_score" not in obj:

--- a/external-import/taxii2/src/connector/process_objects.py
+++ b/external-import/taxii2/src/connector/process_objects.py
@@ -120,23 +120,23 @@ class ProcessObjects:
                 # High score labels
                 for high_label in self.config.indicator_high_score_labels:
                     if high_label.lower() in obj_labels_set:
-                        obj["x_opencti_score"] = self.config.indicator_high_score
+                        obj["x_opencti_score"] = int(self.config.indicator_high_score)
                         break
                 # Medium score labels (if high score not already assigned)
                 if "x_opencti_score" not in obj:
                     for med_label in self.config.indicator_medium_score_labels:
                         if med_label.lower() in obj_labels_set:
-                            obj["x_opencti_score"] = self.config.indicator_medium_score
+                            obj["x_opencti_score"] = int(self.config.indicator_medium_score)
                             break
                 # Low score labels (if neither high nor medium score assigned)
                 if "x_opencti_score" not in obj:
                     for low_label in self.config.indicator_low_score_labels:
                         if low_label.lower() in obj_labels_set:
-                            obj["x_opencti_score"] = self.config.indicator_low_score
+                            obj["x_opencti_score"] = int(self.config.indicator_low_score)
                             break
                 # Default score if no match found
                 if "x_opencti_score" not in obj:
-                    obj["x_opencti_score"] = self.config.default_x_opencti_score
+                    obj["x_opencti_score"] = int(self.config.default_x_opencti_score)
         return stix_objects
 
     def set_indicator_as_detection(self, stix_objects: list) -> list:


### PR DESCRIPTION
### Proposed changes

* Defined variable type for integers which are pulled from config. In some customer environments these could be stored as strings, which will cause an error.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/9949
* https://github.com/OpenCTI-Platform/connectors/issues/3525

### Checklist



- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

