### PR TITLE
[Recorded Future] Fix invalid escape in rf_alerts.py

### DIFF
--- a/external-import/recorded-future/src/rflib/rf_alerts.py
+++ b/external-import/recorded-future/src/rflib/rf_alerts.py
@@ -425,7 +425,7 @@ class RecordedFutureAlertConnector(threading.Thread):
                             in str(hit["document"]["source"]["name"]).lower()
                         ):
                             value = search(
-                                "(https:\/\/t.me\/.+?(?=\/))|(https:\/\/twitter.com\/.+?(?=\/))",
+                                r"(https:\/\/t.me\/.+?(?=\/))|(https:\/\/twitter.com\/.+?(?=\/))",
                                 hit["document"]["url"],
                             )
                             if value is None:


### PR DESCRIPTION
This connector was causing an invalid escape. The patch fixes the issue by using a string literal for the regular expression.

### Proposed changes

* Fix regex in connector which was throwing an invalid escape error.
*

### Related issues

*
*

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Trivial change.