### PR TITLE
[Tenable Vuln Management] fix: last_scan_target attribute inconsistent presence in API response should be handled gracefully

### DIFF
--- a/external-import/tenable-vuln-management/src/tenable_vuln_management/models/tenable.py
+++ b/external-import/tenable-vuln-management/src/tenable_vuln_management/models/tenable.py
@@ -287,7 +287,7 @@ class Asset(FrozenBaseModelWithWarnedExtra):
     )
     tracked: bool = Field(..., description="Indicates if the asset is being tracked.")
     last_scan_target: Optional[str] = Field(
-        ...,
+        None,
         description="The IP address or fully qualified domain name \
                                   (FQDN) of the asset targeted in the last scan.",
     )

--- a/external-import/tenable-vuln-management/src/tenable_vuln_management/models/tenable.py
+++ b/external-import/tenable-vuln-management/src/tenable_vuln_management/models/tenable.py
@@ -286,7 +286,7 @@ class Asset(FrozenBaseModelWithWarnedExtra):
         ..., description="The ID of the network the asset belongs to."
     )
     tracked: bool = Field(..., description="Indicates if the asset is being tracked.")
-    last_scan_target: str = Field(
+    last_scan_target: Optional[str] = Field(
         ...,
         description="The IP address or fully qualified domain name \
                                   (FQDN) of the asset targeted in the last scan.",


### PR DESCRIPTION
### Proposed changes

* Make last_target_scan field optional in tenable API response validator

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3473?issue=OpenCTI-Platform%7Cconnectors%7C3542

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

https://www.notion.so/filigran/Tenable-Vuln-Management-Tenable-Breaking-API-Changes-1a48fce17f2a807e8275fd416f7df756?pvs=4#1ab8fce17f2a8004b503fb022ed808db
