### PR TITLE
[cve] fix: infinite loop when fetching all CVEs & reduce RAM consumption

### DIFF
--- a/external-import/cve/src/services/client/vulnerability.py
+++ b/external-import/cve/src/services/client/vulnerability.py
@@ -1,12 +1,14 @@
+from typing import Generator
+
 from .api import CVEClient
 
 
 class CVEVulnerability(CVEClient):
-    def get_vulnerabilities(self, cve_params=None) -> list:
+    def get_vulnerabilities(self, cve_params=None) -> Generator[list, None, None]:
         """
         Get and filter CVE with scoring system V3
         :param cve_params: Dict of params
-        :return: A list of dicts of CVE
+        :return: A generator for lists of dicts of CVE
         """
 
         cve_collection = self.get_complete_collection(cve_params)
@@ -20,12 +22,18 @@ class CVEVulnerability(CVEClient):
         cve_vulnerabilities_total = cve_collection["vulnerabilities"]
         total_items = cve_collection["totalResults"]
 
+        filtered_vulnerabilities = self._filter_cvss31(
+            cve_collection["vulnerabilities"]
+        )
+
         if page_size == 0:
             msg = "[API] No Vulnerabilities to retrieve..."
             self.helper.log_info(msg)
+            yield filtered_vulnerabilities
         elif page_size >= total_items:
             msg = f"[API] Received all {page_size} items. Pagination not required."
             self.helper.log_info(msg)
+            yield filtered_vulnerabilities
         else:
             msg = f"[API] Received first {page_size} items of {total_items} total items, start pagination..."
             self.helper.log_info(msg)
@@ -46,21 +54,26 @@ class CVEVulnerability(CVEClient):
                     )
 
                 page_size = cve_collection["resultsPerPage"]
+                total_items = cve_collection["totalResults"]
                 start_index += page_size
 
                 msg = f"[API] Received next {page_size} items, currently received {start_index} items of {total_items} total items."
                 self.helper.log_info(msg)
 
-                cve_vulnerabilities_total += cve_collection["vulnerabilities"]
+                filtered_vulnerabilities = self._filter_cvss31(
+                    cve_collection["vulnerabilities"]
+                )
+                yield filtered_vulnerabilities
 
         info_msg = (
             f"[API] All CVEs are retrieved. "
-            f"Getting {len(cve_vulnerabilities_total)} vulnerabilities in total"
+            f"Got {len(cve_vulnerabilities_total)} vulnerabilities in total"
         )
         self.helper.log_info(info_msg)
 
+    def _filter_cvss31(self, cve_vulnerabilities) -> list:
         cve_vulnerabilities_filtered = []
-        for cve_vulnerability in cve_vulnerabilities_total:
+        for cve_vulnerability in cve_vulnerabilities:
             metric_exist = cve_vulnerability["cve"]["metrics"]
             if metric_exist:
                 for key, value in metric_exist.items():
@@ -69,8 +82,7 @@ class CVEVulnerability(CVEClient):
 
         info_msg = (
             f"[API] Filter for only CVSS 3.1 CVEs. "
-            f"Getting {len(cve_vulnerabilities_filtered)} vulnerabilities in total"
+            f"Got {len(cve_vulnerabilities_filtered)} vulnerabilities in total"
         )
         self.helper.log_info(info_msg)
-
         return cve_vulnerabilities_filtered

--- a/external-import/cve/src/services/converter/vulnerabilityToStix2.py
+++ b/external-import/cve/src/services/converter/vulnerabilityToStix2.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Generator
 
 import stix2
 from pycti import Identity, StixCoreRelationship, Vulnerability  # type: ignore
