### PR TITLE
[splunk] Add basic auth for splunk<7.3

### DIFF
--- a/stream/splunk/README.md
+++ b/stream/splunk/README.md
@@ -24,6 +24,7 @@ This connector allows organizations to feed a **Splunk** KV Store using OpenCTI 
 | `connector_live_stream_start_timestamp` | `CONNECTOR_LIVE_STREAM_START_TIMESTAMP` | No        | Start timestamp used on connector first start.                                                |
 | `splunk_url`                            | `SPLUNK_URL`                            | Yes       | The Splunk instances REST API URLs as array                                                   |
 | `splunk_token`                          | `SPLUNK_TOKEN`                          | Yes       | The Splunk token                                                                              |
+| `splunk_auth_type`                      | `SPLUNK_AUTH_TYPE`                      | Yes       | The Splunk auth type: Bearer or Basic (default: `Bearer`)                                     |
 | `splunk_owner`                          | `SPLUNK_OWNER`                          | Yes       | The Splunk KV store owners as array (same order as URLs)                                      |
 | `splunk_ssl_verify`                     | `SPLUNK_SSL_VERIFY`                     | Yes       | Enable the SSL certificate check for all instances (default: `true`)                          |
 | `splunk_app`                            | `SPLUNK_APP`                            | Yes       | The app of the KV Store for all instances.                                                    |
@@ -37,6 +38,7 @@ This connector allows organizations to feed a **Splunk** KV Store using OpenCTI 
 
 - This connector will connect your Splunk API as the user specified in field splunk_owner (recommended value is `nobody` which is the default for splunk to create a kvstore)
 - You have to create a token in Splunk (beware of expiration time): Settings > Users and Authentication > Tokens
+- If you are using Splunk version lower than 7.3, you must use Basic authentication (`SPLUNK_AUTH_TYPE=Basic`) instead of Bearer tokens. In this case, set the `SPLUNK_TOKEN` parameter to your credentials encoded as base64(user:password), as required by Basic authentication.
 - You may have to whitelist your connector EGRESS IP address to hit the API endpoint: Settings > Server Settings > IP allow list > Search head API Access (tab)
 - As a splunk_url, it is recommended to use your search head instance, so that the created kvstore is replicated across your other splunk instances. Note that any kvstore created on "non-search head" won't be replicated nor visible on the search head.
 - The connector will create a kvstore named as per splunk_kv_store_name field value. Note that no other existing object in your splunk instance can have the same name.

--- a/stream/splunk/docker-compose.yml
+++ b/stream/splunk/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - CONNECTOR_LOG_LEVEL=error
       - SPLUNK_URL=https://splunk1.changeme.com:8089
       - SPLUNK_TOKEN=Token1
+      - SPLUNK_AUTH_TYPE=Bearer
       - SPLUNK_OWNER=nobody
       - SPLUNK_SSL_VERIFY=true
       - SPLUNK_APP=search

--- a/stream/splunk/src/config.yml.sample
+++ b/stream/splunk/src/config.yml.sample
@@ -16,6 +16,7 @@ connector:
 splunk:
   url: 'https://splunk1.changeme.com:8089'
   token: 'ChangeMe'
+  auth_type: 'Bearer'
   owner: 'nobody'
   ssl_verify: true
   app: 'search'

--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -38,6 +38,7 @@ class KVStore:
         self,
         splunk_url: str,
         splunk_token: str,
+        splunk_auth_type: str,
         splunk_app: str,
         splunk_owner: str,
         splunk_kv_store_name: str,
@@ -45,6 +46,7 @@ class KVStore:
     ) -> None:
         self.splunk_url = splunk_url
         self.splunk_token = splunk_token
+        self.splunk_auth_type = splunk_auth_type
         self.splunk_app = splunk_app
         self.splunk_owner = splunk_owner
         self.splunk_kv_store_name = splunk_kv_store_name
@@ -57,7 +59,7 @@ class KVStore:
     @property
     def headers(self) -> dict:
         return {
-            "Authorization": f"Bearer {self.splunk_token}",
+            "Authorization": f"{self.splunk_auth_type} {self.splunk_token}",
             "Content-Type": "application/json",
         }
 
@@ -356,6 +358,8 @@ if __name__ == "__main__":
         ).split(",")
         splunk_url = get_config_variable("SPLUNK_URL", ["splunk", "url"], config)
         splunk_token = get_config_variable("SPLUNK_TOKEN", ["splunk", "token"], config)
+        splunk_auth_type: str = get_config_variable(
+            "SPLUNK_AUTH_TYPE", ["splunk","auth_type"], config, default="Bearer")
         splunk_owner = get_config_variable("SPLUNK_OWNER", ["splunk", "owner"], config)
         splunk_ssl_verify = get_config_variable(
             "SPLUNK_SSL_VERIFY", ["splunk", "ssl_verify"], config, False, True
@@ -389,6 +393,7 @@ if __name__ == "__main__":
         kvstore = KVStore(
             splunk_url,
             splunk_token,
+            splunk_auth_type,
             splunk_app,
             splunk_owner,
             splunk_kv_store_name,

--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -359,7 +359,8 @@ if __name__ == "__main__":
         splunk_url = get_config_variable("SPLUNK_URL", ["splunk", "url"], config)
         splunk_token = get_config_variable("SPLUNK_TOKEN", ["splunk", "token"], config)
         splunk_auth_type: str = get_config_variable(
-            "SPLUNK_AUTH_TYPE", ["splunk","auth_type"], config, default="Bearer")
+            "SPLUNK_AUTH_TYPE", ["splunk", "auth_type"], config, default="Bearer"
+        )
         splunk_owner = get_config_variable("SPLUNK_OWNER", ["splunk", "owner"], config)
         splunk_ssl_verify = get_config_variable(
             "SPLUNK_SSL_VERIFY", ["splunk", "ssl_verify"], config, False, True


### PR DESCRIPTION
### Proposed changes
* Add Basic authentication to Splunk connector based on [docs](https://docs.splunk.com/Documentation/Splunk/latest/RESTUM/RESTusing#Authentication_and_authorization). 
* Basic authentication can help with incredibly old environments like Splunk<7.3 where you can't use Bearer authentication.

### Related issue
- https://github.com/OpenCTI-Platform/connectors/issues/4055

### Checklist
- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
