### PR TITLE
[microsoft-sentinel-incidents]: File hashes contained in File Evidence are not correctly converted into Observables

### DIFF
--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
@@ -268,7 +268,6 @@ class ConverterToStix:
                 return None
 
         if hashes:
-            print(hashes)
             stix_file = stix2.File(
                 hashes=hashes,
                 name=file.get("fileName") if isinstance(file, dict) else None,

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
@@ -235,7 +235,11 @@ class ConverterToStix:
         }
         hashes = {}
 
-        file = evidence.get("ImageFile") or evidence.get("value") or evidence.get("FileHashes")
+        file = (
+            evidence.get("ImageFile")
+            or evidence.get("value")
+            or evidence.get("FileHashes")
+        )
 
         # FileHashes evidences
         if isinstance(file, list):

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
@@ -234,7 +234,19 @@ class ConverterToStix:
             "sha256": "SHA-256",
         }
         hashes = {}
-        file = evidence.get("ImageFile") or evidence.get("value")
+
+        file = evidence.get("ImageFile") or evidence.get("value") or evidence.get("FileHashes")
+
+        # FileHashes evidences
+        if isinstance(file, list):
+            for file_hash in file:
+                if "Type" in file_hash and file_hash.get("Type") == "filehash":
+                    hash_name = hashes_mapping.get(file_hash.get("Algorithm").lower())
+                    if hash_name:
+                        hashes[hash_name] = file_hash.get("Value")
+                        self.all_hashes.add(file_hash.get("Value"))
+                    else:
+                        continue
 
         # process and file
         if isinstance(file, dict):
@@ -256,6 +268,7 @@ class ConverterToStix:
                 return None
 
         if hashes:
+            print(hashes)
             stix_file = stix2.File(
                 hashes=hashes,
                 name=file.get("fileName") if isinstance(file, dict) else None,


### PR DESCRIPTION
### Proposed changes

* handle of FileHashes contained in File Evidence

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3673

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
