### PR TITLE
[Ransomwarelive] Fix missing dates

### DIFF
--- a/external-import/ransomwarelive/requirements.txt
+++ b/external-import/ransomwarelive/requirements.txt
@@ -1,4 +1,5 @@
 pycti==6.6.8
 stix2==3.0.1
 validators==0.34.0
+pydantic>=2.10, <3
 tldextract


### PR DESCRIPTION
### Proposed changes

* Fix of missing dates in relationships between: 
  - An intrusion group and a victim.
  - A threat actor and a victim.

* Values used:
  - `Discovered` in Ransomwarelive -> `created` in OpenCTI (relationship)
  - `AttackDate` in Ransomwarelive -> `start_time` in OpenCTI (relationship)

### Related issues

* #3475

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
