### PR TITLE
[ALL] - feat: add tools to ensure commits are signed and renovate pr-commit-config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,11 +23,13 @@ By doing this, you are actively helping us to improve the quality of the entire 
 -->
 
 - [ ] I consider the submitted work as finished
+- [ ] I have signed my commits using GPG key.
 - [ ] I tested the code for its functionality using different use cases
 - [ ] I added/update the relevant documentation (either on github or on notion)
 - [ ] Where necessary I refactored code to improve the overall quality
 
 <!-- For completed items, change [ ] to [x]. -->
+<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->
 
 ### Further comments
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
--   repo: https://github.com/psf/black
-    rev: 20.8b1
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 25.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/flake8
-    rev: 3.8.4
+    rev: 7.1.0
     hooks:
     -   id: flake8
         args: ['--ignore=E,W']
@@ -13,8 +13,8 @@ repos:
     hooks:
     -   id: check-yaml
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
     - id: isort
       name: isort (python)
-      arts: ['--profile black']
+      args: ['--profile black']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,11 @@ repos:
     - id: isort
       name: isort (python)
       args: ['--profile black']
+-   repo: local
+    hooks:
+    - id: gpg-signed-commit
+      name: GPG Signed Commit Check
+      entry: bash -c 'for commit_sha in $(git log --pretty=%h master..); do git verify-commit "$commit_sha" || echo "error unisgned commit $commit_sha" && exit 1; done'
+      language: system
+      stages: [pre-push, manual]
+      minimum_pre_commit_version: '3.2.0'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
     - id: gpg-signed-commit
       name: GPG Signed Commit Check
-      entry: bash -c 'for commit_sha in $(git log --pretty=%h master..); do git verify-commit "$commit_sha" || echo "error unisgned commit $commit_sha" && exit 1; done'
+      entry: bash -c 'for commit_sha in $(git log --pretty=%h master..); do git verify-commit "$commit_sha" || echo "error unsigned commit $commit_sha" && exit 1; done'
       language: system
       stages: [pre-push, manual]
       minimum_pre_commit_version: '3.2.0'

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "local>uis/devops/renovate-config:enablePreCommit"
   ],
   "labels": [
     "dependencies",


### PR DESCRIPTION
### Proposed changes

* Manually renovate pre-commit-config linters version
* Add pre-commit-config to renovate bot
* Add pre-push hook to check if commits are signed
* Alter PR Template to remind contributor to sign their commits

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3565
* https://github.com/OpenCTI-Platform/connectors/issues/3566

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


### How to test
```bash
# Setup
python -m pip install pre-commit
pre-commit install --hook-type pre-commit --hook-type pre-push

git checkout -b "test_branch"

touch test.py
echo "import os" > test.py

git add test.py

git commit -m "signed commit with flake8 error" -S

echo 'import os

_ = os.environ' > test.py

git add test.py

git commit -m "unsigned commit" --no-gpg-sign

git push -u origin test_branch

# clean up
git checkout master
git branch -D test_branch 
rm test.py
```
