### PR TITLE
[vulncheck] Fix for 3953, connector verification.

### DIFF
--- a/external-import/vulncheck/README.md
+++ b/external-import/vulncheck/README.md
@@ -77,16 +77,17 @@ Below are the parameters you'll need to set for OpenCTI:
 
 Below are the parameters you'll need to set for running the connector:
 
-| Parameter       | config.yml     | Docker Environment Variable        | Default                                                                                                                     | Mandatory | Description                                                                 |
-|-----------------|----------------|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|-----------|-----------------------------------------------------------------------------|
-| Connector ID    | `id`           | `CONNECTOR_ID`                     | /                                                                                                                           | Yes       | A unique `UUIDv4` identifier for this connector.                            |
-| Connector Type  | `type`         | `CONNECTOR_TYPE`                   | EXTERNAL_IMPORT                                                                                                             | Yes       | Specifies the type of connector. Should always be set to `EXTERNAL_IMPORT`. |
-| Connector Name  | `name`         | `CONNECTOR_NAME`                   | VulnCheck                                                                                                                   | Yes       | The name of the connector as it will appear in OpenCTI.                     |
-| Connector Scope | `scope`        | `CONNECTOR_SCOPE`                  | vulnerability,malware,threat-actor,infrastructure,location,ip-addr,indicator,external-reference                             | Yes       | The scope of data to import, a list of Stix Objects. |
-| Log Level       | `log_level`    | `CONNECTOR_LOG_LEVEL`              | info                                                                                                                        | Yes       | Sets the verbosity of logs. Options: `debug`, `info`, `warn`, `error`.      |
-| API Base URL    | `api_base_url` | `CONNECTOR_VULNCHECK_API_BASE_URL` | None                                                                                                                        | Yes       | The base URL for the VulnCheck API (e.g., `https://api.vulncheck.com/v3`).  |
-| API Key         | `api_key`      | `CONNECTOR_VULNCHECK_API_KEY`      | None                                                                                                                        | Yes       | The API key for authenticating with VulnCheck's API.                        |
-| Data Sources    | `data_sources` | `CONNECTOR_VULNCHECK_DATA_SOURCES` | botnets,epss,exploits,initial-access,ipintel,nist-nvd2,ransomware,snort,suricata,threat-actors,vulncheck-kev,vulncheck-nvd2 | Yes       | List of data sources to collect intelligence from.                          |
+| Parameter                 | config.yml        | Docker Environment Variable          | Default                                                                                                                     | Mandatory   | Description                                                                   |
+| -----------------         | ----------------  | ------------------------------------ |-----------------------------------------------------------------------------------------------------------------------------| ----------- | ----------------------------------------------------------------------------- |
+| API Key                   | `api_key`         | `CONNECTOR_VULNCHECK_API_KEY`        | None                                                                                                                        | Yes         | The API key for authenticating with VulnCheck's API.                          |
+| Connector ID              | `id`              | `CONNECTOR_ID`                       | /                                                                                                                           | No          | A unique `UUIDv4` identifier for this connector.                              |
+| Connector Type            | `type`            | `CONNECTOR_TYPE`                     | EXTERNAL_IMPORT                                                                                                             | No          | Specifies the type of connector. Should always be set to `EXTERNAL_IMPORT`.   |
+| Connector Name            | `name`            | `CONNECTOR_NAME`                     | VulnCheck Connector                                                                                                         | No          | The name of the connector as it will appear in OpenCTI.                       |
+| Connector Scope           | `scope`           | `CONNECTOR_SCOPE`                    | vulnerability,malware,threat-actor,infrastructure,location,ip-addr,indicator,external-reference,software                    | No          | The scope of data to import, a list of Stix Objects.                          |
+| Connector Duration period | `duration_period` | `CONNECTOR_DURATION_PERIOD`          | PT1H                                                                                                                        | No          | The time period for which to fetch data. Default is 24 hours.                 |
+| Log Level                 | `log_level`       | `CONNECTOR_LOG_LEVEL`                | info                                                                                                                        | No          | Sets the verbosity of logs. Options: `debug`, `info`, `warn`, `error`.        |
+| API Base URL              | `api_base_url`    | `CONNECTOR_VULNCHECK_API_BASE_URL`   | https://api.vulncheck.com/v3                                                                                                | No          | The base URL for the VulnCheck API (e.g., `https://api.vulncheck.com/v3`).    |
+| Data Sources              | `data_sources`    | `CONNECTOR_VULNCHECK_DATA_SOURCES`   | botnets,epss,exploits,initial-access,ipintel,nist-nvd2,ransomware,snort,suricata,threat-actors,vulncheck-kev,vulncheck-nvd2 | No          | List of data sources to collect intelligence from.                            |
 
 ## Deployment
 
