### PR TITLE
fix(shodan-internetdb): Remove use of deprecated pycti api call

### DIFF
--- a/internal-enrichment/shodan-internetdb/src/shodan_internetdb/connector.py
+++ b/internal-enrichment/shodan-internetdb/src/shodan_internetdb/connector.py
@@ -12,6 +12,7 @@ import validators
 import yaml
 from pycti import (
     STIX_EXT_OCTI_SCO,
+    Identity,
     Note,
     OpenCTIConnectorHelper,
     OpenCTIStix2,
@@ -45,12 +46,13 @@ class ShodanInternetDBConnector:
         self._config = RootConfig.parse_obj(config)
         self._helper = OpenCTIConnectorHelper(config, True)
 
-        self._identity = self._helper.api.identity.create(
-            type="Organization",
+        self._identity = stix2.Identity(
+            id=Identity.generate_id(name="Shodan", identity_class="organization"),
             name="Shodan",
+            identity_class="organization",
             description="Shodan is a search engine for Internet-connected devices.",
         )
-        self._identity_id = self._identity["standard_id"]
+        self._identity_id = self._identity["id"]
         self._object_marking_id = stix2.TLP_WHITE["id"]
 
         self._client = ShodanInternetDbClient(verify=self._config.shodan.ssl_verify)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Deprecate the use of pycti api call

### Related issues

- https://github.com/OpenCTI-Platform/connectors/issues/3670

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
