### PR TITLE
Thehive fix "updateAt"

### DIFF
--- a/external-import/thehive/src/thehive.py
+++ b/external-import/thehive/src/thehive.py
@@ -312,7 +312,7 @@ class TheHive:
         return mappings.get(key, mappings[0])
 
     def get_updated_date(self, item, last_date):
-        """Get the highest date observed within item and last_date."""
+        """Get the highest date observed within item and "last_date"."""
         if "updatedAt" in item and item["updatedAt"] is not None:
             new_date = int(item["updatedAt"] / 1000) + 1
             self.helper.log_debug(

--- a/external-import/thehive/src/thehive.py
+++ b/external-import/thehive/src/thehive.py
@@ -312,16 +312,16 @@ class TheHive:
         return mappings.get(key, mappings[0])
 
     def get_updated_date(self, item, last_date):
-        """Get the highest date observed within item and "last_date"."""
-        if "updatedAt" in item and item["updatedAt"] is not None:
-            new_date = int(item["updatedAt"] / 1000) + 1
+        """Get the highest date observed within item and "last_date."""
+        if "_updatedAt" in item and item["_updatedAt"] is not None:
+            new_date = int(item["_updatedAt"] / 1000) + 1
             self.helper.log_debug(
-                f"Using 'updatedAt' for last date calculation: {last_date} new date calculation: {new_date}"
+                f"Using '_updatedAt' for last date calculation: {last_date} new date calculation: {new_date}"
             )
         else:
             new_date = int(item.get("_createdAt") / 1000) + 1
             self.helper.log_debug(
-                f"Using 'createdAt' for last date calculation: {last_date} new date calculation: {new_date}"
+                f"Using '_createdAt' for last date calculation: {last_date} new date calculation: {new_date}"
             )
         return max(last_date, new_date)
 


### PR DESCRIPTION
Hello 

I've updated the script to correctly handle the **_updatedAt** field. Previously, the function get_updated_date was checking for **updatedAt** (without the underscore), which caused it to always fall back on **_createdAt**, even when **_updatedAt** was available.

**In this update:**

 - The condition now properly checks for the presence of _updatedAt before falling back to _createdAt.

 - This change ensures that the most accurate update timestamp is used when generating STIX bundles for alerts and cases.

 - The construct_query method has also been verified to query using _updatedAt, aligning the entire flow with the correct timestamp field.

 - I have also add the underscore in the log of "_createAt" (line 324)

Thank you.

The connector now respects the intended logic for object updates

### Proposed changes

*
*

### Related issues

*https://customer.support.filigran.io/servicedesk/customer/portal/6/OCTI2-726
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