@@ -94,7 +95,7 @@ Below are the parameters you'll need to set for running the connector:
 
 Before building the Docker container, you need to set the version of pycti in
 `requirements.txt` equal to whatever version of OpenCTI you're running.
-Example, `pycti==6.6.11`. If you don't, it will take the latest version, but
+Example, `pycti==6.6.10`. If you don't, it will take the latest version, but
 sometimes the OpenCTI SDK fails to initialize.
 
 Build a Docker Image using the provided `Dockerfile`.

--- a/external-import/vulncheck/docker-compose.yml
+++ b/external-import/vulncheck/docker-compose.yml
@@ -1,17 +1,17 @@
 version: "3"
 services:
   connector-vulncheck:
-    image: opencti/connector-vulncheck:6.6.11
+    image: opencti/connector-vulncheck:6.6.9
     environment:
       # Connector's generic execution parameters
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=CHANGEME
-      # Connector's definition parameters REQUIRED
-      - CONNECTOR_ID=CHANGEME
-      - CONNECTOR_NAME=VulnCheck
-      - CONNECTOR_SCOPE=vulnerability,malware,threat-actor,infrastructure,location,ip-addr,indicator,external-reference
-      - CONNECTOR_LOG_LEVEL=error
-      - CONNECTOR_DURATION_PERIOD=PT5M # ISO8601 format in String, start with 'P...' for Period
+      # Connector's definition parameters Defaulted
+      # - CONNECTOR_ID=
+      # - CONNECTOR_NAME=VulnCheck Connector
+      # - CONNECTOR_SCOPE=vulnerability,malware,threat-actor,infrastructure,location,ip-addr,indicator,external-reference
+      # - CONNECTOR_LOG_LEVEL=info
+      # - CONNECTOR_DURATION_PERIOD=PT1H # ISO8601 format in String, start with 'P...' for Period
 
       # Connector's definition parameters OPTIONAL
       # - CONNECTOR_QUEUE_THRESHOLD=500 # Default 500Mo, Float accepted
@@ -22,9 +22,10 @@ services:
       # - CONNECTOR_SEND_TO_DIRECTORY_RETENTION=7 # Default 7, in days
 
       # Connector's custom execution parameters
-      - CONNECTOR_VULNCHECK_API_BASE_URL=https://api.vulncheck.com/v3
       - CONNECTOR_VULNCHECK_API_KEY=CHANGEME
-      - CONNECTOR_VULNCHECK_DATA_SOURCES=botnets,epss,exploits,initial-access,ipintel,nist-nvd2,ransomware,snort,suricata,threat-actors,vulncheck-kev,vulncheck-nvd2
+      # Defaulted parameters
+      # - CONNECTOR_VULNCHECK_API_BASE_URL=https://api.vulncheck.com/v3
+      # - CONNECTOR_VULNCHECK_DATA_SOURCES=botnets,epss,exploits,initial-access,ipintel,nist-nvd2,ransomware,snort,suricata,threat-actors,vulncheck-kev,vulncheck-nvd2
 
       # Add proxy parameters below if needed
       # - HTTP_PROXY=CHANGEME

--- a/external-import/vulncheck/src/config.yml.sample
+++ b/external-import/vulncheck/src/config.yml.sample
@@ -2,24 +2,24 @@ opencti:
   url: "http://localhost:PORT"
   token: "ChangeMe"
 
