### PR TITLE
[Dogesec] Fix all connector dogesec for circleci

### DIFF
--- a/external-import/dogesec-ctibutler/Dockerfile
+++ b/external-import/dogesec-ctibutler/Dockerfile
@@ -2,13 +2,14 @@ FROM python:3.12-alpine
 ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
 
 # Copy the connector
-COPY src /opt/opencti-ctibutler
+COPY src /opt/opencti-connector-dogesec-ctibutler
 
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apk update && apk upgrade && \
-    apk --no-cache add git build-base libmagic libxslt libxslt-dev libxml2 libxml2-dev && \
-    cd /opt/opencti-ctibutler && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN cd /opt/opencti-connector-dogesec-ctibutler && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base && \
     rm -rf /var/cache/apk/*

--- a/external-import/dogesec-ctibutler/docker-compose.yml
+++ b/external-import/dogesec-ctibutler/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  connector-ctibutler:
+  connector-dogesec-ctibutler:
     image: opencti/connector-dogesec-ctibutler:6.6.4
     environment:
       - OPENCTI_URL=http://opencti:8080

--- a/external-import/dogesec-ctibutler/entrypoint.sh
+++ b/external-import/dogesec-ctibutler/entrypoint.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Go to the right directory
+cd /opt/opencti-connector-dogesec-ctibutler
+
 # Start the connector
 python src/connector.py

--- a/external-import/dogesec-obstracts/Dockerfile
+++ b/external-import/dogesec-obstracts/Dockerfile
@@ -2,17 +2,19 @@ FROM python:3.12-alpine
 ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
 
 # Copy the connector
-COPY . /opt/opencti-obstracts
-WORKDIR /opt/opencti-obstracts
+COPY src /opt/opencti-connector-dogesec-obstracts
 
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apk update && apk upgrade && \
-    apk --no-cache add git build-base libmagic libxslt libxslt-dev libxml2 libxml2-dev && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN cd /opt/opencti-connector-dogesec-obstracts && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base && \
     rm -rf /var/cache/apk/*
 
-RUN chmod +x entrypoint.sh
-
-ENTRYPOINT ["/opt/opencti-obstracts/entrypoint.sh"]
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/dogesec-obstracts/docker-compose.yml
+++ b/external-import/dogesec-obstracts/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  connector-obstracts:
+  connector-dogesec-obstracts:
     image: opencti/connector-dogesec-obstracts:6.6.4
     environment:
       - OPENCTI_URL=http://opencti:8080

--- a/external-import/dogesec-obstracts/entrypoint.sh
+++ b/external-import/dogesec-obstracts/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
-echo rragarfg
+# Go to the right directory
+cd /opt/opencti-connector-dogesec-obstracts
+
 # Start the connector
 python src/obstracts.py

--- a/external-import/dogesec-stixify/Dockerfile
+++ b/external-import/dogesec-stixify/Dockerfile
@@ -2,17 +2,19 @@ FROM python:3.12-alpine
 ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
 
 # Copy the connector
-COPY . /opt/opencti-stixify
-WORKDIR /opt/opencti-stixify
+COPY src /opt/opencti-connector-dogesec-stixify
 
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apk update && apk upgrade && \
-    apk --no-cache add git build-base libmagic libxslt libxslt-dev libxml2 libxml2-dev && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN cd /opt/opencti-connector-dogesec-stixify && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base && \
     rm -rf /var/cache/apk/*
 
-RUN chmod +x entrypoint.sh
-
-ENTRYPOINT ["/opt/opencti-stixify/entrypoint.sh"]
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/dogesec-stixify/docker-compose.yml
+++ b/external-import/dogesec-stixify/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  connector-stixify:
+  connector-dogesec-stixify:
     image: opencti/connector-dogesec-stixify:6.6.8
     environment:
       - OPENCTI_URL=http://opencti:8080

--- a/external-import/dogesec-stixify/entrypoint.sh
+++ b/external-import/dogesec-stixify/entrypoint.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Go to the right directory
+cd /opt/opencti-connector-dogesec-stixify
+
 # Start the connector
 python src/connector.py

--- a/external-import/dogesec-vulmatch/Dockerfile
+++ b/external-import/dogesec-vulmatch/Dockerfile
@@ -2,13 +2,14 @@ FROM python:3.12-alpine
 ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
 
 # Copy the connector
-COPY src /opt/opencti-vulmatch
+COPY src /opt/opencti-connector-dogesec-vulmatch
 
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apk update && apk upgrade && \
-    apk --no-cache add git build-base libmagic libxslt libxslt-dev libxml2 libxml2-dev && \
-    cd /opt/opencti-vulmatch && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN cd /opt/opencti-connector-dogesec-vulmatch && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base && \
     rm -rf /var/cache/apk/*

--- a/external-import/dogesec-vulmatch/docker-compose.yml
+++ b/external-import/dogesec-vulmatch/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  connector-vulmatch:
+  connector-dogesec-vulmatch:
     image: opencti/connector-dogesec-vulmatch:6.6.8
     environment:
       - OPENCTI_URL=http://opencti:8080

--- a/external-import/dogesec-vulmatch/entrypoint.sh
+++ b/external-import/dogesec-vulmatch/entrypoint.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Go to the right directory
+cd /opt/opencti-connector-dogesec-vulmatch
+
 # Start the connector
 python src/connector.py


### PR DESCRIPTION
### Proposed changes

CircleCI problem for Dogesec connectors (External-Import):

- dogesec-ctibutler
- dogesec-obstracts
- dogesec-stixify
- dogesec-vulmatch

### Related issues

* #3913 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
