### PR TITLE
[Tenable Vuln Management] fix: Unhandled CPE URI formats should be skipped

### DIFF
--- a/external-import/tenable-vuln-management/tests/test_converter_to_stix.py
+++ b/external-import/tenable-vuln-management/tests/test_converter_to_stix.py
@@ -442,6 +442,26 @@ def test_converter_to_stix_make_targeted_software_s(
     assert software.cpe == "cpe:/a:microsoft:sharepoint_server"
 
 
+def test_unhandled_cpe_uri_are_skipped(mock_helper, mock_config, fake_plugin):
+    # Test added in the same time than a fix for the issue
+    # https://github.com/OpenCTI-Platform/connectors/issues/3473
+    # Given a converter to stix instance
+    converter_to_stix = ConverterToStix(
+        helper=mock_helper, config=mock_config, default_marking="TLP:CLEAR"
+    )
+    # And a fake plugin with unhandled CPE URI
+    fake_plugin = fake_plugin.model_copy(
+        update={"cpe": ["p-cpe:/a:unhandled:unhandled"]}
+    )
+
+    # When calling _make_targeted_software_s
+    targeted_software = converter_to_stix._make_targeted_software_s(plugin=fake_plugin)
+
+    # Then the result should contain no software objects
+    assert len(targeted_software) == 0
+    # and nothing raised error...
+
+
 def test_converter_to_stix_make_vulnerabilities(mock_helper, mock_config, fake_plugin):
     # Given a converter to stix instance and a fake plugin instance
     converter_to_stix = ConverterToStix(


### PR DESCRIPTION
### Proposed changes

* Skip unhandled CPE URI formats with a warning log
* Add unit test relative to this issue

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3473?issue=OpenCTI-Platform%7Cconnectors%7C3543

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

https://www.notion.so/filigran/Tenable-Vuln-Management-Tenable-Breaking-API-Changes-1a48fce17f2a807e8275fd416f7df756?pvs=4#1ab8fce17f2a8004b488da72420fbae9
