### PR TITLE
[malwarebazaar-recent-additions] Allow optional storage of malware samples

### DIFF
--- a/external-import/malwarebazaar-recent-additions/docker-compose.yml
+++ b/external-import/malwarebazaar-recent-additions/docker-compose.yml
@@ -7,11 +7,16 @@ services:
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
       - "CONNECTOR_NAME=MalwareBazaar Recent Additions"
+      - CONNECTOR_CONFIDENCE_LEVEL=40 # From 0 (Unknown) to 100 (Fully trusted); ENV or can be set in config.yml
+      - CONNECTOR_UPDATE_EXISTING_DATA=false # ENV or can be set in config.yml
+      - CONNECTOR_CREATE_INDICATOR=false # ENV or can be set in config.yml
       - CONNECTOR_LOG_LEVEL=error
+      - MALWAREBAZAAR_RECENT_ADDITIONS_USER_TOKEN=your-token-here # Free Auth-Key Required - https://bazaar.abuse.ch/api/#auth_key
       - MALWAREBAZAAR_RECENT_ADDITIONS_API_URL=https://mb-api.abuse.ch/api/v1/
       - MALWAREBAZAAR_RECENT_ADDITIONS_COOLDOWN_SECONDS=300 # Time to wait in seconds between subsequent requests
       - MALWAREBAZAAR_RECENT_ADDITIONS_INCLUDE_TAGS=exe,dll,docm,docx,doc,xls,xlsx,xlsm,js # (Optional) Only download files if any tag matches. (Comma separated)
       - MALWAREBAZAAR_RECENT_ADDITIONS_INCLUDE_REPORTERS= # (Optional) Only download files uploaded by these reporters. (Comma separated)
       - MALWAREBAZAAR_RECENT_ADDITIONS_LABELS=malware-bazaar # (Optional) Labels to apply to uploaded Artifacts. (Comma separated)
       - MALWAREBAZAAR_RECENT_ADDITIONS_LABELS_COLOR=#54483b # Color to use for labels
+      - MALWAREBAZAAR_RECENT_ADDITIONS_DISABLE_MALWARE_SAMPLE=true # If true, malware will be replaced with a benign Text file sample.
     restart: always

--- a/external-import/malwarebazaar-recent-additions/docker-compose.yml
+++ b/external-import/malwarebazaar-recent-additions/docker-compose.yml
@@ -15,8 +15,5 @@ services:
       - MALWAREBAZAAR_RECENT_ADDITIONS_INCLUDE_REPORTERS= # (Optional) Only download files uploaded by these reporters. (Comma separated)
       - MALWAREBAZAAR_RECENT_ADDITIONS_LABELS=malware-bazaar # (Optional) Labels to apply to uploaded Artifacts. (Comma separated)
       - MALWAREBAZAAR_RECENT_ADDITIONS_LABELS_COLOR=#54483b # Color to use for labels
-      - MALWAREBAZAAR_RECENT_ADDITIONS_SCORE=40 # From 0 (Unknown) to 100 (Fully trusted); ENV or can be set in config.yml
-      - MALWAREBAZAAR_RECENT_ADDITIONS_UPDATE_EXISTING_DATA=false # ENV or can be set in config.yml
-      - MALWAREBAZAAR_RECENT_ADDITIONS_CREATE_INDICATOR=false # ENV or can be set in config.yml
-      - MALWAREBAZAAR_RECENT_ADDITIONS_DISABLE_MALWARE_SAMPLE=true # If true, malware will be replaced with a benign Text file sample.
+      - MALWAREBAZAAR_RECENT_ADDITIONS_DISABLE_MALWARE_SAMPLE=false # If true, malware will be replaced with a benign Text file sample.
     restart: always

--- a/external-import/malwarebazaar-recent-additions/docker-compose.yml
+++ b/external-import/malwarebazaar-recent-additions/docker-compose.yml
@@ -7,9 +7,6 @@ services:
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
       - "CONNECTOR_NAME=MalwareBazaar Recent Additions"
