### PR TITLE
[PROOFPOINT TAP] doc: correct config variable names

### DIFF
--- a/external-import/proofpoint-tap/README.md
+++ b/external-import/proofpoint-tap/README.md
@@ -97,8 +97,8 @@ Below are the parameters you'll need to set for the connector:
 | Parameter                              | Docker environment variable       | Default | Mandatory | Description                                                                                     |
 |----------------------------------------|-----------------------------------|---------|-----------|-------------------------------------------------------------------------------------------------|
 | API base URL                           | `TAP_API_BASE_URL`                |         | Yes       | Base URL for Proofpoint TAP API                                                        |
-| API access key                         | `TAP_API_PRINCIPAL_KEY`           |         | Yes       | Access key for Proofpoint TAP  API                                                      |
-| API secret key                         | `TAP_API_SECRET_KEY`              |         | Yes       | Secret key for Proofpoint TAP  API                                                      |
+| API access key                         | `TAP_API_PRINCIPAL`               |         | Yes       | Access key for Proofpoint TAP API                                                       |
+| API secret key                         | `TAP_API_SECRET`                  |         | Yes       | Secret key for Proofpoint TAP API                                                       |
 | API timeout                            | `TAP_API_TIMEOUT`                 |         | Yes       | Timeout for API requests in ISO8601                                                          |
 | API backoff                            | `TAP_API_BACKOFF`                 |         | Yes       | Backoff time in ISO8601 for API retries                                                         |
 | API retries                            | `TAP_API_RETRIES`                 |         | Yes       | Number of retries for API requests                                                              |


### PR DESCRIPTION
### Proposed changes

* remove _KEY suffix for TAP_API_PRINCIPAL and TAP_API_SECRET in README.md file

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3594

### Checklist


- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

https://www.notion.so/filigran/Proofpoint-TAP-Env-variable-name-should-be-aligned-with-documentation-1b68fce17f2a80979c4feab938c0b23f?pvs=4
