### PR TITLE
[Zscaler] Modified category blacklist

### DIFF
--- a/stream/zscaler/src/stream_connector/connector.py
+++ b/stream/zscaler/src/stream_connector/connector.py
@@ -209,7 +209,8 @@ class ZscalerConnector:
 
         if response and response.status_code == 200:
             data = response.json()
-            blocked_domains = data.get("dbCategorizedUrls", [])
+
+            blocked_domains = data.get("urls", [])
             return blocked_domains
         else:
             code = response.status_code if response else "No code"
@@ -256,9 +257,10 @@ class ZscalerConnector:
 
         if event_type == "create":
             base_url = f"https://zsapi.zscalertwo.net/api/v1/urlCategories/{self.zscaler_blacklist_name}?action=ADD_TO_LIST"
+            
             payload = {
                 "configuredName": self.zscaler_blacklist_name,
-                "dbCategorizedUrls": [domain],
+                "urls": [domain],
             }
         elif event_type == "delete":
             base_url = f"https://zsapi.zscalertwo.net/api/v1/urlCategories/{self.zscaler_blacklist_name}?action=REMOVE_FROM_LIST"

--- a/stream/zscaler/src/stream_connector/connector.py
+++ b/stream/zscaler/src/stream_connector/connector.py
@@ -257,7 +257,7 @@ class ZscalerConnector:
 
         if event_type == "create":
             base_url = f"https://zsapi.zscalertwo.net/api/v1/urlCategories/{self.zscaler_blacklist_name}?action=ADD_TO_LIST"
-            
+
             payload = {
                 "configuredName": self.zscaler_blacklist_name,
                 "urls": [domain],


### PR DESCRIPTION

### Proposed changes

I updated the script so that domains are added to **"Custom URLs"** instead of **"URLs retaining parent category"** in Zscaler. 

Specifically:

In get_**zscaler_blocked_domains**, the script now reads the blocked domain list from the **urls** field instead of **dbCategorizedUrls**.

In **send_to_zscaler**, both creation and deletion events use **"urls"** in the payload instead of **"dbCategorizedUrls"**.
These changes ensure that domains appear under **"Custom URLs"** within the chosen Zscaler category.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3690


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
