### PR TITLE
[Tenable Vuln Management] feat:  Connector handles inconsitent API response with scan object

### DIFF
--- a/external-import/tenable-vuln-management/src/tenable_vuln_management/models/tenable.py
+++ b/external-import/tenable-vuln-management/src/tenable_vuln_management/models/tenable.py
@@ -317,7 +317,7 @@ class Scan(FrozenBaseModelWithWarnedExtra):
         ..., description="The timestamp when the scan started."
     )
     uuid: str = Field(..., description="The UUID of the scan.")
-    target: str = Field(
+    target: Optional[str] = Field(
         ...,
         description="The IP address or fully qualified domain name of the asset targeted in the scan.",
     )

--- a/external-import/tenable-vuln-management/tests/test_models/test_tenable.py
+++ b/external-import/tenable-vuln-management/tests/test_models/test_tenable.py
@@ -74,3 +74,21 @@ def test_extra_field_in_resposnse_should_warn_with_ValidationWarning(
 
     with pytest.warns(ValidationWarning):
         _ = VulnerabilityFinding.model_validate(tenable_api_response_1_report)
+
+
+@pytest.mark.parametrize(
+    "tenable_api_response_1_report",
+    [
+        pytest.param(raw_report, id=raw_report["plugin"]["name"])
+        for raw_report in load_responses()
+    ],
+)
+def test_vulbearbility_finding_model_should_not_accept_not_to_have_scan_target_attribute(
+    tenable_api_response_1_report,
+):
+    # Given a tenable api response with no scan.target field
+    tenable_api_response_1_report["scan"]["target"] = None
+    # When instantiating a vulnerability_finding
+    vf = VulnerabilityFinding.model_validate(tenable_api_response_1_report)
+    # Then no ValidationError is raised
+    assert vf.scan.target is None


### PR DESCRIPTION


### Proposed changes

* Handle gracefully the absence of scan target in API response for some Tenable plugin
See also https://github.com/OpenCTI-Platform/connectors/issues/3542

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3574
*

### Checklist

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments
N/A
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
