### PR TITLE
Added trust_env=True in all aiohttp-based connectors

### DIFF
--- a/external-import/dragos/client_api/v1/common.py
+++ b/external-import/dragos/client_api/v1/common.py
@@ -141,6 +141,7 @@ class BaseClientAPIV1(ABC):  # noqa: B024
         async with ClientSession(
             headers=headers,
             timeout=self._timeout,
+            trust_env=True,
         ) as session:
             async with session.get(query_url) as resp:
                 _ = await resp.read()  # consume the response

--- a/external-import/proofpoint-tap/proofpoint_tap/client_api/common.py
+++ b/external-import/proofpoint-tap/proofpoint_tap/client_api/common.py
@@ -206,6 +206,7 @@ class BaseClient(  # noqa: B024 # Even though there is no abstract method, it is
             auth=self.auth,
             timeout=self._timeout,
             trace_configs=[trace_config],
+            trust_env=True,
         ) as session:
             async with RetryClient(
                 client_session=session,

--- a/external-import/servicenow/src/connector/services/client_api.py
+++ b/external-import/servicenow/src/connector/services/client_api.py
@@ -274,7 +274,9 @@ class ServiceNowClient:
         )
         async def _retry_wrapped():
             async with ClientSession(
-                headers=self.headers, raise_for_status=True
+                headers=self.headers,
+                raise_for_status=True,
+                trust_env=True,
             ) as session:
                 async with session.get(url=url_built) as response:
                     return await response.json()

--- a/internal-enrichment/proofpoint-et-intelligence/src/connector/services/client_api.py
+++ b/internal-enrichment/proofpoint-et-intelligence/src/connector/services/client_api.py
@@ -68,7 +68,9 @@ class ProofpointEtIntelligenceClient:
                 entity_value, source_entity_type, target_entity_type
             )
             async with ClientSession(
-                headers=self.headers, raise_for_status=True
+                headers=self.headers,
+                raise_for_status=True,
+                trust_env=True,
             ) as session:
                 async with session.get(url=url_built) as response:
                     return await response.json()


### PR DESCRIPTION
Some Python connectors use the `aiohttp` module for HTTP requests.

However, as opposed to `requests` and most other languages and libraries, `aiohttp` [chooses](https://github.com/aio-libs/aiohttp/issues/529) not to use the `HTTP_PROXY` and `HTTPS_PROXY` environment variables to supply proxy configuration. This can be a great issue in enterprise deployments when a proxy has to be used.

However, it is possible for `aiohttp` to consider these environment variables by passing `trust_env=True` to the `aiohttp.ClientSession` constructor ([reference](https://docs.aiohttp.org/en/stable/client_advanced.html))

This pull requests adds it in all `aiohttp`-based connectors.

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
