### PR TITLE
[Templates] Isolate config & helper from the connector template

### DIFF
--- a/templates/external-import/src/external_import_connector/connector.py
+++ b/templates/external-import/src/external_import_connector/connector.py
@@ -44,14 +44,14 @@ class ConnectorTemplate:
 
     """
 
-    def __init__(self):
+    def __init__(self, config: ConfigConnector, helper: OpenCTIConnectorHelper):
         """
         Initialize the Connector with necessary configurations
         """
 
         # Load configuration file and connection helper
-        self.config = ConfigConnector()
-        self.helper = OpenCTIConnectorHelper(self.config.load)
+        self.config = config
+        self.helper = helper
         self.client = ConnectorClient(self.helper, self.config)
         self.converter_to_stix = ConverterToStix(self.helper, self.config)
 

--- a/templates/external-import/src/main.py
+++ b/templates/external-import/src/main.py
@@ -1,6 +1,8 @@
 import traceback
 
 from external_import_connector import ConnectorTemplate
+from external_import_connector.config_loader import ConfigConnector
+from pycti import OpenCTIConnectorHelper
 
 if __name__ == "__main__":
     """
@@ -13,7 +15,10 @@ if __name__ == "__main__":
     It signals to the operating system and any calling processes that the program did not complete successfully.
     """
     try:
-        connector = ConnectorTemplate()
+        config = ConfigConnector()
+        helper = OpenCTIConnectorHelper(config=config.load)
+
+        connector = ConnectorTemplate(config=config, helper=helper)
         connector.run()
     except Exception:
         traceback.print_exc()

--- a/templates/internal-enrichment/src/internal_enrichment_connector/connector.py
+++ b/templates/internal-enrichment/src/internal_enrichment_connector/connector.py
@@ -41,17 +41,14 @@ class ConnectorTemplate:
 
     """
 
-    def __init__(self):
+    def __init__(self, config: ConfigConnector, helper: OpenCTIConnectorHelper):
         """
         Initialize the Connector with necessary configurations
         """
 
         # Load configuration file and connection helper
-        self.config = ConfigConnector()
-        # playbook_compatible=True only if a bundle is sent !
-        self.helper = OpenCTIConnectorHelper(
-            config=self.config.load, playbook_compatible=True
-        )
+        self.config = config
+        self.helper = helper
         self.client = ConnectorClient(self.helper, self.config)
         self.converter_to_stix = ConverterToStix(self.helper)
 

--- a/templates/internal-enrichment/src/main.py
+++ b/templates/internal-enrichment/src/main.py
@@ -1,6 +1,8 @@
 import traceback
 
 from internal_enrichment_connector import ConnectorTemplate
+from internal_enrichment_connector.config_loader import ConfigConnector
+from pycti import OpenCTIConnectorHelper
 
 if __name__ == "__main__":
     """
@@ -13,7 +15,11 @@ if __name__ == "__main__":
     It signals to the operating system and any calling processes that the program did not complete successfully.
     """
     try:
-        connector = ConnectorTemplate()
+        config = ConfigConnector()
+        # playbook_compatible=True only if a bundle is sent !
+        helper = OpenCTIConnectorHelper(config=config.load, playbook_compatible=True)
+
+        connector = ConnectorTemplate(config=config, helper=helper)
         connector.run()
     except Exception:
         traceback.print_exc()

--- a/templates/internal-export-file/src/internal_export_file_connector/connector.py
+++ b/templates/internal-export-file/src/internal_export_file_connector/connector.py
@@ -34,14 +34,14 @@ class ConnectorTemplate:
 
     """
 
-    def __init__(self):
+    def __init__(self, config: ConfigConnector, helper: OpenCTIConnectorHelper):
         """
         Initialize the Connector with necessary configurations
         """
 
         # Load configuration file and connection helper
-        self.config = ConfigConnector()
-        self.helper = OpenCTIConnectorHelper(self.config.load)
+        self.config = config
+        self.helper = helper
 
     def process_message(self, data: dict) -> str:
         """