@@ -25,95 +26,96 @@ class CVEConverter:
         :param work_id: work id in string
         :return:
         """
-        vulnerabilities_objects = self.vulnerabilities_to_stix2(cve_params)
+        vulnerability_object_generator = self.vulnerabilities_to_stix2(cve_params)
+        for vulnerabilities_objects in vulnerability_object_generator:
+            if len(vulnerabilities_objects) != 0:
+                vulnerabilities_objects.append(self.author)
+                vulnerabilities_bundle = self._to_stix_bundle(vulnerabilities_objects)
+                vulnerabilities_to_json = self._to_json_bundle(vulnerabilities_bundle)
 
-        if len(vulnerabilities_objects) != 0:
-            vulnerabilities_objects.append(self.author)
-            vulnerabilities_bundle = self._to_stix_bundle(vulnerabilities_objects)
-            vulnerabilities_to_json = self._to_json_bundle(vulnerabilities_bundle)
+                # Retrieve the author object for the info message
+                info_msg = (
+                    f"[CONVERTER] Sending bundle to server with {len(vulnerabilities_bundle)} objects, "
+                    f"concerning {len(vulnerabilities_objects) - 1} vulnerabilities"
+                )
+                self.helper.log_info(info_msg)
 
-            # Retrieve the author object for the info message
-            info_msg = (
-                f"[CONVERTER] Sending bundle to server with {len(vulnerabilities_bundle)} objects, "
-                f"concerning {len(vulnerabilities_objects) - 1} vulnerabilities"
-            )
-            self.helper.log_info(info_msg)
+                self.helper.send_stix2_bundle(
+                    vulnerabilities_to_json,
+                    work_id=work_id,
+                )
 
-            self.helper.send_stix2_bundle(
-                vulnerabilities_to_json,
-                work_id=work_id,
-            )
-        else:
-            pass
-
-    def vulnerabilities_to_stix2(self, cve_params: dict) -> list:
+    def vulnerabilities_to_stix2(self, cve_params: dict) -> Generator[list, None, None]:
         """
         Retrieve all CVEs from NVD to convert into STIX2 format
         :param cve_params: Dict of params
