### PR TITLE
[qradar]: No error logs when the connector is not able to contact configured QRadar instance

### DIFF
--- a/stream/qradar/src/qradar.py
+++ b/stream/qradar/src/qradar.py
@@ -58,6 +58,17 @@ class QRadarConnector:
         )
         self.headers = {"SEC": self.qradar_token}
 
+        try:
+            self._initialize_reference_sets()
+        except Exception as ex:
+            self.helper.connector_logger.error(
+                "[RefSet Init] Failed processing data {" + str(ex) + "}"
+            )
+
+    def _initialize_reference_sets(self):
+        """
+        :return:
+        """
         # Collections sets
         self.collection_sets = {
             "ipv4-addr": {
@@ -116,6 +127,7 @@ class QRadarConnector:
         r = requests.get(
             url=self.base_url_sets, headers=self.headers, verify=self.qradar_ssl_verify
         )
+        r.raise_for_status()
         data = r.json()
         for key in self.collection_sets.keys():
             already_exist = False
@@ -133,6 +145,7 @@ class QRadarConnector:
                     headers=self.headers,
                     verify=self.qradar_ssl_verify,
                 )
+                r.raise_for_status()
                 result = r.json()
                 self.collection_sets[key]["qradar_id"] = result["id"]
 


### PR DESCRIPTION
### Proposed changes

* Better handle reference sets creation responses

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3853

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
