### PR TITLE
[Jira] Add missing SSL verification config to the Jira client

### DIFF
--- a/stream/jira/src/main.py
+++ b/stream/jira/src/main.py
@@ -95,6 +95,7 @@ class JiraConnector:
         self.jira_client = JIRA(
             server=self.jira_url,
             basic_auth=(self.jira_login_email, self.jira_api_token),
+            options={"verify": self.jira_ssl_verify},
         )
 
     def _process_message(self, msg):


### PR DESCRIPTION
### Proposed changes

* Add missing SSL verification config to the Jira client according to [their documentation](https://github.com/pycontribs/jira/blob/main/jira/client.py#L510)

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4100