### PR TITLE
[Virustotal] Adds Attributes for Virustotal Notes

### DIFF
--- a/internal-enrichment/virustotal/README.md
+++ b/internal-enrichment/virustotal/README.md
@@ -90,6 +90,15 @@ Configuration parameters are provided using environment variables as described b
 
 ---
 
+## Generic Config Settings for File, Artifact IP, Domain, URL
+
+| Parameter `virustotal`         | config.yml                       | Docker environment variable                 | Default | Mandatory | Description                                                                           |
+|--------------------------------|----------------------------------|---------------------------------------------|---------|-----------|---------------------------------------------------------------------------------------|
+| Include Attributes in Note              | `include_attributes_in_note`              | `VIRUSTOTAL_INCLUDE_ATTRIBUTES_IN_NOTE`              | `False`  | No        | Whether or not to include the attributes info in Note                 |
+
+
+---
+
 ### Debugging
 
 Set the appropriate log level for debugging. Use `self.helper.log_{LOG_LEVEL}("Message")` for logging, e.g., `self.helper.log_error("Error message")`.

--- a/internal-enrichment/virustotal/docker-compose.yml
+++ b/internal-enrichment/virustotal/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - VIRUSTOTAL_URL_INDICATOR_CREATE_POSITIVES=10 # Create an indicator for Url based observables once this positive theshold is reached. Note: specify 0 to disable indicator creation
       - VIRUSTOTAL_URL_INDICATOR_VALID_MINUTES=2880 # How long the indicator is valid for in minutes
       - VIRUSTOTAL_URL_INDICATOR_DETECT=true # Whether or not to set detection for the indicator to true
+      # Generic config settings for File, IP, Domain, URL
+      - VIRUSTOTAL_INCLUDE_ATTRIBUTES_IN_NOTE=false # Whether or not to include the attributes info in Note
     deploy:
       mode: replicated
       replicas: 1

--- a/internal-enrichment/virustotal/src/config.yml.sample
+++ b/internal-enrichment/virustotal/src/config.yml.sample
@@ -41,3 +41,6 @@ virustotal:
   url_indicator_create_positives: 10 # Create an indicator for Url based observables once this positive threshold is reached. Note: specify 0 to disable indicator creation
   url_indicator_valid_minutes: 2880 # How long the indicator is valid for in minutes
   url_indicator_detect: true # Whether or not to set detection for the indicator to true
+
+  # Generic config settings for File, IP, Domain, URL
+  include_attributes_in_note:  false # Whether or not to include the attributes info in Note

--- a/internal-enrichment/virustotal/src/virustotal/builder.py
+++ b/internal-enrichment/virustotal/src/virustotal/builder.py
@@ -32,6 +32,8 @@ class VirusTotalBuilder:
         stix_entity: dict,
         opencti_entity: dict,
         data: dict,
+        include_attributes_in_note: Optional[bool] = False,
+        url_related_object_data: dict = {}
     ) -> None:
         """Initialize Virustotal builder."""
         self.helper = helper
@@ -42,6 +44,8 @@ class VirusTotalBuilder:
         self.stix_entity = stix_entity
         self.attributes = data["attributes"]
         self.score = self._compute_score(self.attributes["last_analysis_stats"])
+        self.include_attributes_in_note = include_attributes_in_note
+        self.url_related_object_data = url_related_object_data
 
         # Update score of observable.
         OpenCTIStix2.put_attribute_in_extension(
@@ -366,6 +370,7 @@ class VirusTotalBuilder:
                     + (result["result"] if result["result"] is not None else "N/A")
                     + " | \n"
                 )