-      - CONNECTOR_CONFIDENCE_LEVEL=40 # From 0 (Unknown) to 100 (Fully trusted); ENV or can be set in config.yml
-      - CONNECTOR_UPDATE_EXISTING_DATA=false # ENV or can be set in config.yml
-      - CONNECTOR_CREATE_INDICATOR=false # ENV or can be set in config.yml
       - CONNECTOR_LOG_LEVEL=error
       - MALWAREBAZAAR_RECENT_ADDITIONS_USER_TOKEN=your-token-here # Free Auth-Key Required - https://bazaar.abuse.ch/api/#auth_key
       - MALWAREBAZAAR_RECENT_ADDITIONS_API_URL=https://mb-api.abuse.ch/api/v1/
@@ -18,5 +15,8 @@ services:
       - MALWAREBAZAAR_RECENT_ADDITIONS_INCLUDE_REPORTERS= # (Optional) Only download files uploaded by these reporters. (Comma separated)
       - MALWAREBAZAAR_RECENT_ADDITIONS_LABELS=malware-bazaar # (Optional) Labels to apply to uploaded Artifacts. (Comma separated)
       - MALWAREBAZAAR_RECENT_ADDITIONS_LABELS_COLOR=#54483b # Color to use for labels
+      - MALWAREBAZAAR_RECENT_ADDITIONS_SCORE=40 # From 0 (Unknown) to 100 (Fully trusted); ENV or can be set in config.yml
+      - MALWAREBAZAAR_RECENT_ADDITIONS_UPDATE_EXISTING_DATA=false # ENV or can be set in config.yml
+      - MALWAREBAZAAR_RECENT_ADDITIONS_CREATE_INDICATOR=false # ENV or can be set in config.yml
       - MALWAREBAZAAR_RECENT_ADDITIONS_DISABLE_MALWARE_SAMPLE=true # If true, malware will be replaced with a benign Text file sample.
     restart: always

--- a/external-import/malwarebazaar-recent-additions/src/config.yml.sample
+++ b/external-import/malwarebazaar-recent-additions/src/config.yml.sample
@@ -16,7 +16,4 @@ malwarebazaar_recent_additions:
   include_reporters: '' # (Optional) Only download files uploaded by these reporters. (Comma separated)
   labels: 'malware-bazaar' # (Optional) Labels to apply to uploaded Artifacts. (Comma separated)
   labels_color: '#54483b' # Color to use for all labels
-  score: 40 # From 0 (Unknown) to 100 (Fully trusted)
-  create_indicator: false
-  update_existing_data: false
   disable_malware_sample: false # If true, malware will be replaced with a benign Text file sample.

--- a/external-import/malwarebazaar-recent-additions/src/config.yml.sample
+++ b/external-import/malwarebazaar-recent-additions/src/config.yml.sample
@@ -7,9 +7,6 @@ connector:
   type: 'EXTERNAL_IMPORT'
   name: 'MalwareBazaar Recent Additions'
   scope: 'malwarebazaar_recent_additions'
-  confidence_level: 40 # From 0 (Unknown) to 100 (Fully trusted)
-  create_indicator: false
-  update_existing_data: false
   log_level: 'info'
 
 malwarebazaar_recent_additions:
@@ -19,4 +16,7 @@ malwarebazaar_recent_additions:
   include_reporters: '' # (Optional) Only download files uploaded by these reporters. (Comma separated)
   labels: 'malware-bazaar' # (Optional) Labels to apply to uploaded Artifacts. (Comma separated)
   labels_color: '#54483b' # Color to use for all labels
+  score: 40 # From 0 (Unknown) to 100 (Fully trusted)
+  create_indicator: false
+  update_existing_data: false
   disable_malware_sample: false # If true, malware will be replaced with a benign Text file sample.

--- a/external-import/malwarebazaar-recent-additions/src/config.yml.sample
+++ b/external-import/malwarebazaar-recent-additions/src/config.yml.sample
@@ -8,7 +8,7 @@ connector:
   name: 'MalwareBazaar Recent Additions'
   scope: 'malwarebazaar_recent_additions'
   confidence_level: 40 # From 0 (Unknown) to 100 (Fully trusted)
-  create_indicator: False
+  create_indicator: false
   update_existing_data: false
   log_level: 'info'
 
@@ -19,3 +19,4 @@ malwarebazaar_recent_additions:
   include_reporters: '' # (Optional) Only download files uploaded by these reporters. (Comma separated)
   labels: 'malware-bazaar' # (Optional) Labels to apply to uploaded Artifacts. (Comma separated)
   labels_color: '#54483b' # Color to use for all labels
+  disable_malware_sample: false # If true, malware will be replaced with a benign Text file sample.

