### PR TITLE
[Sekoia] Small fixes + add new config on importing IOC related object

### DIFF
--- a/external-import/sekoia/README.md
+++ b/external-import/sekoia/README.md
@@ -31,6 +31,7 @@ connector-sekoia:
       - SEKOIA_LIMIT=100                # Optional, the number of elements to fetch in each request. Defaults to 200, maximum 2000
       - SEKOIA_CREATE_OBSERVABLES=true  # Create observables from indicators
       - SEKOIA_IMPORT_SOURCE_LIST=false # Create the list of sources observed by Sekoia as label
+      - SEKOIA_IMPORT_IOC_RELATIONSHIPS=true # Optional, Import IOCs relationships and related objects - Default: true
     restart: always
     depends_on:
       - opencti
@@ -84,6 +85,24 @@ Here are the elements of the Sekoia feed that can be found on OpenCTI after expo
 | Malwares	      | Malwares       |
 | Intrusion Set	 | Intrusion-sets |
 | Indicators	    | Indicators     |
+
+## Known behavior
+
+The configuration option `SEKOIA_IMPORT_IOC_RELATIONSHIPS` is setting to `true` by default to obtain in OpenCTI the same richness of information as offered through your portal BUT please note that as we ingest more data, the process of ingesting an IOC may take longer.
+
+To enhance ingestion performance, deploy two specialized connectors:
+
+- Primary Connector: Rapidly ingests IOCs without related objects for immediate processing
+
+- Secondary Connector: Asynchronously enriches IOCs with related objects during off-peak periods
+
+This parallel approach decouples initial ingestion from relationship processing, significantly reducing latency while maintaining data completeness. The separation of concerns allows:
+
+- Near-real-time IOC availability
+
+- Reduced load during peak ingestion windows
+
+- Gradual relationship mapping without blocking core ingestion
 
 ## Troubleshoot
 

--- a/external-import/sekoia/docker-compose.yml
+++ b/external-import/sekoia/docker-compose.yml
@@ -15,3 +15,4 @@ services:
       - SEKOIA_LIMIT=100                # Optional, the number of elements to fetch in each request. Defaults to 200, maximum 2000
       - SEKOIA_CREATE_OBSERVABLES=true  # Create observables from indicators
       - SEKOIA_IMPORT_SOURCE_LIST=false # Create the list of sources observed by Sekoia as label
+      - SEKOIA_IMPORT_IOC_RELATIONSHIPS=true # Optional, Import IOCs relationships and related objects - Default: true

--- a/external-import/sekoia/src/config.yml.sample
+++ b/external-import/sekoia/src/config.yml.sample
@@ -18,3 +18,4 @@ sekoia:
   limit: 100                # Optional, the number of elements to fetch in each request. Defaults to 200, maximum 2000
   create_observables: true  # Create observables from indicators
   import_source_list: false # Create the list of sources observed by Sekoia as label
+  import_ioc_relationships: true # Optional, Import IOCs relationships and related objects - Default: true

--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -57,16 +57,22 @@ class Sekoia(object):
             config,
             default=False,
         )
+        self.import_ioc_relationships = get_config_variable(
+            "SEKOIA_IMPORT_IOC_RELATIONSHIPS",
+            ["sekoia", "import_ioc_relationships"],
+            config,
+            default=True,
+        )
         self.all_labels = []
 
-        self.helper.log_info("Setting up api key")
+        self.helper.connector_logger.info("Setting up api key")
         self.api_key = self.get_config("api_key", config)
         if not self.api_key:
-            self.helper.log_error("API key is Missing")
+            self.helper.connector_logger.error("API key is Missing")
             raise ValueError("API key is Missing")
 
         self._load_data_sets()
-        self.helper.log_info("All datasets has been loaded")
+        self.helper.connector_logger.info("All datasets has been loaded")
 
         self.helper.api.identity.create(
             stix_id="identity--357447d7-9229-4ce1-b7fa-f1b83587048e",
@@ -85,10 +91,10 @@ class Sekoia(object):
         return self.helper.connect_scope
 
     def process_message(self):
-        self.helper.log_info("Starting SEKOIA.IO connector")
+        self.helper.connector_logger.info("Starting SEKOIA.IO connector")
         state = self.helper.get_state() or {}
         cursor = state.get("last_cursor", self.generate_first_cursor())
-        self.helper.log_info(f"Starting with {cursor}")
+        self.helper.connector_logger.info(f"Starting with {cursor}")
 
         friendly_name = "SEKOIA run @ " + datetime.now(timezone.utc).isoformat()
         try:
@@ -97,10 +103,10 @@ class Sekoia(object):
             )
             cursor = self._run(cursor, work_id)
             message = f"Connector successfully run, cursor updated to {cursor}"
-            self.helper.log_info(message)
+            self.helper.connector_logger.info(message)
             self.helper.api.work.to_processed(work_id, message)
         except (KeyboardInterrupt, SystemExit):
-            self.helper.log_info("Connector stop")
+            self.helper.connector_logger.info("Connector stop")
             self.helper.api.work.to_processed(work_id, "Connector is stopping")
             sys.exit(0)
         except Exception as ex:
