### PR TITLE
[EmailIntelImap & EmailIntelMicrosoft] Fix: Align required Pydantic version for connectors with PyCTI dependencies.

### DIFF
--- a/external-import/email-intel-imap/src/base_connector/requirements.txt
+++ b/external-import/email-intel-imap/src/base_connector/requirements.txt
@@ -1,3 +1,3 @@
-pycti==6.5.10
-pydantic==2.10.6
+pycti==6.6.12
+pydantic~=2.11.3
 pydantic-settings==2.8.1

--- a/external-import/email-intel-imap/src/requirements.txt
+++ b/external-import/email-intel-imap/src/requirements.txt
@@ -1,7 +1,7 @@
 -r ./base_connector/requirements.txt
 imap-tools==1.10.0
-pycti==6.5.10
-pydantic==2.10.6
+pycti==6.6.12
+pydantic~=2.11.3
 google-api-python-client>=2.169.0
 google-api-core==2.24.2
 google-auth==2.40.1

--- a/external-import/email-intel-microsoft/src/base_connector/requirements.txt
+++ b/external-import/email-intel-microsoft/src/base_connector/requirements.txt
@@ -1,3 +1,3 @@
-pycti==6.6.10
-pydantic==2.11.4
+pycti==6.6.12
+pydantic~=2.11.3
 pydantic-settings==2.9.1

--- a/external-import/email-intel-microsoft/src/requirements.txt
+++ b/external-import/email-intel-microsoft/src/requirements.txt
@@ -2,6 +2,6 @@
 azure-identity==1.22.0
 email_validator==2.2.0
 msgraph-sdk==1.28.0
-pycti==6.6.10
-pydantic==2.11.4
+pycti==6.6.12
+pydantic~=2.11.3
 pydantic-settings==2.9.1


### PR DESCRIPTION
### Proposed changes

* Fix dependencies conflict: 

```
#0 6.365 ERROR: Cannot install -r /opt/opencti-connector-email-intel-imap/base_connector/requirements.txt (line 1), -r /opt/opencti-connector-email-intel-imap/base_connector/requirements.txt (line 3) and pydantic==2.10.6 because these package versions have conflicting dependencies.
#0 6.366 
#0 6.366 The conflict is caused by:
#0 6.366     The user requested pydantic==2.10.6
#0 6.366     The user requested pydantic==2.10.6
#0 6.366     pydantic-settings 2.8.1 depends on pydantic>=2.7.0
#0 6.366     pycti 6.6.12 depends on pydantic~=2.11.3
#0 6.366 
#0 6.366 To fix this you could try to:
#0 6.366 1. loosen the range of package versions you've specified
#0 6.366 2. remove package versions to allow pip to attempt to solve the dependency conflict
```

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4043