--- a/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
+++ b/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
@@ -64,12 +64,14 @@ class MalwareBazaarRecentAdditions:
             config,
         )
 
+        # Could be just: self.helper.opencti_url
         self.url_base = get_config_variable(
             "OPENCTI_URL",
             ["opencti", "url"],
             config,
         )
 
+        # Could be just: self.helper.opencti_token
         self.api_key_opencti = get_config_variable(
             "OPENCTI_TOKEN",
             ["opencti", "token"],
@@ -115,27 +117,6 @@ class MalwareBazaarRecentAdditions:
             config,
         )
         self.disable_malware_sample = bool(self.disable_malware_sample)
-
-        self.score = get_config_variable(
-            "MALWAREBAZAAR_RECENT_ADDITIONS_SCORE",
-            ["malwarebazaar_recent_additions", "score"],
-            config,
-        )
-        self.score = int(self.score)
-
-        self.create_indicator = get_config_variable(
-            "MALWAREBAZAAR_RECENT_ADDITIONS_CREATE_INDICATOR",
-            ["malwarebazaar_recent_additions", "create_indicator"],
-            config,
-        )
-        self.create_indicator = bool(self.create_indicator)
-
-        self.update_existing_data = get_config_variable(
-            "MALWAREBAZAAR_RECENT_ADDITIONS_UPDATE_EXISTING",
-            ["malwarebazaar_recent_additions", "update_existing_data"],
-            config,
-        )
-        self.update_existing_data = bool(self.update_existing_data)
 
     def run(self):
         """
@@ -197,8 +178,10 @@ class MalwareBazaarRecentAdditions:
                         # "disable_malware_sample" setting.
                         response = self.helper.api.stix_cyber_observable.create(
                             type="Artifact",
-                            update=self.update_existing_data,
-                            createIndicator=self.create_indicator,
+                            # Sending via Connector deprecated per OpenCTI 6.0+ - Enforced by OpenCTI Connector
+                            # User Settings
+                            # update=self.update_existing_data,
+                            # createIndicator=self.create_indicator,
                             x_opencti_additional_names=sha256,
                             objectMarking=stix2.TLP_WHITE["id"],
                             observableData={
@@ -211,7 +194,7 @@ class MalwareBazaarRecentAdditions:
                                     "sha-512": sha512,
                                     "md5": md5,
                                 },
-                                "x_opencti_score": self.score,
+                                # "x_opencti_score": self.helper.connect_confidence_level,
                                 "x_opencti_description": f"Uploaded to MalwareBazaar by Twitter user: {reporter}.",
                                 "payload_bin": base64.b64encode(file_contents),
                             },

--- a/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
+++ b/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
@@ -66,13 +66,13 @@ class MalwareBazaarRecentAdditions:
 
         self.url_base = get_config_variable(
             "OPENCTI_URL",
-            ["malwarebazaar_recent_additions", "opencti_url"],
+            ["opencti", "url"],
             config,
         )
 
         self.api_key_opencti = get_config_variable(
             "OPENCTI_TOKEN",
-            ["malwarebazaar_recent_additions", "opencti_token"],
+            ["opencti", "token"],
             config,
         )
 
@@ -458,6 +458,7 @@ class MalwareBazaarRecentAdditions:
             valid_from=valid_from,
             x_opencti_main_observable_type="Artifact",
             objectLabel=tags,
+            objectMarking=stix2.TLP_WHITE["id"],
         )
 
         indicator_id = None
@@ -480,6 +481,7 @@ class MalwareBazaarRecentAdditions:
             fromId=artifact_id,
             toType="Indicator",
             toId=indicator_id,
+            objectMarking=stix2.TLP_WHITE["id"],
             relationship_type="related-to",
             description="Relationship between artifact and indicator.",
             first_seen=datetime.datetime.now(datetime.timezone.utc)

--- a/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
+++ b/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
@@ -116,23 +116,23 @@ class MalwareBazaarRecentAdditions:
         )
         self.disable_malware_sample = bool(self.disable_malware_sample)
 
-        self.confidence_level = get_config_variable(
-            "CONNECTOR_CONFIDENCE_LEVEL",
-            ["connector", "confidence_level"],
+        self.score = get_config_variable(
+            "MALWAREBAZAAR_RECENT_ADDITIONS_SCORE",
+            ["malwarebazaar_recent_additions", "score"],
             config,
         )
-        self.confidence_level = int(self.confidence_level)
+        self.score = int(self.score)
 
         self.create_indicator = get_config_variable(
-            "CONNECTOR_CREATE_INDICATOR",
-            ["connector", "create_indicator"],
+            "MALWAREBAZAAR_RECENT_ADDITIONS_CREATE_INDICATOR",
+            ["malwarebazaar_recent_additions", "create_indicator"],
             config,
         )
         self.create_indicator = bool(self.create_indicator)
 
         self.update_existing_data = get_config_variable(
-            "CONNECTOR_UPDATE_EXISTING",
-            ["connector", "update_existing_data"],
+            "MALWAREBAZAAR_RECENT_ADDITIONS_UPDATE_EXISTING",
+            ["malwarebazaar_recent_additions", "update_existing_data"],
             config,
         )
         self.update_existing_data = bool(self.update_existing_data)
@@ -211,17 +211,20 @@ class MalwareBazaarRecentAdditions:
                                     "sha-512": sha512,
                                     "md5": md5,
                                 },
-                                "x_opencti_score": self.confidence_level,
+                                "x_opencti_score": self.score,
                                 "x_opencti_description": f"Uploaded to MalwareBazaar by Twitter user: {reporter}.",
                                 "payload_bin": base64.b64encode(file_contents),
                             },
                         )
-                    except:
+                    # W0703: Catching too general exception Exception (broad-except)
+                    except (
+                        Exception
+                    ) as nested_exception_local:  # pylint: disable=broad-except
                         self.helper.log_error(
-                            f"Error downloading and unzipping {sha256}."
+                            f"Error downloading and unzipping {sha256}. {nested_exception_local}"
                         )
                         continue
-                    
+
                     # Create external reference to MalwareBazaar report
                     external_reference = self.helper.api.external_reference.create(
                         source_name="MalwareBazaar Recent Additions",
@@ -301,7 +304,7 @@ class MalwareBazaarRecentAdditions:
                 "Key 'data' not found in the response from MalwareBazaar API."
             )
             return []
-        
+
     def download_unzip(self, sha256):
         """
         Download and unzip a sample from MalwareBazaar.
