### PR TITLE
Add description extraction from extensions

### DIFF
--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -173,6 +173,16 @@ class SplunkConnector:
         # add stream name
         payload["stream_name"] = self.helper.get_stream_collection()["name"]
 
+        # Check for description in various places
+        if "x_opencti_description" in payload:
+            payload["description"] = payload["x_opencti_description"]
+        elif "extensions" in payload:
+            # Look for description in extensions
+            for ext_id, extension in payload["extensions"].items():
+                if "description" in extension:
+                    payload["description"] = extension["description"]
+                    break
+
         if "type" in payload:
             if payload["type"] == "indicator" and payload["pattern_type"].startswith(
                 "stix"
@@ -232,6 +242,7 @@ class SplunkConnector:
                     "labels",
                     "is_inferred",
                     "main_observable_type",
+                    "description",
                 ]:
                     attribute_value = extension_definition.get(attribute_name)
                     if attribute_value:


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Initially it was feature request https://github.com/OpenCTI-Platform/connectors/issues/3614
* Extraction of the description from (extensions) field have been added to support description field in 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
