### PR TITLE
[Flashpoint]: Embedded images in Flashpoint reports are not being properly retrieved

### DIFF
--- a/external-import/flashpoint/src/flashpoint_connector/client_api.py
+++ b/external-import/flashpoint/src/flashpoint_connector/client_api.py
@@ -111,6 +111,7 @@ class ConnectorClient:
             "limit": limit,
             "skip": 0,
             "sort": "updated_at:asc",
+            "embed": "asset"
         }
         has_more = True
         reports = []


### PR DESCRIPTION

### Proposed changes

* Added the embed=asset parameter when retrieving reports to have base64 images within reports body.
*

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3800

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
