### PR TITLE
[Sekoia] Allow configuration of API query limit

### DIFF
--- a/external-import/sekoia/README.md
+++ b/external-import/sekoia/README.md
@@ -28,6 +28,7 @@ connector-sekoia:
       - SEKOIA_API_KEY=<Replace_by_Sekoia_API_key>
       - SEKOIA_COLLECTION=d6092c37-d8d7-45c3-8aff-c4dc26030608
       - SEKOIA_START_DATE=2022-01-01    # Optional, the date to start consuming data from. Maybe in the formats YYYY-MM-DD or YYYY-MM-DDT00:00:00
+      - SEKOIA_LIMIT=100                # Optional, the number of elements to fetch in each request. Defaults to 200, maximum 2000
       - SEKOIA_CREATE_OBSERVABLES=true  # Create observables from indicators
       - SEKOIA_IMPORT_SOURCE_LIST=false # Create the list of sources observed by Sekoia as label
     restart: always
@@ -94,3 +95,4 @@ Here are the elements of the Sekoia feed that can be found on OpenCTI after expo
 ## Other resources
 
 - [OpenCTI documentation - Connectors](https://docs.opencti.io/latest/deployment/connectors/)
+- [Sekoia.io API documentation](https://docs.sekoia.io/developer/api/)

--- a/external-import/sekoia/docker-compose.yml
+++ b/external-import/sekoia/docker-compose.yml
@@ -12,5 +12,6 @@ services:
       - SEKOIA_API_KEY=ChangeMe
       - SEKOIA_COLLECTION=d6092c37-d8d7-45c3-8aff-c4dc26030608
       - SEKOIA_START_DATE=2022-01-01    # Optional, the date to start consuming data from. Maybe in the formats YYYY-MM-DD or YYYY-MM-DDT00:00:00
+      - SEKOIA_LIMIT=100                # Optional, the number of elements to fetch in each request. Defaults to 200, maximum 2000
       - SEKOIA_CREATE_OBSERVABLES=true  # Create observables from indicators
       - SEKOIA_IMPORT_SOURCE_LIST=false # Create the list of sources observed by Sekoia as label

--- a/external-import/sekoia/src/config.yml.sample
+++ b/external-import/sekoia/src/config.yml.sample
@@ -15,5 +15,6 @@ sekoia:
   collection: 'd6092c37-d8d7-45c3-8aff-c4dc26030608'
   api_key: 'ChangeMe'
   start_date: '2022-01-01'  # Optional, the date to start consuming data from. Maybe in the formats YYYY-MM-DD or YYYY-MM-DDT00:00:00
+  limit: 100                # Optional, the number of elements to fetch in each request. Defaults to 200, maximum 2000
   create_observables: true  # Create observables from indicators
   import_source_list: false # Create the list of sources observed by Sekoia as label

--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -25,8 +25,6 @@ gbl_scriptDir: str = os.path.dirname(os.path.realpath(__file__))
 
 
 class Sekoia(object):
-    limit = 200
-
     def __init__(self):
         # Instantiate the connector helper from config
         config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
@@ -48,6 +46,7 @@ class Sekoia(object):
 
         self.base_url = self.get_config("base_url", config, "https://api.sekoia.io")
         self.start_date: str = self.get_config("start_date", config, None)
+        self.limit = self.get_config("limit", config, 200)
         self.collection = self.get_config(
             "collection", config, "d6092c37-d8d7-45c3-8aff-c4dc26030608"
         )


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

The number of objects fetched from the Sekoia API is currently hardcoded to 200, which may be too low, especially during the initial ingestion of historical intelligence. This PR allows the user to configure this setting while keeping `200` as the default value.

### Related issue
- https://github.com/OpenCTI-Platform/connectors/issues/4073

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->