+            content += self.create_notes_attributes_content() if self.include_attributes_in_note else ""
             self.create_note(
                 "VirusTotal Results",
                 content,
@@ -378,6 +383,7 @@ class VirusTotalBuilder:
                 content += (
                     "| " + key + " | " + self.attributes["categories"][key] + " | \n"
                 )
+            content += self.create_notes_attributes_content() if self.include_attributes_in_note else ""
             self.create_note("VirusTotal Categories", content)
 
     def create_yara(
@@ -558,3 +564,45 @@ class VirusTotalBuilder:
             f'[VirusTotal] updating size with {self.attributes["size"]}'
         )
         self.stix_entity["size"] = self.attributes["size"]
+    
+    def create_notes_attributes_content(self):
+        attributes_content = ""
+        attributes_scope = {
+            "StixFile" : {
+                "File Type" : self.attributes.get("type_description"),
+                "Type Tags" : ', '.join(self.attributes.get("type_tags",[])),
+                "Last Submission" : self.attributes.get("last_submission_date"),
+                "Popular Threat Label" : self.attributes.get("popular_threat_classification",
+                                                             {}).get("suggested_threat_label"),
+                "Signature Verification":self.attributes.get("signature_info",{}).get("verified"),
+                "Names" : ', '.join(self.attributes.get("names",[])) 
+                
+            },
+            "IPv4-Addr" : {
+                "Country" : self.attributes.get("country"),
+                "Autonomous System Label" : self.attributes.get("as_owner")
+            },
+            "Domain-Name" : {
+                "Creation Date" : self.attributes.get("creation_date"),
+                "Last Analysis Date" : self.attributes.get("last_analysis_date")
+            },
+            "Url" : {
+                "Final URL" : self.attributes.get("last_final_url"),
+                "Last Analysis Date" : self.attributes.get("last_analysis_date"),
+                "Serving IP Address" : self.url_related_object_data.get("id")
+            }    
+        }
+        attributes_scope = attributes_scope.get(self.opencti_entity.get('entity_type'))
+        if self.include_attributes_in_note and attributes_scope:
+            for attribute, value in attributes_scope.items():
+                attributes_content += (
+                        "| " + attribute + " | " + str(value or "N/A") + " | \n"
+                        )
+            if attributes_content:
+                content = "## Attributes Info\n\n"
+                content += "Any falsy value will be replaced by ‘N/A’\n"
+                content += "| Attributes |      |\n"
+                content += "|--------|----------|\n"
+                content += attributes_content
+                return content  
+        return ""

--- a/internal-enrichment/virustotal/src/virustotal/builder.py
+++ b/internal-enrichment/virustotal/src/virustotal/builder.py
@@ -33,7 +33,7 @@ class VirusTotalBuilder:
         opencti_entity: dict,
         data: dict,
         include_attributes_in_note: Optional[bool] = False,
-        url_related_object_data: dict = {}
+        url_related_object_data: dict = {},
     ) -> None:
         """Initialize Virustotal builder."""
         self.helper = helper
@@ -370,7 +370,11 @@ class VirusTotalBuilder:
                     + (result["result"] if result["result"] is not None else "N/A")
                     + " | \n"
                 )
