### PR TITLE
[wiz]: fix: Unify and fix datetime comparison

### DIFF
--- a/external-import/wiz/src/external_import_connector/connector.py
+++ b/external-import/wiz/src/external_import_connector/connector.py
@@ -41,8 +41,8 @@ class ConnectorWiz:
                 last_run = datetime.datetime.fromisoformat(state["last_run"])
                 if last_run.tzinfo is None:
                     warning_message = (
-                        f"Found ISOFORMAT in state, last_run = {last_run} without TimeZone, "
-                        f"this is deprecated and will be replaced by ISOFORMAT with TimeZone UTC."
+                        "ISOFORMAT without timezone is deprecated and will be replaced "
+                        "by ISOFORMAT with timezone."
                     )
                     warnings.warn(
                         warning_message,

--- a/external-import/wiz/tests/test_wiz_connector.py
+++ b/external-import/wiz/tests/test_wiz_connector.py
@@ -85,7 +85,7 @@ def test_send_stix2_bundle_update_argument(mocked_helper: OpenCTIConnectorHelper
 
 @freezegun.freeze_time("2025-03-13T10:24:00Z")
 @pytest.mark.usefixtures("mocked_requests")
-def test_modified_entity_and_state(mocked_helper: OpenCTIConnectorHelper):
+def test_deprecated_modified_entity_and_state(mocked_helper: OpenCTIConnectorHelper):
     connector = ConnectorWiz(config=ConfigConnector(), helper=mocked_helper)
 
     entities = connector._collect_intelligence()
@@ -96,3 +96,7 @@ def test_modified_entity_and_state(mocked_helper: OpenCTIConnectorHelper):
 
     # Campaign, Threat and Attack Pattern are modified before the last run, so ignore in the second run
     assert len(entities) == 5
+    assert mocked_helper.connector_logger.warning.call_args.args == (
+        "ISOFORMAT without timezone is deprecated and will be replaced by ISOFORMAT with timezone.",
+        {"last_run": datetime.datetime.fromisoformat("2025-03-13 10:24")},
+    )

--- a/external-import/wiz/tests/test_wiz_connector.py
+++ b/external-import/wiz/tests/test_wiz_connector.py
@@ -1,3 +1,5 @@
+import datetime
+
 import freezegun
 import pytest
 import stix2
@@ -79,3 +81,18 @@ def test_send_stix2_bundle_update_argument(mocked_helper: OpenCTIConnectorHelper
     connector.process_message()
 
     assert not mocked_helper.send_stix2_bundle.call_args.kwargs.get("update", False)
+
+
+@freezegun.freeze_time("2025-03-13T10:24:00Z")
+@pytest.mark.usefixtures("mocked_requests")
+def test_modified_entity_and_state(mocked_helper: OpenCTIConnectorHelper):
+    connector = ConnectorWiz(config=ConfigConnector(), helper=mocked_helper)
+
+    entities = connector._collect_intelligence()
+    assert len(entities) == 8
+
+    mocked_helper.get_state = lambda: {"last_run": str(datetime.datetime.now())}
+    entities = connector._collect_intelligence()
+
+    # Campaign, Threat and Attack Pattern are modified before the last run, so ignore in the second run
+    assert len(entities) == 5


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- Use the same types for the comparison : 
```
# Before :
entity["modified"] => '2025-03-09T00:00:00.000Z'
entity["last_run"] => '2025-03-09 14:55:02'

# After
entity["modified"] => datetime
entity["last_run"] => datetime
 
```

### Related issues

- https://github.com/OpenCTI-Platform/connectors/issues/3666

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
