### PR TITLE
fix(.pre-commit): Isort needs its own line-length config (https://github.com/astral-sh/ruff/issues/3206)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,11 @@ repos:
     hooks:
     - id: isort
       name: isort (python)
-      args: ['--profile black']
+      args:
+        - '--profile'
+        - 'black'
+        - '--line-length'
+        - '88'
 -   repo: local
     hooks:
     - id: gpg-signed-commit


### PR DESCRIPTION
### Proposed changes

### Related issues

- https://github.com/OpenCTI-Platform/connectors/issues/3668

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