@@ -403,6 +406,9 @@ class MalwareBazaarRecentAdditions:
         return False
 
     def update_state(self):
+        """
+        Update connector cycle state
+        """
         timestamp = int(time.time())
         interval = self.cooldown_seconds
         new_state = {"last_run": timestamp}
@@ -454,14 +460,19 @@ class MalwareBazaarRecentAdditions:
             objectLabel=tags,
         )
 
+        indicator_id = None
         if indicator:
             self.helper.log_info(f"Indicator with {sha256} created in OpenCTI.")
             indicator_id = indicator["id"]
-            return indicator_id
         else:
             self.helper.log_error("Error creating indicator in OpenCTI.")
 
+        return indicator_id
+
     def relation_ship(self, url, token, artifact_id, indicator_id):
+        """
+        Create Artifact and Indicator Relationship
+        """
         api_client = OpenCTIApiClient(url, token)
 
         relation = api_client.stix_core_relationship.create(
@@ -480,7 +491,7 @@ class MalwareBazaarRecentAdditions:
         )
 
         if relation:
-            self.helper.log_info(f"Relation {relation["id"]} created in OpenCTI.")
+            self.helper.log_info(f"Relation {relation['id']} created in OpenCTI.")
         else:
             self.helper.log_info("Error creating relation in OpenCTI.")
 

--- a/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
+++ b/external-import/malwarebazaar-recent-additions/src/malwarebazaar-recent-additions.py
@@ -1,4 +1,13 @@
+"""
+MalwareBazaar is a platform from abuse.ch and Spamhaus, dedicated to sharing malware samples with the infosec
+community, antivirus vendors, and threat intelligence providers.
+
+This connector will communicate with the Malware Bazaar API and pull data into OpenCTI.
+"""
+
+import base64
 import datetime
+import hashlib
 import io
 import json
 import os
