### PR TITLE
[client] Add support for export of Indicator pattern field

### DIFF
--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -26,6 +26,7 @@ class ExportFileTxt:
         export_scope = data["export_scope"]
         main_filter = data.get("main_filter")
         access_filter = data.get("access_filter")
+        export_type = data.get("export_type")
 
         if export_scope == "single":
             raise ValueError("This connector only supports list exports")
@@ -119,6 +120,11 @@ class ExportFileTxt:
                     if entity_type == "Malware-Analysis":
                         for entity in entities_list:
                             entity["name"] = entity["result_name"]
+                    # Pattern Type Export
+                    if entity_type == "Indicator" and export_type == "pattern":
+                        for entity in entities_list:
+                            entity["name"] = entity["pattern"]
+
                     entities_values = [f["name"] for f in entities_list if "name" in f]
                     entities_values_bytes = "\n".join(entities_values)
                     self.helper.api.stix_domain_object.push_list_export(


### PR DESCRIPTION
### Proposed changes

* Allow the export of the "pattern" field on indicators when using the export-file-txt (i.e. text/plain) option via the export panel.
* A separate required PR in OpenCTI project will be linked to this to allow the menu option for "Pattern Export (just the entity pattern field)"

![image](https://github.com/user-attachments/assets/742508b7-fcf8-45da-8b94-716284671ebc)


### Related issues

* Supports PR in OpenCTI - (https://github.com/OpenCTI-Platform/opencti/pull/10440)
* Supports PR in OpenCTI - (https://github.com/OpenCTI-Platform/opencti/pull/10766)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I have signed my commits using GPG key.
- [X] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

None
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