-connector:
-  id: "ChangeMe"
-  type: "EXTERNAL_IMPORT"
-  name: "External Import Connector VulnCheck"
-  scope: "vulnerability,malware,threat-actor,software,infrastructure,location,ip-addr,indicator,external-reference"
-  log_level: "info"
-  duration_period: "PT5M" # Interval given for scheduler process in ISO-8601 format
-  #============================================#
-  # Optional connector's definition parameters #
-  #============================================#
-  #queue_threshold: 500
-  #run_and_terminate: 'False'
-  #send_to_queue: 'True'
-  #send_to_directory: 'False'
-  #send_to_directory_path: 'ChangeMe'
-  #send_to_directory_retention: 7
+#connector:
+# ======= Defaulted Parameters =======
+#  id: ""
+#  type: "EXTERNAL_IMPORT"
+#  name: "VulnCheck Connector"
+#  scope: "vulnerability,malware,threat-actor,software,infrastructure,location,ip-addr,indicator,external-reference"
+#  log_level: "info"
+#  duration_period: "PT1H" # Interval given for scheduler process in ISO-8601 format
+# ======= Optional Parameters =======
+#  queue_threshold: 500
+#  run_and_terminate: 'False'
+#  send_to_queue: 'True'
+#  send_to_directory: 'False'
+#  send_to_directory_path: 'ChangeMe'
+#  send_to_directory_retention: 7
 
 connector_vulncheck:
-  api_base_url: "ChangeMe"
   api_key: "ChangeMe"
-  data_sources: "botnets,epss,exploits,initial-access,ipintel,nist-nvd2,snort,suricata,ransomware,threat-actors,vulncheck-kev,vulncheck-nvd2"
+# ======= Defaulted Parameters =======
+#  api_base_url: https://api.vulncheck.com/v3
+#  data_sources: "botnets,epss,exploits,initial-access,ipintel,nist-nvd2,snort,suricata,ransomware,threat-actors,vulncheck-kev,vulncheck-nvd2"

--- a/external-import/vulncheck/src/requirements.txt
+++ b/external-import/vulncheck/src/requirements.txt
@@ -1,5 +1,6 @@
 vulncheck-sdk==0.0.11
-pycti==6.6.11
+pycti==6.6.9
 pydantic==2.11.3
-validators==0.35.0
+validators==0.34.0
 psutil==7.0.0
+stix2==3.0.1

--- a/external-import/vulncheck/src/vclib/config_variables.py
+++ b/external-import/vulncheck/src/vclib/config_variables.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from uuid import uuid4
 
 import yaml
 from pycti import get_config_variable
@@ -13,8 +14,9 @@ class ConfigConnector:
         """
 
         # Load configuration file
-        self.load = self._load_config()
+        self.load_yml = self._load_config()
         self._initialize_configurations()
+        self.load = self.to_dict()
 
     @staticmethod
     def _load_config() -> dict:
@@ -37,33 +39,121 @@ class ConfigConnector:
         :return: None
         """
         # OpenCTI configurations
