### PR TITLE
[Recorded Future] Fix handling of IPv6 addresses from RF alerts

### DIFF
--- a/external-import/recorded-future/src/rflib/rf_alerts.py
+++ b/external-import/recorded-future/src/rflib/rf_alerts.py
@@ -331,7 +331,9 @@ class RecordedFutureAlertConnector(threading.Thread):
                             },
                         )
                     else:
-                        raise ValueError(f"Invalid IP address: {ip_address_value}")
+                        self.helper.connector_logger.warning(
+                            f"Invalid IP address: {ip_address_value}. The entity will be skipped."
+                        )
 
                     if stix_ip_address:
                         stix_relationship = self._generate_stix_relationship(

--- a/external-import/recorded-future/src/rflib/rf_alerts.py
+++ b/external-import/recorded-future/src/rflib/rf_alerts.py
@@ -14,7 +14,7 @@ from pycti import (
 )
 
 from .constants import TLP_MAP
-from .make_markdown_table import make_markdown_table
+from .utils import make_markdown_table, is_ip_v4_address, is_ip_v6_address
 
 
 class Vocabulary:

--- a/external-import/recorded-future/src/rflib/rf_alerts.py
+++ b/external-import/recorded-future/src/rflib/rf_alerts.py
@@ -332,7 +332,8 @@ class RecordedFutureAlertConnector(threading.Thread):
                         )
                     else:
                         self.helper.connector_logger.warning(
-                            f"Invalid IP address: {ip_address_value}. The entity will be skipped."
+                            "Invalid IP address, the entity will be skipped.",
+                            {"ip_address": ip_address_value},
                         )
 
                     if stix_ip_address:

--- a/external-import/recorded-future/src/rflib/rf_alerts.py
+++ b/external-import/recorded-future/src/rflib/rf_alerts.py
@@ -14,7 +14,7 @@ from pycti import (
 )
 
 from .constants import TLP_MAP
-from .utils import make_markdown_table, is_ip_v4_address, is_ip_v6_address
+from .utils import is_ip_v4_address, is_ip_v6_address, make_markdown_table
 
 
 class Vocabulary:

--- a/external-import/recorded-future/src/rflib/rf_alerts.py
+++ b/external-import/recorded-future/src/rflib/rf_alerts.py
@@ -312,18 +312,33 @@ class RecordedFutureAlertConnector(threading.Thread):
                     bundle_objects.append(stix_relationship)
 
                 elif entity["type"] == "IpAddress":
-                    stix_ipv4address = stix2.IPv4Address(
-                        value=entity["name"],
-                        object_marking_refs=self.tlp,
-                        custom_properties={
-                            "x_opencti_created_by_ref": self.author["id"],
-                        },
-                    )
-                    stix_relationship = self._generate_stix_relationship(
-                        stix_ipv4address.id, "related-to", stix_incident.id
-                    )
-                    bundle_objects.append(stix_ipv4address)
-                    bundle_objects.append(stix_relationship)
+                    stix_ip_address = None
+                    ip_address_value = entity["name"]
+                    if is_ip_v4_address(ip_address_value):
+                        stix_ip_address = stix2.IPv4Address(
+                            value=ip_address_value,
+                            object_marking_refs=self.tlp,
+                            custom_properties={
+                                "x_opencti_created_by_ref": self.author["id"],
+                            },
+                        )
+                    elif is_ip_v6_address(ip_address_value):
+                        stix_ip_address = stix2.IPv6Address(
+                            value=ip_address_value,
+                            object_marking_refs=self.tlp,
+                            custom_properties={
+                                "x_opencti_created_by_ref": self.author["id"],
+                            },
+                        )
+                    else:
+                        raise ValueError(f"Invalid IP address: {ip_address_value}")
+
+                    if stix_ip_address:
+                        stix_relationship = self._generate_stix_relationship(
+                            stix_ip_address.id, "related-to", stix_incident.id
+                        )
+                        bundle_objects.append(stix_ip_address)
+                        bundle_objects.append(stix_relationship)
                 elif entity["type"] == "EmailAddress":
                     stix_emailaddress = stix2.EmailAddress(
                         value=entity["name"],

--- a/external-import/recorded-future/src/rflib/rf_playbook_alerts.py
+++ b/external-import/recorded-future/src/rflib/rf_playbook_alerts.py
@@ -7,7 +7,7 @@ import stix2
 from pycti import StixCoreRelationship
 
 from .constants import TLP_MAP
-from .make_markdown_table import make_markdown_table
+from .utils import make_markdown_table
 
 
 class RecordedFuturePlaybookAlertConnector(threading.Thread):

--- a/external-import/recorded-future/src/rflib/utils.py
+++ b/external-import/recorded-future/src/rflib/utils.py
@@ -1,3 +1,6 @@
+import ipaddress
+
+
 def make_markdown_table(array):
     """the same input as above"""
 
@@ -19,3 +22,21 @@ def make_markdown_table(array):
     markdown += "> "
 
     return markdown
+
+
+def is_ip_v4_address(value: str) -> bool:
+    """Check if value is a valid IP V4 address."""
+    try:
+        ipaddress.IPv4Address(value)
+        return True
+    except ipaddress.AddressValueError:
+        return False
+
+
+def is_ip_v6_address(value: str) -> bool:
+    """Check if value is a valid IP V6 address."""
+    try:
+        ipaddress.IPv6Address(value)
+        return True
+    except ipaddress.AddressValueError:
+        return False


### PR DESCRIPTION

### Proposed changes

* Add util functions to check ip addresses format
* Create STIX IPv4Address/IPv6Address observable according to ip address format

### Related issues

* #3480 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

I wasn't able to see the error mentioned in the issue, but I could still investigated and prevent trying to ingest an IPv6 address as an IPv4Address observable.