@@ -108,7 +114,7 @@ class Sekoia(object):
             # since `_run` updates it after every successful request
             state = self.helper.get_state() or {}
             cursor = state.get("last_cursor", cursor)
-            self.helper.log_error(str(ex))
+            self.helper.connector_logger.error(str(ex))
             message = f"Connector encountered an error, cursor updated to {cursor}"
             self.helper.api.work.to_processed(work_id, message)
 
@@ -149,15 +155,15 @@ class Sekoia(object):
         Generate the first cursor to interrogate the API
         so we don't start at the beginning.
         """
-        start = f"{(datetime.utcnow() - timedelta(hours=1)).isoformat()}Z"
+        start = f"{(datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()}Z"
         if self.start_date:
-            self.helper.log_info(
+            self.helper.connector_logger.info(
                 f"Using date provided to the connector: {self.start_date}"
             )
             try:
                 start = f"{parse(self.start_date).isoformat()}Z"
             except ParserError:
-                self.helper.log_error(
+                self.helper.connector_logger.error(
                     f"Impossible to parse the date provided: {self.start_date}. Starting from one hour ago"
                 )
 
@@ -196,23 +202,26 @@ class Sekoia(object):
         self._clean_external_references_fields(items)
         items = self._clean_ic_fields(items)
         self._add_files_to_items(items)
-        [all_related_objects, all_relationships] = (
-            self._retrieve_related_objects_and_relationships(items)
-        )
 
-        if self.import_source_list:
-            all_related_objects = self._add_sources_to_items(all_related_objects)
+        if self.import_ioc_relationships:
+            [all_related_objects, all_relationships] = (
+                self._retrieve_related_objects_and_relationships(items)
+            )
 
-        items += all_related_objects + all_relationships
+            if self.import_source_list:
+                all_related_objects = self._add_sources_to_items(all_related_objects)
+
+            items += all_related_objects + all_relationships
+
         bundle = self.helper.stix2_create_bundle(items)
         try:
             self.helper.send_stix2_bundle(bundle, work_id=work_id)
         except RecursionError:
-            self.helper.log_error(
+            self.helper.connector_logger.error(
                 "A recursion error occured, circular dependencies detected in the Sekoia bundle, sending the whole "
                 "bundle but please fix it "
             )
-            self.helper.send_stix2_bundle(bundle, work_id=work_id, bypass_split=True)
+            self.helper.send_stix2_bundle(bundle, work_id=work_id)
 
         self.helper.set_state({"last_cursor": cursor})
         if len(items) < self.limit:
@@ -456,7 +465,7 @@ class Sekoia(object):
             param_string = (
                 "&".join(f"{k}={v}" for k, v in params.items()) if params else ""
             )
-            self.helper.log_debug(
+            self.helper.connector_logger.debug(
                 f"Sending request to: {url} with params {param_string}"
             )
             res = requests.get(url, params=params, headers=headers)
@@ -467,9 +476,9 @@ class Sekoia(object):
         except RequestException as ex:
             if ex.response:
                 error = f"Request failed with status: {ex.response.status_code}"
-                self.helper.log_error(error)
+                self.helper.connector_logger.error(error)
             else:
-                self.helper.log_error(str(ex))
+                self.helper.connector_logger.error(str(ex))
             return None
 
     def _load_data_sets(self):
@@ -479,22 +488,22 @@ class Sekoia(object):
         #   For using absolute path and not relative ones
         global gbl_scriptDir  # noqa: F824
 
-        self.helper.log_info("Loading locations mapping")
+        self.helper.connector_logger.info("Loading locations mapping")
         with open(gbl_scriptDir + "/data/geography_mapping.json") as fp:
             self._geography_mapping: Dict = json.load(fp)
 
-        self.helper.log_info("Loading sectors mapping")
+        self.helper.connector_logger.info("Loading sectors mapping")
         with open(gbl_scriptDir + "/data/sectors_mapping.json") as fp:
             self._sectors_mapping: Dict = json.load(fp)
 
         # Adds OpenCTI sectors/locations to cache
-        self.helper.log_info("Loading OpenCTI sectors")
+        self.helper.connector_logger.info("Loading OpenCTI sectors")
         with open(gbl_scriptDir + "/data/sectors.json") as fp:
             objects = json.load(fp)["objects"]
             for sector in objects:
                 self._clean_and_add_to_cache(sector)
 
-        self.helper.log_info("Loading OpenCTI locations")
+        self.helper.connector_logger.info("Loading OpenCTI locations")
         with open(gbl_scriptDir + "/data/geography.json") as fp:
             for geography in json.load(fp)["objects"]:
                 self._clean_and_add_to_cache(geography)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add an option in the connector to configure the import of indicators, with or without relationships avoiding big ingestion delays
* Remove bypass_split as it is not used anymore
* Update logger
* Remove deprecated usage of `utcnow()`

![image](https://github.com/user-attachments/assets/c7e40dd2-3074-4692-b278-a7fe9c8f7658)


### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4184

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
