### PR TITLE
[cvelistv5] New external-import connector for the CVE Program git repository

### DIFF
--- a/external-import/cvelistv5/.dockerignore
+++ b/external-import/cvelistv5/.dockerignore
@@ -1,0 +1,2 @@
+src/config.yml
+src/__pycache__

--- a/external-import/cvelistv5/Dockerfile
+++ b/external-import/cvelistv5/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-alpine
+ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
+
+# Copy the connector
+COPY src /opt/opencti-connector-cvelistv5
+WORKDIR /opt/opencti-connector-cvelistv5
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk --no-cache add git build-base libmagic libffi-dev && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del build-base
+
+# GitPython relies on `uname` being on $PATH (see GitPython issue 1979).
+RUN ln -sv "$(which uname)" /usr/bin/uname
+
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/cvelistv5/README.md
+++ b/external-import/cvelistv5/README.md
@@ -1,0 +1,161 @@
+# CVEProject cvelistV5 connector
+
+An alternative CVE connector that fetches updates straight from the
+[CVEProject/cvelistV5](https://github.com/CVEProject/cvelistV5) GitHub
+repository instead of querying the NVD REST API. The connector clones the
+repository locally and uses `git log` to discover the records that were
+added or modified between two runs.
+
+## Summary
+
+- [Introduction](#introduction)
+- [Requirements](#requirements)
+- [Configuration variables](#configuration-variables)
+- [Deployment](#deployment)
+  - [Docker deployment](#docker-deployment)
+  - [Manual deployment](#manual-deployment)
+- [Behavior](#behavior)
+  - [Initial population](#initial-population)
+  - [Pull CVE updates](#pull-cve-updates)
+  - [Errors](#errors)
+- [Usage](#usage)
+- [Sources](#sources)
+
+---
+
+### Introduction
+
+CVE records are fetched from the [CVEProject/cvelistV5](https://github.com/CVEProject/cvelistV5)
+repository. Each record follows the [CVE v5.1 schema](https://github.com/CVEProject/cve-schema/tree/main)
+and is transformed into a STIX 2.1 `Vulnerability` object. Information that
+cannot be expressed natively in STIX 2.1 is attached as STIX `Note` objects
+linked to the vulnerability.
+
+Extra information that the connector exposes as notes includes:
+
+- **Workarounds**
+- **Solutions**
+- **Configurations** that make the vulnerability more severe
+- **Exploits** that are publicly documented
+
+When the affected products of a CVE expose `cpes` or `versions` entries, the
+connector also creates `Software` and `Identity` (vendor) objects, plus the
+relationships between them (`software has vulnerability`,
+`software related-to vendor`). This makes it possible to display the
+organizations exposed to a given vulnerability by relying on existing
+`Software` observables.
+
+### Requirements
+
+- OpenCTI Platform version 6.6 or higher
+- Outbound HTTPS access to `github.com` so the connector can clone and pull
+  the upstream repository
+- A persistent volume for the clone (a few GB) when running in Docker
+
+### Configuration variables
+
+Below are the parameters you need to set for OpenCTI connectivity:
+
+| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
+|---------------|------------|-----------------------------|-----------|------------------------------------------------------|
+| OpenCTI URL   | `url`      | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
+| OpenCTI Token | `token`    | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+
+Below are the generic connector parameters:
+
+| Parameter               | config.yml          | Docker environment variable    | Default                              | Mandatory | Description                                                                                       |
+|-------------------------|---------------------|--------------------------------|--------------------------------------|-----------|---------------------------------------------------------------------------------------------------|
+| Connector ID            | `id`                | `CONNECTOR_ID`                 | /                                    | Yes       | A unique `UUIDv4` identifier for this connector instance.                                         |
+| Connector Name          | `name`              | `CONNECTOR_NAME`               | `CVEProject cvelistV5`               | No        | Name of the connector as displayed in the OpenCTI UI.                                             |
+| Connector Scope         | `scope`             | `CONNECTOR_SCOPE`              | `identity,vulnerability,software`    | No        | The scope of data produced by the connector.                                                      |
+| Log Level               | `log_level`         | `CONNECTOR_LOG_LEVEL`          | `info`                               | No        | Verbosity of the logs: `debug`, `info`, `warn`, or `error`.                                       |
+| Duration Period         | `duration_period`   | `CONNECTOR_DURATION_PERIOD`    | `PT1H`                               | No        | ISO 8601 duration between two runs (e.g. `PT1H` for hourly, `P1D` for daily).                     |
+
+Below are the connector specific parameters:
+
+| Parameter            | config.yml           | Docker environment variable    | Default                                          | Mandatory | Description                                                                                                              |
+|----------------------|----------------------|--------------------------------|--------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
+| Repository URL       | `repo_url`           | `CVELISTV5_REPO_URL`           | `https://github.com/CVEProject/cvelistV5.git`    | No        | URL of the upstream git repository. Override only if you maintain a private mirror.                                      |
+| Repository branch    | `repo_branch`        | `CVELISTV5_REPO_BRANCH`        | `main`                                           | No        | Branch to track in the upstream repository.                                                                              |
+| Local clone path     | `local_path`         | `CVELISTV5_LOCAL_PATH`         | `/opt/cvelistV5`                                 | No        | Local path where the clone is kept. Should map to a persistent volume in production.                                     |
+| History start year   | `history_start_year` | `CVELISTV5_HISTORY_START_YEAR` | `2024`                                           | No        | Oldest year of CVE records to import on the **initial** run. Minimum recommended value is `2019` for CVSS v3.1 coverage. |
+
+### Deployment
+
+#### Docker deployment
+
+Build a docker image using the provided `Dockerfile`:
+
+```shell
+docker build . -t opencti/connector-cvelistv5:latest
+```
+
+Update the environment variables in `docker-compose.yml` with the appropriate
+values for your environment, then start the container:
+
+```shell
+docker compose up -d
+```
+
+In production, mount a named volume on `/opt/cvelistV5` so the clone survives
+container restarts (a sample volume declaration is provided in
+`docker-compose.yml`).
+
+#### Manual deployment
+
+Create `config.yml` from `config.yml.sample` and adjust the configuration
+variables (especially `ChangeMe` placeholders).
+
+Install the Python dependencies, preferably in a virtual environment:
+
+```shell
+pip3 install -r src/requirements.txt
+```
+
+Then start the connector from the `src` directory:
+
+```shell
+python3 main.py
+```
+
+### Behavior
+
+#### Initial population
+
+For the first run, the connector clones `CVEProject/cvelistV5`. Depending on
+network throughput this can take a few minutes. Once the clone is complete,
+the connector walks the `cves/<year>/` folders starting from
+`history_start_year` and converts every CVE record into a STIX bundle which
+is sent to OpenCTI.
+
+#### Pull CVE updates
+
+After the initial run, the connector waits for the duration defined by
+`CONNECTOR_DURATION_PERIOD`. On every subsequent run it fetches the latest
+commits, lists the JSON files that changed since the previous run, and
+re-imports them. The state stores the ISO 8601 timestamp of the previous run
+under the key `last_run`.
+
+#### Errors
+
+Per-record failures are logged with the offending CVE identifier and the
+connector keeps processing the remaining files. Runs that fail before any
+record is processed (typically network errors during the `git fetch`) are
+reported as failed work in the OpenCTI UI.
+
+### Usage
+
+After installation, the connector requires no manual interaction. It will
+run periodically according to the configured duration. To force a run, open
+*Data* → *Connectors* in OpenCTI, find the connector and click the refresh
+icon.
+
+The Software objects created by the connector can be linked to your
+organizations via the standard OpenCTI relationship editor, in order to
+visualize the vulnerabilities affecting your fleet.
+
+### Sources
+
+- [The CVE Project repository](https://github.com/CVEProject/cvelistV5)
+- [Default CVE connector](https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/cve)
+- [CISA KEV connector](https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/cisa-known-exploited-vulnerabilities)

--- a/external-import/cvelistv5/__metadata__/connector_manifest.json
+++ b/external-import/cvelistv5/__metadata__/connector_manifest.json
@@ -1,0 +1,22 @@
+{
+  "title": "CVEProject cvelistV5",
+  "slug": "cvelistv5",
+  "description": "Alternative CVE connector that fetches updates directly from the CVEProject/cvelistV5 GitHub repository instead of querying the NVD REST API. The connector keeps a local clone of the upstream repository, uses git history to detect modified records between runs, and converts each CVE v5.1 record into STIX 2.1 Vulnerability objects. Workarounds, solutions, configurations and exploits exposed by upstream are attached as STIX Note objects. When the affected products of a CVE expose CPEs or version ranges, Software and Identity (vendor) objects are also created so analysts can model the exposure of their fleet.",
+  "short_description": "Fetch CVE records straight from the CVEProject/cvelistV5 GitHub repository and import them as STIX 2.1 Vulnerability objects.",
+  "logo": null,
+  "use_cases": [
+    "Vulnerability Management",
+    "Open Source Threat Intel"
+  ],
+  "verified": false,
+  "last_verified_date": null,
+  "playbook_supported": false,
+  "max_confidence_level": 80,
+  "support_version": ">=6.6.0",
+  "subscription_link": null,
+  "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/cvelistv5",
+  "manager_supported": false,
+  "container_version": "rolling",
+  "container_image": "opencti/connector-cvelistv5",
+  "container_type": "EXTERNAL_IMPORT"
+}

--- a/external-import/cvelistv5/docker-compose.yml
+++ b/external-import/cvelistv5/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  connector-cvelistv5:
+    image: opencti/connector-cvelistv5:latest
+    environment:
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=ChangeMe
+      - CONNECTOR_ID=ChangeMe
+      - CONNECTOR_NAME=CVEProject cvelistV5
+      - CONNECTOR_SCOPE=identity,vulnerability,software
+      - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_DURATION_PERIOD=PT1H # ISO 8601 duration period
+      # Optional overrides
+      # - CVELISTV5_REPO_URL=https://github.com/CVEProject/cvelistV5.git
+      # - CVELISTV5_REPO_BRANCH=main
+      # - CVELISTV5_LOCAL_PATH=/opt/cvelistV5
+      - CVELISTV5_HISTORY_START_YEAR=2019 # Min 2019 to ensure CVSS v3.1 coverage
+    volumes:
+      - cvelistv5-clone:/opt/cvelistV5
+    restart: always
+
+volumes:
+  cvelistv5-clone:

--- a/external-import/cvelistv5/entrypoint.sh
+++ b/external-import/cvelistv5/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+cd /opt/opencti-connector-cvelistv5
+exec python3 main.py

--- a/external-import/cvelistv5/src/config.yml.sample
+++ b/external-import/cvelistv5/src/config.yml.sample
@@ -1,0 +1,21 @@
+opencti:
+  url: 'http://localhost:8080'
+  token: 'ChangeMe'
+
+connector:
+  id: 'ChangeMe'
+  type: 'EXTERNAL_IMPORT'
+  name: 'CVEProject cvelistV5'
+  scope: 'identity,vulnerability,software'
+  log_level: 'info'
+  duration_period: 'PT1H' # ISO 8601 duration period
+
+cvelistv5:
+  # Upstream git repository. Override only if you mirror cvelistV5 internally.
+  repo_url: 'https://github.com/CVEProject/cvelistV5.git'
+  repo_branch: 'main'
+  # Local path where the clone is kept. Must be writable by the connector.
+  local_path: '/opt/cvelistV5'
+  # Oldest year of CVE records to import (initial run only). Most CVSS v3.1
+  # metrics were back-filled from 2019 onwards.
+  history_start_year: 2019

--- a/external-import/cvelistv5/src/cve_processor.py
+++ b/external-import/cvelistv5/src/cve_processor.py
@@ -1,0 +1,352 @@
+"""Transform CVE 5.1 records into STIX 2.1 objects and send them to OpenCTI."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Iterable
+
+import stix2
+from pycti import (
+    Identity,
+    Note,
+    OpenCTIConnectorHelper,
+    StixCoreRelationship,
+    Vulnerability,
+)
+
+# CVE record states that should not be ingested as live vulnerabilities.
+SKIPPED_STATES = {"REJECTED", "RESERVED"}
+CWE_PATTERN = re.compile(r"\bCWE-\d+\b")
+SECTIONS_TO_NOTES = {
+    "workarounds": "workaround",
+    "solutions": "solution",
+    "exploits": "exploit",
+    "configurations": "configuration",
+}
+# CVSS extraction precedence (most recent / detailed metric first).
+CVSS_VERSIONS = ("cvssV4_0", "cvssV3_1", "cvssV3_0")
+
+
+class CVEProcessor:
+    """Convert CVE records to STIX bundles and push them to OpenCTI."""
+
+    def __init__(self, helper: OpenCTIConnectorHelper) -> None:
+        self.helper = helper
+        self.author = self._create_author()
+
+    def process_cve_file(self, file_path: str, work_id: str) -> None:
+        with open(file_path, encoding="utf-8") as cve_file:
+            cve_data = json.load(cve_file)
+
+        metadata = cve_data.get("cveMetadata") or {}
+        cve_id = metadata.get("cveId")
+        if not cve_id:
+            self.helper.connector_logger.warning(
+                "Skipping CVE record without an identifier.", {"file": file_path}
+            )
+            return
+
+        state = metadata.get("state")
+        if state in SKIPPED_STATES:
+            self.helper.connector_logger.debug(
+                "Skipping CVE record in non-public state.",
+                {"cve_id": cve_id, "state": state},
+            )
+            return
+
+        stix_objects = self._cve_record_to_stix(cve_data)
+        if not stix_objects:
+            return
+
+        bundle = self.helper.stix2_create_bundle(stix_objects)
+        self.helper.send_stix2_bundle(bundle, work_id=work_id, update=True)
+        self.helper.connector_logger.info(
+            "CVE record sent to OpenCTI.", {"cve_id": cve_id}
+        )
+
+    def _cve_record_to_stix(self, cve_data: dict[str, Any]) -> list[Any]:
+        metadata = cve_data.get("cveMetadata") or {}
+        containers = cve_data.get("containers") or {}
+        cna = containers.get("cna") or {}
+        adp_containers = containers.get("adp") or []
+
+        cve_id = metadata["cveId"]
+        published_date = self._normalize_date(metadata.get("datePublished"))
+        modified_date = self._normalize_date(
+            metadata.get("dateUpdated") or metadata.get("dateReserved")
+        )
+        description = self._extract_description(cna)
+        if description is None:
+            self.helper.connector_logger.debug(
+                "CVE record has no English description, skipping.",
+                {"cve_id": cve_id},
+            )
+            return []
+
+        external_references = self._extract_external_references(cna)
+        labels = self._extract_labels(cna)
+        custom_properties = self._extract_cvss_properties(cna, adp_containers)
+
+        vulnerability = stix2.Vulnerability(
+            id=Vulnerability.generate_id(cve_id),
+            name=cve_id,
+            description=description,
+            created=published_date,
+            modified=modified_date,
+            external_references=external_references or None,
+            created_by_ref=self.author["id"],
+            custom_properties=custom_properties,
+            labels=labels or None,
+            allow_custom=True,
+        )
+        stix_objects: list[Any] = [self.author, vulnerability]
+
+        for product in cna.get("affected") or []:
+            stix_objects.extend(self._build_affected_objects(product, vulnerability))
+
+        for section, label in SECTIONS_TO_NOTES.items():
+            entries = cna.get(section)
+            if not entries:
+                continue
+            stix_objects.extend(
+                self._create_related_notes(label, entries, vulnerability)
+            )
+
+        return stix_objects
+
+    def _build_affected_objects(
+        self, product: dict[str, Any], vulnerability: stix2.Vulnerability
+    ) -> list[Any]:
+        product_name = product.get("product") or product.get("packageName")
+        if not product_name:
+            return []
+
+        vendor_name = product.get("vendor") or "Unknown"
+        software_vendor = stix2.Identity(
+            id=Identity.generate_id(vendor_name, "organization"),
+            name=vendor_name,
+            identity_class="organization",
+            description="Software Vendor",
+            created_by_ref=self.author["id"],
+            custom_properties={"x_opencti_organization_type": "vendor"},
+            allow_custom=True,
+        )
+
+        stix_objects: list[Any] = [software_vendor]
+
+        cpes = product.get("cpes") or []
+        if cpes:
+            for cpe in cpes:
+                version_value = self._extract_cpe_version(cpe)
+                stix_objects.extend(
+                    self._create_affected_software(
+                        product_name,
+                        version_value,
+                        software_vendor,
+                        vulnerability,
+                        cpe=cpe,
+                    )
+                )
+            return stix_objects
+
+        for version in product.get("versions") or []:
+            if version.get("status") != "affected":
+                continue
+            version_value = self._format_version(version)
+            stix_objects.extend(
+                self._create_affected_software(
+                    f"{product_name} {version.get('version', '')}".strip(),
+                    version_value,
+                    software_vendor,
+                    vulnerability,
+                )
+            )
+        return stix_objects
+
+    def _create_affected_software(
+        self,
+        name: str,
+        version: str,
+        vendor: stix2.Identity,
+        vulnerability: stix2.Vulnerability,
+        cpe: str = "",
+    ) -> list[Any]:
+        software = stix2.Software(
+            name=name,
+            version=version or "unspecified",
+            vendor=vendor.name,
+            cpe=cpe or None,
+            custom_properties={"x_opencti_created_by_ref": self.author["id"]},
+            allow_custom=True,
+        )
+
+        vulnerability_relationship = stix2.Relationship(
+            id=StixCoreRelationship.generate_id("has", software.id, vulnerability.id),
+            relationship_type="has",
+            source_ref=software.id,
+            target_ref=vulnerability.id,
+            created_by_ref=self.author["id"],
+            allow_custom=True,
+        )
+
+        software_vendor_relationship = stix2.Relationship(
+            id=StixCoreRelationship.generate_id("related-to", software.id, vendor.id),
+            relationship_type="related-to",
+            description="This software is maintained by",
+            source_ref=software.id,
+            target_ref=vendor.id,
+            created_by_ref=self.author["id"],
+            allow_custom=True,
+        )
+
+        return [software, vulnerability_relationship, software_vendor_relationship]
+
+    def _create_related_notes(
+        self,
+        section_label: str,
+        entries: Iterable[dict[str, Any]],
+        vulnerability: stix2.Vulnerability,
+    ) -> list[Any]:
+        stix_objects: list[Any] = []
+        for entry in entries:
+            content = entry.get("value")
+            if not content:
+                continue
+            note = stix2.Note(
+                id=Note.generate_id(created=None, content=content),
+                abstract=f"{vulnerability.name} - {section_label}",
+                content=content,
+                object_refs=[vulnerability.id],
+                labels=[section_label],
+                created_by_ref=self.author["id"],
+                allow_custom=True,
+            )
+            stix_objects.append(note)
+        return stix_objects
+
+    @staticmethod
+    def _normalize_date(value: str | None) -> str | None:
+        if not value:
+            return None
+        if value.endswith("Z"):
+            return value
+        # CVE feeds occasionally publish ``+00:00`` and bare datetimes. STIX 2.1
+        # expects a ``Z`` suffix, so normalize accordingly.
+        if value.endswith("+00:00"):
+            return f"{value[:-6]}Z"
+        return f"{value}Z"
+
+    @staticmethod
+    def _extract_description(cna: dict[str, Any]) -> str | None:
+        descriptions = cna.get("descriptions") or []
+        for description in descriptions:
+            if description.get("lang", "").lower().startswith("en"):
+                value = description.get("value")
+                if value:
+                    return value
+        if descriptions:
+            return descriptions[0].get("value")
+        return None
+
+    @staticmethod
+    def _extract_external_references(
+        cna: dict[str, Any],
+    ) -> list[stix2.ExternalReference]:
+        references: list[stix2.ExternalReference] = []
+        for reference in cna.get("references") or []:
+            url = reference.get("url")
+            if not url:
+                continue
+            source_name = reference.get("name")
+            if not source_name:
+                tags = reference.get("tags") or []
+                source_name = tags[0] if tags else url
+            references.append(stix2.ExternalReference(source_name=source_name, url=url))
+        return references
+
+    @staticmethod
+    def _extract_labels(cna: dict[str, Any]) -> list[str]:
+        labels: list[str] = []
+        seen: set[str] = set()
+        for problem_type in cna.get("problemTypes") or []:
+            for entry in problem_type.get("descriptions") or []:
+                cwe_id = entry.get("cweId")
+                description = entry.get("description") or ""
+                if not cwe_id:
+                    match = CWE_PATTERN.search(description)
+                    if match:
+                        cwe_id = match.group(0)
+                if cwe_id and cwe_id not in seen:
+                    seen.add(cwe_id)
+                    labels.append(cwe_id)
+                if description:
+                    clean = CWE_PATTERN.sub("", description).strip(" :-")
+                    if clean and clean not in seen:
+                        seen.add(clean)
+                        labels.append(clean)
+        return labels
+
+    @classmethod
+    def _extract_cvss_properties(
+        cls,
+        cna: dict[str, Any],
+        adp_containers: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        metric = cls._find_cvss_metric(cna.get("metrics") or [])
+        if metric is None:
+            for adp in adp_containers:
+                metric = cls._find_cvss_metric(adp.get("metrics") or [])
+                if metric is not None:
+                    break
+        if metric is None:
+            return {}
+
+        return {
+            "x_opencti_cvss_base_score": metric.get("baseScore", ""),
+            "x_opencti_cvss_base_severity": metric.get("baseSeverity", ""),
+            "x_opencti_cvss_attack_vector": metric.get("attackVector", ""),
+            "x_opencti_cvss_integrity_impact": metric.get("integrityImpact", ""),
+            "x_opencti_cvss_availability_impact": metric.get("availabilityImpact", ""),
+            "x_opencti_cvss_confidentiality_impact": metric.get(
+                "confidentialityImpact", ""
+            ),
+        }
+
+    @staticmethod
+    def _find_cvss_metric(metrics: list[dict[str, Any]]) -> dict[str, Any] | None:
+        for version in CVSS_VERSIONS:
+            for metric in metrics:
+                if version in metric and isinstance(metric[version], dict):
+                    return metric[version]
+        return None
+
+    @staticmethod
+    def _extract_cpe_version(cpe: str) -> str:
+        parts = cpe.split(":")
+        if len(parts) >= 7:
+            update = parts[6]
+            if update not in ("-", "*", ""):
+                return f"{parts[5]}-{update}"
+            return parts[5]
+        if len(parts) >= 6:
+            return parts[5]
+        if len(parts) >= 5:
+            return parts[4]
+        return ""
+
+    @staticmethod
+    def _format_version(version: dict[str, Any]) -> str:
+        if "lessThan" in version:
+            return f"<{version['lessThan']}"
+        if "lessThanOrEqual" in version:
+            return f"<={version['lessThanOrEqual']}"
+        return version.get("version", "")
+
+    @staticmethod
+    def _create_author() -> stix2.Identity:
+        return stix2.Identity(
+            id=Identity.generate_id("The CVE Program", "organization"),
+            name="The CVE Program",
+            identity_class="organization",
+        )

--- a/external-import/cvelistv5/src/git_handler.py
+++ b/external-import/cvelistv5/src/git_handler.py
@@ -1,0 +1,133 @@
+"""Git interactions for the cvelistV5 connector.
+
+The connector consumes CVE records straight from the CVEProject/cvelistV5
+GitHub repository. This module is responsible for keeping a local clone in
+sync and listing the JSON files that need to be (re)processed for a given
+connector run.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Iterable
+
+import git
+
+CVES_DIRECTORY = "cves"
+# Files that live inside the repository but should never be processed as CVE
+# records. They are aggregate artifacts produced by upstream tooling.
+EXCLUDED_FILE_SUFFIXES = ("delta.json", "deltaLog.json")
+
+
+class GitHandler:
+    """Wrapper around :mod:`git` used to keep a local clone in sync."""
+
+    def __init__(
+        self,
+        repo_url: str,
+        local_path: str,
+        branch: str = "main",
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.repo_url = repo_url
+        self.local_path = local_path
+        self.branch = branch
+        self.logger = logger or logging.getLogger(__name__)
+        self.repo = self._init_repo()
+        self.last_run_time: datetime | None = None
+
+    def _init_repo(self) -> git.Repo:
+        """Return a :class:`git.Repo` rooted at ``self.local_path``.
+
+        Clones the upstream repository when the directory is empty, otherwise
+        opens the existing clone.
+        """
+        if not os.path.exists(self.local_path) or not os.listdir(self.local_path):
+            self.logger.info(
+                "Cloning upstream repository.",
+                {"repo_url": self.repo_url, "local_path": self.local_path},
+            )
+            os.makedirs(self.local_path, exist_ok=True)
+            return git.Repo.clone_from(
+                self.repo_url,
+                self.local_path,
+                branch=self.branch,
+                single_branch=True,
+            )
+        return git.Repo(self.local_path)
+
+    def pull_updates(self) -> None:
+        """Hard-reset the clone to the latest remote branch tip.
+
+        Using ``fetch`` + ``reset --hard`` instead of ``pull`` makes the
+        operation idempotent and avoids merge conflicts if the working tree
+        is somehow modified between runs.
+        """
+        origin = self.repo.remotes.origin
+        origin.fetch(self.branch, prune=True)
+        remote_ref = f"origin/{self.branch}"
+        self.repo.git.reset("--hard", remote_ref)
+
+    def get_updated_files(self, start_year: int) -> list[str]:
+        """Return the list of CVE JSON files to (re)process for this run."""
+        if self.last_run_time is None:
+            files = self._get_all_files_from_year(start_year)
+        else:
+            files = list(self._get_files_since(self.last_run_time, start_year))
+        return files
+
+    def update_last_run_time(self, run_time: datetime | None = None) -> None:
+        if run_time is None:
+            run_time = datetime.now(timezone.utc)
+        elif run_time.tzinfo is None:
+            run_time = run_time.replace(tzinfo=timezone.utc)
+        self.last_run_time = run_time
+
+    def _get_all_files_from_year(self, start_year: int) -> list[str]:
+        all_files: list[str] = []
+        cves_path = os.path.join(self.local_path, CVES_DIRECTORY)
+        if not os.path.isdir(cves_path):
+            self.logger.warning(
+                "Expected CVE directory is missing in the clone.",
+                {"path": cves_path},
+            )
+            return all_files
+
+        for folder_name in sorted(os.listdir(cves_path)):
+            if not folder_name.isdigit():
+                continue
+            if int(folder_name) < start_year:
+                continue
+            folder_path = os.path.join(cves_path, folder_name)
+            for root, _, files in os.walk(folder_path):
+                for file_name in files:
+                    if not file_name.endswith(".json"):
+                        continue
+                    if file_name.endswith(EXCLUDED_FILE_SUFFIXES):
+                        continue
+                    all_files.append(os.path.join(root, file_name))
+        return all_files
+
+    def _get_files_since(self, since: datetime, start_year: int) -> Iterable[str]:
+        commits = list(self.repo.iter_commits(self.branch, since=since.isoformat()))
+        updated_files: set[str] = set()
+        for commit in commits:
+            updated_files.update(commit.stats.files.keys())
+
+        prefix = f"{CVES_DIRECTORY}/"
+        for relative_path in updated_files:
+            if not relative_path.startswith(prefix):
+                continue
+            if not relative_path.endswith(".json"):
+                continue
+            if relative_path.endswith(EXCLUDED_FILE_SUFFIXES):
+                continue
+            # Records are organised under ``cves/<year>/...``. Skip records
+            # older than the configured horizon.
+            parts = relative_path.split("/")
+            if len(parts) >= 2 and parts[1].isdigit():
+                if int(parts[1]) < start_year:
+                    continue
+            yield os.path.join(self.local_path, relative_path)

--- a/external-import/cvelistv5/src/main.py
+++ b/external-import/cvelistv5/src/main.py
@@ -1,0 +1,186 @@
+"""OpenCTI cvelistV5 connector entrypoint."""
+
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+import yaml
+from cve_processor import CVEProcessor
+from git_handler import GitHandler
+from pycti import OpenCTIConnectorHelper, get_config_variable
+
+DEFAULT_REPO_URL = "https://github.com/CVEProject/cvelistV5.git"
+DEFAULT_REPO_BRANCH = "main"
+DEFAULT_LOCAL_PATH = "/opt/cvelistV5"
+DEFAULT_START_YEAR = 2024
+MIN_START_YEAR = 1999
+
+
+class CVEListV5Connector:
+    """External import connector that ingests CVEs from CVEProject/cvelistV5."""
+
+    def __init__(self) -> None:
+        config_file_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "config.yml"
+        )
+        if os.path.isfile(config_file_path):
+            with open(config_file_path, encoding="utf-8") as config_file:
+                config = yaml.safe_load(config_file) or {}
+        else:
+            config = {}
+
+        self.helper = OpenCTIConnectorHelper(config)
+
+        self.repo_url = (
+            get_config_variable(
+                "CVELISTV5_REPO_URL",
+                ["cvelistv5", "repo_url"],
+                config,
+            )
+            or DEFAULT_REPO_URL
+        )
+        self.repo_branch = (
+            get_config_variable(
+                "CVELISTV5_REPO_BRANCH",
+                ["cvelistv5", "repo_branch"],
+                config,
+            )
+            or DEFAULT_REPO_BRANCH
+        )
+        self.local_path = (
+            get_config_variable(
+                "CVELISTV5_LOCAL_PATH",
+                ["cvelistv5", "local_path"],
+                config,
+            )
+            or DEFAULT_LOCAL_PATH
+        )
+
+        start_year = get_config_variable(
+            "CVELISTV5_HISTORY_START_YEAR",
+            ["cvelistv5", "history_start_year"],
+            config,
+            isNumber=True,
+            default=DEFAULT_START_YEAR,
+        )
+        try:
+            start_year = int(start_year)
+        except (TypeError, ValueError):
+            start_year = DEFAULT_START_YEAR
+        if start_year < MIN_START_YEAR:
+            self.helper.connector_logger.warning(
+                "Configured history_start_year is below the minimum supported year, "
+                "falling back to default.",
+                {"configured": start_year, "minimum": MIN_START_YEAR},
+            )
+            start_year = DEFAULT_START_YEAR
+        self.start_year = start_year
+
+        self.duration_period = get_config_variable(
+            "CONNECTOR_DURATION_PERIOD",
+            ["connector", "duration_period"],
+            config,
+            default="PT1H",
+        )
+
+        # Lazy initialized inside _process_updates() so a missing / unreachable
+        # upstream repository does not prevent the connector container from booting.
+        self.git_handler: GitHandler | None = None
+        self.cve_processor = CVEProcessor(self.helper)
+
+    def _ensure_git_handler(self) -> GitHandler:
+        if self.git_handler is None:
+            self.helper.connector_logger.info(
+                "Initializing local clone of cvelistV5 repository (this may take a "
+                "few minutes on first run)...",
+                {"repo_url": self.repo_url, "local_path": self.local_path},
+            )
+            self.git_handler = GitHandler(
+                repo_url=self.repo_url,
+                local_path=self.local_path,
+                branch=self.repo_branch,
+                logger=self.helper.connector_logger,
+            )
+            state = self.helper.get_state() or {}
+            last_run_iso = state.get("last_run")
+            if last_run_iso:
+                try:
+                    self.git_handler.last_run_time = datetime.fromisoformat(
+                        last_run_iso
+                    )
+                except ValueError:
+                    self.helper.connector_logger.warning(
+                        "Could not parse last_run timestamp from state, "
+                        "falling back to full import.",
+                        {"last_run": last_run_iso},
+                    )
+            self.helper.connector_logger.info("Local clone is ready.")
+        return self.git_handler
+
+    def _process_updates(self) -> None:
+        run_started_at = datetime.now(timezone.utc)
+        friendly_name = (
+            f"CVEListV5 run @ {run_started_at.strftime('%Y-%m-%d %H:%M:%S')} UTC"
+        )
+        work_id = self.helper.api.work.initiate_work(
+            self.helper.connect_id, friendly_name
+        )
+        try:
+            git_handler = self._ensure_git_handler()
+            git_handler.pull_updates()
+            files_to_process = git_handler.get_updated_files(self.start_year)
+            self.helper.connector_logger.info(
+                "Processing CVE records.", {"files": len(files_to_process)}
+            )
+
+            processed = 0
+            failed = 0
+            for file_path in files_to_process:
+                self.helper.connector_logger.debug(
+                    "Processing CVE file.", {"file": file_path}
+                )
+                try:
+                    self.cve_processor.process_cve_file(file_path, work_id)
+                    processed += 1
+                except Exception as exc:  # noqa: BLE001 - we want to keep going
+                    failed += 1
+                    self.helper.connector_logger.error(
+                        "Could not process CVE file.",
+                        {"file": file_path, "error": str(exc)},
+                    )
+
+            git_handler.update_last_run_time(run_started_at)
+            self.helper.set_state(
+                {
+                    "last_run": run_started_at.isoformat(),
+                    "last_run_processed": processed,
+                    "last_run_failed": failed,
+                }
+            )
+
+            message = (
+                f"CVEListV5 connector run done: {processed} processed, "
+                f"{failed} failed (total candidates: {len(files_to_process)})."
+            )
+            self.helper.connector_logger.info(message)
+            self.helper.api.work.to_processed(work_id, message)
+        except Exception as exc:  # noqa: BLE001
+            message = f"CVEListV5 connector run failed: {exc}"
+            self.helper.connector_logger.error(message)
+            self.helper.api.work.to_processed(work_id, message, in_error=True)
+
+    def start(self) -> None:
+        self.helper.connector_logger.info("Starting CVEListV5 connector.")
+        self.helper.schedule_iso(
+            message_callback=self._process_updates,
+            duration_period=self.duration_period,
+        )
+
+
+if __name__ == "__main__":
+    try:
+        CVEListV5Connector().start()
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)

--- a/external-import/cvelistv5/src/requirements.txt
+++ b/external-import/cvelistv5/src/requirements.txt
@@ -1,0 +1,4 @@
+pycti==7.260512.0
+stix2~=3.0
+GitPython~=3.1
+PyYAML>=6.0,<7


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* New `external-import/cvelistv5` connector that clones the [CVEProject/cvelistV5](https://github.com/CVEProject/cvelistV5) GitHub repository and converts every record into a STIX 2.1 `Vulnerability` (description, CVSS v4.0/v3.1/v3.0, CWE labels, external references).
* Subsequent runs use `git log` to detect modified records since the previous run, so they are cheap.
* Optionally creates `Software` + vendor `Identity` objects with `has`/`related-to` relationships, so analysts can model the exposure of their fleet.
* Exposes upstream workarounds, solutions, configurations and exploits as STIX `Note` objects linked to the vulnerability.
* `repo_url`, `repo_branch`, `local_path` and `history_start_year` are all configurable.

### Related issues

* Closes #6388

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

On the first run the connector clones `CVEProject/cvelistV5` into `/opt/cvelistV5` (mounted as a persistent docker volume). The clone is then walked starting from `CVELISTV5_HISTORY_START_YEAR` and every CVE is sent to OpenCTI as a STIX bundle. The connector keeps the ISO 8601 timestamp of the previous run in its state, so subsequent runs only re-process the records that changed since then.

Vulnerabilities are labelled with their CWE identifiers (and free-form CWE descriptions when available). When the affected products of a CVE expose `cpes` or `versions`, the connector emits the corresponding `Software` and vendor `Identity` objects so analysts can link them to their assets.

Local validation that was run on the squashed commit:

- `isort==6.0.1 --profile black` (clean, matches `ci-requirements.txt`)
- `black==25.1.0 --check` (clean, matches `ci-requirements.txt`)
- `flake8 --ignore=E,W` (clean)
- `pylint --disable=all --enable=no_generated_id_stix,no-value-for-parameter,unused-import --load-plugins linter_stix_id_generator` → 10/10

![image](https://github.com/user-attachments/assets/1be4dd18-0e79-47a6-a33c-e8e52081d6c5)
![image](https://github.com/user-attachments/assets/8350a0f8-9735-478f-86b3-b57effc97e2f)
