### PR TITLE
[MISP] Adds propagate labels from Event to Attribute option #3495

### DIFF
--- a/external-import/misp/README.md
+++ b/external-import/misp/README.md
@@ -48,6 +48,7 @@ If you are using it independently, remember that the connector will try to conne
 | `misp_import_to_ids_no_score`                 | `MISP_IMPORT_TO_IDS_NO_SCORE`                 | No           | A score (`Integer`) value for the indicator/observable if the attribute `to_ids` value is no.        |
 | `misp_import_unsupported_observables_as_text` | `MISP_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT` | No           | Import unsupported observable as x_opencti_text                                                      |
 | `misp_interval`                               | `MISP_INTERVAL`                               | Yes          | Check for new event to import every `n` minutes.                                                     |
+| `misp_propagate_labels`                       | `MISP_PROPAGATE_LABELS`               | No           | Apply labels from Misp EVENT to OpenCTI observables on top of MISP Attribute labels |
 
 ## Behavior
 

--- a/external-import/misp/docker-compose.yml
+++ b/external-import/misp/docker-compose.yml
@@ -43,4 +43,5 @@ services:
       - MISP_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT=false #  Optional, import unsupported observable as x_opencti_text
       - MISP_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT_TRANSPARENT=true #  Optional, import unsupported observable as x_opencti_text just with the value
       - MISP_INTERVAL=5 # Required, in minutes
+      - MISP_PROPAGATE_LABELS=false # Optional, propagate labels to the observables
     restart: always

--- a/external-import/misp/src/config.yml.sample
+++ b/external-import/misp/src/config.yml.sample
@@ -48,3 +48,4 @@ misp:
   import_unsupported_observables_as_text: false # Optional, import unsupported observable as x_opencti_text
   import_unsupported_observables_as_text_transparent: true # Optional, import unsupported observable as x_opencti_text just with the value
   interval: 5 # Required, in minutes
+  propagate_labels: false # Optional, propagate labels to the observables

--- a/external-import/misp/src/misp.py
+++ b/external-import/misp/src/misp.py
@@ -329,6 +329,13 @@ class Misp:
             "MISP_INTERVAL", ["misp", "interval"], config, isNumber=True
         )
 
+        self.misp_propagate_labels = get_config_variable(
+            "MISP_PROPAGATE_LABELS",
+            ["misp", "propagate_labels"],
+            config,
+            default=False,
+        )
+
         # Initialize MISP
         self.misp = PyMISP(
             url=self.misp_url,
@@ -1114,7 +1121,12 @@ class Misp:
                 attribute_markings = self.resolve_markings(
                     attribute["Tag"], with_default=False
                 )
-                attribute_tags = self.resolve_tags(attribute["Tag"])
+
+                if not self.misp_propagate_labels:
+                    attribute_tags = self.resolve_tags(attribute["Tag"])
+                else:
+                    attribute_tags.extend(self.resolve_tags(attribute["Tag"]))
+
                 if len(attribute_markings) == 0:
                     attribute_markings = event_markings
             else:


### PR DESCRIPTION
Currently the Attributes tags take precedence over the Events tags (if attribute has tags)

This commit allows for the option to allow the labels that are present on an Event (OpenCTI Reports) to apply on top of the labels set by the Attributes (Observables and/or Indicators). While not changing behaviour by introducting a setting that defaults to the previous behaviour.

### Proposed changes

* Add setting for this new feature with default of old behaviour
* Add the Event labels to the Attribute labels when setting is set to true, otherwise keep old behaviour

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3495

### Checklist

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality using different use cases
- [X] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

### Further comments

This would be my first PR to this project any guidance where needed is appreciated.