### PR TITLE
[Bambenek] fix: stix id should be determinist, correct observable type is Domain-Name, generated stix objects should be sent to the platform

### DIFF
--- a/external-import/bambenek/src/bambenek_connector/config_variables.py
+++ b/external-import/bambenek/src/bambenek_connector/config_variables.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
-from utils import SUPPORTED_COLLECTIONS
+from .utils import SUPPORTED_COLLECTIONS
 
 
 class ConfigConnector:

--- a/external-import/bambenek/src/bambenek_connector/config_variables.py
+++ b/external-import/bambenek/src/bambenek_connector/config_variables.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import yaml
 from pycti import OpenCTIConnectorHelper, get_config_variable
+
 from .utils import SUPPORTED_COLLECTIONS
 
 

--- a/external-import/bambenek/src/bambenek_connector/connector.py
+++ b/external-import/bambenek/src/bambenek_connector/connector.py
@@ -27,7 +27,6 @@ class ConnectorBambenek:
     def _collect_intelligence(self) -> list[stix2.v21._STIXBase21]:
         """
         Collect intelligence from Bambenek and convert into STIX object
-        :param from_date: Minimum Bambenek IOC creation date timestamp
         :return: List of STIX objects
         """
 

--- a/external-import/bambenek/src/bambenek_connector/converter_to_stix.py
+++ b/external-import/bambenek/src/bambenek_connector/converter_to_stix.py
@@ -2,6 +2,7 @@ from csv import DictReader
 from datetime import datetime, timezone
 from ipaddress import AddressValueError, ip_address
 
+import pycti
 from dateutil.parser import parse
 from pycti import StixCoreRelationship
 from stix2 import (
@@ -44,7 +45,7 @@ class ConverterToStix:
         :return: Author as STIX 2.1 Identity object
         """
         author = Identity(
-            id=Identity.generate_id(name="Bambenek", identity_class="organization"),
+            id=pycti.Identity.generate_id(name="Bambenek", identity_class="organization"),
             name="Bambenek",
             identity_class="organization",
         )
@@ -63,7 +64,7 @@ class ConverterToStix:
         Convenience method to return an indicator using common patterns from the Bambenek feeds
         """
         return Indicator(
-            id=Indicator.generate_id(pattern_value),
+            id=pycti.Indicator.generate_id(pattern_value),
             name=name,
             description="",
             created_by_ref=self.author["id"],
@@ -170,7 +171,7 @@ class ConverterToStix:
             stix_indicator = self._create_stix_indicator(
                 pattern_value=pattern_value,
                 name=entity.get("domain"),
-                observable_type="Domain",
+                observable_type="Domain-Name",
                 labels=[cleaned_tag, collection],
                 valid_from=parse(
                     entity.get("fetch_date", datetime.now(timezone.utc).isoformat())
@@ -185,7 +186,7 @@ class ConverterToStix:
             bundle_objects.append(stix_indicator)
             bundle_objects.append(stix_observable)
             bundle_objects.append(stix_relationship)
-            stix_objects.append(bundle_objects)
+            stix_objects.extend(bundle_objects)
         return stix_objects
 
     def convert_ip_ioc_to_stix(self, entities, collection):
@@ -228,5 +229,5 @@ class ConverterToStix:
             bundle_objects.append(stix_indicator)
             bundle_objects.append(stix_observable)
             bundle_objects.append(stix_relationship)
-            stix_objects.append(bundle_objects)
+            stix_objects.extend(bundle_objects)
         return stix_objects

--- a/external-import/bambenek/src/bambenek_connector/converter_to_stix.py
+++ b/external-import/bambenek/src/bambenek_connector/converter_to_stix.py
@@ -45,7 +45,9 @@ class ConverterToStix:
         :return: Author as STIX 2.1 Identity object
         """
         author = Identity(
-            id=pycti.Identity.generate_id(name="Bambenek", identity_class="organization"),
+            id=pycti.Identity.generate_id(
+                name="Bambenek", identity_class="organization"
+            ),
             name="Bambenek",
             identity_class="organization",
         )


### PR DESCRIPTION
### Proposed changes

* Resolution of various bugs 

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3621
* https://github.com/OpenCTI-Platform/connectors/issues/3620

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
