### PR TITLE
[Ransomwarelive] Fix replace wrong whois dependency with python-whois

### DIFF
--- a/external-import/ransomwarelive/requirements.txt
+++ b/external-import/ransomwarelive/requirements.txt
@@ -3,4 +3,4 @@ stix2==3.0.1
 validators==0.35.0
 pydantic>=2.10, <3
 tldextract
-whois==1.20240129.2
+python-whois>=0.9.5


### PR DESCRIPTION
### Proposed changes

* Fixes an import problem caused by the wrong `whois` package in `requirements.txt`. The connector was pulling `whois`, which doesn't have the necessary `whois.whois()` functionality. This PR changes the dependency to `python-whois`, resolving runtime errors in the next Docker image (`6.6.15`).


### Related issues

* #4080

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

