### PR TITLE
Fixed Defender Delete Issue

### DIFF
--- a/stream/sentinel-intel/src/sentinel_intel_connector/connector.py
+++ b/stream/sentinel-intel/src/sentinel_intel_connector/connector.py
@@ -113,7 +113,7 @@ class SentinelIntelConnector:
 
     def get_indicator_external_references(self, indicator_id, source_name):
         """
-        Retrieves the external references associated with a specific indicator
+        Retrieves all external references associated with a specific indicator
         and filters them by source_name.
 
         Args:

--- a/stream/sentinel-intel/src/sentinel_intel_connector/connector.py
+++ b/stream/sentinel-intel/src/sentinel_intel_connector/connector.py
@@ -255,7 +255,7 @@ class SentinelIntelConnector:
         """
         Extracts the external_id from the observable data
         :param: observable_data: OpenCTI observable data
-        :return: Sentinel / Defender external_id or none if not found
+        :return: Sentinel or Defender external_id or none if not found
         """
         external_id_list = []
         source_name =  self.config.target_product

--- a/stream/sentinel-intel/src/sentinel_intel_connector/connector.py
+++ b/stream/sentinel-intel/src/sentinel_intel_connector/connector.py
@@ -1,11 +1,13 @@
 import json
+from json import JSONDecodeError
 
 from pycti import OpenCTIConnectorHelper
-from stix_shifter.stix_translation import stix_translation
 
 from .api_handler import SentinelApiHandler, SentinelApiHandlerError
 from .config_variables import ConfigConnector
 from .utils import (
+    FILE_HASH_TYPES_MAPPER,
+    NETWORK_ATTRIBUTES_LIST,
     get_hash_type,
     get_hash_value,
     get_ioc_type,
@@ -65,41 +67,41 @@ class SentinelIntelConnector:
     def _convert_indicator_to_observables(self, data) -> list[dict]:
         """
         Convert an OpenCTI indicator to its corresponding observables.
+        Observables taken into account:
         :param data: OpenCTI indicator data
         :return: Observables data
         """
         try:
             observables = []
-            translation = stix_translation.StixTranslation()
-            parsed = translation.translate("splunk", "parse", "{}", data["pattern"])
-            if "parsed_stix" in parsed:
-                results = parsed["parsed_stix"]
-                for result in results:
+
+            parsed_observables = self.helper.get_attribute_in_extension(
+                "observable_values", data
+            )
+
+            if parsed_observables:
+
+                # Iterate over the parsed observables
+                for observable in parsed_observables:
                     observable_data = {}
                     observable_data.update(data)
 
-                    network_attributes = [
-                        "domain-name:value",
-                        "hostname:value",
-                        "ipv4-addr:value",
-                        "ipv6-addr:value",
-                        "url:value",
-                    ]
-                    file_attributes = [
-                        "file:hashes.'SHA-256'",
-                        "file:hashes.'SHA-1'",
-                        "file:hashes.MD5",
-                    ]
-                    if result["attribute"] in network_attributes:
-                        stix_type = result["attribute"].replace(":value", "")
-                        observable_data["type"] = stix_type
-                        observable_data["value"] = result["value"]
+                    x_opencti_observable_type = observable.get("type").lower()
+
+                    if x_opencti_observable_type in NETWORK_ATTRIBUTES_LIST:
+                        observable_data["type"] = x_opencti_observable_type
+                        observable_data["value"] = observable.get("value")
                         observables.append(observable_data)
-                    elif result["attribute"] in file_attributes:
-                        hash_type = result["attribute"].split(".")[1].replace("'", "")
-                        observable_data["type"] = "file"
-                        observable_data["hashes"] = {hash_type: result["value"]}
-                        observables.append(observable_data)
+                    elif x_opencti_observable_type == "stixfile":
+                        file = {}
+                        for key, value in observable.get("hashes", {}).items():
+                            hash_type = FILE_HASH_TYPES_MAPPER.get(key.lower())
+                            if hash_type is not None:
+                                file[hash_type] = value
+                        if file:
+                            observable_data["type"] = "file"
+                            observable_data["hashes"] = file
+                            observables.append(observable_data)
+
             return observables
         except:
             indicator_opencti_id = OpenCTIConnectorHelper.get_attribute_in_extension(
@@ -157,7 +159,7 @@ class SentinelIntelConnector:
         for indicator_data in indicators_data:
             if observable_data["type"] == "file":
                 observable_hash_type = get_hash_type(observable_data)
-                observable_hash_value = get_hash_value(observable_data).lower()
+                observable_hash_value = get_hash_value(observable_data)
                 indicator_hash_type = indicator_data.get("fileHashType")
                 indicator_hash_value = indicator_data.get("fileHashValue", "").lower()
                 if (
@@ -193,28 +195,6 @@ class SentinelIntelConnector:
                 },
             )
 
-    def _get_external_id(self, observable_data):
-        """
-        Extracts the external_id from the observable data
-        :param: observable_data: OpenCTI observable data
-        :return: Sentinel / Defender external_id or none if not found
-        """
-        try:
-            if "external_references" in observable_data: 
-                external_references = observable_data["external_references"] 
-                for ref in external_references:
-                    if ref.get("source_name") == "Microsoft Defender ATP" and ref.get("external_id"):
-                        return ref["external_id"]
-                    elif ref.get("source_name") == "Azure Sentinel" and ref.get("external_id"):
-                        return ref["external_id"]
-        except KeyError as e:
-            print(f"KeyError: {e}")
-            return None
-        except TypeError as e:
-            print(f"TypeError: {e}")
-            return None
-        return None
-    
     def _delete_sentinel_indicator(self, observable_data) -> bool:
         """
         Delete Threat Intelligence Indicators on Sentinel corresponding to an OpenCTI observable.
