### PR TITLE
[Feedly] Modify relationship_type when transforming threat actors to intrusion set

### DIFF
--- a/external-import/feedly/src/feedly/opencti_connector/connector.py
+++ b/external-import/feedly/src/feedly/opencti_connector/connector.py
@@ -74,6 +74,11 @@ def _transform_threat_actors_to_intrusion_sets(bundle: dict) -> None:
             o["target_ref"] = o.get("target_ref").replace(
                 "threat-actor", "intrusion-set"
             )
+            if o["relationship_type"] == "located-at" and (
+                o["source_ref"].startswith("intrusion-set")
+                or o["target_ref"].startswith("intrusion-set")
+            ):
+                o["relationship_type"] = "originates-from"
         for i, object_ref in enumerate(o.get("object_refs", [])):
             o["object_refs"][i] = object_ref.replace("threat-actor", "intrusion-set")
 

--- a/external-import/feedly/src/feedly/opencti_connector/connector.py
+++ b/external-import/feedly/src/feedly/opencti_connector/connector.py
@@ -74,6 +74,8 @@ def _transform_threat_actors_to_intrusion_sets(bundle: dict) -> None:
             o["target_ref"] = o.get("target_ref").replace(
                 "threat-actor", "intrusion-set"
             )
+        for i, object_ref in enumerate(o.get("object_refs", [])):
+            o["object_refs"][i] = object_ref.replace("threat-actor", "intrusion-set")
 
 
 def _add_source_name_as_author_to_all_reports(bundle: dict) -> None:


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Modify the relationship_type when transforming threat actors to intrusion set if the type is located-at
* Not required but implemented:
  * Fix objects_refs when present during transformation threat-actor to intrusion-set

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3915