### PR TITLE
[Tenable security center] feat: inconsistent repository id types in api response could be handled

### DIFF
--- a/external-import/tenable-security-center/tenable_security_center/adapters/tsc_api/v5_13_from_asset.py
+++ b/external-import/tenable-security-center/tenable_security_center/adapters/tsc_api/v5_13_from_asset.py
@@ -855,7 +855,11 @@ class _ScanResultsAPI:
             json_data = resp_scan_result.json()["response"]
             if not json_data["progress"]:  # could be an empty list, empty dict or null
                 return "", ""
-            return json_data["progress"]["scannedIPs"], json_data["repository"]["id"]
+            # explicit casting because of inconsitent return types.
+            # see : https://github.com/OpenCTI-Platform/connectors/issues/3564
+            ips = json_data["progress"]["scannedIPs"]
+            repository_id = json_data["repository"]["id"]
+            return str(ips) if ips else "", str(repository_id) if repository_id else ""
 
         except (HTTPError, IndexError) as e:
             self.logger.error(

--- a/external-import/tenable-security-center/tests/test_adapters/test_tsc_api/test_v5_13_from_asset.py
+++ b/external-import/tenable-security-center/tests/test_adapters/test_tsc_api/test_v5_13_from_asset.py
@@ -1,0 +1,36 @@
+# isort:skip_file
+# pragma: no cover
+from tenable_security_center.adapters.tsc_api.v5_13_from_asset import _ScanResultsAPI
+
+from unittest.mock import Mock
+
+
+def test_scan_results_api_get_scanned_assets_info_should_return_tuple_of_string():
+    """Test that the method returns a tuple of strings.
+
+    This is important because the results is then used in AssetAPI._fetch_data_chunks and can raise error if not properly formated.
+    See https://github.com/OpenCTI-Platform/connectors/issues/3564
+
+    """
+
+    # Given
+    # A Mocked Client with a get method returning bad formatted data
+    tsc_api_client = Mock()
+    tsc_api_client.get.return_value.json.return_value = {
+        "response": {
+            "progress": {"scannedIPs": "0.0.0.0"},
+            "repository": {"id": 1},
+        }
+    }
+    api = _ScanResultsAPI(
+        tsc_client=tsc_api_client, logger=Mock(), since_datetime=Mock()
+    )
+
+    # When
+    # We call the method
+    result = api.get_scanned_assets_info(scan_id="scan_id")
+
+    # Then
+    # The method should return a tuple of strings
+    assert result[0] == "0.0.0.0"  # noqa: S101 # we use assert in unit test context
+    assert result[1] == "1"  # noqa: S101


### PR DESCRIPTION
### Proposed changes

* Explicitly converts both scannedIPs and repository id to strings to handle type inconsistencies.
* Adds a unit test to verify the corrected output from the API adapter.


### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3564


### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Investigation Notion Page : https://www.notion.so/filigran/Tenable-Security-Center-Varying-repository_id-types-in-API-response-should-be-handled-1b68fce17f2a802eaeede3457963836c
