### PR TITLE
[export-csv] Improve management when data are incomplete (#3617)

### DIFF
--- a/external-import/mandiant/src/connector/reports.py
+++ b/external-import/mandiant/src/connector/reports.py
@@ -3,7 +3,7 @@ import itertools
 import re
 
 import stix2
-from pycti import Note
+from pycti import Note, Report
 
 from . import utils
 from .common import create_stix_relationship
@@ -170,6 +170,9 @@ class MandiantReport:
 
     def update_report(self):
         report = utils.retrieve(self.bundle, "type", "report")
+        report["published"] = report["created"]
+        report["x_opencti_stix_ids"] = [report["id"]]
+        report["id"] = Report.generate_id(report["name"], report["published"])
         report["created_by_ref"] = self.identity["standard_id"]
         report["report_types"] = [self.report_type]
         report["object_refs"] = list(

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -26,6 +26,7 @@ class ExportFileCsv:
             False,
             ";",
         )
+        self.errors: list[Exception] = [] # error holder to be reset before each new process
 
     def export_dict_list_to_csv(self, data):
         output = io.StringIO()
@@ -166,6 +167,8 @@ class ExportFileCsv:
         entity_type = data["entity_type"]
         main_filter = data.get("main_filter")
         access_filter = data.get("access_filter")
+        self.errors = [] # reset before launching main process
+        
 
         # Single export always containing object_refs
         # Full but no relationships
@@ -302,6 +305,9 @@ class ExportFileCsv:
             list_filters = json.dumps(list_params)
             self._export_list(data, entities_list, list_filters)
 
+        if errors:
+            msg = f"Some values were not processed in CSV ({len(self.errors)}). See connector logs for details."
+            return msg
         return "Export done"
 
     # Start the main loop

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -26,7 +26,9 @@ class ExportFileCsv:
             False,
             ";",
         )
-        self.errors: list[Exception] = [] # error holder to be reset before each new process
+        self.errors: list[Exception] = (
+            []
+        )  # error holder to be reset before each new process
 
     def export_dict_list_to_csv(self, data):
         output = io.StringIO()
@@ -102,8 +104,12 @@ class ExportFileCsv:
                         row.append("")
                 csv_data.append(row)
             except Exception as err:
-                self.helper.connector_logger.warning("Error with csv input data, one line cannot be exported." + str(err))
-                self.errors.append("Error with csv input data, one line cannot be exported.")
+                self.helper.connector_logger.warning(
+                    "Error with csv input data, one line cannot be exported." + str(err)
+                )
+                self.errors.append(
+                    "Error with csv input data, one line cannot be exported."
+                )
         writer = csv.writer(
             output,
             delimiter=self.export_file_csv_delimiter,
@@ -168,8 +174,7 @@ class ExportFileCsv:
         entity_type = data["entity_type"]
         main_filter = data.get("main_filter")
         access_filter = data.get("access_filter")
-        self.errors = [] # reset before launching main process
-        
+        self.errors = []  # reset before launching main process
 
         # Single export always containing object_refs
         # Full but no relationships
@@ -309,9 +314,9 @@ class ExportFileCsv:
         if len(self.errors) > 0:
             msg = f"Some values were not processed in CSV (for {len(self.errors)} lines). See connector logs for details."
             # to uncomment when it's possible to download a csv on OpenCTI despite warning on export.
-            #self.helper.api.work.report_expectation(
+            # self.helper.api.work.report_expectation(
             #    work_id=self.helper.work_id, error={"error": msg, "source": "CONNECTOR"}
-            #)
+            # )
             return msg
         return "Export done"
 

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -40,53 +40,68 @@ class ExportFileCsv:
             ]
         csv_data = [headers]
         for d in data:
-            row = []
-            for h in headers:
-                if h.startswith("hashes_") and "hashes" in d:
-                    hashes = {}
-                    for hash in d["hashes"]:
-                        hashes[hash["algorithm"]] = hash["hash"]
-                    if h.split("_")[1] in hashes:
-                        row.append(hashes[h.split("_")[1]])
+            try:
+                row = []
+                for h in headers:
+                    if h.startswith("hashes_") and "hashes" in d:
+                        hashes = {}
+                        for hash in d["hashes"]:
+                            hashes[hash["algorithm"]] = hash["hash"]
+                        if h.split("_")[1] in hashes:
+                            row.append(hashes[h.split("_")[1]])
+                        else:
+                            row.append("")
+                    elif h not in d:
+                        row.append("")
+                    elif isinstance(d[h], str):
+                        row.append(d[h])
+                    elif isinstance(d[h], int):
+                        row.append(str(d[h]))
+                    elif isinstance(d[h], float):
+                        row.append(str(d[h]))
+                    elif isinstance(d[h], list):
+                        if len(d[h]) > 0 and isinstance(d[h][0], str):
+                            row.append(",".join(d[h]))
+                        elif len(d[h]) > 0 and isinstance(d[h][0], dict):
+                            rrow = []
+                            for r in d[h]:
+                                if "name" in r:
+                                    if r["name"] is not None:
+                                        rrow.append(r["name"])
+                                    else:
+                                        rrow.append("")
+                                elif "definition" in r:
+                                    if r["definition"] is not None:
+                                        rrow.append(r["definition"])
+                                    else:
+                                        rrow.append("")
+                                elif "value" in r:
+                                    if r["value"] is not None:
+                                        rrow.append(r["value"])
+                                    else:
+                                        rrow.append("")
+                                elif "observable_value" in r:
+                                    if r["observable_value"] is not None:
+                                        rrow.append(r["observable_value"])
+                                    else:
+                                        rrow.append("")
+                            row.append(",".join(rrow))
+                        else:
+                            row.append("")
+                    elif isinstance(d[h], dict):
+                        if "name" in d[h]:
+                            row.append(d[h]["name"])
+                        elif "value" in d[h]:
+                            row.append(d[h]["value"])
+                        elif "observable_value" in d[h]:
+                            row.append(d[h]["observable_value"])
+                        else:
+                            row.append("")
                     else:
                         row.append("")
