### PR TITLE
[Tenable Vuln Management] fix: Connector config loader only works with config.yaml 

### DIFF
--- a/external-import/tenable-vuln-management/src/tenable_vuln_management/config_variables.py
+++ b/external-import/tenable-vuln-management/src/tenable_vuln_management/config_variables.py
@@ -13,7 +13,9 @@ class ConfigConnector:
 
         # Load configuration file
         self.load = self._load_config()
-        # Update connector type to "EXTERNAL_IMPORT"
+        # Update connector type to "EXTERNAL_IMPORT" if it exists else create it
+        if "connector" not in self.load:
+            self.load["connector"] = {}
         self.load["connector"]["type"] = "EXTERNAL_IMPORT"
         self._initialize_configurations()
 

--- a/external-import/tenable-vuln-management/src/tenable_vuln_management/config_variables.py
+++ b/external-import/tenable-vuln-management/src/tenable_vuln_management/config_variables.py
@@ -14,9 +14,7 @@ class ConfigConnector:
         # Load configuration file
         self.load = self._load_config()
         # Update connector type to "EXTERNAL_IMPORT" if it exists else create it
-        if "connector" not in self.load:
-            self.load["connector"] = {}
-        self.load["connector"]["type"] = "EXTERNAL_IMPORT"
+        self.load.setdefault("connector", {}).update({"type": "EXTERNAL_IMPORT"})
         self._initialize_configurations()
 
     @staticmethod


### PR DESCRIPTION
### Proposed changes

* Ensure connector key exists before setting connector.type variable

This fixes bug introduced with https://github.com/OpenCTI-Platform/connectors/pull/3463

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3518

### Checklist


- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases 
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Related Investigation Notion Page : https://www.notion.so/filigran/tenable-vuln-management-config-loader-is-broken-1ab8fce17f2a806a9c8ac535a350d39b?pvs=4
