### PR TITLE
[Proofpoint TAP] fix: siem client should request a minimum 30 seconds interval duration

### DIFF
--- a/external-import/proofpoint-tap/proofpoint_tap/adapters/events.py
+++ b/external-import/proofpoint-tap/proofpoint_tap/adapters/events.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import timedelta
+from math import ceil
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generator, Literal, Optional
 
 from proofpoint_tap.client_api.v2.siem import (
@@ -323,7 +324,7 @@ class EventsAPIV2(EventsPort):
             >>> list(EventsAPIV2._chunk_30_minutes_intervals(start, stop))
 
         """
-        number_of_intervals = int((stop_time - start_time).total_seconds() / 1800) + 1
+        number_of_intervals = int(ceil((stop_time - start_time).total_seconds() / 1800))
         padded_start_time = stop_time - number_of_intervals * timedelta(minutes=30)
         for i in range(number_of_intervals):
             start = padded_start_time + timedelta(seconds=i * 1800)

--- a/external-import/proofpoint-tap/proofpoint_tap/adapters/events.py
+++ b/external-import/proofpoint-tap/proofpoint_tap/adapters/events.py
@@ -310,6 +310,13 @@ class EventsAPIV2(EventsPort):
     ) -> Generator[tuple["datetime", "datetime"], Any, Any]:
         """Chunk the interval into 30 minutes intervals.
 
+        Note: To prevent generating intervals that are too short (e.g., when a single short
+        interval is provided as input or when the difference between start and stop time
+        is just slightly above 30 minutes, such as 30 minutes and 1 second), we adjust the
+        start time to ensure an exact number of 30-minute chunks rather than simply trimming
+        the interval at stop_time. I.E. we prefer overlapping in the past rather than missing
+        an element close to the stop_time.
+
         Example:
             >>> start = datetime(2021,1,1,0,15,0)
             >>> stop = datetime(2021,1,1,3,11,0)
@@ -317,11 +324,11 @@ class EventsAPIV2(EventsPort):
 
         """
         number_of_intervals = int((stop_time - start_time).total_seconds() / 1800) + 1
+        padded_start_time = stop_time - number_of_intervals * timedelta(minutes=30)
         for i in range(number_of_intervals):
-            if start_time + timedelta(seconds=i * 1800) < stop_time:
-                start = start_time + timedelta(seconds=i * 1800)
-                stop = min(start_time + timedelta(seconds=(i + 1) * 1800), stop_time)
-                yield (start, stop)
+            start = padded_start_time + timedelta(seconds=i * 1800)
+            stop = min(padded_start_time + timedelta(seconds=(i + 1) * 1800), stop_time)
+            yield (start, stop)
 
     async def _fetch(
         self,

--- a/external-import/proofpoint-tap/proofpoint_tap/client_api/v2/siem.py
+++ b/external-import/proofpoint-tap/proofpoint_tap/client_api/v2/siem.py
@@ -397,7 +397,7 @@ class SIEMClient(BaseClient):
             raise ProofPointAPIRequestParamsError(
                 "The time range must be less than 1 hour."
             )
-        if (end_time - start_time) <= timedelta(seconds=30):
+        if (end_time - start_time) < timedelta(seconds=30):
             raise ProofPointAPIRequestParamsError(
                 "The time range must be at least 30 seconds."
             )

--- a/external-import/proofpoint-tap/proofpoint_tap/client_api/v2/siem.py
+++ b/external-import/proofpoint-tap/proofpoint_tap/client_api/v2/siem.py
@@ -397,6 +397,10 @@ class SIEMClient(BaseClient):
             raise ProofPointAPIRequestParamsError(
                 "The time range must be less than 1 hour."
             )
+        if (end_time - start_time) <= timedelta(seconds=30):
+            raise ProofPointAPIRequestParamsError(
+                "The time range must be at least 30 seconds."
+            )
 
         return f"{start_time.isoformat()}/{end_time.isoformat()}"
 

--- a/external-import/proofpoint-tap/tests/test_adapters/test_events.py
+++ b/external-import/proofpoint-tap/tests/test_adapters/test_events.py
@@ -1,0 +1,120 @@
+# isort:skip_file
+# pragma: no cover # do not include tests modules in coverage metrics
+"""Test the events adapters."""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from aiohttp import ClientResponse
+from pydantic import SecretStr
+from yarl import URL
+
+from proofpoint_tap.adapters.events import EventsAPIV2
+from proofpoint_tap.client_api.v2.siem import SIEMClient
+
+
+def make_fake_get_client_response() -> ClientResponse:
+    """Return a fake ClientResponse object."""
+    return ClientResponse(
+        method="GET",
+        url=URL("/dummy"),
+        writer=Mock(),
+        continue100=None,
+        timer=Mock(),
+        request_info=Mock(),
+        traces=[],
+        loop=Mock(),
+        session=Mock(),
+    )
+
+
+def mock_siem_v2_client_instance() -> SIEMClient:
+    """Return a mock Client instance."""
+    client = SIEMClient(
+        base_url=URL("http://example.com"),
+        principal=SecretStr("principal"),
+        secret=SecretStr("*****"),  # noqa: S106  # we indeed harcode a secret here...
+        timeout=timedelta(seconds=1),
+        retry=1,
+        backoff=timedelta(seconds=1),
+    )
+    # For safety, we deactivate _get method.
+    client._get = AsyncMock()
+    return client
+
+@pytest.fixture(scope="function")
+def siem_v2_client_instance():
+    """Return a mock Client instance."""
+    return mock_siem_v2_client_instance()
+
+def mock_events_api_v2_adapter():
+    """Return a mock Client instance."""
+    adapter =  EventsAPIV2(
+        base_url=URL("http://example.com"),
+        principal=SecretStr("principal"),
+        secret=SecretStr("*****"),  # noqa: S106  # we indeed harcode a secret here...
+        timeout=timedelta(seconds=1),
+        retry=1,
+        backoff=timedelta(seconds=1)
+    )
+    adapter._client = mock_siem_v2_client_instance()
+    return adapter
+
+@pytest.fixture(scope="function")
+def events_api_v2_adapter():
+    """Return a mock Client instance."""
+    return mock_events_api_v2_adapter()
+
+
+# test interval is splited correctly
+@pytest.mark.parametrize(
+    "start_time, stop_time",
+    [
+        pytest.param(
+            datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(1970, 1, 1, 0, 30, 0, tzinfo=timezone.utc),
+            id="prefered_duration",
+        ),
+        pytest.param(
+            datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(1970, 1, 1, 0, 15, 0, tzinfo=timezone.utc),
+            id="shorter_than_prefered_interval",
+        ),
+        pytest.param(
+            datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(1970, 1, 1, 1, 0, 0, tzinfo=timezone.utc),
+            id="2_times_prefered_duration",
+        ),
+        pytest.param(
+            datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(1970, 1, 1, 1, 15, 0, tzinfo=timezone.utc),
+            id="2.5_times_prefered_duration",
+        )
+    ]
+)
+def test_events_api_v2_splits_interval_correctly(start_time, stop_time):
+    """Test interval computation."""
+    # Given time range to split
+    # When splitting time into 30 minutes chunks
+    iterable = EventsAPIV2._chunk_30_minutes_intervals(
+        start_time=start_time,
+        stop_time=stop_time,
+    )
+    intervals = list(iterable)
+    # Then the correct intervals should be present
+    assert ( # noqa: S101
+        # start_time is contained in the first list item
+        # stop_time is contained in the last list item
+        # all intervals last the same amount of time
+        intervals[0][0] <= start_time <= intervals[0][1]
+    )
+    assert ( # noqa: S101
+        intervals[-1][0] <= stop_time <= intervals[-1][1]
+    )
+    duration_seconds = (intervals[0][1]-intervals[0][0]).total_seconds()
+    assert ( # noqa: S101
+        60 <= duration_seconds <= 3600
+    )
+    assert ( # noqa: S101
+        all((interval[1]-interval[0]).total_seconds()==duration_seconds for interval in intervals)
+    )

--- a/external-import/proofpoint-tap/tests/test_adapters/test_events.py
+++ b/external-import/proofpoint-tap/tests/test_adapters/test_events.py
@@ -42,23 +42,26 @@ def mock_siem_v2_client_instance() -> SIEMClient:
     client._get = AsyncMock()
     return client
 
+
 @pytest.fixture(scope="function")
 def siem_v2_client_instance():
     """Return a mock Client instance."""
     return mock_siem_v2_client_instance()
 
+
 def mock_events_api_v2_adapter():
     """Return a mock Client instance."""
-    adapter =  EventsAPIV2(
+    adapter = EventsAPIV2(
         base_url=URL("http://example.com"),
         principal=SecretStr("principal"),
         secret=SecretStr("*****"),  # noqa: S106  # we indeed harcode a secret here...
         timeout=timedelta(seconds=1),
         retry=1,
-        backoff=timedelta(seconds=1)
+        backoff=timedelta(seconds=1),
     )
     adapter._client = mock_siem_v2_client_instance()
     return adapter
+
 
 @pytest.fixture(scope="function")
 def events_api_v2_adapter():
@@ -89,8 +92,8 @@ def events_api_v2_adapter():
             datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
             datetime(1970, 1, 1, 1, 15, 0, tzinfo=timezone.utc),
             id="2.5_times_prefered_duration",
-        )
-    ]
+        ),
+    ],
 )
 def test_events_api_v2_splits_interval_correctly(start_time, stop_time):
     """Test interval computation."""
@@ -102,19 +105,18 @@ def test_events_api_v2_splits_interval_correctly(start_time, stop_time):
     )
     intervals = list(iterable)
     # Then the correct intervals should be present
-    assert ( # noqa: S101
+    assert (  # noqa: S101
         # start_time is contained in the first list item
         # stop_time is contained in the last list item
         # all intervals last the same amount of time
-        intervals[0][0] <= start_time <= intervals[0][1]
+        intervals[0][0]
+        <= start_time
+        <= intervals[0][1]
     )
-    assert ( # noqa: S101
-        intervals[-1][0] <= stop_time <= intervals[-1][1]
-    )
-    duration_seconds = (intervals[0][1]-intervals[0][0]).total_seconds()
-    assert ( # noqa: S101
-        60 <= duration_seconds <= 3600
-    )
-    assert ( # noqa: S101
-        all((interval[1]-interval[0]).total_seconds()==duration_seconds for interval in intervals)
+    assert intervals[-1][0] <= stop_time <= intervals[-1][1]  # noqa: S101
+    duration_seconds = (intervals[0][1] - intervals[0][0]).total_seconds()
+    assert 60 <= duration_seconds <= 3600  # noqa: S101
+    assert all(  # noqa: S101
+        (interval[1] - interval[0]).total_seconds() == duration_seconds
+        for interval in intervals
     )

--- a/external-import/proofpoint-tap/tests/test_client_api/test_v2/test_siem.py
+++ b/external-import/proofpoint-tap/tests/test_client_api/test_v2/test_siem.py
@@ -70,20 +70,24 @@ def mark_parametrize_all_public_methods(func: Callable[..., Any]) -> Callable[..
         ],
     )(func)
 
+
 # Test client interval computation
 def test_interval_formatting(client_instance: SIEMClient) -> None:
     """Test interval computation."""
     # Given a client instance
     # When calling the _format_interval_param method
-    yesterday_midnight = (datetime.now(timezone.utc) - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    yesterday_midnight = (datetime.now(timezone.utc) - timedelta(days=1)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
     yesterday_1_am = yesterday_midnight + timedelta(hours=1)
     res = client_instance._format_interval_param(
         start_time=yesterday_midnight,
         end_time=yesterday_1_am,
     )
     # Then the interval should be computed correctly
-    assert ( # noqa: S101 # We indeed call assert in unit tests.
-        res == f"{yesterday_midnight.year}-{yesterday_midnight.month:02d}-{yesterday_midnight.day:02d}T00:00:00+00:00/{yesterday_1_am.year}-{yesterday_1_am.month:02d}-{yesterday_1_am.day:02d}T01:00:00+00:00"
+    assert (  # noqa: S101 # We indeed call assert in unit tests.
+        res
+        == f"{yesterday_midnight.year}-{yesterday_midnight.month:02d}-{yesterday_midnight.day:02d}T00:00:00+00:00/{yesterday_1_am.year}-{yesterday_1_am.month:02d}-{yesterday_1_am.day:02d}T01:00:00+00:00"
     )
 
 

--- a/external-import/proofpoint-tap/tests/test_client_api/test_v2/test_siem.py
+++ b/external-import/proofpoint-tap/tests/test_client_api/test_v2/test_siem.py
@@ -70,6 +70,22 @@ def mark_parametrize_all_public_methods(func: Callable[..., Any]) -> Callable[..
         ],
     )(func)
 
+# Test client interval computation
+def test_interval_formatting(client_instance: SIEMClient) -> None:
+    """Test interval computation."""
+    # Given a client instance
+    # When calling the _format_interval_param method
+    yesterday_midnight = (datetime.now(timezone.utc) - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    yesterday_1_am = yesterday_midnight + timedelta(hours=1)
+    res = client_instance._format_interval_param(
+        start_time=yesterday_midnight,
+        end_time=yesterday_1_am,
+    )
+    # Then the interval should be computed correctly
+    assert ( # noqa: S101 # We indeed call assert in unit tests.
+        res == f"{yesterday_midnight.year}-{yesterday_midnight.month:02d}-{yesterday_midnight.day:02d}T00:00:00+00:00/{yesterday_1_am.year}-{yesterday_1_am.month:02d}-{yesterday_1_am.day:02d}T01:00:00+00:00"
+    )
+
 
 # Test request formatting
 @pytest.mark.asyncio
@@ -90,6 +106,11 @@ def mark_parametrize_all_public_methods(func: Callable[..., Any]) -> Callable[..
             datetime.now(timezone.utc) - timedelta(minutes=30),
             datetime.now(timezone.utc) + timedelta(minutes=10),
             id="interval in the future",
+        ),
+        pytest.param(
+            datetime.now(timezone.utc) - timedelta(minutes=10),
+            datetime.now(timezone.utc) - timedelta(minutes=10, seconds=1),
+            id="interval is too short",
         ),
     ],
 )


### PR DESCRIPTION
### Proposed changes

* rework chunking method to request v2/siem data

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3600

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

https://www.notion.so/filigran/Proofpoint-TAP-SIEM-client-should-request-a-minimum-30-seconds-interval-duration-1b28fce17f2a8012b2acd0d54a1520ab