### PR TITLE
[CI] add auto label filigran team

### DIFF
--- a/.github/workflows/auto-set-labels.yml
+++ b/.github/workflows/auto-set-labels.yml
@@ -1,0 +1,11 @@
+name: Assign labels on PR from an organization
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setting labels
+        uses: FiligranHQ/auto-label@1.0.0
+        with:
+          labels_by_organization: "{\"FiligranHQ\":[\"filigran team\"]}"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add automatically "filigran team" labels on PR from Filigran employees.

Same as opencti one https://github.com/OpenCTI-Platform/opencti/blob/master/.github/workflows/auto-set-labels.yml


### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
