### PR TITLE
[Dragos] fix: missing api_secret in Dragos config

### DIFF
--- a/external-import/dragos/dragos/adapters/config/env.py
+++ b/external-import/dragos/dragos/adapters/config/env.py
@@ -91,6 +91,10 @@ class _ConfigLoaderEnvDragos(ConfigLoaderDragos):
         return os.getenv("DRAGOS_API_TOKEN")
 
     @property
+    def _api_secret(self) -> str:
+        return os.getenv("DRAGOS_API_SECRET")
+
+    @property
     def _import_start_date(self) -> str:
         return os.getenv("DRAGOS_IMPORT_START_DATE")
 

--- a/external-import/dragos/dragos/adapters/config/yaml.py
+++ b/external-import/dragos/dragos/adapters/config/yaml.py
@@ -127,6 +127,10 @@ class _ConfigLoaderYAMLDragos(ConfigLoaderDragos):
         return self._raw_config.get("api_token")
 
     @property
+    def _api_secret(self) -> str:
+        return self._raw_config.get("api_secret")
+
+    @property
     def _import_start_date(self) -> str:
         return self._raw_config.get("import_start_date")
 

--- a/external-import/dragos/dragos/interfaces/config.py
+++ b/external-import/dragos/dragos/interfaces/config.py
@@ -368,7 +368,7 @@ class ConfigLoader(ABC, FrozenBaseModel):
                 "id": self.connector.id,
                 "type": self.connector.type,
                 "name": self.connector.name,
-                "scope": self.connector.scope,
+                "scope": ",".join(self.connector.scope),
                 "log_level": self.connector.log_level,
                 "duration": self.connector.duration_period,
                 "queue_threshold": self.connector.queue_threshold,

--- a/external-import/dragos/dragos/interfaces/config.py
+++ b/external-import/dragos/dragos/interfaces/config.py
@@ -355,7 +355,7 @@ class ConfigLoader(ABC, FrozenBaseModel):
 
     def to_dict(self, token_as_plaintext: bool = False) -> dict[str, Any]:
         """Gather configuration settings and return them as a dictionary."""
-        dct =  {
+        dct = {
             "opencti": {
                 "url": self.opencti.url,
                 "token": (
@@ -394,6 +394,7 @@ class ConfigLoader(ABC, FrozenBaseModel):
                 "tlp_level": self.dragos.tlp_level,
             },
         }
+
         # recursively remove all None key/value pairs from the dictionary
         def _remove_none(d: dict[str, Any]) -> dict[str, Any]:
             """Recursively remove None values from a dictionary.
@@ -403,5 +404,10 @@ class ConfigLoader(ABC, FrozenBaseModel):
                 {'a': 1, 'c': {'d': 2}}
 
             """
-            return {k: _remove_none(v) if isinstance(v, dict) else v for k, v in d.items() if v is not None}
+            return {
+                k: _remove_none(v) if isinstance(v, dict) else v
+                for k, v in d.items()
+                if v is not None
+            }
+
         return _remove_none(dct)

--- a/external-import/dragos/tests/tests_dragos/tests_adapters/tests_config/test_env.py
+++ b/external-import/dragos/tests/tests_dragos/tests_adapters/tests_config/test_env.py
@@ -26,6 +26,7 @@ def valid_config(monkeypatch):
             "CONNECTOR_SEND_TO_DIRECTORY": "false",
             "DRAGOS_API_BASE_URL": "https://api.dragos.com",
             "DRAGOS_API_TOKEN": "dragos_token",
+            "DRAGOS_API_SECRET": "dragos_secret",
             "DRAGOS_IMPORT_START_DATE": "2023-01-01T00:00:00Z",
             "DRAGOS_TLP_LEVEL": "amber",
         }

--- a/external-import/dragos/tests/tests_dragos/tests_adapters/tests_config/test_yaml.py
+++ b/external-import/dragos/tests/tests_dragos/tests_adapters/tests_config/test_yaml.py
@@ -27,6 +27,7 @@ connector:
 dragos:
     api_base_url: "https://api.dragos.com"
     api_token: "dragos_token"
+    api_secret: "dragos_secret"
     import_start_date: "2023-01-01T00:00:00Z"
     tlp_level: "amber"
 """

--- a/external-import/dragos/tests/tests_dragos/tests_interfaces/test_config.py
+++ b/external-import/dragos/tests/tests_dragos/tests_interfaces/test_config.py
@@ -98,6 +98,7 @@ class StubConfigLoaderDragos(ConfigLoaderDragos):
     def _tlp_level(self):
         return "amber"
 
+
 @pytest.fixture(scope="function")
 def config_loader_dragos():
     """Fixture for the ConfigLoaderDragos class."""
@@ -269,7 +270,9 @@ def test_config_loader_dragos_has_correct_attributes():
 
 
 @freeze_time("2010-01-01T01:00:00", tz_offset=2)  # CEST
-def test_config_dragos_import_start_handless_relative_import_start_date(config_loader_dragos):
+def test_config_dragos_import_start_handless_relative_import_start_date(
+    config_loader_dragos,
+):
     """Test that the _ConfigLoaderDragos handles relative import start date."""
 
     # Given: Valid implementation of ConfigLoaderDragos

--- a/external-import/dragos/tests/tests_dragos/tests_interfaces/test_config.py
+++ b/external-import/dragos/tests/tests_dragos/tests_interfaces/test_config.py
@@ -80,11 +80,15 @@ class StubConfigLoaderDragos(ConfigLoaderDragos):
 
     @property
     def _api_base_url(self):
-        return "http://localhost:8080"
+        return "http://localhost:4000"
 
     @property
     def _api_token(self):
         return "api-token"
+
+    @property
+    def _api_secret(self):
+        return "api-secret"
 
     @property
     def _import_start_date(self):
@@ -93,6 +97,11 @@ class StubConfigLoaderDragos(ConfigLoaderDragos):
     @property
     def _tlp_level(self):
         return "amber"
+
+@pytest.fixture(scope="function")
+def config_loader_dragos():
+    """Fixture for the ConfigLoaderDragos class."""
+    return StubConfigLoaderDragos()
 
 
 class StubConfigLoader(ConfigLoader):
@@ -248,7 +257,7 @@ def test_config_loader_dragos_has_correct_attributes():
 
     # Then: The instance should have the correct attributes
     assert (  # noqa: S101 # we indeed call assert in test
-        str(stub_config_loader_dragos.api_base_url) == "http://localhost:8080/"
+        str(stub_config_loader_dragos.api_base_url) == "http://localhost:4000/"
     )  # trailing slash is coming from URL object serialization
     assert (  # noqa: S101
         stub_config_loader_dragos.api_token.get_secret_value() == "api-token"
@@ -260,7 +269,7 @@ def test_config_loader_dragos_has_correct_attributes():
 
 
 @freeze_time("2010-01-01T01:00:00", tz_offset=2)  # CEST
-def test_config_dragos_import_start_handless_relative_import_start_date():
+def test_config_dragos_import_start_handless_relative_import_start_date(config_loader_dragos):
     """Test that the _ConfigLoaderDragos handles relative import start date."""
 
     # Given: Valid implementation of ConfigLoaderDragos
@@ -275,6 +284,10 @@ def test_config_dragos_import_start_handless_relative_import_start_date():
         @property
         def _api_token(self):
             return "api-token"
+
+        @property
+        def _api_secret(self):
+            return "api-secret"
 
         @property
         def _import_start_date(self):


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add api_secret for dragos

Aside :
* fix None config values handled by pycti
* fix scopes as a joined str for pycti interpretation

### Related issues

* N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->