@@ -222,18 +202,21 @@ class SentinelIntelConnector:
         :return: True if the indicators have been successfully deleted, False otherwise
         """
         did_delete = False
-        
+
         opencti_id = OpenCTIConnectorHelper.get_attribute_in_extension(
             "id", observable_data
         )
-        external_id = self._get_external_id(observable_data)
-        result = self.api.delete_indicator(external_id)
-        if result:
-            self.helper.connector_logger.info(
-                "[DELETE] Indicator deleted",
-                {"sentinel_id": external_id, "opencti_id": opencti_id},
-            )
-        did_delete = result
+        indicators_data = self.api.search_indicators(opencti_id=opencti_id)
+        for indicator_data in indicators_data:
+            if indicator_data["externalId"] == opencti_id:
+                result = self.api.delete_indicator(indicator_data["id"])
+                # TODO: should we delete external references on OpenCTI too?
+                if result:
+                    self.helper.connector_logger.info(
+                        "[DELETE] Indicator deleted",
+                        {"sentinel_id": indicator_data["id"], "opencti_id": opencti_id},
+                    )
+                did_delete = result
         return did_delete
 
     def _handle_create_event(self, data):
@@ -275,6 +258,21 @@ class SentinelIntelConnector:
                 {"opencti_id": opencti_id},
             )
 
+    def validate_json(self, msg) -> dict | JSONDecodeError:
+        """
+        Validate the JSON data from the stream
+        :param msg: Message event from stream
+        :return: Parsed JSON data or raise JSONDecodeError if JSON data cannot be parsed
+        """
+        try:
+            parsed_msg = json.loads(msg.data)
+            return parsed_msg
+        except json.JSONDecodeError:
+            self.helper.connector_logger.error(
+                "[ERROR] Data cannot be parsed to JSON", {"msg_data": msg.data}
+            )
+            raise JSONDecodeError("Data cannot be parsed to JSON", msg.data, 0)
+
     def process_message(self, msg) -> None:
         """
         Main process if connector successfully works
@@ -286,13 +284,8 @@ class SentinelIntelConnector:
         try:
             self._check_stream_id()
 
-            try:
-                data = json.loads(msg.data)["data"]
-            except json.JSONDecodeError:
-                self.helper.connector_logger.error(
-                    "[ERROR] Cannot process the message", {"msg_data": msg.data}
-                )
-                return None
+            parsed_msg = self.validate_json(msg)
+            data = parsed_msg["data"]
 
             if msg.event == "create":
                 self._handle_create_event(data)

--- a/stream/sentinel-intel/src/sentinel_intel_connector/connector.py
+++ b/stream/sentinel-intel/src/sentinel_intel_connector/connector.py
@@ -161,6 +161,7 @@ class SentinelIntelConnector:
     def _create_sentinel_indicator(self, observable_data):
         """
         Create a Threat Intelligence Indicator on Sentinel from an OpenCTI observable.
+        Identify and delete existing external references from the target product, replacing with the most current. 
         :param observable_data: OpenCTI observable data
         :return: True if the indicator has been successfully created, False otherwise
         """

--- a/stream/sentinel-intel/src/sentinel_intel_connector/connector.py
+++ b/stream/sentinel-intel/src/sentinel_intel_connector/connector.py
@@ -275,7 +275,7 @@ class SentinelIntelConnector:
     
     def _delete_sentinel_indicator(self, observable_data) -> bool:
         """
-        Delete Threat Intelligence Indicators on Sentinel corresponding to an OpenCTI observable.
+        Delete Threat Intelligence Indicators on Sentinel or Defender corresponding to an OpenCTI observable.
         :param observable_data: OpenCTI observable data
         :return: True if the indicators have been successfully deleted, False otherwise
         """

--- a/stream/sentinel-intel/src/sentinel_intel_connector/connector.py
+++ b/stream/sentinel-intel/src/sentinel_intel_connector/connector.py
@@ -111,6 +111,53 @@ class SentinelIntelConnector:
                 "[CREATE] Cannot convert STIX indicator { " + indicator_opencti_id + "}"
             )
 
