### PR TITLE
[Tenable Vuln Management] fix: inconsistent pagination section presence in response api should be handled gracefully

### DIFF
--- a/external-import/tenable-vuln-management/src/tenable_vuln_management/client_api.py
+++ b/external-import/tenable-vuln-management/src/tenable_vuln_management/client_api.py
@@ -272,8 +272,16 @@ class ConnectorClient:
             ),
         )
         resp.raise_for_status()
-        content = resp.json()
-        pagination = content["pagination"]
+        content = dict(resp.json())
+        if "pagination" not in content.keys():
+            self.helper.connector_logger.warning(
+                "[API] Unexpected response format : pagination section not in response",
+                {"response": content},
+            )
+            pagination = None
+        else:
+            pagination = content.get("pagination", {})
+
         return content["findings"], (
             pagination.get("next") if pagination is not None else None
         )


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Modify code not to enforce pagination key presence in response.
* add a warning log indicating response format seems incoherent. 
* include response available keys in the warning log.


### Related issues

*  https://github.com/OpenCTI-Platform/connectors/issues/3544

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments
https://www.notion.so/filigran/Tenable-Vuln-Management-Tenable-Breaking-API-Changes-1a48fce17f2a807e8275fd416f7df756?pvs=4#1a48fce17f2a81a89dd9c6d4bd373a69
