### PR TITLE
[vulncheck ] Use append for SCOPE_SOFTWARE in vulncheck (nistnvd2 source)

### DIFF
--- a/external-import/vulncheck/src/vclib/sources/nistnvd2.py
+++ b/external-import/vulncheck/src/vclib/sources/nistnvd2.py
@@ -111,7 +111,7 @@ def _extract_stix_from_nistnvd2(
                 cpe=cpe, converter_to_stix=converter_to_stix, logger=logger
             )
             if vuln is not None:
-                result.extend(
+                result.append(
                     _create_rel_has(
                         software=software,
                         vulnerability=vuln,


### PR DESCRIPTION
### Proposed changes

* Replace `extend()` with `append()` to correctly add the object without string iteration.


### Related issues

* This pull request fixes an issue in the vulncheck connector (nistnvd2 source) where the SCOPE_SOFTWARE data was not being handled correctly. The error occurred because extend was used to add a single relationship object, which caused Python to iterate over the object (string iteration). 
* https://github.com/OpenCTI-Platform/connectors/issues/3524