### PR TITLE
[URLScan-Enrichment] Fix error when no snapshot

### DIFF
--- a/internal-enrichment/urlscan-enrichment/src/main.py
+++ b/internal-enrichment/urlscan-enrichment/src/main.py
@@ -129,10 +129,9 @@ class UrlscanConnector:
         )
 
         if is_submission:
-            existing_screenshot_title = data["page"].get("title", None)
             prepared_file_png = (
                 self.utils.prepare_file_png(data)
-                if self.config.import_screenshot and existing_screenshot_title
+                if self.config.import_screenshot
                 else None
             )
             labels = self._generate_labels(data)

--- a/internal-enrichment/urlscan-enrichment/src/main.py
+++ b/internal-enrichment/urlscan-enrichment/src/main.py
@@ -128,10 +128,11 @@ class UrlscanConnector:
             {"entity_type": stix_entity["type"], "entity_value": stix_entity["value"]},
         )
 
-        if is_submission is True:
+        if is_submission:
+            existing_screenshot_title = data["page"].get("title", None)
             prepared_file_png = (
                 self.utils.prepare_file_png(data)
-                if self.config.import_screenshot
+                if self.config.import_screenshot and existing_screenshot_title
                 else None
             )
             labels = self._generate_labels(data)

--- a/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/client.py
+++ b/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/client.py
@@ -144,15 +144,14 @@ class UrlscanClient:
                         )
                         if new_attempt.status_code == 200:
                             json_new_attempt = new_attempt.json()
-                            if (
-                                json_new_attempt["data"]["requests"][0]["response"][
-                                    "dataLength"
-                                ]
-                                == 0
-                            ):
-                                raise ValueError(
+                            data_length = json_new_attempt["data"]["requests"][0][
+                                "response"
+                            ]["dataLength"]
+
+                            if data_length == 0:
+                                self.helper.connector_logger.warning(
                                     "[API-RESULT] The request has been submitted to URLScan, "
-                                    "but the URL does not return any data."
+                                    "but the URL does not return any screenshot."
                                 )
                             return json_new_attempt
 
@@ -167,9 +166,11 @@ class UrlscanClient:
                 )
             else:
                 result = response.json()
-                if result["data"]["requests"][0]["response"]["dataLength"] == 0:
-                    raise ValueError(
-                        "[API-RESULT] The request has been submitted to URLScan, but the URL does not return any data."
+                data_length = result["data"]["requests"][0]["response"]["dataLength"]
+                if data_length == 0:
+                    self.helper.connector_logger.warning(
+                        "[API-RESULT] The request has been submitted to URLScan, "
+                        "but the URL does not return any screenshot."
                     )
                 return result
 

--- a/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/utils.py
+++ b/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/utils.py
@@ -18,6 +18,10 @@ class UrlscanUtils:
         :return: dict | None
         """
 
+        data_page_title = data.get("page", {}).get("title")
+        if not data_page_title:
+            return None
+
         data_screenshot = data["task"]["screenshotURL"]
         data_uuid = data["task"]["uuid"]
         data_title = data["page"]["title"].replace(" ", "-")


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Do not raise but warn when user submits url and urlscan returns information but no DOM snapshot.
* Add a condition when preparing the file, the title of the snapshot must exist.

### Related issues

* #4111 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
