### PR TITLE
[dogesec cti butler/obstracts/stixify/vulmatch] fix entrypoints for dogesec-*

### DIFF
--- a/external-import/dogesec-ctibutler/entrypoint.sh
+++ b/external-import/dogesec-ctibutler/entrypoint.sh
@@ -3,4 +3,4 @@
 cd /opt/opencti-connector-dogesec-ctibutler
 
 # Start the connector
-python src/connector.py
+python connector.py

--- a/external-import/dogesec-obstracts/entrypoint.sh
+++ b/external-import/dogesec-obstracts/entrypoint.sh
@@ -3,4 +3,4 @@
 cd /opt/opencti-connector-dogesec-obstracts
 
 # Start the connector
-python src/obstracts.py
+python obstracts.py

--- a/external-import/dogesec-stixify/entrypoint.sh
+++ b/external-import/dogesec-stixify/entrypoint.sh
@@ -3,4 +3,4 @@
 cd /opt/opencti-connector-dogesec-stixify
 
 # Start the connector
-python src/connector.py
+python connector.py

--- a/external-import/dogesec-vulmatch/entrypoint.sh
+++ b/external-import/dogesec-vulmatch/entrypoint.sh
@@ -3,4 +3,4 @@
 cd /opt/opencti-connector-dogesec-vulmatch
 
 # Start the connector
-python src/connector.py
+python connector.py


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* modify entrypoint file path to point to correct file

### Related issues
- https://github.com/OpenCTI-Platform/connectors/issues/3930

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