@@ -19,10 +28,13 @@ class MalwareBazaarRecentAdditions:
     """
 
     def __init__(self):
+        """
+        Init Malware Bazaar Connector
+        """
         # Instantiate the connector helper from config
         config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
         config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
+            yaml.load(open(config_file_path, encoding="utf-8"), Loader=yaml.FullLoader)
             if os.path.isfile(config_file_path)
             else {}
         )
@@ -97,7 +109,38 @@ class MalwareBazaarRecentAdditions:
                 if created_label is not None:
                     self.label_ids.append(created_label["id"])
 
+        self.disable_malware_sample = get_config_variable(
+            "MALWAREBAZAAR_RECENT_ADDITIONS_DISABLE_MALWARE_SAMPLE",
+            ["malwarebazaar_recent_additions", "disable_malware_sample"],
+            config,
+        )
+        self.disable_malware_sample = bool(self.disable_malware_sample)
+
+        self.confidence_level = get_config_variable(
+            "CONNECTOR_CONFIDENCE_LEVEL",
+            ["connector", "confidence_level"],
+            config,
+        )
+        self.confidence_level = int(self.confidence_level)
+
+        self.create_indicator = get_config_variable(
+            "CONNECTOR_CREATE_INDICATOR",
+            ["connector", "create_indicator"],
+            config,
+        )
+        self.create_indicator = bool(self.create_indicator)
+
+        self.update_existing_data = get_config_variable(
+            "CONNECTOR_UPDATE_EXISTING",
+            ["connector", "update_existing_data"],
+            config,
+        )
+        self.update_existing_data = bool(self.update_existing_data)
+
     def run(self):
+        """
+        Run Malware Bazaar connector in a loop
+        """
         self.helper.log_info("Starting MalwareBazaar Recent Additions Connector")
         while True:
             try:
@@ -106,6 +149,8 @@ class MalwareBazaarRecentAdditions:
                 for recent_additions_dict in recent_additions_list:
                     self.helper.log_info(f"Processing: {recent_additions_dict}")
                     sha256 = recent_additions_dict["sha256_hash"]
+                    sha1 = recent_additions_dict["sha1_hash"]
+                    md5 = recent_additions_dict["md5_hash"]
                     reporter = recent_additions_dict["reporter"]
                     file_name = recent_additions_dict["file_name"]
                     tags = (
@@ -138,20 +183,45 @@ class MalwareBazaarRecentAdditions:
 
                     # Download the artifact and unzip with default "infected" password
                     try:
-                        file_contents = self.download_unzip(sha256)
+                        # "sha512_computed" is based on the "real" malware sample regardless of the
+                        # "disable_malware_sample" setting.
+                        # "file_contents" will either be the "real" malware sample or a benign replacement based on the
+                        # "disable_malware_sample" setting.
+                        file_data = self.download_unzip(sha256)
+                        file_contents = file_data["file_contents"]
+                        sha512 = file_data["sha512_computed"]
+                        mime_type = file_data["mime_type"]
+
+                        # Using the Observable Create API to create an Artifact with the proper Hash values and
+                        # either the real malware sample or the replaced benign sample, based on the
+                        # "disable_malware_sample" setting.
+                        response = self.helper.api.stix_cyber_observable.create(
+                            type="Artifact",
+                            update=self.update_existing_data,
+                            createIndicator=self.create_indicator,
+                            x_opencti_additional_names=sha256,
+                            objectMarking=stix2.TLP_WHITE["id"],
+                            observableData={
+                                "type": "Artifact",
+                                "mime_type": mime_type,
+                                "x_opencti_additional_names": [file_name],
+                                "hashes": {
+                                    "sha-1": sha1,
+                                    "sha-256": sha256,
+                                    "sha-512": sha512,
+                                    "md5": md5,
+                                },
+                                "x_opencti_score": self.confidence_level,
+                                "x_opencti_description": f"Uploaded to MalwareBazaar by Twitter user: {reporter}.",
+                                "payload_bin": base64.b64encode(file_contents),
+                            },
+                        )
                     except:
                         self.helper.log_error(
                             f"Error downloading and unzipping {sha256}."
                         )
                         continue
-
-                    # Upload the artifact to OpenCTI
-                    response = self.upload_artifact_opencti(
-                        file_name,
-                        file_contents,
-                        f"Uploaded to MalwareBazaar by Twitter user: {reporter}.",
-                    )
-
+                    
                     # Create external reference to MalwareBazaar report
                     external_reference = self.helper.api.external_reference.create(
                         source_name="MalwareBazaar Recent Additions",
@@ -195,14 +265,18 @@ class MalwareBazaarRecentAdditions:
                 self.helper.log_info("Connector stop")
                 sys.exit(0)
 
-            except Exception as e:
-                self.helper.log_error(str(e))
+            # W0703: Catching too general exception Exception (broad-except)
+            except Exception as broad_exception_local:  # pylint: disable=broad-except
+                self.helper.log_error(str(broad_exception_local))
 
             if self.helper.connect_run_and_terminate:
                 self.helper.log_info("Connector stop")
                 self.helper.force_ping()
                 sys.exit(0)
 
+            self.helper.log_info(
+                f"Re-checking for new additions in {self.cooldown_seconds} seconds..."
+            )
             time.sleep(self.cooldown_seconds)
 
     def get_recent_additions(self):
@@ -219,9 +293,7 @@ class MalwareBazaarRecentAdditions:
         resp = requests.post(self.api_url, data=data)
 
         # Handle the response data
-
         recent_additions_list = resp.json()
-
         if "data" in recent_additions_list:
             return recent_additions_list["data"]
         else:
@@ -229,13 +301,88 @@ class MalwareBazaarRecentAdditions:
                 "Key 'data' not found in the response from MalwareBazaar API."
             )
             return []
+        
+    def download_unzip(self, sha256):
+        """
+        Download and unzip a sample from MalwareBazaar.
+
+        sha256: a str representing the sample's sha256.
+        returns: Dict containing:
+                                'file_contents': a bytes object containing the contents of the file
+                                'sha512_computed': sha512 computed value of real malware sample,
+                                'mime_type': mime_type for real malware sample
+
+        Rate Limited to restrict the number of file downloads on our file download API to 2,000 per IP address/day.
+        https://bazaar.abuse.ch/faq/#api-limit
+
+        """
+        # Generic bytes data replacement of malware controlled by disable_malware_sample config setting
+        data_string = "This would normally be Malware, but we have disabled the saving of the real malware."
+        # Store password in a variable
+        static_password = "infected"
+
+        #
+        # Process the Malware Sample like normal from the API. We need the file regardless of the disable_malware_sample
+        # in order to calculate the SHA512 value. The SHA512 is not provided via the API, but OpenCTI needs it.
+        # After calculation, if disable_malware_sample=true, then the file will be replaced with a benign sample, but
+        # keep the accurate SHA512
+        #
+        # Note: There is an API rate-limit set for download by Malware Bazaar
+        #       See the policy here - https://bazaar.abuse.ch/faq/#api-limit
+        #
+
+        data = {"query": "get_file", "sha256_hash": sha256}
+        resp = requests.post(self.api_url, data=data)
+        zip_contents = resp.content
+        zip_obj = io.BytesIO(zip_contents)
+        zip_file = pyzipper.AESZipFile(zip_obj)
+        zip_file.setpassword(
+            static_password.encode()
+        )  # stored in a variable above, as it it used multiple times.
+        file_name = zip_file.namelist()[0]
+        return_bytes = zip_file.read(file_name)
+        # Get known hash before it is possibly replaced with Generic Bytes Data string based on
+        # 'disable_malware_sample' settings
+        sha512_computed = hashlib.sha512(  # pylint: disable=unexpected-keyword-arg
+            return_bytes, usedforsecurity=False
+        ).hexdigest()
+        mime_type = magic.from_buffer(return_bytes, mime=True)
+
+        # Replace actual malware sample file with generic/benign text
+        if self.disable_malware_sample:
+            # Generic bytes data replacement of malware controlled by disable_malware_sample config setting
+            data_string = "This would normally be Malware, but you have disabled the saving of the real malware."
+            compression_method = pyzipper.ZIP_DEFLATED
+            zip_buffer = io.BytesIO()
+            with pyzipper.AESZipFile(
+                zip_buffer,
+                "w",
+                compression=compression_method,
+                encryption=pyzipper.WZ_AES,
+            ) as zf_tmp:
+                zf_tmp.setpassword(
+                    static_password.encode()
+                )  # stored in a variable above, as it it used multiple times.
+                zf_tmp.setencryption(pyzipper.WZ_AES, nbits=128)
+                zf_tmp.writestr(
+                    file_name, data_string.encode("utf-8")
+                )  # Encode string to bytes
+            zip_file_benign = pyzipper.AESZipFile(zip_buffer)
+            zip_file_benign.setpassword(static_password.encode())
+            return_bytes = zip_file_benign.read(file_name)
+
+        return {
+            "file_contents": return_bytes,
+            "sha512_computed": sha512_computed,
+            "mime_type": mime_type,
+        }
 
     def artifact_exists_opencti(self, sha256):
         """
         Determine whether or not an Artifact already exists in OpenCTI.
 
         sha256: a str representing the sha256 of the artifact's file contents
