### PR TITLE
Revert "Update dependency pyTenable to v1.7.4"

### DIFF
--- a/external-import/tenable-security-center/pyproject.toml
+++ b/external-import/tenable-security-center/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pycti==6.6.5",
     "validators~=0.34.0",
     "pydantic>=2.8.2,<3.0.0",
-    "pytenable~=1.7.4", # for now we handle API from 5.13 to 6.4
+    "pytenable~=1.5.3", # for now we handle API from 5.13 to 6.4
     "cvss~=3.3",
     "semver>=3,<4",
     "requests~=2.32.2",

--- a/external-import/tenable-vuln-management/requirements.txt
+++ b/external-import/tenable-vuln-management/requirements.txt
@@ -1,4 +1,4 @@
-pyTenable==1.7.4
+pyTenable==1.5.3
 python-dateutil==2.9.0.post0
 pycti==6.6.5
 validators==0.34.0


### PR DESCRIPTION
Reverts OpenCTI-Platform/connectors#3623

pytenable contains broken update => reverting to 1.5.x

See https://app.circleci.com/pipelines/github/OpenCTI-Platform/connectors/9281/workflows/187def5b-1e4f-4174-aa46-96f919dc33ab/jobs/95156