+    def get_indicator_external_references(self, indicator_id, source_name):
+        """
+        Retrieves the external references associated with a specific indicator
+        and filters them by source_name.
+
+        Args:
+            indicator_id: The ID of the indicator.
+            source_name: The source_name to filter by.
+
+        Returns:
+            A list of external references that match the source_name.
+        """
+        try:
+            # Construct the GraphQL query
+            query = """
+                query IndicatorExternalReferences($id: String!) {
+                    stixDomainObject(id: $id) {
+                        externalReferences {
+                            edges {
+                                node {
+                                    id
+                                    source_name
+                                    # Add other fields you need
+                                }
+                            }
+                        }
+                    }
+                }
+            """
+
+            # Execute the query
+            result = self.helper.api.query(query, {"id": indicator_id})
+
+            external_references = []
+
+            if result and result.get("data") and result["data"].get("stixDomainObject") and result["data"]["stixDomainObject"].get("externalReferences") and result["data"]["stixDomainObject"]["externalReferences"].get("edges"):
+                for edge in result["data"]["stixDomainObject"]["externalReferences"]["edges"]:
+                    reference = edge["node"]
+                    if reference.get("source_name") == source_name:
+                        external_references.append(reference)
+
+            return external_references
+
+        except Exception as e:
+            self.helper.connector_logger.error(f"Error retrieving external references: {e}")
+            return []
+        
     def _create_sentinel_indicator(self, observable_data):
         """
         Create a Threat Intelligence Indicator on Sentinel from an OpenCTI observable.
@@ -118,15 +165,24 @@ class SentinelIntelConnector:
         :return: True if the indicator has been successfully created, False otherwise
         """
         result = self.api.post_indicator(observable_data)
+
         if result:
             observable_opencti_id = OpenCTIConnectorHelper.get_attribute_in_extension(
                 "id", observable_data
             )
+            source_name = self.config.target_product
             self.helper.connector_logger.info(
                 "[CREATE] Indicator created",
                 {"sentinel_id": result["id"], "opencti_id": observable_opencti_id},
             )
 
+            # Check for existing external references with the same source_name
+            indicator_external_references = self.get_indicator_external_references(
+                observable_opencti_id, source_name
+            )
+                    # Delete existing references if any
+            for ref in indicator_external_references:
+                self.helper.api.external_reference.delete(id=ref["id"])
             # Update OpenCTI SDO external references
             external_reference = self.helper.api.external_reference.create(
                 source_name=self.config.target_product.replace("Azure", "Microsoft"),
@@ -201,21 +257,21 @@ class SentinelIntelConnector:
         :param: observable_data: OpenCTI observable data
         :return: Sentinel / Defender external_id or none if not found
         """
+        external_id_list = []
+        source_name =  self.config.target_product
+
         try:
             if "external_references" in observable_data: 
                 external_references = observable_data["external_references"] 
                 for ref in external_references:
-                    if ref.get("source_name") == "Microsoft Defender ATP" and ref.get("external_id"):
-                        return ref["external_id"]
-                    elif ref.get("source_name") == "Azure Sentinel" and ref.get("external_id"):
-                        return ref["external_id"]
+                    if ref.get("source_name") == source_name and ref.get("external_id"):
+                        external_id_list.append(ref["external_id"])
         except KeyError as e:
             print(f"KeyError: {e}")
-            return None
         except TypeError as e:
             print(f"TypeError: {e}")
-            return None
-        return None
+        return external_id_list
+    
     
     def _delete_sentinel_indicator(self, observable_data) -> bool:
         """
@@ -227,14 +283,21 @@ class SentinelIntelConnector:
         opencti_id = OpenCTIConnectorHelper.get_attribute_in_extension(
             "id", observable_data
         )
-        external_id = self._get_external_id(observable_data)
-        result = self.api.delete_indicator(external_id)
-        if result:
-            self.helper.connector_logger.info(
-                "[DELETE] Indicator deleted",
-                {"sentinel_id": external_id, "opencti_id": opencti_id},
-            )
-        did_delete = result
+        target_product = self.config.target_product
+        external_id_list = self._get_external_id(observable_data)
+
+        for external_id in external_id_list:
+            if target_product in observable_data["external_references"][0]["source_name"]:
+                result = self.api.delete_indicator(external_id)
+                if result:
+                    log_message = "[DELETE] Indicator deleted"
+                    log_attributes = {
+                        f"{target_product.lower().replace(' ', '_')}_id": external_id,
+                        "opencti_id": opencti_id,
+                    }
+                    self.helper.connector_logger.info(log_message, log_attributes)
+                    did_delete = True
+
         return did_delete
 
     def _handle_create_event(self, data):


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added function to pull external reference id from indicator data
* Altered delete indicator function to look for external references with source_id matching target_product and use this external reference ID to delete the indicator. (previous iteration pulled a list of all indicators and attempted to match one to an opencti id, which is not passed to MDE tenants, resulting in inability to delete indicators).
* Altered create indicator function to look for existing external references matching target_product and replace them with the most current external reference ID value. This addressed edge case in which multiple external references (from test indicators sent to MDE multiple times) prevented the delete function from passing the correct value. 

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3641
* https://github.com/OpenCTI-Platform/connectors/issues/3177 (incorrectly marked solved)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ X] I consider the submitted work as finished
- [X ] I have signed my commits using GPG key.
- [X ] I tested the code for its functionality using different use cases
- [ X] I added/update the relevant documentation (either on github or on notion)
- [ X] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- n/a -->
