### PR TITLE
[microsoft-defender-incidents]: Errors when converting “IPEvidence” containing IPv6 addresses

### DIFF
--- a/external-import/microsoft-defender-incidents/src/microsoft_defender_incidents_connector/connector.py
+++ b/external-import/microsoft-defender-incidents/src/microsoft_defender_incidents_connector/connector.py
@@ -7,7 +7,7 @@ from pycti import OpenCTIConnectorHelper
 from .client_api import ConnectorClient
 from .config_variables import ConfigConnector
 from .converter_to_stix import ConverterToStix
-from .utils import find_matching_file_ids, format_date, detect_ip_version
+from .utils import detect_ip_version, find_matching_file_ids, format_date
 
 
 class MicrosoftDefenderIncidentsConnector:

--- a/external-import/microsoft-defender-incidents/src/microsoft_defender_incidents_connector/connector.py
+++ b/external-import/microsoft-defender-incidents/src/microsoft_defender_incidents_connector/connector.py
@@ -7,7 +7,7 @@ from pycti import OpenCTIConnectorHelper
 from .client_api import ConnectorClient
 from .config_variables import ConfigConnector
 from .converter_to_stix import ConverterToStix
-from .utils import find_matching_file_ids, format_date
+from .utils import find_matching_file_ids, format_date, detect_ip_version
 
 
 class MicrosoftDefenderIncidentsConnector:
@@ -156,8 +156,16 @@ class MicrosoftDefenderIncidentsConnector:
 
                     # ipEvidence
                     case "#microsoft.graph.security.ipEvidence":
+                        version = detect_ip_version(evidence.get("ipAddress"))
                         # Create Stix IPv4Address
-                        stix_ip = self.converter_to_stix.create_evidence_ipv4(evidence)
+                        if version == "ipv4":
+                            stix_ip = self.converter_to_stix.create_evidence_ipv4(
+                                evidence
+                            )
+                        else:
+                            stix_ip = self.converter_to_stix.create_evidence_ipv6(
+                                evidence
+                            )
                         if stix_ip:
                             stix_objects.append(stix_ip)
                             stix_relationship_ip = (

--- a/external-import/microsoft-defender-incidents/src/microsoft_defender_incidents_connector/utils.py
+++ b/external-import/microsoft-defender-incidents/src/microsoft_defender_incidents_connector/utils.py
@@ -1,6 +1,6 @@
-import ipaddress
-from datetime import datetime
 import re
+from datetime import datetime
+
 import stix2
 from dateutil.parser import parse
 

--- a/external-import/microsoft-defender-incidents/src/microsoft_defender_incidents_connector/utils.py
+++ b/external-import/microsoft-defender-incidents/src/microsoft_defender_incidents_connector/utils.py
@@ -1,6 +1,6 @@
 import ipaddress
 from datetime import datetime
-
+import re
 import stix2
 from dateutil.parser import parse
 
@@ -12,6 +12,20 @@ CASE_INCIDENT_PRIORITIES = {
     "high": "P1",
     "unknownFutureValue": "P3",
 }
+
+
+def detect_ip_version(value):
+    """
+    :param value:
+    :return:
+    """
+    if re.match(
+        r"^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}(\/([1-9]|[1-2]\d|3[0-2]))?$",
+        value,
+    ):
+        return "ipv4"
+    else:
+        return "ipv6"
 
 
 def format_datetime(date_str: str | None) -> str:
@@ -35,21 +49,12 @@ def format_datetime(date_str: str | None) -> str:
 
 
 def format_date(date: str) -> int:
+    """
+    :param date:
+    :return:
+    """
     incident_last_update_timestamp = parse(date).timestamp()
     return int(round(incident_last_update_timestamp))
-
-
-def is_ipv4(value: str) -> bool:
-    """
-    Determine whether the provided IP string is IPv4 or not
-    :param value: Value in string
-    :return: True is value is a valid IP address, otherwise False
-    """
-    try:
-        ipaddress.IPv4Address(value)
-        return True
-    except ipaddress.AddressValueError:
-        return False
 
 
 def find_matching_file_ids(malware_name: str, stix_objects: list) -> list | None:


### PR DESCRIPTION
### Proposed changes

* check IP value version
* add a check for System entity creation

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3556
* https://github.com/OpenCTI-Platform/connectors/issues/3539

### Checklist
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
