### PR TITLE
[Microsoft Sentinel Incidents] fix: Parsing Remediation steps should not raise error.

### DIFF
--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
@@ -76,7 +76,7 @@ class ConverterToStix:
     def create_incident(self, alert: dict) -> stix2.Incident | None:
         def _get_remediation(remediation_steps: str | None) -> str:
             try:
-                return f"  \n{'  \n'.join(json.loads(remediation_steps, '[]') or [])}"
+                return f"  \n{'  \n'.join(json.loads(remediation_steps) if remediation_steps else [])}"
             except json.JSONDecodeError:
                 self.helper.connector_logger.warning(
                     "Error while decoding remediation steps, RemediationSteps must be a valid JSON list:"


### PR DESCRIPTION
### Proposed changes

* Correct syntax using json.loads method

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4107

### Checklist


- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments
Tested only with basic local use cases : 
* using remediation_steps = "abc"=> JSONDECODEERROR is excepted gracefully
* using remediation_steps = None => empty list is provided as expected