### PR TITLE
[Ransomware.Live] Fix post_title variable in ransomwarelive

### DIFF
--- a/external-import/ransomwarelive/src/lib/ransom_conn.py
+++ b/external-import/ransomwarelive/src/lib/ransom_conn.py
@@ -397,7 +397,7 @@ class RansomwareAPIConnector:
         """Generates STIX objects from the ransomware.live API data"""
 
         # Creating Victim object
-        post_title = item.get("victims")
+        post_title = item.get("victim")
         victim_name, identity_class = (
             (post_title, "organization")
             if len(post_title) > 2


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix typo in `post_title` variable to be `victim` rather than `victims`. 

### Related issues

* #3513

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

The Ransomware.Live connector is currently failing because the v2 API uses `victim`, not the plural `victims`. This seemed to fix it on my instance. 