### PR TITLE
[Recorded Future] URLencode indicator's value used as Record Future API's endpoint's path params

### DIFF
--- a/external-import/recorded-future/src/rflib/rf_client.py
+++ b/external-import/recorded-future/src/rflib/rf_client.py
@@ -168,7 +168,7 @@ class RFClient:
             The risk score as an int
         """
         indicator_params = {"fields": "risk"}
-        value_indicator = value if type != "url" else parse.quote(value, safe="")
+        value_indicator = parse.quote(value, safe="")
         res = self.session.get(
             CONNECT_BASE + "/" + type + "/" + value_indicator, params=indicator_params
         )


### PR DESCRIPTION
### Proposed changes

* Always URLencode value, not just when it's a url 

### Related issues

* #3393 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