-        returns: a bool indicidating the aforementioned
+        returns: a bool indicating the aforementioned
         """
 
         custom_attributes = """
@@ -254,45 +401,6 @@ class MalwareBazaarRecentAdditions:
         if response:
             return True
         return False
-
-    def upload_artifact_opencti(self, file_name, file_contents, description):
-        """
-        Upload a file to OpenCTI.
-
-        file_name: a str representing the name of the file
-        file_contents: a bytes object representing the file contents
-        description: a str representing the description for the upload
-
-        returns: response of upload
-        """
-
-        mime_type = magic.from_buffer(file_contents, mime=True)
-
-        kwargs = {
-            "file_name": file_name,
-            "data": file_contents,
-            "mime_type": mime_type,
-            "x_opencti_description": description,
-            "objectMarking": stix2.TLP_WHITE["id"],
-        }
-
-        return self.helper.api.stix_cyber_observable.upload_artifact(**kwargs)
-
-    def download_unzip(self, sha256):
-        """
-        Download and unzip a sample from MalwareBazaar.
-
-        sha256: a str representing the sample's sha256.
-        returns: a bytes object containing the contents of the file
-        """
-        data = {"query": "get_file", "sha256_hash": sha256}
-        resp = requests.post(self.api_url, data=data)
-        zip_contents = resp.content
-        zip_obj = io.BytesIO(zip_contents)
-        zip_file = pyzipper.AESZipFile(zip_obj)
-        zip_file.setpassword(b"infected")
-        file_name = zip_file.namelist()[0]
-        return zip_file.read(file_name)
 
     def update_state(self):
         timestamp = int(time.time())
