### PR TITLE
[CVE] Use the correct apiKey field for header

### DIFF
--- a/external-import/cve/src/services/client/api.py
+++ b/external-import/cve/src/services/client/api.py
@@ -19,7 +19,7 @@ class CVEClient:
         :param helper: OCTI helper
         :param header:
         """
-        headers = {"Bearer": api_key, "User-Agent": header}
+        headers = {"apiKey": api_key, "User-Agent": header}
         self.token = api_key
         self.helper = helper
         self.session = requests.Session()


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Use the correct apiKey field for header

Output
- Response status is 200 even if the wrong key is given BUT it's limited 
- Following NVD:

> Including apiKey:{key value}, (without brackets or spaces) allows users to make a greater number of requests in a given time than they could otherwise

Link to NVD documentation : [HERE](https://nvd.nist.gov/developers/start-here#:~:text=Including%20apiKey%3A%7Bkey%20value%7D%2C%20(without%20brackets%20or%20spaces)%20allows%20users%20to%20make%20a%20greater%20number%20of%20requests%20in%20a%20given%20time%20than%20they%20could%20otherwise)

This change add apiKey field to avoid rate limiting issues

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3813

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
