### PR TITLE
[Disinfox] Rename env var for get_config_variable()

### DIFF
--- a/external-import/disinfox/docker-compose.yml
+++ b/external-import/disinfox/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       # - CONNECTOR_SEND_TO_DIRECTORY_RETENTION=7 # Default 7, in days
 
       # Connector's custom execution parameters
-      - DISINFOX_BASE_URL=${DISINFOX_URL}
+      - DISINFOX_URL=${DISINFOX_URL}
       - DISINFOX_API_KEY=${DISINFOX_API_KEY}
 
       # Add proxy parameters below if needed

--- a/external-import/disinfox/src/config.yml.sample
+++ b/external-import/disinfox/src/config.yml.sample
@@ -20,5 +20,5 @@ connector:
   #send_to_directory_retention: 7
 
 disinfox:
-  api_base_url: 'ChangeMe'
+  url: 'ChangeMe'
   api_key: 'ChangeMe'

--- a/external-import/disinfox/src/external_import_connector/config_variables.py
+++ b/external-import/disinfox/src/external_import_connector/config_variables.py
@@ -44,8 +44,8 @@ class ConfigConnector:
 
         # Connector extra parameters
         self.api_base_url = get_config_variable(
-            "DISINFOX_BASE_URL",
-            ["disinfox", "api_base_url"],
+            "DISINFOX_URL",
+            ["disinfox", "url"],
             self.load,
         )
 


### PR DESCRIPTION
ensure same name is used everywhere while mitigating breaking changes

### Proposed changes

* replace `DISINFOX_BASE_URL` by `DISINFOX_URL` as `get_config_variable()` argument
* ensure same name is used everywhere (_docker-compose.yml_, _config.yml_)

### Related issues

* #3904 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] ~~I added/update the relevant documentation (either on github or on notion)~~ not necessary
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This PR ensure same config behavior when launching the connector both manually and as a docker image, while mitigating the breaking changes. This is why the code has been changed to correspond to the _.env_ file and not the opposite.
