### PR TITLE
Correct crowdstrike taxonomy

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/actor/builder.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/actor/builder.py
@@ -33,14 +33,12 @@ class ActorBundleBuilder:
     """Actor bundle builder."""
 
     _CS_MOTIVATION_CRIMINAL = "Criminal"
-    _CS_MOTIVATION_DESTRUCTION = "Destruction"
-    _CS_MOTIVATION_ESPIONAGE = "Espionage"
-    _CS_MOTIVATION_HACKTIVIST = "Hacktivist"
+    _CS_MOTIVATION_HACKTIVIST = "Hacktivism"
+    _CS_MOTIVATION_STATE_SPONSORED = "State-Sponsored"
 
     _CS_MOTIVATION_TO_STIX_MOTIVATION = {
         _CS_MOTIVATION_CRIMINAL: "personal-gain",
-        _CS_MOTIVATION_DESTRUCTION: "dominance",
-        _CS_MOTIVATION_ESPIONAGE: "organizational-gain",
+        _CS_MOTIVATION_STATE_SPONSORED: "organizational-gain",
         _CS_MOTIVATION_HACKTIVIST: "ideology",
     }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Update CrowdStrike connector to use correct vocabulary mapping

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3531
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

I did a bulk scan of actors on the CrowdStrike API, looking for all iterations of motivation that may be returned. Almost all actors us State-Sponsored, Criminal, or Hacktivism (this also matches their web UI query fields). There seems to be some legacy entries using defacement, so I included it as well.
