### PR TITLE
Rename MicrosoftDefenderIntelConnector to MicrosoftDefenderIntelSynch…

### DIFF
--- a/stream/microsoft-defender-intel-synchronizer/src/main.py
+++ b/stream/microsoft-defender-intel-synchronizer/src/main.py
@@ -1,7 +1,7 @@
 import traceback
 
 from microsoft_defender_intel_synchronizer_connector import (
-    MicrosoftDefenderIntelConnector,
+    MicrosoftDefenderIntelSynchronizerConnector,
 )
 
 if __name__ == "__main__":
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     It signals to the operating system and any calling processes that the program did not complete successfully.
     """
     try:
-        connector = MicrosoftDefenderIntelConnector()
+        connector = MicrosoftDefenderIntelSynchronizerConnector()
         connector.run()
     except Exception:
         traceback.print_exc()


### PR DESCRIPTION
Thank you for posting this connector! It works wonderfully with a tiny update.

### Files Changed:

1. **`stream/microsoft-defender-intel-synchronizer/src/main.py`**
    - The import statement and the instantiation of the connector class were updated for consistency. Without this change, the connector generates the following error on startup: `ImportError: cannot import name 'MicrosoftDefenderIntelConnector' from 'microsoft_defender_intel_synchronizer_connector' (/opt/opencti-connector-microsoft-defender-intel-synchronizer/microsoft_defender_intel_synchronizer_connector/__init__.py)`

### Proposed change

This change ensures that the class names used in the `main.py` file are consistent with the intended naming convention, aligning with `MicrosoftDefenderIntelSynchronizerConnector`.

