### PR TITLE
[Import Document AI] Import Document AI matches existing TTP

### DIFF
--- a/internal-import-file/import-document-ai/src/reportimporter/util.py
+++ b/internal-import-file/import-document-ai/src/reportimporter/util.py
@@ -114,7 +114,7 @@ stix_object_mapping = {
         allow_custom=True,
     ),
     "Attack-Pattern.x_mitre_id": lambda value, object_markings, custom_properties: stix2.AttackPattern(
-        id=AttackPattern.generate_id(value),
+        id=AttackPattern.generate_id(name=value, x_mitre_id=value),
         name=value,
         object_markings=object_markings,
         custom_properties=custom_properties,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* When a TTP is extracted by Import Document AI connector, check if it exists in the platform to avoid duplication

### Related issue

* https://github.com/OpenCTI-Platform/connectors/issues/3871

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

There has been a quick demo to product to ensure the solution is sufficient