@@ -381,7 +489,8 @@ if __name__ == "__main__":
     try:
         malwarebazaar_recent_additions = MalwareBazaarRecentAdditions()
         malwarebazaar_recent_additions.run()
-    except Exception as e:
-        print(e)
+    # W0703: Catching too general exception Exception (broad-except)
+    except Exception as broad_exception:  # pylint: disable=broad-except
+        print(broad_exception)
         time.sleep(10)
         sys.exit(0)


### PR DESCRIPTION
### Proposed changes

The core intent of this update is to support the "optional" storage of the malware files related to the Malware Bazaar data fetches. Some users may not wish to "actually" store the "real" malware files on their system disk. This could be due to security requirements, or could be because they never use the actual file and it is needlessly increasing their S3/MinIO storage requirements. This update allows for access to the Artifact entries and metadata about the malware artifacts - but removes the storage of the "real" malware when enabled. The malware is replaced with a file that is 85 bytes in size and when downloaded within OpenCTI states:

_"This would normally be Malware, but we have disabled the saving of the real malware."_

Changes:

- Cleaned up code for autopep8/black/isort/pylint compliance.

- Removed references to `confidence_level`, `create_indicator`, and `update_existing_data` as these within the connector are `deprecated`. This data is now handled within the OpenCTI platform based on the Connector User/Group configuration.

- Added the following in the `docker-compose.yml` to show connector values could be in the `config.yml` or here and added the missing Auth-Key token reference that is required for the connector to function properly.
```
      - MALWAREBAZAAR_RECENT_ADDITIONS_USER_TOKEN=your-token-here # Free Auth-Key Required - https://bazaar.abuse.ch/api/#auth_key
``` 

- Added the new key **disable_malware_sample** to both `docker-compose.yml` and `config.yml.sample` in order to support NOT actually storing the real malware in S3/MinIO storage.

```
      - MALWAREBAZAAR_RECENT_ADDITIONS_DISABLE_MALWARE_SAMPLE=true # If true, malware will be replaced with a benign Text file sample.
```
```
  disable_malware_sample: false # If true, malware will be replaced with a benign Text file sample.
```

- Added code changes required to support this capability enhancement.


### Related issues

* None

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality using different use cases
     - [X] Tested connector with the **disable_malware_sample** set to **true**
     - [X] Tested connector with the **disable_malware_sample** set to **false**
- [X] I added/update the relevant documentation (within connector code)
- [X] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

N/A
