### PR TITLE
[ransomwarelive] Add missing whois library

### DIFF
--- a/external-import/ransomwarelive/requirements.txt
+++ b/external-import/ransomwarelive/requirements.txt
@@ -3,3 +3,4 @@ stix2==3.0.1
 validators==0.34.0
 pydantic>=2.10, <3
 tldextract
+whois==1.20240129.2


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add missing whois library in requirements.txt file

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3941

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
