### PR TITLE
[RansomwareLive] Fix import victim key attribute

### DIFF
--- a/external-import/ransomwarelive/src/lib/ransom_conn.py
+++ b/external-import/ransomwarelive/src/lib/ransom_conn.py
@@ -397,7 +397,7 @@ class RansomwareAPIConnector:
         """Generates STIX objects from the ransomware.live API data"""
 
         # Creating Victim object
-        post_title = item.get("victims")
+        post_title = item.get("victim")
         victim_name, identity_class = (
             (post_title, "organization")
             if len(post_title) > 2


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix import victim key attribute

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3374

### Additional information

This following issue can be raised when the configuration variable `CONNECTOR_CREATE_THREAT_ACTOR` is not set to True

```{"timestamp": "2025-01-31T13:21:39.672778Z", "level": "ERROR", "name": "Ransomware Live", "message": "cannot access local variable 'relation_sec_TA' where it is not associated with a value", "exc_info": "Traceback (most recent call last):\n  File \"/opt/connector/lib/ransom_conn.py\", line 552, in stix_object_generator\n    bundle.append(relation_sec_TA)\n                  ^^^^^^^^^^^^^^^\nUnboundLocalError: cannot access local variable 'relation_sec_TA' where it is not associated with a value", "taskName": null}``` 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
