### PR TITLE
[Cofense-ThreatHQ] Add extra parameter to allow

### DIFF
--- a/external-import/cofense-threathq/src/connector/models/common.py
+++ b/external-import/cofense-threathq/src/connector/models/common.py
@@ -10,4 +10,5 @@ class ConfigBaseSettings(BaseSettings):
         frozen=True,
         str_strip_whitespace=True,
         str_min_length=1,
+        extra='allow',
     )

--- a/external-import/cofense-threathq/src/connector/models/common.py
+++ b/external-import/cofense-threathq/src/connector/models/common.py
@@ -10,5 +10,5 @@ class ConfigBaseSettings(BaseSettings):
         frozen=True,
         str_strip_whitespace=True,
         str_min_length=1,
-        extra='allow',
+        extra="allow",
     )


### PR DESCRIPTION
### Proposed changes

* Added configuration in pydantic to allow all environment variables considered as extra parameters

### Related issues

* #4085

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
