### PR TITLE
[Silobreaker] Improve error handling while fetching list

### DIFF
--- a/external-import/silobreaker/src/silobreaker.py
+++ b/external-import/silobreaker/src/silobreaker.py
@@ -160,8 +160,24 @@ class Silobreaker:
                 with urllib.request.urlopen(req) as response:
                     responseJson = response.read()
                 return json.loads(responseJson.decode("utf-8"))
-        except:
+        except urllib.request.HTTPError as err:
+            # In this specific case, get error from API response
+            error_metadata = {
+                "error_status_reason": err.reason,
+                "error_status": str(err.status),
+                "url": err.url,
+            }
+            self.helper.connector_logger.error(
+                "[API] An error occurred while trying to request the list",
+                error_metadata,
+            )
             return {}
+        except Exception as err:
+            error_metadata = {"error": err}
+            self.helper.connector_logger.error(
+                "[API] An error occurred while trying to request the list",
+                error_metadata,
+            )
 
     def _convert_to_markdown(self, content):
         text_maker = html2text.HTML2Text()


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  Improve error handling while fetching list to not send only empty dict when error occurs

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3642

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments
https://www.notion.so/filigran/Silobreaker-Strange-behavior-on-lists-filters-1ba8fce17f2a8085add4d24ae6693abd