-        self.duration_period = get_config_variable(
-            "CONNECTOR_DURATION_PERIOD",
-            ["connector", "duration_period"],
-            self.load,
+        # Required
+        self.opencti_url = get_config_variable(
+            "OPENCTI_URL",
+            ["opencti", "url"],
+            self.load_yml,
+            required=True,
         )
+
+        self.opencti_token = get_config_variable(
+            "OPENCTI_TOKEN",
+            ["opencti", "token"],
+            self.load_yml,
+            required=True,
+        )
+
+        self.api_key = get_config_variable(
+            "CONNECTOR_VULNCHECK_API_KEY",
+            ["connector_vulncheck", "api_key"],
+            self.load_yml,
+            required=True,
+        )
+
+        # Defaulted or Optional
+        self.id = get_config_variable(
+            "CONNECTOR_ID",
+            ["connector", "id"],
+            self.load_yml,
+            required=False,
+            default=f"{uuid4()}",
+        )
+
+        self.type = get_config_variable(
+            "CONNECTOR_TYPE",
+            ["connector", "type"],
+            self.load_yml,
+            required=False,
+            default="EXTERNAL_IMPORT",
+        )
+
+        self.name = get_config_variable(
+            "CONNECTOR_NAME",
+            ["connector", "name"],
+            self.load_yml,
+            required=False,
+            default="VulnCheck Connector",
+        )
+
         self.scope = get_config_variable(
             "CONNECTOR_SCOPE",
             ["connector", "scope"],
-            self.load,
+            self.load_yml,
+            required=False,
+            default="vulnerability,malware,threat-actor,infrastructure,location,ip-addr,indicator,external-reference,software",
+        )
+
+        self.log_level = get_config_variable(
+            "CONNECTOR_LOG_LEVEL",
+            ["connector", "log_level"],
+            self.load_yml,
+            required=False,
+            default="info",
+        )
+
+        self.duration_period = get_config_variable(
+            "CONNECTOR_DURATION_PERIOD",
+            ["connector", "duration_period"],
+            self.load_yml,
+            required=False,
+            default="PT1H",
         )
 
         # Connector extra parameters
         self.api_base_url = get_config_variable(
             "CONNECTOR_VULNCHECK_API_BASE_URL",
             ["connector_vulncheck", "api_base_url"],
-            self.load,
-        )
-
-        self.api_key = get_config_variable(
-            "CONNECTOR_VULNCHECK_API_KEY",
-            ["connector_vulncheck", "api_key"],
-            self.load,
+            self.load_yml,
+            required=False,
+            default="https://api.vulncheck.com/v3",
         )
 
         self.data_sources = get_config_variable(
             "CONNECTOR_VULNCHECK_DATA_SOURCES",
             ["connector_vulncheck", "data_sources"],
-            self.load,
+            self.load_yml,
+            required=False,
             default=DataSource.get_all_data_source_strings(),
         )
+
+    def to_dict(self) -> dict:
+        """Gather configuration settings and return them as a dictionary."""
+        if (
+            self.opencti_url is None
+            or self.opencti_token is None
+            or self.api_key is None
+        ):
+            raise ValueError(
+                f"Missing required configuration variables: {'OPENCTI_URL' if self.opencti_url is None else ''} {'OPENCTI_TOKEN' if self.opencti_token is None else ''} {'CONNECTOR_VULNCHECK_API_KEY' if self.api_key is None else ''}"
+            )
+        dct = {
+            "opencti": {
+                "url": self.opencti_url,
+                "token": self.opencti_token,
+            },
+            "connector": {
+                "id": self.id,
+                "type": self.type,
+                "name": self.name,
+                "scope": self.scope,
+                "log_level": self.log_level,
+                "duration": self.duration_period,
+            },
+            "connector_vulncheck": {
+                "api_key": self.api_key,
+                "api_base_url": self.api_base_url,
+                "data_sources": self.data_sources,
+            },
+        }
+        return dct

--- a/external-import/vulncheck/src/vclib/connector.py
+++ b/external-import/vulncheck/src/vclib/connector.py
@@ -49,7 +49,7 @@ class ConnectorVulnCheck:
         Collect intelligence from the source and convert into STIX object
         """
         for source in target_data_sources:
-            self.helper.log_info(
+            self.helper.connector_logger.info(
                 f"[CONNECTOR] Collecting data for {source.name}",
             )
             # Get entities from source
@@ -158,7 +158,7 @@ class ConnectorVulnCheck:
                 self._collect_intelligence(target_data_sources, connector_state)
 
             except Exception as e:
-                self.helper.log_error(str(e))
+                self.helper.connector_logger.error(str(e))
 
             # Store the current timestamp as a last run of the connector
             self.helper.connector_logger.debug(

--- a/external-import/vulncheck/src/vclib/sources/nistnvd2.py
+++ b/external-import/vulncheck/src/vclib/sources/nistnvd2.py
@@ -110,6 +110,7 @@ def _extract_stix_from_nistnvd2(
             software = _create_software(
                 cpe=cpe, converter_to_stix=converter_to_stix, logger=logger
             )
+            result.append(software)
             if vuln is not None:
                 result.append(
                     _create_rel_has(

--- a/external-import/vulncheck/src/vclib/sources/vcnvd2.py
+++ b/external-import/vulncheck/src/vclib/sources/vcnvd2.py
@@ -112,6 +112,7 @@ def _extract_stix_from_vcnvd2(
             software = _create_software(
                 cpe=cpe, converter_to_stix=converter_to_stix, logger=logger
             )
+            result.append(software)
             if vuln is not None:
                 result.extend(
                     _create_rel_has(


### PR DESCRIPTION

### Proposed changes

Various fixes for the verification process.

|Finding||Actions|
|---|---|
|Replace `self.helper.log_*()` calls in `connector.py`| replace `helper.log_*` with `.helper.connector_logger.*` |
|Default connector configuration values per new guidelines| setup default vars for most of the connector setup |
|Audit and add missing dependencies in `requirements.txt`| add missing dep and update readme |
|Investigate and resolve ingestion errors| fix the ingestion errors |

### Related issues

* To Verified: https://github.com/OpenCTI-Platform/connectors/issues/3953

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


### Further comments

The ingestion errors was due to the facts that for several sources, stix21 software was created `in code` but never append to the `result` list who is the one convert in bundle and inject.
And so one, this connector didn't created software required for relationships.
