### PR TITLE
[malwarebazaar] MalwareBazaar Connector that will create a File Observable; Supports disabling of the upload of the actual malware file.

### DIFF
--- a/external-import/malwarebazaar/.dockerignore
+++ b/external-import/malwarebazaar/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/malwarebazaar/Dockerfile
+++ b/external-import/malwarebazaar/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-alpine
+ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
+
+# Copy the connector
+COPY src /opt/opencti-connector-malwarebazaar
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk update && apk upgrade && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN cd /opt/opencti-connector-malwarebazaar && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/malwarebazaar/README.md
+++ b/external-import/malwarebazaar/README.md
@@ -1,0 +1,171 @@
+# OpenCTI MalwareBazaar Connector
+
+Table of Contents
+
+- [OpenCTI MalwareBazaar Connector](#OpenCTI-MalwareBazaar-Connector)
+  - [Introduction](#introduction)
+    - [Difference](#difference)
+  - [Installation](#installation)
+    - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenCTI environment variables](#opencti-environment-variables)
+    - [Base connector environment variables](#base-connector-environment-variables)
+    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
+
+## Introduction
+
+MalwareBazaar is a platform from abuse.ch and Spamhaus, dedicated to sharing malware samples with the infosec
+community, antivirus vendors, and threat intelligence providers.
+
+This connector will communicate with the Malware Bazaar API and pull data into OpenCTI.
+
+
+### Difference
+
+There is another Malware Bazaar connector named `MalwareBazaar-Recent-Additions`. The difference between MalwareBazaar versus MalwareBazaar-Recent-Additions can be summarized as the following:
+- MalwareBazaar uses the newer connecter template that pushes objects onto the RabbitMQ queue for processing.
+- MalwareBazaar creates a File Observable (versus an Artifact).
+- MalwareBazaar does NOT upload the real malware file to your storage system (or even touch during communication with MalwareBazaar). Only JSON metadata is processed.
+- Since this connector does not download the malware file, the `MALWAREBAZAAR_API_KEY` is optional, since the current implementatio of this connector only downloads recent meta data entries. This API query (`get_recent`) will permit a query and provide a response, without an API key.
+
+
+## Installation
+
+### Requirements
+
+- OpenCTI Platform >= 6.6.12
+
+### Configuration Variables
+
+### OpenCTI environment variables
+
+Below are the parameters you'll need to set for OpenCTI:
+
+| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
+|---------------|------------|-----------------------------|-----------|------------------------------------------------------|
+| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
+| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+
+### Base connector environment variables
+
+Below are the parameters you'll need to set for running the connector properly:
+
+| Parameter       | config.yml | Docker environment variable | Default         | Mandatory | Description                                                                              |
+|-----------------|------------|-----------------------------|-----------------|-----------|------------------------------------------------------------------------------------------|
+| Connector ID    | id         | `CONNECTOR_ID`              | ChangeMe               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
+| Connector Type  | type       | `CONNECTOR_TYPE`            | EXTERNAL_IMPORT | Yes       | Should always be set to `EXTERNAL_IMPORT` for this connector.                            |
+| Connector Name  | name       | `CONNECTOR_NAME`            | MalwareBazaar                | Yes       | Name of the connector.                                                                   |
+| Duration Period       | `duration_period`   | `CONNECTOR_DURATION_PERIOD`   | PT5M           | Yes       | Determines the time interval between each launch of the connector in ISO 8601, ex: `PT5M` Will run the process every 5 minutes.        |
+| Connector Scope | scope      | `CONNECTOR_SCOPE`           | StixFile                | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
+| Log Level       | log_level  | `CONNECTOR_LOG_LEVEL`       | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
+
+### Connector extra parameters environment variables
+
+Below are the parameters you'll need to set for the connector:
+
+| Parameter    | config.yml   | Docker environment variable | Default | Mandatory | Description |
+|--------------|--------------|-----------------------------|---------|-----------|-------------|
+| `malwarebazaar_api_base_url`        | `MALWAREBAZAAR_API_BASE_URL`        | Yes       | API Endpoint for MalwareBazaar - https://mb-api.abuse.ch/api/v1/ |
+| `malwarebazaar_api_key`        | `MALWAREBAZAAR_API_KEY`        | No       | Not required for current implementation; Issued by MalwareBazaar - Free Auth-Key - https://bazaar.abuse.ch/api/#auth_key |
+| `malwarebazaar_tlp_level`        | `MALWAREBAZAAR_TLP_LEVEL`        | Yes       | available values are: clear, white, green, amber, amber+strict, red - Default: 'clear' |
+| `malwarebazaar_x_opencti_score`        | `MALWAREBAZAAR_X_OPENCTI_SCORE`        | Yes       | Range is 0 - 100, will degrade over time see: https://docs.opencti.io/latest/usage/indicators-lifecycle/#score-decay |
+| `malwarebazaar_include_tags`        | `MALWAREBAZAAR_INCLUDE_TAGS`        | No       | (Optional) Only download files if any tag matches. (Comma separated... exe,dll,docm,docx,doc,xls,xlsx,xlsm,js) |
+| `malwarebazaar_include_reporters`        | `MALWAREBAZAAR_INCLUDE_TAGS`        | No       | (Optional) Only download files uploaded by these reporters. (Comma separated) |
+| `malwarebazaar_labels`        | `MALWAREBAZAAR_LABELS`        | No       | (Optional) Labels to apply to uploaded Artifacts. (Comma separated) |
+
+## Deployment
+
+### Docker Deployment
+
+Before building the Docker container, you need to set the version of pycti in `requirements.txt` equal to whatever
+version of OpenCTI you're running. Example, `pycti==5.12.20`. If you don't, it will take the latest version, but
+sometimes the OpenCTI SDK fails to initialize.
+
+Build a Docker Image using the provided `Dockerfile`.
+
+Example:
+
+```shell
+# Replace the IMAGE NAME with the appropriate value
+docker build . -t [IMAGE NAME]:latest
+```
+
+Make sure to replace the environment variables in `docker-compose.yml` with the appropriate configurations for your
+environment. Then, start the docker container with the provided docker-compose.yml
+
+```shell
+docker compose up -d
+# -d for detached
+```
+
+### Manual Deployment
+
+Create a file `config.yml` based on the provided `config.yml.sample`.
+
+Replace the configuration variables (especially the "**ChangeMe**" variables) with the appropriate configurations for
+you environment.
+
+Install the required python dependencies (preferably in a virtual environment):
+
+```shell
+pip3 install -r requirements.txt
+```
+
+Then, start the connector from recorded-future/src:
+
+```shell
+python3 main.py
+```
+
+## Usage
+
+After Installation, the connector should require minimal interaction to use, and should update automatically at a regular interval specified in your `docker-compose.yml` or `config.yml` in `duration_period`.
+
+However, if you would like to force an immediate download of a new batch of entities, navigate to:
+
+`Data management` -> `Ingestion` -> `Connectors` in the OpenCTI platform.
+
+Find the connector, and click on the refresh button to reset the connector's state and force a new
+download of data by re-running the connector.
+
+## Behavior
+
+<!--
+Describe how the connector functions:
+* What data is ingested, updated, or modified
+* Important considerations for users when utilizing this connector
+* Additional relevant details
+-->
+This connector, for fidelity of data, requires that ingested objects have the following required fields defined:
+- MD5 hash
+- SHA1 hash
+- SHA256 hash
+- An associated reporter
+- An associated filename
+
+Entities missing these require fields will be skipped and an error entry will be sent to the error log for the connector.
+
+## Debugging
+
+The connector can be debugged by setting the appropiate log level.
+Note that logging messages can be added using `self.helper.connector_logger,{LOG_LEVEL}("Sample message")`, i.
+e., `self.helper.connector_logger.error("An error message")`.
+
+<!-- Any additional information to help future users debug and report detailed issues concerning this connector -->
+
+## Additional information
+
+None
+<!--
+Any additional information about this connector
+* What information is ingested/updated/changed
+* What should the user take into account when using this connector
+* ...
+-->

--- a/external-import/malwarebazaar/README.md
+++ b/external-import/malwarebazaar/README.md
@@ -77,7 +77,7 @@ Below are the parameters you'll need to set for the connector:
 | `malwarebazaar_tlp_level`        | `MALWAREBAZAAR_TLP_LEVEL`        | Yes       | available values are: clear, white, green, amber, amber+strict, red - Default: 'clear' |
 | `malwarebazaar_x_opencti_score`        | `MALWAREBAZAAR_X_OPENCTI_SCORE`        | Yes       | Range is 0 - 100, will degrade over time see: https://docs.opencti.io/latest/usage/indicators-lifecycle/#score-decay |
 | `malwarebazaar_include_tags`        | `MALWAREBAZAAR_INCLUDE_TAGS`        | No       | (Optional) Only download files if any tag matches. (Comma separated... exe,dll,docm,docx,doc,xls,xlsx,xlsm,js) |
-| `malwarebazaar_include_reporters`        | `MALWAREBAZAAR_INCLUDE_TAGS`        | No       | (Optional) Only download files uploaded by these reporters. (Comma separated) |
+| `malwarebazaar_include_reporters`        | `MALWAREBAZAAR_INCLUDE_REPORTERS`        | No       | (Optional) Only download files uploaded by these reporters. (Comma separated) |
 | `malwarebazaar_labels`        | `MALWAREBAZAAR_LABELS`        | No       | (Optional) Labels to apply to uploaded Artifacts. (Comma separated) |
 
 ## Deployment

--- a/external-import/malwarebazaar/docker-compose.yml
+++ b/external-import/malwarebazaar/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   connector-malware-bazaar:
-    image: opencti/connector-malwarebazaar:6.6.12
+    image: opencti/connector-malwarebazaar:6.6.15
     environment:
       # Connector's generic execution parameters
       - OPENCTI_URL=http://opencti:8080
@@ -11,7 +11,7 @@ services:
       - CONNECTOR_NAME=MalwareBazaar
       - CONNECTOR_SCOPE=StixFile
       - CONNECTOR_LOG_LEVEL=info
-      - CONNECTOR_DURATION_PERIOD=PT5M # ISO8601 format in String, start with 'P...' for Period
+      - CONNECTOR_DURATION_PERIOD=PT50M # ISO8601 format in String, start with 'P...' for Period
       # Connector's definition parameters OPTIONAL
       # - CONNECTOR_QUEUE_THRESHOLD=500 # Default 500Mo, Float accepted
       # - CONNECTOR_RUN_AND_TERMINATE=False # Default False, True run connector once
@@ -21,7 +21,7 @@ services:
       # - CONNECTOR_SEND_TO_DIRECTORY_RETENTION=7 # Default 7, in days
       # Connector's custom execution parameters
       - MALWAREBAZAAR_API_BASE_URL=https://mb-api.abuse.ch/api/v1/
-      - MALWAREBAZAAR_API_KEY=${MALWAREBAZAAR_USER_TOKEN} # Stored in ENVAR, but can be hardcoded. Do not check TOKEN into version control
+      # - MALWAREBAZAAR_API_KEY=${MALWAREBAZAAR_USER_TOKEN} # Stored in ENVAR, but can be hardcoded. Do not check TOKEN into version control. Not required in this implementation, left here for reference if ever needed.
       - MALWAREBAZAAR_TLP_LEVEL=clear # available values are: clear, white, green, amber, amber+strict, red - Default: 'clear'
       - MALWAREBAZAAR_X_OPENCTI_SCORE=100 # Range is 0 - 100, will degrade over time see: https://docs.opencti.io/latest/usage/indicators-lifecycle/#score-decay
       - MALWAREBAZAAR_INCLUDE_TAGS=exe,dll,docm,docx,doc,xls,xlsx,xlsm,js # (Optional) Only download files if any tag matches. (Comma separated)

--- a/external-import/malwarebazaar/docker-compose.yml
+++ b/external-import/malwarebazaar/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  connector-malware-bazaar:
+    image: opencti/connector-malwarebazaar:6.6.12
+    environment:
+      # Connector's generic execution parameters
+      - OPENCTI_URL=http://opencti:8080
+      - OPENCTI_TOKEN=CHANGEME
+      # Connector's definition parameters REQUIRED
+      - CONNECTOR_ID=${MALWAREBAZAAR_CONNECTOR_ID} # Make sure to define this in ENV or config.yml
+      - CONNECTOR_TYPE=EXTERNAL_IMPORT
+      - CONNECTOR_NAME=MalwareBazaar
+      - CONNECTOR_SCOPE=StixFile
+      - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_DURATION_PERIOD=PT5M # ISO8601 format in String, start with 'P...' for Period
+      # Connector's definition parameters OPTIONAL
+      # - CONNECTOR_QUEUE_THRESHOLD=500 # Default 500Mo, Float accepted
+      # - CONNECTOR_RUN_AND_TERMINATE=False # Default False, True run connector once
+      # - CONNECTOR_SEND_TO_QUEUE=True # Default True
+      # - CONNECTOR_SEND_TO_DIRECTORY=False # Default False 
+      # - CONNECTOR_SEND_TO_DIRECTORY_PATH=CHANGEME # if CONNECTOR_SEND_TO_DIRECTORY is True, you must specify a path
+      # - CONNECTOR_SEND_TO_DIRECTORY_RETENTION=7 # Default 7, in days
+      # Connector's custom execution parameters
+      - MALWAREBAZAAR_API_BASE_URL=https://mb-api.abuse.ch/api/v1/
+      - MALWAREBAZAAR_API_KEY=${MALWAREBAZAAR_USER_TOKEN} # Stored in ENVAR, but can be hardcoded. Do not check TOKEN into version control
+      - MALWAREBAZAAR_TLP_LEVEL=clear # available values are: clear, white, green, amber, amber+strict, red - Default: 'clear'
+      - MALWAREBAZAAR_X_OPENCTI_SCORE=100 # Range is 0 - 100, will degrade over time see: https://docs.opencti.io/latest/usage/indicators-lifecycle/#score-decay
+      - MALWAREBAZAAR_INCLUDE_TAGS=exe,dll,docm,docx,doc,xls,xlsx,xlsm,js # (Optional) Only download files if any tag matches. (Comma separated)
+      - MALWAREBAZAAR_INCLUDE_REPORTERS= # (Optional) Only download files uploaded by these reporters. (Comma separated)
+      - MALWAREBAZAAR_LABELS=malware-bazaar # (Optional) Labels to apply to uploaded Artifacts. (Comma separated)
+      # Add proxy parameters below if needed
+      # - HTTP_PROXY=CHANGEME
+      # - HTTPS_PROXY=CHANGEME
+      # - NO_PROXY=CHANGEME
+    restart: always
+    # networks:
+    #   - docker_default
+
+# networks:
+#   default:
+#     external: true
+#     name: docker_default

--- a/external-import/malwarebazaar/entrypoint.sh
+++ b/external-import/malwarebazaar/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Correct working directory
+cd /opt/opencti-connector-malwarebazaar
+
+# Start the connector
+python3 main.py

--- a/external-import/malwarebazaar/src/config.yml.sample
+++ b/external-import/malwarebazaar/src/config.yml.sample
@@ -8,7 +8,7 @@ connector:
   name: 'MalwareBazaar'
   scope: 'StixFile'
   log_level: 'info'
-  duration_period: 'PT5M' # Interval given for scheduler process in ISO-8601 format
+  duration_period: 'PT50M' # Interval given for scheduler process in ISO-8601 format
   #============================================#
   # Optional connector's definition parameters #
   #============================================#
@@ -21,7 +21,7 @@ connector:
 
 malwarebazaar:
   api_base_url: 'https://mb-api.abuse.ch/api/v1/'
-  api_key: 'ChangeMe'
+  # api_key: 'ChangeMe' # Not required in this implementation, left here for reference if ever needed.
   tlp_level: 'clear' # available values are: clear, white, green, amber, amber+strict, red - Default: 'clear'
   x_opencti_score: 100 # Range is 0 - 100, will degrade over time see: https://docs.opencti.io/latest/usage/indicators-lifecycle/#score-decay
   include_tags: 'exe,dll,docm,docx,doc,xls,xlsx,xlsm,js' # (Optional) Only download files if any tag matches. (Comma separated)

--- a/external-import/malwarebazaar/src/config.yml.sample
+++ b/external-import/malwarebazaar/src/config.yml.sample
@@ -1,0 +1,31 @@
+opencti:
+  url: 'http://localhost:PORT'
+  token: 'ChangeMe'
+
+connector:
+  id: 'ChangeMe'
+  type: 'EXTERNAL_IMPORT'
+  name: 'MalwareBazaar'
+  scope: 'StixFile'
+  log_level: 'info'
+  duration_period: 'PT5M' # Interval given for scheduler process in ISO-8601 format
+  #============================================#
+  # Optional connector's definition parameters #
+  #============================================#
+  #queue_threshold: 500
+  #run_and_terminate: 'False'
+  #send_to_queue: 'True'
+  #send_to_directory: 'False'
+  #send_to_directory_path: 'ChangeMe'
+  #send_to_directory_retention: 7
+
+malwarebazaar:
+  api_base_url: 'https://mb-api.abuse.ch/api/v1/'
+  api_key: 'ChangeMe'
+  tlp_level: 'clear' # available values are: clear, white, green, amber, amber+strict, red - Default: 'clear'
+  x_opencti_score: 100 # Range is 0 - 100, will degrade over time see: https://docs.opencti.io/latest/usage/indicators-lifecycle/#score-decay
+  include_tags: 'exe,dll,docm,docx,doc,xls,xlsx,xlsm,js' # (Optional) Only download files if any tag matches. (Comma separated)
+  include_reporters: '' # (Optional) Only download files uploaded by these reporters. (Comma separated)
+  labels: 'malware-bazaar' # (Optional) Labels to apply to uploaded Artifacts. (Comma separated)
+  labels_color: '#54483b' # Color to use for all labels
+  disable_malware_sample: false # If true, malware will be replaced with a benign Text file sample.

--- a/external-import/malwarebazaar/src/main.py
+++ b/external-import/malwarebazaar/src/main.py
@@ -1,0 +1,26 @@
+import traceback
+
+from pycti import OpenCTIConnectorHelper
+
+from malwarebazaar_connector import ConnectorMalwareBazaar
+from malwarebazaar_connector.config_loader import ConfigConnector
+
+if __name__ == "__main__":
+    """
+    Entry point of the script
+
+    - traceback.print_exc(): This function prints the traceback of the exception to the standard error (stderr).
+    The traceback includes information about the point in the program where the exception occurred,
+    which is very useful for debugging purposes.
+    - exit(1): effective way to terminate a Python program when an error is encountered.
+    It signals to the operating system and any calling processes that the program did not complete successfully.
+    """
+    try:
+        config = ConfigConnector()
+        helper = OpenCTIConnectorHelper(config=config.load)
+
+        connector = ConnectorMalwareBazaar(config=config, helper=helper)
+        connector.run()
+    except Exception:
+        traceback.print_exc()
+        exit(1)

--- a/external-import/malwarebazaar/src/main.py
+++ b/external-import/malwarebazaar/src/main.py
@@ -1,9 +1,8 @@
 import traceback
 
-from pycti import OpenCTIConnectorHelper
-
 from malwarebazaar_connector import ConnectorMalwareBazaar
 from malwarebazaar_connector.config_loader import ConfigConnector
+from pycti import OpenCTIConnectorHelper
 
 if __name__ == "__main__":
     """

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/__init__.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/__init__.py
@@ -1,0 +1,11 @@
+from .client_api import ConnectorClient
+from .config_loader import ConfigConnector
+from .connector import ConnectorMalwareBazaar
+from .converter_to_stix import ConverterToStix
+
+__all__ = [
+    "ConnectorClient",
+    "ConnectorMalwareBazaar",
+    "ConfigConnector",
+    "ConverterToStix",
+]

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/client_api.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/client_api.py
@@ -1,0 +1,84 @@
+"""
+MalwareBazaar is a platform from abuse.ch and Spamhaus, dedicated to sharing malware samples with the infosec
+community, antivirus vendors, and threat intelligence providers.
+
+This connector will communicate with the Malware Bazaar API and pull data into OpenCTI.
+
+In order to interact with the MalwareBazaar API, you need to obtain an Auth-Key first.
+If you don't have one you can get one for free here:
+        https://bazaar.abuse.ch/api/#auth_key
+
+MalwareBazaar API is rate Limited to restrict the number of file downloads on our file download API
+to 2,000 per IP address/day.
+        https://bazaar.abuse.ch/faq/#api-limit
+"""
+
+import requests
+
+
+class ConnectorClient:
+    def __init__(self, helper, config):
+        """
+        Represent MalwareBazaar API client interface.
+        """
+        self.helper = helper
+        self.config = config
+
+        # Define headers in session and update when needed
+        headers = {"Bearer": self.config.api_key}
+        self.session = requests.Session()
+        self.session.headers.update(headers)
+
+    def _request_data(self, api_url: str, params=None):
+        """
+        Internal method to handle API requests
+        :return: Response in JSON format
+        """
+        try:
+            response = self.session.get(api_url, params=params)
+
+            self.helper.connector_logger.info(
+                "[API] HTTP Get Request to endpoint", {"url_path": api_url}
+            )
+
+            response.raise_for_status()
+            return response
+
+        except requests.RequestException as err:
+            error_msg = "[API] Error while fetching data: "
+            self.helper.connector_logger.error(
+                error_msg, {"url_path": {api_url}, "error": {str(err)}}
+            )
+            return None
+
+    def get_entities(self, params=None) -> dict:
+        """
+        Get recent additions to MalwareBazaar.
+
+        See https://bazaar.abuse.ch/api/#latest_additions
+
+        returns: a dict containing the recent additions in the last 60 minutes to MalwareBazaar.
+        """
+        try:
+            return_data = []
+            data = {"query": "get_recent", "selector": "time"}
+            # Auth-Key not required for the 'get_recent' query for Malware Bazaar
+            # headers = {"Auth-Key": params["API_KEY"]}
+            headers = {}
+            resp = requests.post(
+                params["API_BASE_URL"], data=data, timeout=15, headers=headers
+            )
+
+            # Handle the response data
+            recent_additions_list = resp.json()
+            if "data" in recent_additions_list:
+                return_data = recent_additions_list["data"]
+            else:
+                self.helper.log_error(
+                    f"Key 'data' not found in the response from MalwareBazaar API. Did you set your API_KEY? {resp.json()} Auth-Key: {params['API_KEY']}"
+                )
+
+            return return_data
+
+        except Exception as err:
+            self.helper.connector_logger.error(err)

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/client_api.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/client_api.py
@@ -24,32 +24,10 @@ class ConnectorClient:
         self.helper = helper
         self.config = config
 
-        # Define headers in session and update when needed
-        headers = {"Bearer": self.config.api_key}
+        # Define headers in session and update when needed, if ever extended and needing api_key, add here
+        headers = {}
         self.session = requests.Session()
         self.session.headers.update(headers)
-
-    def _request_data(self, api_url: str, params=None):
-        """
-        Internal method to handle API requests
-        :return: Response in JSON format
-        """
-        try:
-            response = self.session.get(api_url, params=params)
-
-            self.helper.connector_logger.info(
-                "[API] HTTP Get Request to endpoint", {"url_path": api_url}
-            )
-
-            response.raise_for_status()
-            return response
-
-        except requests.RequestException as err:
-            error_msg = "[API] Error while fetching data: "
-            self.helper.connector_logger.error(
-                error_msg, {"url_path": {api_url}, "error": {str(err)}}
-            )
-            return None
 
     def get_entities(self, params=None) -> dict:
         """
@@ -62,8 +40,7 @@ class ConnectorClient:
         try:
             return_data = []
             data = {"query": "get_recent", "selector": "time"}
-            # Auth-Key not required for the 'get_recent' query for Malware Bazaar
-            # headers = {"Auth-Key": params["API_KEY"]}
+            # Auth-Key not required for the 'get_recent' query for Malware Bazaar, headers can be empty
             headers = {}
             resp = requests.post(
                 params["API_BASE_URL"], data=data, timeout=15, headers=headers
@@ -74,8 +51,8 @@ class ConnectorClient:
             if "data" in recent_additions_list:
                 return_data = recent_additions_list["data"]
             else:
-                self.helper.log_error(
-                    f"Key 'data' not found in the response from MalwareBazaar API. Did you set your API_KEY? {resp.json()} Auth-Key: {params['API_KEY']}"
+                self.helper.connector_logger.error(
+                    "Key 'data' not found in the response from MalwareBazaar API."
                 )
 
             return return_data

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/config_loader.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/config_loader.py
@@ -55,11 +55,11 @@ class ConfigConnector:
         # In order to interact with the MalwareBazaar API, you need to obtain an Auth-Key first.
         # If you don't have one you can get one for free here:
         #         https://bazaar.abuse.ch/api/#auth_key
-        self.api_key = get_config_variable(
-            "MALWAREBAZAAR_API_KEY",
-            ["malwarebazaar", "api_key"],
-            self.load,
-        )
+        # self.api_key = get_config_variable(
+        #     "MALWAREBAZAAR_API_KEY",
+        #     ["malwarebazaar", "api_key"],
+        #     self.load,
+        # )
 
         self.tlp_level = get_config_variable(
             "MALWAREBAZAAR_TLP_LEVEL",

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/config_loader.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/config_loader.py
@@ -1,0 +1,99 @@
+import os
+from pathlib import Path
+
+import yaml
+from pycti import get_config_variable
+
+
+class ConfigConnector:
+    def __init__(self):
+        """
+        Initialize the connector with necessary configurations
+        """
+
+        # Load configuration file
+        self.load = self._load_config()
+        self._initialize_configurations()
+
+    @staticmethod
+    def _load_config() -> dict:
+        """
+        Load the configuration from the YAML file
+        :return: Configuration dictionary
+        """
+        config_file_path = Path(__file__).parents[1].joinpath("config.yml")
+        config = (
+            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
+            if os.path.isfile(config_file_path)
+            else {}
+        )
+
+        return config
+
+    def _initialize_configurations(self) -> None:
+        """
+        Connector configuration variables
+        :return: None
+        """
+
+        # OpenCTI configurations
+        self.duration_period = get_config_variable(
+            "CONNECTOR_DURATION_PERIOD",
+            ["connector", "duration_period"],
+            self.load,
+            default="PT5M",
+        )
+
+        # Connector API URL
+        self.api_base_url = get_config_variable(
+            "MALWAREBAZAAR_API_BASE_URL",
+            ["malwarebazaar", "api_base_url"],
+            self.load,
+            default="https://mb-api.abuse.ch/api/v1/",
+        )
+
+        # In order to interact with the MalwareBazaar API, you need to obtain an Auth-Key first.
+        # If you don't have one you can get one for free here:
+        #         https://bazaar.abuse.ch/api/#auth_key
+        self.api_key = get_config_variable(
+            "MALWAREBAZAAR_API_KEY",
+            ["malwarebazaar", "api_key"],
+            self.load,
+        )
+
+        self.tlp_level = get_config_variable(
+            "MALWAREBAZAAR_TLP_LEVEL",
+            ["malwarebazaar", "tlp_level"],
+            self.load,
+            default="clear",
+        )
+
+        self.x_opencti_score = get_config_variable(
+            "MALWAREBAZAAR_X_OPENCTI_SCORE",
+            ["malwarebazaar", "x_opencti_score"],
+            self.load,
+            default=100,
+        )
+
+        self.include_tags = get_config_variable(
+            "MALWAREBAZAAR_INCLUDE_TAGS",
+            ["malwarebazaar", "include_tags"],
+            self.load,
+        )
+        if self.include_tags:
+            self.include_tags = self.include_tags.split(",")
+
+        self.include_reporters = get_config_variable(
+            "MALWAREBAZAAR_INCLUDE_REPORTERS",
+            ["malwarebazaar", "include_reporters"],
+            self.load,
+        )
+        if self.include_reporters:
+            self.include_reporters = self.include_reporters.split(",")
+
+        self.labels = get_config_variable(
+            "MALWAREBAZAAR_LABELS",
+            ["malwarebazaar", "labels"],
+            self.load,
+            default="malware-bazaar",
+        )

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/connector.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/connector.py
@@ -74,7 +74,7 @@ class ConnectorMalwareBazaar:
 
             # If the file has defined reporter and not in reporters, skip processing
             if self.client.config.include_reporters:
-                if entity["reporter"] not in self.include_reporters:
+                if entity["reporter"] not in self.client.config.include_reporters:
                     self.helper.connector_logger.info(
                         f"Skipping {entity['sha256_hash']} as it was from a reporter not in the included list: {entity['reporter']}"
                     )

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/connector.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/connector.py
@@ -1,0 +1,249 @@
+import sys
+from datetime import datetime, timezone
+
+from pycti import OpenCTIConnectorHelper
+
+from .client_api import ConnectorClient
+from .config_loader import ConfigConnector
+from .converter_to_stix import ConverterToStix
+
+
+class ConnectorMalwareBazaar:
+    """
+    Specifications of the external import connector
+
+    This class encapsulates the main actions, expected to be run by any external import connector.
+    Note that the attributes defined below will be complemented per each connector type.
+    This type of connector aim to fetch external data to create STIX bundle and send it in a RabbitMQ queue.
+    The STIX bundle in the queue will be processed by the workers.
+    This type of connector uses the basic methods of the helper.
+
+    ---
+
+    Attributes
+        - `config (ConfigConnector())`:
+            Initialize the connector with necessary configuration environment variables
+
+        - `helper (OpenCTIConnectorHelper(config))`:
+            This is the helper to use.
+            ALL connectors have to instantiate the connector helper with configurations.
+            Doing this will do a lot of operations behind the scene.
+
+        - `converter_to_stix (ConnectorConverter(helper))`:
+            Provide methods for converting various types of input data into STIX 2.1 objects.
+
+    ---
+
+    Best practices
+        - `self.helper.api.work.initiate_work(...)` is used to initiate a new work
+        - `self.helper.schedule_iso()` is used to encapsulate the main process in a scheduler
+        - `self.helper.connector_logger.[info/debug/warning/error]` is used when logging a message
+        - `self.helper.stix2_create_bundle(stix_objects)` is used when creating a bundle
+        - `self.helper.send_stix2_bundle(stix_objects_bundle)` is used to send the bundle to RabbitMQ
+        - `self.helper.set_state()` is used to set state
+
+    """
+
+    def __init__(self, config: ConfigConnector, helper: OpenCTIConnectorHelper):
+        """
+        Initialize the Connector with necessary configurations
+        """
+
+        # Load configuration file and connection helper
+        self.config = config
+        self.helper = helper
+        self.client = ConnectorClient(self.helper, self.config)
+        self.converter_to_stix = ConverterToStix(self.helper, self.config)
+
+    def _collect_intelligence(self) -> list:
+        """
+        Collect intelligence from the source and convert into STIX object
+        :return: List of STIX objects
+        """
+        stix_objects = []
+
+        # Get entities from external sources
+        entities = self.client.get_entities(
+            params={
+                "API_BASE_URL": self.client.config.api_base_url,
+                "API_KEY": self.client.config.api_key,
+            }
+        )
+
+        # Convert into STIX2 object and add it on a list
+        for entity in entities:
+
+            # If the file has defined reporter and not in reporters, skip processing
+            if self.client.config.include_reporters:
+                if entity["reporter"] not in self.include_reporters:
+                    self.helper.log_info(
+                        f"Skipping {entity['sha256_hash']} as it was from a reporter not in the included list: {entity['reporter']}"
+                    )
+                    continue
+
+            # If the file has an excluded tag (i.e. file extension), skip processing
+            tags = entity["tags"] if entity["tags"] else []
+            if self.client.config.include_tags:
+                if not any(x in tags for x in self.client.config.include_tags):
+                    self.helper.log_info(
+                        f"Skipping {entity['sha256_hash']} as it did not contain a tag in the included list."
+                    )
+                    continue
+
+            # If the file already exists in OpenCTI skip it
+            if self.file_exists_opencti(entity["sha256_hash"]):
+                self.helper.log_info(
+                    f"Skipping File with \"{entity['sha256_hash']}\" as it already exists in OpenCTI."
+                )
+                continue
+
+            entity_set_to_stix = self.converter_to_stix.create_obs(entity)
+            if entity_set_to_stix["FILE_OBSERVABLE"] is not None:
+                stix_objects.append(entity_set_to_stix["FILE_OBSERVABLE"])
+                stix_objects.append(entity_set_to_stix["INDICATOR_4_FILE"])
+                stix_objects.append(entity_set_to_stix["FILE_2_INDICATOR_RELATIONSHIP"])
+
+        # Ensure consistent bundle by adding the author and TLP marking
+        if len(stix_objects):
+            stix_objects.append(self.converter_to_stix.author)
+            stix_objects.append(self.converter_to_stix.tlp_marking)
+
+        return stix_objects
+
+    def file_exists_opencti(self, sha256) -> bool:
+        """
+        Determine whether or not an File already exists in OpenCTI.
+
+        sha256: a str representing the sha256 of the file's contents
+        returns: a bool indicating the aforementioned
+        """
+
+        custom_attributes = """
+            id
+            entity_type
+        """
+        response = self.helper.api.stix_cyber_observable.read(
+            filters={
+                "mode": "and",
+                "filters": [{"key": "hashes.SHA-256", "values": [sha256]}],
+                "filterGroups": [],
+            },
+            customAttributes=custom_attributes,
+        )
+
+        if response:
+            return True
+        return False
+
+    def process_message(self) -> None:
+        """
+        Connector main process to collect intelligence
+        :return: None
+        """
+        self.helper.connector_logger.info(
+            "[CONNECTOR] Starting connector...",
+            {"connector_name": self.helper.connect_name},
+        )
+
+        try:
+            # Get the current state
+            now = datetime.now()
+            current_timestamp = int(datetime.timestamp(now))
+            current_state = self.helper.get_state()
+
+            if current_state is not None and "last_run" in current_state:
+                last_run = current_state["last_run"]
+
+                self.helper.connector_logger.info(
+                    "[CONNECTOR] Connector last run",
+                    {"last_run_datetime": last_run},
+                )
+            else:
+                self.helper.connector_logger.info(
+                    "[CONNECTOR] Connector has never run..."
+                )
+
+            # Friendly name will be displayed on OpenCTI platform
+            friendly_name = f"Connector {self.helper.connect_name}"
+
+            # Initiate a new work
+            work_id = self.helper.api.work.initiate_work(
+                self.helper.connect_id, friendly_name
+            )
+
+            self.helper.connector_logger.info(
+                "[CONNECTOR] Running connector...",
+                {"connector_name": self.helper.connect_name},
+            )
+
+            # Performing the collection of intelligence
+            # ===========================
+            # === Add your code below ===
+            # ===========================
+            stix_objects = self._collect_intelligence()
+
+            if len(stix_objects):
+                stix_objects_bundle = self.helper.stix2_create_bundle(stix_objects)
+                bundles_sent = self.helper.send_stix2_bundle(
+                    stix_objects_bundle,
+                    work_id=work_id,
+                    cleanup_inconsistent_bundle=True,
+                )
+
+                self.helper.connector_logger.info(
+                    "Sending STIX objects to OpenCTI...",
+                    {"bundles_sent": {str(len(bundles_sent))}},
+                )
+            # ===========================
+            # === Add your code above ===
+            # ===========================
+
+            # Store the current timestamp as a last run of the connector
+            self.helper.connector_logger.debug(
+                "Getting current state and update it with last run of the connector",
+                {"current_timestamp": current_timestamp},
+            )
+            current_state = self.helper.get_state()
+            current_state_datetime = now.strftime("%Y-%m-%d %H:%M:%S")
+            last_run_datetime = datetime.fromtimestamp(
+                current_timestamp, tz=timezone.utc
+            ).strftime("%Y-%m-%d %H:%M:%S")
+            if current_state:
+                current_state["last_run"] = current_state_datetime
+            else:
+                current_state = {"last_run": current_state_datetime}
+            self.helper.set_state(current_state)
+
+            message = (
+                f"{self.helper.connect_name} connector successfully run, storing last_run as "
+                + str(last_run_datetime)
+            )
+
+            self.helper.api.work.to_processed(work_id, message)
+            self.helper.connector_logger.info(message)
+
+        except (KeyboardInterrupt, SystemExit):
+            self.helper.connector_logger.info(
+                "[CONNECTOR] Connector stopped...",
+                {"connector_name": self.helper.connect_name},
+            )
+            sys.exit(0)
+        except Exception as err:
+            self.helper.connector_logger.error(str(err))
+
+    def run(self) -> None:
+        """
+        Run the main process encapsulated in a scheduler
+        It allows you to schedule the process to run at a certain intervals
+        This specific scheduler from the pycti connector helper will also check the queue size of a connector
+        If `CONNECTOR_QUEUE_THRESHOLD` is set, if the connector's queue size exceeds the queue threshold,
+        the connector's main process will not run until the queue is ingested and reduced sufficiently,
+        allowing it to restart during the next scheduler check. (default is 500MB)
+        It requires the `duration_period` connector variable in ISO-8601 standard format
+        Example: `CONNECTOR_DURATION_PERIOD=PT5M` => Will run the process every 5 minutes
+        :return: None
+        """
+        self.helper.schedule_iso(
+            message_callback=self.process_message,
+            duration_period=self.config.duration_period,
+        )

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/connector.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/connector.py
@@ -66,7 +66,6 @@ class ConnectorMalwareBazaar:
         entities = self.client.get_entities(
             params={
                 "API_BASE_URL": self.client.config.api_base_url,
-                "API_KEY": self.client.config.api_key,
             }
         )
 
@@ -76,7 +75,7 @@ class ConnectorMalwareBazaar:
             # If the file has defined reporter and not in reporters, skip processing
             if self.client.config.include_reporters:
                 if entity["reporter"] not in self.include_reporters:
-                    self.helper.log_info(
+                    self.helper.connector_logger.info(
                         f"Skipping {entity['sha256_hash']} as it was from a reporter not in the included list: {entity['reporter']}"
                     )
                     continue
@@ -85,14 +84,14 @@ class ConnectorMalwareBazaar:
             tags = entity["tags"] if entity["tags"] else []
             if self.client.config.include_tags:
                 if not any(x in tags for x in self.client.config.include_tags):
-                    self.helper.log_info(
+                    self.helper.connector_logger.info(
                         f"Skipping {entity['sha256_hash']} as it did not contain a tag in the included list."
                     )
                     continue
 
             # If the file already exists in OpenCTI skip it
             if self.file_exists_opencti(entity["sha256_hash"]):
-                self.helper.log_info(
+                self.helper.connector_logger.info(
                     f"Skipping File with \"{entity['sha256_hash']}\" as it already exists in OpenCTI."
                 )
                 continue

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/converter_to_stix.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/converter_to_stix.py
@@ -1,0 +1,244 @@
+import stix2
+import validators
+from pycti import Identity, Indicator, MarkingDefinition, StixCoreRelationship
+
+
+class ConverterToStix:
+    """
+    Provides methods for converting various types of input data into STIX 2.1 objects.
+
+    REQUIREMENTS:
+    - generate_id() for each entity from OpenCTI pycti library except observables to create
+    """
+
+    def __init__(self, helper, config):
+        self.helper = helper
+        self.config = config
+        self.author = self.create_author(self.helper.connect_name)
+        self.tlp_marking = self._create_tlp_marking(level=self.config.tlp_level.lower())
+
+    @staticmethod
+    def create_author(connector_name: str) -> dict:
+        """
+        Create Author based on configured CONNECTOR_NAME
+        :return: Author in Stix2 object
+        """
+        # Allocate an Author Organization of based on CONNECTOR_NAME for the connector to use
+        author = stix2.Identity(
+            id=Identity.generate_id(name=connector_name, identity_class="organization"),
+            name=connector_name,
+            identity_class="organization",
+            description="For more info, see https://bazaar.abuse.ch/about/",
+            custom_properties={
+                "x_opencti_organization_type": "vendor",
+            },
+        )
+        return author
+
+    @staticmethod
+    def _create_tlp_marking(level) -> str:
+        mapping = {
+            "white": stix2.TLP_WHITE,
+            "clear": stix2.TLP_WHITE,
+            "green": stix2.TLP_GREEN,
+            "amber": stix2.TLP_AMBER,
+            "amber+strict": stix2.MarkingDefinition(
+                id=MarkingDefinition.generate_id("TLP", "TLP:AMBER+STRICT"),
+                definition_type="statement",
+                definition={"statement": "custom"},
+                custom_properties={
+                    "x_opencti_definition_type": "TLP",
+                    "x_opencti_definition": "TLP:AMBER+STRICT",
+                },
+            ),
+            "red": stix2.TLP_RED,
+        }
+        return mapping[level]
+
+    def create_file_observable(self, entity: dict, labels: list) -> dict:
+        """
+        Creates File Observable object based on MalwareBazaar Entity Data
+        :param entity: entity dict from MalwareBazaar
+        :param labels: List of Labels/Tags to apply
+        :return: File Observable STIX2 object
+        """
+        file_observable = stix2.File(
+            name=entity["file_name"],
+            size=entity["file_size"],
+            mime_type=entity["file_type_mime"],
+            hashes={
+                "MD5": entity["md5_hash"],
+                "SHA-1": entity["sha1_hash"],
+                "SHA-256": entity["sha256_hash"],
+                # "SHA-512": entity["sha512_hash"], # API for MalwareBazaar currently does NOT provide a SHA512
+            },
+            object_marking_refs=self.tlp_marking,
+            custom_properties={
+                "x_opencti_created_by_ref": self.author["id"],
+                # "x_opencti_external_references": self.external_reference,
+                "x_opencti_additional_names": [
+                    entity["sha256_hash"],
+                    # entity["file_name"],
+                ],
+                "x_opencti_score": int(self.config.x_opencti_score),
+                "x_opencti_description": f'Uploaded to MalwareBazaar by Twitter user: {entity["reporter"]}',
+                "x_opencti_labels": labels,
+            },
+        )
+
+        return file_observable
+
+    def create_indicator(self, entity: dict, labels: list) -> dict:
+        """
+        Creates Indicator object based on File SHA256
+        :param entity: entity dict from MalwareBazaar
+        :param labels: List of Labels/Tags to apply
+        :return: Indicator STIX2 object
+        """
+        indicator_pattern = f"[file:hashes.'SHA-256' = '{entity['sha256_hash']}']"
+        indicator_description = f"Indicator for hash SHA256 {entity['sha256_hash']}"
+        indicator = stix2.Indicator(
+            id=Indicator.generate_id(indicator_pattern),
+            name=f"{entity['sha256_hash']}",
+            pattern=indicator_pattern,
+            pattern_type="stix",
+            description=indicator_description,
+            labels=labels,
+            created_by_ref=self.author["id"],
+            object_marking_refs=self.tlp_marking,
+            custom_properties={
+                "x_opencti_score": int(self.config.x_opencti_score),
+                "x_opencti_main_observable_type": "File",
+            },
+        )
+
+        return indicator
+
+    def create_relationship(
+        self, source_id: str, relationship_type: str, target_id: str, labels: list
+    ) -> dict:
+        """
+        Creates Relationship object
+        :param source_id: ID of source in string
+        :param relationship_type: Relationship type in string
+        :param target_id: ID of target in string
+        :param labels: List of Labels/Tags to apply
+        :return: Relationship STIX2 object
+        """
+        relationship = stix2.Relationship(
+            id=StixCoreRelationship.generate_id(
+                relationship_type, source_id, target_id
+            ),
+            relationship_type=relationship_type,
+            source_ref=source_id,
+            target_ref=target_id,
+            labels=labels,
+            created_by_ref=self.author["id"],
+            object_marking_refs=self.tlp_marking,
+            # external_references=self.external_reference,
+        )
+        return relationship
+
+    @staticmethod
+    def _is_valid_md5(value: str) -> bool:
+        """
+        Determine whether the string is a valid MD5
+        :param value: Value in string
+        :return: A boolean
+        """
+        if validators.hashes.md5(value):
+            return True
+        else:
+            return False
+
+    @staticmethod
+    def _is_valid_sha1(value: str) -> bool:
+        """
+        Determine whether the string is a valid SHA1
+        :param value: Value in string
+        :return: A boolean
+        """
+        if validators.hashes.sha1(value):
+            return True
+        else:
+            return False
+
+    @staticmethod
+    def _is_valid_sha256(value: str) -> bool:
+        """
+        Determine whether the string is a valid SHA256
+        :param value: Value in string
+        :return: A boolean
+        """
+        if validators.hashes.sha256(value):
+            return True
+        else:
+            return False
+
+    @staticmethod
+    def _is_valid_sha512(value: str) -> bool:
+        """
+        Determine whether the string is a valid SHA512
+        :param value: Value in string
+        :return: A boolean
+        """
+        if validators.hashes.sha512(value):
+            return True
+        else:
+            return False
+
+    def create_obs(self, entity: dict) -> dict:
+        """
+        Create observable according to given file data
+        :param dict: Returned JSON Dict from Malware Bazaar of a malicious file object
+        :return: Stix object for StixFile
+        """
+        file_observable_set = {
+            "FILE_OBSERVABLE": None,
+            "INDICATOR_4_FILE": None,
+            "FILE_2_INDICATOR_RELATIONSHIP": None,
+        }
+        if (
+            self._is_valid_md5(entity["md5_hash"]) is True
+            and self._is_valid_sha1(entity["sha1_hash"]) is True
+            and self._is_valid_sha256(entity["sha256_hash"]) is True
+            and len(entity["reporter"]) >= 1
+            and len(entity["file_name"]) >= 1
+        ):
+            # Customize the tags/labels to apply
+            tags_as_labels = entity["tags"] if entity["tags"] else []
+            if self.config.labels:
+                labels = self.config.labels.split(",")
+                for label in labels:
+                    tags_as_labels.append(label)
+
+            # Create the STIX File observable object
+            file_observable = self.create_file_observable(
+                entity=entity, labels=tags_as_labels
+            )
+
+            # Create Indicator based on SHA256 of File
+            indicator = self.create_indicator(entity=entity, labels=tags_as_labels)
+
+            # Create Relationship between Indicator and File Observable
+            relationship = self.create_relationship(
+                source_id=indicator["id"],
+                relationship_type="based-on",
+                target_id=file_observable["id"],
+                labels=tags_as_labels,
+            )
+
+            # Define set of data to return
+            file_observable_set = {
+                "FILE_OBSERVABLE": file_observable,
+                "INDICATOR_4_FILE": indicator,
+                "FILE_2_INDICATOR_RELATIONSHIP": relationship,
+            }
+
+        else:
+            self.helper.connector_logger.error(
+                "This observable entity is not a valid for ingest, missing one or more required fields (md5_hash, sha1_hash, sha256_hash, reporter, or filename): ",
+                {"entity": entity},
+            )
+
+        return file_observable_set

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/utils.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/utils.py
@@ -1,0 +1,1 @@
+#  Utilities: helper functions, classes, or modules that provide common, reusable functionality across a codebase

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/utils.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/utils.py
@@ -1,1 +1,0 @@
-#  Utilities: helper functions, classes, or modules that provide common, reusable functionality across a codebase

--- a/external-import/malwarebazaar/src/requirements.txt
+++ b/external-import/malwarebazaar/src/requirements.txt
@@ -1,4 +1,4 @@
-pycti==6.6.12
+pycti==6.6.15
 requests~=2.32.3
 stix2==3.0.1
 validators==0.35.0

--- a/external-import/malwarebazaar/src/requirements.txt
+++ b/external-import/malwarebazaar/src/requirements.txt
@@ -1,0 +1,4 @@
+pycti==6.6.12
+requests~=2.32.3
+stix2==3.0.1
+validators==0.35.0


### PR DESCRIPTION
### Proposed changes

* Based on Conversation in PR (https://github.com/OpenCTI-Platform/connectors/pull/3503) - @romain-filigran request a new MalwareBazaar Connector that would create File Observables.
* This new connector supports the proposed changes of:
     * Creates a File Observable, Indicator, and a Relationship between the entities
     * No malware file is uploaded
     * Uses new 6.6.x connector template to send data to RabbitMQ
     * Sets an `x_opencti_score` based on the configuration, defaulted to 100 

### Related issues
 N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I have signed my commits using GPG key.
- [X] I tested the code for its functionality using different use cases
- [X] I added/update the relevant documentation (either on github or on notion) (Added a README.MD)
- [X] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

None
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