-        :return: List of data converted into STIX2
+        :return: Generator of lists of data converted into STIX2
         """
-        vulnerabilities = self.client_api.get_vulnerabilities(cve_params)
+        vulnerabilities_generator = self.client_api.get_vulnerabilities(cve_params)
 
-        vulnerabilities_to_stix2 = []
-
-        for vulnerability in vulnerabilities:
-            # Getting different fields
-            name = vulnerability["cve"]["id"]
-            description = vulnerability["cve"]["descriptions"][0]["value"]
-            created_date = datetime.datetime.strptime(
-                vulnerability["cve"]["published"], "%Y-%m-%dT%H:%M:%S.%f"
-            )
-            modified_date = datetime.datetime.strptime(
-                vulnerability["cve"]["lastModified"], "%Y-%m-%dT%H:%M:%S.%f"
-            )
-
-            # Create external references
-            external_reference = stix2.ExternalReference(
-                source_name="NIST NVD", url=f"https://nvd.nist.gov/vuln/detail/{name}"
-            )
-            external_references = [external_reference]
-
-            if "references" in vulnerability["cve"]:
-                for reference in vulnerability["cve"]["references"]:
-                    external_reference = stix2.ExternalReference(
-                        source_name=reference["source"], url=reference["url"]
-                    )
-                    external_references.append(external_reference)
-
-            # Getting metrics based on CVSS V3.1
-            cvss_metrics = vulnerability["cve"]["metrics"]["cvssMetricV31"][0][
-                "cvssData"
+        for vulnerabilities in vulnerabilities_generator:
+            vulnerabilities_stix2 = [
+                self._vulnerability_to_stix2(vulnerability)
+                for vulnerability in vulnerabilities
             ]
-            attack_vector = cvss_metrics["attackVector"]
-            availability_impact = cvss_metrics["availabilityImpact"]
-            base_score = cvss_metrics["baseScore"]
-            base_severity = cvss_metrics["baseSeverity"]
-            confidentiality_impact = cvss_metrics["confidentialityImpact"]
-            integrity_impact = cvss_metrics["integrityImpact"]
+            yield vulnerabilities_stix2
 
-            # Creating the vulnerability with the extracted fields
-            vulnerability_to_stix2 = stix2.Vulnerability(
-                id=Vulnerability.generate_id(name),
-                name=name,
-                created=created_date,
-                modified=modified_date,
-                description=description,
-                created_by_ref=self.author,
-                external_references=external_references,
-                custom_properties={
-                    "x_opencti_base_score": base_score,
-                    "x_opencti_base_severity": base_severity,
-                    "x_opencti_attack_vector": attack_vector,
-                    "x_opencti_integrity_impact": integrity_impact,
-                    "x_opencti_availability_impact": availability_impact,
-                    "x_opencti_confidentiality_impact": confidentiality_impact,
-                },
-            )
+    def _vulnerability_to_stix2(self, vulnerability) -> stix2.Vulnerability:
+        # Getting different fields
+        name = vulnerability["cve"]["id"]
+        description = vulnerability["cve"]["descriptions"][0]["value"]
+        created_date = datetime.datetime.strptime(
+            vulnerability["cve"]["published"], "%Y-%m-%dT%H:%M:%S.%f"
+        )
+        modified_date = datetime.datetime.strptime(
+            vulnerability["cve"]["lastModified"], "%Y-%m-%dT%H:%M:%S.%f"
+        )
 
-            # Adding the vulnerability to the list of vulnerabilities
-            vulnerabilities_to_stix2.append(vulnerability_to_stix2)
+        # Create external references
+        external_reference = stix2.ExternalReference(
+            source_name="NIST NVD", url=f"https://nvd.nist.gov/vuln/detail/{name}"
+        )
+        external_references = [external_reference]
 
-        return vulnerabilities_to_stix2
+        if "references" in vulnerability["cve"]:
+            for reference in vulnerability["cve"]["references"]:
+                external_reference = stix2.ExternalReference(
+                    source_name=reference["source"], url=reference["url"]
+                )
+                external_references.append(external_reference)
+
+        # Getting metrics based on CVSS V3.1
+        cvss_metrics = vulnerability["cve"]["metrics"]["cvssMetricV31"][0]["cvssData"]
+        attack_vector = cvss_metrics["attackVector"]
+        availability_impact = cvss_metrics["availabilityImpact"]
+        base_score = cvss_metrics["baseScore"]
+        base_severity = cvss_metrics["baseSeverity"]
+        confidentiality_impact = cvss_metrics["confidentialityImpact"]
+        integrity_impact = cvss_metrics["integrityImpact"]
+
+        # Creating the vulnerability with the extracted fields
+        vulnerability_to_stix2 = stix2.Vulnerability(
+            id=Vulnerability.generate_id(name),
+            name=name,
+            created=created_date,
+            modified=modified_date,
+            description=description,
+            created_by_ref=self.author,
+            confidence=(
+                100 if description is not None and len(description) > 0 else 60
+            ),
+            external_references=external_references,
+            custom_properties={
+                "x_opencti_base_score": base_score,
+                "x_opencti_base_severity": base_severity,
+                "x_opencti_attack_vector": attack_vector,
+                "x_opencti_integrity_impact": integrity_impact,
+                "x_opencti_availability_impact": availability_impact,
+                "x_opencti_confidentiality_impact": confidentiality_impact,
+            },
+        )
+
+        return vulnerability_to_stix2
 
     def _create_relationship(self, from_id: str, to_id: str, relation):
         """


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
* Fixed an infinite loop caused by the total number of CVEs changing while querying the NVD API.
* Reduced memory consumption of the connector when there are many CVE changes in the queried range.

### Related issues
- https://github.com/OpenCTI-Platform/connectors/issues/3971

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments
I faced a couple problems when using this connector and fetching the entire CVE history on first startup. When the connector queries for changes for the year 2024, it has to fetch 240k+ entries. This takes a while, and it failed for me in a couple of ways. 

The first issue was that if the total number of CVEs changes while querying the API, the connector will never finish the pagination loop, since it will never reach the number of total items fetched that was initially reported by the API. This was a simple single line fix [on line 57 of vulnerability.py](https://github.com/OpenCTI-Platform/connectors/pull/3629/files#diff-8bfca13aaa91b680ed8bf3386f39c48445372c6352131bd5424b3b5cd65af9afR57).

The second issue was that when it needs to query 240k+ CVEs, it required over 4GB of memory in our testing, which it does not need to do. I changed the behavior of the connector to push the CVE updates in chunks, rather than first gathering all of the CVEs into memory, and only then pushing them to the worker queue. In my version, the connector never exceeds 200MB of memory usage.


<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