-                elif h not in d:
-                    row.append("")
-                elif isinstance(d[h], str):
-                    row.append(d[h])
-                elif isinstance(d[h], int):
-                    row.append(str(d[h]))
-                elif isinstance(d[h], float):
-                    row.append(str(d[h]))
-                elif isinstance(d[h], list):
-                    if len(d[h]) > 0 and isinstance(d[h][0], str):
-                        row.append(",".join(d[h]))
-                    elif len(d[h]) > 0 and isinstance(d[h][0], dict):
-                        rrow = []
-                        for r in d[h]:
-                            if "name" in r:
-                                rrow.append(r["name"])
-                            elif "definition" in r:
-                                rrow.append(r["definition"])
-                            elif "value" in r:
-                                rrow.append(r["value"])
-                            elif "observable_value" in r:
-                                rrow.append(r["observable_value"])
-                        row.append(",".join(rrow))
-                    else:
-                        row.append("")
-                elif isinstance(d[h], dict):
-                    if "name" in d[h]:
-                        row.append(d[h]["name"])
-                    elif "value" in d[h]:
-                        row.append(d[h]["value"])
-                    elif "observable_value" in d[h]:
-                        row.append(d[h]["observable_value"])
-                    else:
-                        row.append("")
-                else:
-                    row.append("")
-            csv_data.append(row)
+                csv_data.append(row)
+            except Exception as err:
+                self.helper.log_error("ERROR with csv input data." + str(err))
         writer = csv.writer(
             output,
             delimiter=self.export_file_csv_delimiter,

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -102,7 +102,8 @@ class ExportFileCsv:
                         row.append("")
                 csv_data.append(row)
             except Exception as err:
-                self.helper.connector_logger.warning("ERROR with csv input data." + str(err))
+                self.helper.connector_logger.warning("Error with csv input data, one line cannot be exported." + str(err))
+                self.errors.append("Error with csv input data, one line cannot be exported.")
         writer = csv.writer(
             output,
             delimiter=self.export_file_csv_delimiter,
@@ -305,8 +306,12 @@ class ExportFileCsv:
             list_filters = json.dumps(list_params)
             self._export_list(data, entities_list, list_filters)
 
-        if errors:
-            msg = f"Some values were not processed in CSV ({len(self.errors)}). See connector logs for details."
+        if len(self.errors) > 0:
+            msg = f"Some values were not processed in CSV (for {len(self.errors)} lines). See connector logs for details."
+            # to uncomment when it's possible to download a csv on OpenCTI despite warning on export.
+            #self.helper.api.work.report_expectation(
+            #    work_id=self.helper.work_id, error={"error": msg, "source": "CONNECTOR"}
+            #)
             return msg
         return "Export done"
 

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -107,9 +107,7 @@ class ExportFileCsv:
                 self.helper.connector_logger.warning(
                     "Error with csv input data, one line cannot be exported." + str(err)
                 )
-                self.errors.append(
-                    "Error with csv input data, one line cannot be exported."
-                )
+                self.errors.append(err)
         writer = csv.writer(
             output,
             delimiter=self.export_file_csv_delimiter,
@@ -313,10 +311,9 @@ class ExportFileCsv:
 
         if len(self.errors) > 0:
             msg = f"Some values were not processed in CSV (for {len(self.errors)} lines). See connector logs for details."
-            # to uncomment when it's possible to download a csv on OpenCTI despite warning on export.
-            # self.helper.api.work.report_expectation(
-            #    work_id=self.helper.work_id, error={"error": msg, "source": "CONNECTOR"}
-            # )
+            self.helper.api.work.report_expectation(
+                work_id=self.helper.work_id, error={"error": msg, "source": "CONNECTOR"}
+            )
             return msg
         return "Export done"
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add a global try/cath per csv line, to allow exporting csv event if one line has issue
* Add some test on value that are lists inside, to avoid crashing on null/None values

Error log on catch looks like:
```
{"timestamp": "2025-03-31T12:55:02.411462Z", "level": "WARNING", "name": "ExportFileCsv", "message": "Error with csv input data, one line cannot be exported.sequence item 0: expected str instance, NoneType found"}
```

On opencti connector view when there is an error:
![image](https://github.com/user-attachments/assets/8f8e23eb-2849-460f-91e3-db9480ec598d)



### Related issues

* closes #3617 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