--- a/templates/internal-export-file/src/main.py
+++ b/templates/internal-export-file/src/main.py
@@ -1,6 +1,8 @@
 import traceback
 
 from internal_export_file_connector import ConnectorTemplate
+from internal_export_file_connector.config_loader import ConfigConnector
+from pycti import OpenCTIConnectorHelper
 
 if __name__ == "__main__":
     """
@@ -13,7 +15,10 @@ if __name__ == "__main__":
     It signals to the operating system and any calling processes that the program did not complete successfully.
     """
     try:
-        connector = ConnectorTemplate()
+        config = ConfigConnector()
+        helper = OpenCTIConnectorHelper(config=config.load)
+
+        connector = ConnectorTemplate(config=config, helper=helper)
         connector.run()
     except Exception:
         traceback.print_exc()

--- a/templates/internal-import-file/src/internal_import_file_connector/connector.py
+++ b/templates/internal-import-file/src/internal_import_file_connector/connector.py
@@ -34,14 +34,14 @@ class ConnectorTemplate:
 
     """
 
-    def __init__(self):
+    def __init__(self, config: ConfigConnector, helper: OpenCTIConnectorHelper):
         """
         Initialize the Connector with necessary configurations
         """
 
         # Load configuration file and connection helper
-        self.config = ConfigConnector()
-        self.helper = OpenCTIConnectorHelper(self.config.load)
+        self.config = config
+        self.helper = helper
 
     def process_message(self, data: dict) -> str:
         """

--- a/templates/internal-import-file/src/main.py
+++ b/templates/internal-import-file/src/main.py
@@ -1,6 +1,8 @@
 import traceback
 
 from internal_import_file_connector import ConnectorTemplate
+from internal_import_file_connector.config_loader import ConfigConnector
+from pycti import OpenCTIConnectorHelper
 
 if __name__ == "__main__":
     """
@@ -13,7 +15,10 @@ if __name__ == "__main__":
     It signals to the operating system and any calling processes that the program did not complete successfully.
     """
     try:
-        connector = ConnectorTemplate()
+        config = ConfigConnector()
+        helper = OpenCTIConnectorHelper(config=config.load)
+
+        connector = ConnectorTemplate(config=config, helper=helper)
         connector.run()
     except Exception:
         traceback.print_exc()

--- a/templates/stream/src/main.py
+++ b/templates/stream/src/main.py
@@ -1,6 +1,8 @@
 import traceback
 
+from pycti import OpenCTIConnectorHelper
 from stream_connector import ConnectorTemplate
+from stream_connector.config_loader import ConfigConnector
 
 if __name__ == "__main__":
     """
@@ -13,7 +15,10 @@ if __name__ == "__main__":
     It signals to the operating system and any calling processes that the program did not complete successfully.
     """
     try:
-        connector = ConnectorTemplate()
+        config = ConfigConnector()
+        helper = OpenCTIConnectorHelper(config=config.load)
+
+        connector = ConnectorTemplate(config=config, helper=helper)
         connector.run()
     except Exception:
         traceback.print_exc()

--- a/templates/stream/src/stream_connector/connector.py
+++ b/templates/stream/src/stream_connector/connector.py
@@ -32,14 +32,14 @@ class ConnectorTemplate:
 
     """
 
-    def __init__(self):
+    def __init__(self, config: ConfigConnector, helper: OpenCTIConnectorHelper):
         """
         Initialize the Connector with necessary configurations
         """
 
         # Load configuration file and connection helper
-        self.config = ConfigConnector()
-        self.helper = OpenCTIConnectorHelper(self.config.load)
+        self.config = config
+        self.helper = helper
 
     def check_stream_id(self) -> None:
         """


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Isolate the helper and config from the connector instance

### Related issues

- https://github.com/OpenCTI-Platform/connectors/issues/3635

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