-            content += self.create_notes_attributes_content() if self.include_attributes_in_note else ""
+            content += (
+                self.create_notes_attributes_content()
+                if self.include_attributes_in_note
+                else ""
+            )
             self.create_note(
                 "VirusTotal Results",
                 content,
@@ -383,7 +387,11 @@ class VirusTotalBuilder:
                 content += (
                     "| " + key + " | " + self.attributes["categories"][key] + " | \n"
                 )
-            content += self.create_notes_attributes_content() if self.include_attributes_in_note else ""
+            content += (
+                self.create_notes_attributes_content()
+                if self.include_attributes_in_note
+                else ""
+            )
             self.create_note("VirusTotal Categories", content)
 
     def create_yara(
@@ -564,45 +572,47 @@ class VirusTotalBuilder:
             f'[VirusTotal] updating size with {self.attributes["size"]}'
         )
         self.stix_entity["size"] = self.attributes["size"]
-    
+
     def create_notes_attributes_content(self):
         attributes_content = ""
         attributes_scope = {
-            "StixFile" : {
-                "File Type" : self.attributes.get("type_description"),
-                "Type Tags" : ', '.join(self.attributes.get("type_tags",[])),
-                "Last Submission" : self.attributes.get("last_submission_date"),
-                "Popular Threat Label" : self.attributes.get("popular_threat_classification",
-                                                             {}).get("suggested_threat_label"),
-                "Signature Verification":self.attributes.get("signature_info",{}).get("verified"),
-                "Names" : ', '.join(self.attributes.get("names",[])) 
-                
+            "StixFile": {
+                "File Type": self.attributes.get("type_description"),
+                "Type Tags": ", ".join(self.attributes.get("type_tags", [])),
+                "Last Submission": self.attributes.get("last_submission_date"),
+                "Popular Threat Label": self.attributes.get(
+                    "popular_threat_classification", {}
+                ).get("suggested_threat_label"),
+                "Signature Verification": self.attributes.get("signature_info", {}).get(
+                    "verified"
+                ),
+                "Names": ", ".join(self.attributes.get("names", [])),
             },
-            "IPv4-Addr" : {
-                "Country" : self.attributes.get("country"),
-                "Autonomous System Label" : self.attributes.get("as_owner")
+            "IPv4-Addr": {
+                "Country": self.attributes.get("country"),
+                "Autonomous System Label": self.attributes.get("as_owner"),
             },
-            "Domain-Name" : {
-                "Creation Date" : self.attributes.get("creation_date"),
-                "Last Analysis Date" : self.attributes.get("last_analysis_date")
+            "Domain-Name": {
+                "Creation Date": self.attributes.get("creation_date"),
+                "Last Analysis Date": self.attributes.get("last_analysis_date"),
             },
-            "Url" : {
-                "Final URL" : self.attributes.get("last_final_url"),
-                "Last Analysis Date" : self.attributes.get("last_analysis_date"),
-                "Serving IP Address" : self.url_related_object_data.get("id")
-            }    
+            "Url": {
+                "Final URL": self.attributes.get("last_final_url"),
+                "Last Analysis Date": self.attributes.get("last_analysis_date"),
+                "Serving IP Address": self.url_related_object_data.get("id"),
+            },
         }
-        attributes_scope = attributes_scope.get(self.opencti_entity.get('entity_type'))
+        attributes_scope = attributes_scope.get(self.opencti_entity.get("entity_type"))
         if self.include_attributes_in_note and attributes_scope:
             for attribute, value in attributes_scope.items():
                 attributes_content += (
-                        "| " + attribute + " | " + str(value or "N/A") + " | \n"
-                        )
+                    "| " + attribute + " | " + str(value or "N/A") + " | \n"
+                )
             if attributes_content:
                 content = "## Attributes Info\n\n"
                 content += "Any falsy value will be replaced by ‘N/A’\n"
                 content += "| Attributes |      |\n"
                 content += "|--------|----------|\n"
                 content += attributes_content
-                return content  
+                return content
         return ""

--- a/internal-enrichment/virustotal/src/virustotal/client.py
+++ b/internal-enrichment/virustotal/src/virustotal/client.py
@@ -326,7 +326,7 @@ class VirusTotalClient:
             Base64 encoded string without padding
         """
         return base64.b64encode(contents.encode()).decode().replace("=", "")
-    
+
     def get_url_related_objects(self, url, relationship):
         """
         Retrieve URL report based on the given URL.

--- a/internal-enrichment/virustotal/src/virustotal/client.py
+++ b/internal-enrichment/virustotal/src/virustotal/client.py
@@ -326,3 +326,26 @@ class VirusTotalClient:
             Base64 encoded string without padding
         """
         return base64.b64encode(contents.encode()).decode().replace("=", "")
+    
+    def get_url_related_objects(self, url, relationship):
+        """
+        Retrieve URL report based on the given URL.
+
+        Parameters
+        ----------
+        url : str
+            Url.
+        relationship : str
+            Relationship to Url
+
+        Returns
+        -------
+        dict
+            URL Object, see https://developers.virustotal.com/reference/url-object
+        """
+        base64_url = f"{self.url}/urls/{VirusTotalClient.base64_encode_no_padding(url)}/{relationship}"
+        results = self._query(base64_url)
+        if "error" in results:
+            sha256_url = f"{self.url}/urls/{hashlib.sha256(url.encode()).hexdigest()}/{relationship}"
+            results = self._query(sha256_url)
+        return results

--- a/internal-enrichment/virustotal/src/virustotal/virustotal.py
+++ b/internal-enrichment/virustotal/src/virustotal/virustotal.py
@@ -102,7 +102,7 @@ class VirusTotalConnector:
             "VIRUSTOTAL_INCLUDE_ATTRIBUTES_IN_NOTE",
             ["virustotal", "include_attributes_in_note"],
             config,
-            default=False
+            default=False,
         )
 
     def resolve_default_value(self, stix_entity):
@@ -286,7 +286,11 @@ class VirusTotalConnector:
                         + str(result.get("result") or "N/A")
                         + " | \n"
                     )
-                content += builder.create_notes_attributes_content() if self.include_attributes_in_note else ""
+                content += (
+                    builder.create_notes_attributes_content()
+                    if self.include_attributes_in_note
+                    else ""
+                )
                 builder.create_note("VirusTotal Report", content)
         return builder.send_bundle()
 
@@ -390,9 +394,15 @@ class VirusTotalConnector:
             raise ValueError(json_data["error"]["message"])
         if "data" not in json_data or "attributes" not in json_data["data"]:
             raise ValueError("An error has occurred.")
-        get_url_related_object = self.client.get_url_related_objects(url=opencti_entity["observable_value"],
-                                            relationship="last_serving_ip_address")
-        url_related_object_data = get_url_related_object.get("data", {}) if isinstance(get_url_related_object, dict) else {}
+        get_url_related_object = self.client.get_url_related_objects(
+            url=opencti_entity["observable_value"],
+            relationship="last_serving_ip_address",
+        )
+        url_related_object_data = (
+            get_url_related_object.get("data", {})
+            if isinstance(get_url_related_object, dict)
+            else {}
+        )
 
         builder = VirusTotalBuilder(
             self.helper,

--- a/internal-enrichment/virustotal/src/virustotal/virustotal.py
+++ b/internal-enrichment/virustotal/src/virustotal/virustotal.py
@@ -98,6 +98,12 @@ class VirusTotalConnector:
             default=True,
         )
         self.url_indicator_config = IndicatorConfig.load_indicator_config(config, "URL")
+        self.include_attributes_in_note = get_config_variable(
+            "VIRUSTOTAL_INCLUDE_ATTRIBUTES_IN_NOTE",
+            ["virustotal", "include_attributes_in_note"],
+            config,
+            default=False
+        )
 
     def resolve_default_value(self, stix_entity):
         if "hashes" in stix_entity and "SHA-256" in stix_entity["hashes"]:
@@ -190,6 +196,7 @@ class VirusTotalConnector:
             stix_entity,
             opencti_entity,
             json_data["data"],
+            include_attributes_in_note=self.include_attributes_in_note,
         )
         builder.update_hashes()
 
@@ -279,6 +286,7 @@ class VirusTotalConnector:
                         + str(result.get("result") or "N/A")
                         + " | \n"
                     )
+                content += builder.create_notes_attributes_content() if self.include_attributes_in_note else ""
                 builder.create_note("VirusTotal Report", content)
         return builder.send_bundle()
 
@@ -298,6 +306,7 @@ class VirusTotalConnector:
             stix_entity,
             opencti_entity,
             json_data["data"],
+            include_attributes_in_note=self.include_attributes_in_note,
         )
 
         if self.ip_add_relationships:
@@ -327,6 +336,7 @@ class VirusTotalConnector:
             stix_entity,
             opencti_entity,
             json_data["data"],
+            include_attributes_in_note=self.include_attributes_in_note,
         )
 
         if self.domain_add_relationships:
@@ -380,6 +390,9 @@ class VirusTotalConnector:
             raise ValueError(json_data["error"]["message"])
         if "data" not in json_data or "attributes" not in json_data["data"]:
             raise ValueError("An error has occurred.")
+        get_url_related_object = self.client.get_url_related_objects(url=opencti_entity["observable_value"],
+                                            relationship="last_serving_ip_address")
+        url_related_object_data = get_url_related_object.get("data", {}) if isinstance(get_url_related_object, dict) else {}
 
         builder = VirusTotalBuilder(
             self.helper,
@@ -389,6 +402,8 @@ class VirusTotalConnector:
             stix_entity,
             opencti_entity,
             json_data["data"],
+            include_attributes_in_note=self.include_attributes_in_note,
+            url_related_object_data=url_related_object_data,
         )
 
         builder.create_indicator_based_on(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  Updated the code to include additional attributes from Virustotal API response to Notes.
* Updated the VirusTotal client to fetch URL-related objects.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4024

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
