### PR TITLE
[SOCRadar] Update legacy code

### DIFF
--- a/external-import/socradar/.dockerignore
+++ b/external-import/socradar/.dockerignore
@@ -1,0 +1,5 @@
+src/config.yml
+src/__pycache__
+src/logs
+src/*.gql
+src/.venv

--- a/external-import/socradar/.env.sample
+++ b/external-import/socradar/.env.sample
@@ -1,0 +1,15 @@
+# Connector's generic execution parameters
+OPENCTI_URL=http://opencti:8080
+OPENCTI_TOKEN=CHANGEME
+
+# Connector's definition parameters REQUIRED
+CONNECTOR_ID=CHANGEME
+CONNECTOR_NAME=SOCRadar
+CONNECTOR_SCOPE=CHANGEME
+CONNECTOR_LOG_LEVEL=error
+CONNECTOR_DURATION_PERIOD=PT10M # ISO8601 format in String, start with 'P...' for Period
+
+# Connector's custom execution parameters
+RADAR_BASE_FEED_URL=https://platform.socradar.com/api/threat/intelligence/feed_list/ # required
+RADAR_SOCRADAR_KEY=CHANGEME
+RADAR_FEED_LISTS=CHANGEME

--- a/external-import/socradar/.env.sample
+++ b/external-import/socradar/.env.sample
@@ -12,4 +12,4 @@ CONNECTOR_DURATION_PERIOD=PT10M # ISO8601 format in String, start with 'P...' fo
 # Connector's custom execution parameters
 RADAR_BASE_FEED_URL=https://platform.socradar.com/api/threat/intelligence/feed_list/ # required
 RADAR_SOCRADAR_KEY=CHANGEME
-RADAR_FEED_LISTS=CHANGEME
+RADAR_FEED_LISTS='{"feed_list_1":"ID_1","feed_list_2":"ID_2"}'

--- a/external-import/socradar/.env.sample
+++ b/external-import/socradar/.env.sample
@@ -7,9 +7,9 @@ CONNECTOR_ID=CHANGEME
 CONNECTOR_NAME=SOCRadar
 CONNECTOR_SCOPE=CHANGEME
 CONNECTOR_LOG_LEVEL=error
-CONNECTOR_DURATION_PERIOD=PT10M # ISO8601 format in String, start with 'P...' for Period
+CONNECTOR_DURATION_PERIOD=PT10M
 
 # Connector's custom execution parameters
-RADAR_BASE_FEED_URL=https://platform.socradar.com/api/threat/intelligence/feed_list/ # required
+RADAR_BASE_FEED_URL=https://platform.socradar.com/api/threat/intelligence/feed_list/
 RADAR_SOCRADAR_KEY=CHANGEME
 RADAR_FEED_LISTS='{"feed_list_1":"ID_1","feed_list_2":"ID_2"}'

--- a/external-import/socradar/Dockerfile
+++ b/external-import/socradar/Dockerfile
@@ -1,23 +1,22 @@
-FROM python:3.12
-
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    libmagic1 \
-    libmagic-dev \
-    file \
-    && rm -rf /var/lib/apt/lists/*
+FROM python:3.12-alpine
 
 # Copy the connector
-COPY src /opt/opencti-connector-socradar/src/
-COPY requirements.txt /opt/opencti-connector-socradar/
+COPY src /opt/opencti-connector-socradar
 
-# Set the Python path
-ENV PYTHONPATH="/opt/opencti-connector-socradar/src"
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk update && apk upgrade && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
 
-# Install Python packages
-RUN pip3 install --no-cache-dir -r /opt/opencti-connector-socradar/requirements.txt
+COPY requirements.txt .
 
-# Expose and entrypoint
-COPY entrypoint.sh /
+RUN pip install -r requirements.txt --no-cache-dir --upgrade pip && \
+    rm requirements.txt && \
+    apk del git build-base
+
+# Expose entrypoint.sh
+COPY entrypoint.sh .
+
 RUN chmod +x /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/socradar/README.md
+++ b/external-import/socradar/README.md
@@ -1,72 +1,159 @@
 # OpenCTI SOCRadar Connector
 
+Table of Contents
+
+- [OpenCTI SOCRadar Connector](#opencti-socradar-connector)
+  - [Introduction](#introduction)
+  - [Installation](#installation)
+    - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenCTI environment variables](#opencti-environment-variables)
+    - [Base connector environment variables](#base-connector-environment-variables)
+    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
+
+## Introduction
+
 OpenCTI connector for importing threat intelligence feeds from SOCRadar platform.
 
-## Description
-
 This connector imports threat intelligence data from SOCRadar into OpenCTI. It processes various types of indicators including:
-* IP addresses (IPv4 and IPv6)
-* Domain names
-* URLs
-* File hashes (MD5, SHA1, SHA256)
 
-## Configuration
-
-| Parameter | Docker envvar | Mandatory | Description |
-| --- | --- | --- | --- |
-| `opencti.url` | `OPENCTI_URL` | Yes | The URL of your OpenCTI platform |
-| `opencti.token` | `OPENCTI_TOKEN` | Yes | Your OpenCTI admin token |
-| `radar.radar_base_feed_url` | `RADAR_BASE_FEED_URL` | Yes | SOCRadar API base URL |
-| `radar.radar_socradar_key` | `RADAR_SOCRADAR_KEY` | Yes | Your SOCRadar API key |
-| `radar.radar_run_interval` | `RADAR_RUN_INTERVAL` | Yes | Time between runs (in seconds, default: 600) |
-| `radar.radar_collections_uuid` | `RADAR_COLLECTIONS_UUID` | Yes | Collection IDs to fetch |
-
-The `radar_collections_uuid` parameter should contain the collection IDs you want to fetch from SOCRadar. Example configuration:
-
-```yaml
-radar_collections_uuid:
-  collection_1:
-    id: ["YOUR_COLLECTION_ID"]
-    name: ["YOUR_COLLECTION_NAME"]
-  collection_2:
-    id: ["YOUR_COLLECTION_ID"]
-    name: ["YOUR_COLLECTION_NAME"]
-```
+- IP addresses (IPv4 and IPv6)
+- Domain names
+- URLs
+- File hashes (MD5, SHA1, SHA256)
 
 ## Installation
 
-1. Clone the repository:
-```bash
-git clone https://github.com/OpenCTI-Platform/connectors
-cd connectors/external-import/socradar
-```
+### Requirements
 
-2. Configure the connector:
-```bash
-cp src/config.yml.sample src/config.yml
-```
-Edit `src/config.yml` with your OpenCTI and SOCRadar configurations.
+- OpenCTI Platform >= 6...
 
-3. Add your connector to the `docker-compose.yml`:
+## Configuration variables
+
+There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
+in `config.yml` (for manual deployment).
+
+### OpenCTI environment variables
+
+Below are the parameters you'll need to set for OpenCTI:
+
+| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
+| ------------- | ---------- | --------------------------- | --------- | ---------------------------------------------------- |
+| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
+| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+
+### Base connector environment variables
+
+Below are the parameters you'll need to set for running the connector properly:
+
+| Parameter       | config.yml      | Docker environment variable | Default | Mandatory | Description                                                                              |
+| --------------- | --------------- | --------------------------- | ------- | --------- | ---------------------------------------------------------------------------------------- |
+| Connector ID    | id              | `CONNECTOR_ID`              |         | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
+| Connector Name  | name            | `CONNECTOR_NAME`            |         | Yes       | Name of the connector.                                                                   |
+| Connector Scope | scope           | `CONNECTOR_SCOPE`           |         | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
+| Log Level       | log_level       | `CONNECTOR_LOG_LEVEL`       | error   | No        | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
+| Duration period | duration_period | `CONNECTOR_DURATION_PERIOD` | PT10M   | No        | Time period to await between two runs of the connector.                                  |
+
+### Connector extra parameters environment variables
+
+Below are the parameters you'll need to set for the connector:
+
+| Parameter               | config.yml           | Docker environment variable  | Default | Mandatory | Description                                                                          |
+| ----------------------- | -------------------- | ---------------------------- | ------- | --------- | ------------------------------------------------------------------------------------ |
+| SOCRadar API base URL   | base_feed_url        | `RADAR_BASE_FEED_URL`        |         | Yes       | SOCRadar Feed API Base URL.                                                          |
+| SOCRadar API key        | socradar_key         | `RADAR_SOCRADAR_KEY`         |         | Yes       | Your SOCRadar API key.                                                               |
+| ~~Run interval~~        | ~~run_interval~~     | ~~`RADAR_RUN_INTERVAL`~~     | ~~600~~ | ~~Yes~~   | ~~Time between runs in seconds~~ (Deprecated, replaced by `CONNECTOR_RUN_INTERVAL`). |
+| ~~API Collections IDs~~ | ~~collections_uuid~~ | ~~`RADAR_COLLECTIONS_UUID`~~ |         | ~~Yes~~   | ~~Collection IDs to fetch~~ (Deprecated, replaced by `RADAR_FEED_LISTS_IDS`).        |
+| SOCRadar feed lists IDs | feed_lists           | `RADAR_FEED_LISTS`           |         | Yes       | Name/ID pairs of SOCRadar feed lists to fetch.                                       |
+
+⚠️ Please be aware that `CONNECTOR_DURATION_PERIOD` default value takes precedence over `RADAR_RUN_INTERVAL` default value if none of them are set.
+
+The `RADAR_FEED_LISTS` parameter should contain the name/id pairs of the feed lists to fetch on SOCRadar.
+Example using `config.yml`:
+
 ```yaml
-  connector-socradar:
-    build: ./external-import/socradar
-    container_name: docker-connector-socradar
-    environment:
-      - OPENCTI_URL=http://opencti:8080
-      - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
-    restart: always
-    depends_on:
-      opencti:
-        condition: service_healthy
+feed_lists:
+  feed_list_1: "ID_1"
+  feed_list_2: "ID_2"
 ```
 
-4. Start with Docker:
+Example using env vars:
+
 ```bash
-docker-compose up -d connector-socradar
+RADAR_FEED_LISTS='{"feed_list_1":"ID_1","feed_list_2":"ID_2"}'
 ```
 
-You can check the connector status and logs in the OpenCTI platform UI or using:
-```bash
-docker-compose logs -f connector-socradar
+<br>
+
+> **(Deprecated)**
+>
+> The `RADAR_COLLECTIONS_UUID` parameter should contain the collection IDs you want to fetch from SOCRadar.
+>
+> Example using `config.yml`:
+>
+> ```yaml
+> radar_collections_uuid:
+>   collection_1:
+>     id: ["COLLECTION_ID"]
+>     name: ["COLLECTION_NAME"]
+>   collection_2:
+>     id: ["COLLECTION_ID"]
+>     name: ["COLLECTION_NAME"]
+> ```
+>
+> Example using env vars:
+>
+> ```bash
+> RADAR_COLLECTIONS_UUID='{"collection_1":{"id":["COLLECTION_ID"],"name":["COLLECTION_NAME"]},"collection_2":{"id":["COLLECTION_ID"],"name":["COLLECTION_NAME"]}}'
+> ```
+
+## Deployment
+
+### Docker Deployment
+
+Before building the Docker container, you need to set the version of pycti in `requirements.txt` equal to whatever
+version of OpenCTI you're running. Example, `pycti==6.6.18`. If you don't, it will take the latest version, but
+sometimes the OpenCTI SDK fails to initialize.
+
+Build a Docker Image using the provided `Dockerfile`.
+
+Example:
+
+```shell
+# Replace the IMAGE NAME with the appropriate value
+docker build . -t opencti/connector-socradar:latest
+```
+
+Make sure to replace the environment variables in `docker-compose.yml` with the appropriate configurations for your
+environment and to establish network with OpenCTI. Then, start the docker container with the provided `docker-compose.yml`.
+
+```shell
+docker compose up -d
+# -d for detached
+```
+
+### Manual Deployment
+
+Create a file `config.yml` based on the provided `config.yml.sample`.
+
+Replace the configuration variables (especially the "**ChangeMe**" variables) with the appropriate configurations for
+you environment.
+
+Install the required python dependencies (preferably in a virtual environment):
+
+```shell
+pip3 install -r requirements.txt
+```
+
+Then, start the connector:
+
+```shell
+python3 src/main.py
 ```

--- a/external-import/socradar/README.md
+++ b/external-import/socradar/README.md
@@ -1,3 +1,7 @@
+| Status            | Date       | Comment |
+| ----------------- | ---------- | ------- |
+| Filigran Verified | 2025-09-23 |         |
+
 # OpenCTI SOCRadar Connector
 
 Table of Contents

--- a/external-import/socradar/docker-compose.yml
+++ b/external-import/socradar/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3"
+services:
+  connector-socradar:
+    image: opencti/connector-socradar:6.6.18
+    environment:
+      # Connector's generic execution parameters
+      - OPENCTI_URL=http://opencti:8080
+      - OPENCTI_TOKEN=CHANGEME
+
+      # Connector's definition parameters REQUIRED
+      - CONNECTOR_ID=CHANGEME
+      - CONNECTOR_NAME=SOCRadar
+      - CONNECTOR_SCOPE=CHANGEME
+      - CONNECTOR_LOG_LEVEL=error
+      - CONNECTOR_DURATION_PERIOD=PT10M # ISO8601 format in String, start with 'P...' for Period
+
+      # Connector's definition parameters OPTIONAL
+      # - CONNECTOR_QUEUE_THRESHOLD=500 # Default 500Mo, Float accepted
+      # - CONNECTOR_RUN_AND_TERMINATE=False # Default False, True run connector once
+      # - CONNECTOR_SEND_TO_QUEUE=True # Default True
+      # - CONNECTOR_SEND_TO_DIRECTORY=False # Default False
+      # - CONNECTOR_SEND_TO_DIRECTORY_PATH=CHANGEME # if CONNECTOR_SEND_TO_DIRECTORY is True, you must specify a path
+      # - CONNECTOR_SEND_TO_DIRECTORY_RETENTION=7 # Default 7, in days
+
+      # Connector's custom execution parameters
+      - RADAR_BASE_FEED_URL=https://platform.socradar.com/api/threat/intelligence/feed_list/ # required
+      - RADAR_SOCRADAR_KEY=CHANGEME
+      - RADAR_FEED_LISTS=CHANGEME
+
+      # Add proxy parameters below if needed
+      # - HTTP_PROXY=CHANGEME
+      # - HTTPS_PROXY=CHANGEME
+      # - NO_PROXY=CHANGEME

--- a/external-import/socradar/docker-compose.yml
+++ b/external-import/socradar/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   connector-socradar:
-    image: opencti/connector-socradar:6.6.18
+    image: opencti/connector-socradar:6.7.20
     environment:
       # Connector's generic execution parameters
       - OPENCTI_URL=http://opencti:8080

--- a/external-import/socradar/docker-compose.yml
+++ b/external-import/socradar/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       # Connector's custom execution parameters
       - RADAR_BASE_FEED_URL=https://platform.socradar.com/api/threat/intelligence/feed_list/ # required
       - RADAR_SOCRADAR_KEY=CHANGEME
-      - RADAR_FEED_LISTS=CHANGEME
+      - 'RADAR_FEED_LISTS={"feed_list_1":"ID_1","feed_list_2":"ID_2"}'
 
       # Add proxy parameters below if needed
       # - HTTP_PROXY=CHANGEME

--- a/external-import/socradar/entrypoint.sh
+++ b/external-import/socradar/entrypoint.sh
@@ -3,9 +3,9 @@
 # Add debugging information
 echo "Current directory: $(pwd)"
 echo "Python path: $PYTHONPATH"
-echo "Directory contents:"
-ls -la /opt/opencti-connector-socradar/src
 
-# Directly execute python script
+# Go to the right directory
 cd /opt/opencti-connector-socradar
-python3 src/main.py
+
+# Launch the worker
+python3 main.py

--- a/external-import/socradar/requirements.txt
+++ b/external-import/socradar/requirements.txt
@@ -2,4 +2,5 @@ pycti==6.7.20
 python-dateutil==2.8.2
 requests==2.32.4
 stix2==3.0.1
+pydantic==2.11.7
 pydantic-settings==2.9.1

--- a/external-import/socradar/requirements.txt
+++ b/external-import/socradar/requirements.txt
@@ -1,5 +1,5 @@
 pycti==6.7.20
 python-dateutil==2.8.2
-PyYAML==6.0.2
-requests~=2.32.2
+requests==2.32.4
 stix2==3.0.1
+pydantic-settings==2.9.1

--- a/external-import/socradar/src/config.yml.sample
+++ b/external-import/socradar/src/config.yml.sample
@@ -4,21 +4,14 @@ opencti:
 
 connector:
   id: 'CONNECTOR_ID'
-  type: 'EXTERNAL_IMPORT'
   name: 'SOCRadar'
   scope: 'socradar'
-  confidence_level: 75
-  log_level: 'info'
-  update_existing_data: true
+  log_level: 'error'
+  duration_period: 'PT10M'
 
 radar:
-  radar_base_feed_url: "https://platform.socradar.com/api/threat/intelligence/feed_list/"
-  radar_socradar_key: "SOCRADAR_KEY"
-  radar_run_interval: 600
-  radar_collections_uuid:
-    collection_1:
-      id: ["COLLECTION_UUID"]
-      name: ["COLLECTION_NAME"]
-    collection_2:
-      id: ["COLLECTION_UUID"]
-      name: ["COLLECTION_NAME"]
+  base_feed_url: "https://platform.socradar.com/api/threat/intelligence/feed_list/" # Required
+  socradar_key: "SOCRADAR_KEY"
+  feed_lists_ids:
+    feed_list_1: 'COLLECTION_ID'
+    feed_list_2: 'COLLECTION_ID'

--- a/external-import/socradar/src/config.yml.sample
+++ b/external-import/socradar/src/config.yml.sample
@@ -12,6 +12,6 @@ connector:
 radar:
   base_feed_url: "https://platform.socradar.com/api/threat/intelligence/feed_list/" # Required
   socradar_key: "SOCRADAR_KEY"
-  feed_lists_ids:
+  feed_lists:
     feed_list_1: 'COLLECTION_ID'
     feed_list_2: 'COLLECTION_ID'

--- a/external-import/socradar/src/lib/__init__.py
+++ b/external-import/socradar/src/lib/__init__.py
@@ -1,0 +1,7 @@
+from .config_loader import ConfigLoader
+from .radar import RadarConnector
+
+__all__ = [
+    "RadarConnector",
+    "ConfigLoader",
+]

--- a/external-import/socradar/src/lib/api_client.py
+++ b/external-import/socradar/src/lib/api_client.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timedelta, timezone
+
+import requests
+from requests.adapters import HTTPAdapter, Retry
+
+
+class RadarAPIError(Exception):
+    """Custom wrapper for exceptions raised in RadarAPIClient"""
+
+
+class RadarFeedItemExtraInfo:
+    """Represent a feed item extra info in GET /feed_list/:collection_id.json response."""
+
+    def __init__(self, score: int, seen_count: int):
+        self.score: None | int = score
+        self.seen_count: int = seen_count
+
+
+class RadarFeedItem:
+    """Represent a feed item in GET /feed_list/:collection_id.json response."""
+
+    def __init__(
+        self,
+        feed: str,
+        feed_type: str,
+        first_seen_date: str,
+        latest_seen_date: str,
+        maintainer_name: str,
+        extra_info: dict,
+    ):
+        self.feed = feed
+        self.feed_type = feed_type
+        self.maintainer_name = maintainer_name
+        self.first_seen_date: datetime = (
+            datetime.fromisoformat(first_seen_date).replace(tzinfo=timezone.utc)
+            if first_seen_date
+            else None
+        )
+        self.latest_seen_date: datetime = (
+            datetime.fromisoformat(latest_seen_date).replace(tzinfo=timezone.utc)
+            if latest_seen_date
+            else None
+        )
+        self.extra_info = RadarFeedItemExtraInfo(
+            score=extra_info.get("score"),
+            seen_count=extra_info.get("seen_count"),
+        )
+
+
+class RadarAPIClient:
+    def __init__(
+        self,
+        api_base_url: str,
+        api_key: str,
+        retry: int = 3,
+        backoff: timedelta = timedelta(seconds=1),
+    ):
+        """
+        Initialize the client with necessary configurations
+        """
+        self.api_base_url = api_base_url
+        self.api_key = api_key
+
+        # Define headers in session and update when needed
+        self.session = requests.Session()
+        self.session.headers.update({"Content-Type": "application/json"})
+
+        retry_strategy = Retry(
+            total=retry,
+            backoff_factor=backoff.total_seconds(),
+            status_forcelist=[429, 500, 502, 503, 504],
+            raise_on_status=False,  # do not raise MaxRetryError - let response.raise_for_status() raise exceptions
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        self.session.mount(self.api_base_url, adapter)
+
+    def _send_request(self, method: str, url: str, **kwargs):
+        """
+        Send a request to SOCRadar API.
+        :param method: Request HTTP method
+        :param url: Request URL
+        :param kwargs: Any arguments valid for session.request() method
+        :return: Any data returned by the API
+        """
+        try:
+            response = self.session.request(method, url, **kwargs)
+            response.raise_for_status()
+
+            if response.content:
+                return response.json()
+        except requests.RequestException as err:
+            raise RadarAPIError(
+                f"Error while fetching SOCRadar API: {err}",
+                {"url": f"{method.upper()} {url}", "error": err},
+            ) from err
+
+    def get_feed(self, collection_id: str) -> list[dict]:
+        """
+        Get feed for given collection ID.
+        :param collection_id: Collection ID to get feed from.
+        :return: Collection's feed items
+        """
+        url = f"{self.api_base_url}{collection_id}.json?v=2&key={self.api_key}"
+        data = self._send_request("GET", url, timeout=30)
+
+        return [RadarFeedItem(**item) for item in data]

--- a/external-import/socradar/src/lib/api_client.py
+++ b/external-import/socradar/src/lib/api_client.py
@@ -32,12 +32,12 @@ class RadarFeedItem:
         self.feed_type = feed_type
         self.maintainer_name = maintainer_name
         self.first_seen_date: datetime | None = (
-            datetime.fromisoformat(first_seen_date).astimezone(tz=timezone.utc)
+            datetime.fromisoformat(first_seen_date).replace(tzinfo=timezone.utc)
             if first_seen_date
             else None
         )
         self.latest_seen_date: datetime | None = (
-            datetime.fromisoformat(latest_seen_date).astimezone(tz=timezone.utc)
+            datetime.fromisoformat(latest_seen_date).replace(tzinfo=timezone.utc)
             if latest_seen_date
             else None
         )

--- a/external-import/socradar/src/lib/api_client.py
+++ b/external-import/socradar/src/lib/api_client.py
@@ -32,12 +32,12 @@ class RadarFeedItem:
         self.feed_type = feed_type
         self.maintainer_name = maintainer_name
         self.first_seen_date: datetime = (
-            datetime.fromisoformat(first_seen_date).replace(tzinfo=timezone.utc)
+            datetime.fromisoformat(first_seen_date).astimezone(tzinfo=timezone.utc)
             if first_seen_date
             else None
         )
         self.latest_seen_date: datetime = (
-            datetime.fromisoformat(latest_seen_date).replace(tzinfo=timezone.utc)
+            datetime.fromisoformat(latest_seen_date).astimezone(tzinfo=timezone.utc)
             if latest_seen_date
             else None
         )

--- a/external-import/socradar/src/lib/api_client.py
+++ b/external-import/socradar/src/lib/api_client.py
@@ -31,12 +31,12 @@ class RadarFeedItem:
         self.feed = feed
         self.feed_type = feed_type
         self.maintainer_name = maintainer_name
-        self.first_seen_date: datetime = (
+        self.first_seen_date: datetime | None = (
             datetime.fromisoformat(first_seen_date).astimezone(tzinfo=timezone.utc)
             if first_seen_date
             else None
         )
-        self.latest_seen_date: datetime = (
+        self.latest_seen_date: datetime | None = (
             datetime.fromisoformat(latest_seen_date).astimezone(tzinfo=timezone.utc)
             if latest_seen_date
             else None

--- a/external-import/socradar/src/lib/api_client.py
+++ b/external-import/socradar/src/lib/api_client.py
@@ -32,12 +32,12 @@ class RadarFeedItem:
         self.feed_type = feed_type
         self.maintainer_name = maintainer_name
         self.first_seen_date: datetime | None = (
-            datetime.fromisoformat(first_seen_date).astimezone(tzinfo=timezone.utc)
+            datetime.fromisoformat(first_seen_date).astimezone(tz=timezone.utc)
             if first_seen_date
             else None
         )
         self.latest_seen_date: datetime | None = (
-            datetime.fromisoformat(latest_seen_date).astimezone(tzinfo=timezone.utc)
+            datetime.fromisoformat(latest_seen_date).astimezone(tz=timezone.utc)
             if latest_seen_date
             else None
         )

--- a/external-import/socradar/src/lib/config_loader.py
+++ b/external-import/socradar/src/lib/config_loader.py
@@ -1,0 +1,324 @@
+import json
+import os
+import warnings
+from datetime import timedelta
+from pathlib import Path
+from typing import Annotated, Any, Literal
+
+import __main__
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    HttpUrl,
+    PlainSerializer,
+    field_validator,
+    model_validator,
+)
+from pydantic_core.core_schema import SerializationInfo
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    YamlConfigSettingsSource,
+)
+
+# Get the path of the __main__ module file (the entry point of the connector)
+_MAIN_PATH = os.path.dirname(os.path.abspath(__main__.__file__))
+
+"""
+All the variables that have default values will override configuration from the OpenCTI helper.
+
+All the variables of this classes are customizable through:
+    - config.yml 
+    - .env
+    - environment variables.
+
+If a variable is set in 2 different places, the first one will be used in this order:
+    1. YAML file
+    2. .env file
+    3. Environment variables
+    4. Default value
+    
+WARNING:
+    The Environment variables in the .env or global environment must be set in the following format:
+    OPENCTI_<variable>
+    CONNECTOR_<variable>
+    
+    the split is made on the first occurrence of the "_" character.
+"""
+
+
+class ConfigRetrievalError(Exception):
+    """Known errors wrapper for config loaders."""
+
+
+def comma_separated_list_validator(value: str | list[str]) -> list[str]:
+    """
+    Convert comma-separated string into a list of values.
+
+    Example:
+        > values = comma_separated_list_validator("a,b,c")
+        > print(values) # [ "a", "b", "c" ]
+    """
+    if isinstance(value, str):
+        return [string.strip() for string in value.split(",")]
+    return value
+
+
+def pycti_list_serializer(value: list[str], info: SerializationInfo) -> str | list[str]:
+    """
+    Serialize list of values as comma-separated string.
+
+    Example:
+        > serialized_values = pycti_list_serializer([ "a", "b", "c" ])
+        > print(serialized_values) # "a,b,c"
+    """
+    if isinstance(value, list) and info.context and info.context.get("mode") == "pycti":
+        return ",".join(value)
+    return value
+
+
+ListFromString = Annotated[
+    list[str],
+    BeforeValidator(comma_separated_list_validator),
+    PlainSerializer(pycti_list_serializer, when_used="json"),
+]
+
+
+class ConfigBaseModel(BaseModel):
+    """
+    Base class for frozen config models, i.e. not alter-able after `model_post_init()`.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+
+class OpenCTIConfig(ConfigBaseModel):
+    """
+    Define config specific to OpenCTI.
+    """
+
+    url: HttpUrl = Field(description="The base URL of the OpenCTI instance.")
+    token: str = Field(description="The API token to connect to OpenCTI.")
+    json_logging: bool = Field(
+        description="Whether to format logs as JSON or not.",
+        default=True,
+    )
+    ssl_verify: bool = Field(
+        description="Whether to check SSL certificate or not.",
+        default=False,
+    )
+
+
+class ConnectorConfig(ConfigBaseModel):
+    """
+    Define config specific to this type of connector, e.g. an `external-import`.
+    """
+
+    id: str = Field(description="A UUID v4 to identify the connector in OpenCTI.")
+    name: str = Field(description="The name of the connector.")
+    type: Literal["EXTERNAL_IMPORT"] = "EXTERNAL_IMPORT"
+    scope: ListFromString = Field(
+        description="The scope of the connector, e.g. 'socradar'.",
+        default=["socradar"],
+    )
+    duration_period: timedelta = Field(
+        description="The period of time to await between two runs of the connector.",
+        default=timedelta(minutes=10),
+    )
+
+    log_level: Literal[
+        "debug",
+        "info",
+        "warn",
+        "error",
+    ] = Field(
+        description="The minimum level of logs to display.",
+        default="error",
+    )
+    expose_metrics: bool = Field(
+        description="Whether to expose metrics or not.",
+        default=False,
+    )
+    metrics_port: int = Field(
+        description="The port to expose metrics.",
+        default=9095,
+    )
+    only_contextual: bool = Field(
+        description="Whether to expose metrics or not.",
+        default=False,
+    )
+    run_and_terminate: bool = Field(
+        description="Connector run-and-terminate flag.",
+        default=False,
+    )
+    validate_before_import: bool = Field(
+        description="Whether to validate data before import or not.",
+        default=False,
+    )
+    queue_protocol: str = Field(
+        description="The queue protocol to use.",
+        default="amqp",
+    )
+    queue_threshold: int = Field(
+        description="Connector queue max size in Mbytes. Default to pycti value.",
+        default=500,
+    )
+    send_to_queue: bool = Field(
+        description="Connector send-to-queue flag. Default to True.",
+        default=True,
+    )
+    send_to_directory: bool = Field(
+        description="Connector send-to-directory flag.",
+        default=False,
+    )
+    send_to_directory_path: str | None = Field(
+        description="Connector send-to-directory path.",
+        default=None,
+    )
+    send_to_directory_retention: int = Field(
+        description="Connector send-to-directory retention.",
+        default=7,
+    )
+
+
+class FeedList(ConfigBaseModel):
+    name: str = Field(description="The name of SOCRadar feed list to fetch.")
+    id: str = Field(description="The ID of SOCRadar feed list to fetch.")
+
+
+class RadarConfig(ConfigBaseModel):
+    base_feed_url: str = Field(description="SOCRadar Feed API base URL.")
+    socradar_key: str = Field(description="The API key to connect to SOCRadar.")
+    feed_lists: list[FeedList] = Field(description="The SOCRadar feed lists to fetch.")
+
+    @field_validator("feed_lists", mode="before")
+    @classmethod
+    def convert_collections_uuid(cls, value: Any) -> dict:
+        """
+        Config/env vars must be as flat as possible.
+        This is a util method to format collections, making them easier to use in the rest of the codebase.
+        """
+        if isinstance(value, str):
+            value = json.loads(value)
+        if isinstance(value, dict):
+            return [{"name": name, "id": id} for (name, id) in value.items()]
+        return value
+
+
+class ConfigLoader(BaseSettings):
+    """
+    Define a complete config for a connector with:
+        - opencti: the config specific to OpenCTI
+        - connector: the config specific to the `external-import` connectors
+        - socradar: the config specific to SOCRadar
+    """
+
+    opencti: OpenCTIConfig
+    connector: ConnectorConfig
+    radar: RadarConfig
+
+    # Setup model config and env vars parsing
+    model_config = SettingsConfigDict(
+        frozen=True,
+        env_nested_delimiter="_",
+        env_nested_max_split=1,
+        enable_decoding=False,
+        yaml_file=f"{_MAIN_PATH}/config.yml",
+        env_file=f"{_MAIN_PATH}/../.env",
+    )
+
+    def __init__(self) -> None:
+        """
+        Wrap BaseConnectorConfig initialization to raise custom exception in case of error.
+        """
+        try:
+            super().__init__()
+        except Exception as e:
+            raise ConfigRetrievalError("Invalid connector configuration.", e) from e
+
+    def model_dump_pycti(self) -> dict:
+        """
+        Convert model into a valid dict for `pycti.OpenCTIConnectorHelper`.
+        """
+        return self.model_dump(mode="json", context={"mode": "pycti"})
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """
+        Customise the sources of settings for the connector.
+
+        This method is called by the Pydantic BaseSettings class to determine the order of sources
+
+        The configuration come in this order either from:
+            1. YAML file
+            2. .env file
+            3. Environment variables
+            4. Default values
+        """
+        if Path(settings_cls.model_config["yaml_file"] or "").is_file():  # type: ignore
+            return (YamlConfigSettingsSource(settings_cls),)
+        if Path(settings_cls.model_config["env_file"] or "").is_file():  # type: ignore
+            return (dotenv_settings,)
+        return (env_settings,)
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_deprecated_interval(cls, data: dict) -> dict:
+        """
+        Env var `RADAR_RUN_INTERVAL` is deprecated.
+        This is a workaround to keep the old config working while migrating to `CONNECTOR_DURATION_PERIOD`.
+        """
+        connector_data: dict = data.get("connector", {})
+        radar_data: dict = data.get("radar", {})
+
+        if interval := radar_data.pop("run_interval", None):
+            warnings.warn(
+                "Env var 'RADAR_RUN_INTERVAL' is deprecated. Use 'CONNECTOR_DURATION_PERIOD' instead."
+            )
+
+            connector_data["duration_period"] = timedelta(seconds=int(interval))
+
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_deprecated_collections_uuid(cls, data: dict) -> dict:
+        """
+        Env var `RADAR_COLLECTIONS_UUID` is deprecated.
+        This is a workaround to keep the old config working while migrating to `RADAR_FEED_LISTS`.
+        """
+        radar_data: dict = data.get("radar", {})
+
+        # Legacy: key will differ whether data comes from env vars or from config.yml
+        collections: dict | str = radar_data.pop(
+            "collections_uuid", None
+        ) or radar_data.pop("radar_collections_uuid", None)
+        if collections:
+            warnings.warn(
+                "Env var 'RADAR_COLLECTIONS_UUID' is deprecated. Use 'RADAR_FEED_LISTS' instead."
+            )
+
+            # If data comes from env vars, collections is serialized JSON
+            if isinstance(collections, str):
+                collections: dict = json.loads(collections)
+
+            feed_lists = radar_data.get("feed_lists", {})
+            for collection_data in collections.values():
+                name = collection_data.get("name")
+                id = collection_data.get("id")
+                if name and id:  # /!\ name and id are lists, not strings
+                    feed_lists[name[0]] = id[0]
+
+            radar_data["feed_lists"] = feed_lists
+
+        return data

--- a/external-import/socradar/src/lib/config_loader.py
+++ b/external-import/socradar/src/lib/config_loader.py
@@ -174,7 +174,7 @@ class ConfigLoader(BaseSettings):
     Define a complete config for a connector with:
         - opencti: the config specific to OpenCTI
         - connector: the config specific to the `external-import` connectors
-        - socradar: the config specific to SOCRadar
+        - radar: the config specific to SOCRadar
     """
 
     opencti: OpenCTIConfig

--- a/external-import/socradar/src/lib/config_loader.py
+++ b/external-import/socradar/src/lib/config_loader.py
@@ -144,51 +144,6 @@ class ConnectorConfig(ConfigBaseModel):
         default="error",
     )
 
-    expose_metrics: bool = Field(
-        description="Whether to expose metrics or not.",
-        default=False,
-    )
-    metrics_port: int = Field(
-        description="The port to expose metrics.",
-        default=9095,
-    )
-    only_contextual: bool = Field(
-        description="Whether to expose metrics or not.",
-        default=False,
-    )
-    run_and_terminate: bool = Field(
-        description="Connector run-and-terminate flag.",
-        default=False,
-    )
-    validate_before_import: bool = Field(
-        description="Whether to validate data before import or not.",
-        default=False,
-    )
-    queue_protocol: str = Field(
-        description="The queue protocol to use.",
-        default="amqp",
-    )
-    queue_threshold: int = Field(
-        description="Connector queue max size in Mbytes. Default to pycti value.",
-        default=500,
-    )
-    send_to_queue: bool = Field(
-        description="Connector send-to-queue flag. Default to True.",
-        default=True,
-    )
-    send_to_directory: bool = Field(
-        description="Connector send-to-directory flag.",
-        default=False,
-    )
-    send_to_directory_path: str | None = Field(
-        description="Connector send-to-directory path.",
-        default=None,
-    )
-    send_to_directory_retention: int = Field(
-        description="Connector send-to-directory retention.",
-        default=7,
-    )
-
 
 class FeedList(ConfigBaseModel):
     name: str = Field(description="The name of SOCRadar feed list to fetch.")

--- a/external-import/socradar/src/lib/config_loader.py
+++ b/external-import/socradar/src/lib/config_loader.py
@@ -201,7 +201,7 @@ class RadarConfig(ConfigBaseModel):
 
     @field_validator("feed_lists", mode="before")
     @classmethod
-    def convert_collections_uuid(cls, value: Any) -> dict:
+    def convert_collections_uuid(cls, value: Any) -> list[dict]:
         """
         Config/env vars must be as flat as possible.
         This is a util method to format collections, making them easier to use in the rest of the codebase.

--- a/external-import/socradar/src/lib/config_loader.py
+++ b/external-import/socradar/src/lib/config_loader.py
@@ -92,7 +92,7 @@ class ConfigBaseModel(BaseModel):
     Base class for frozen config models, i.e. not alter-able after `model_post_init()`.
     """
 
-    model_config = ConfigDict(extra="ignore", frozen=True)
+    model_config = ConfigDict(extra="allow", frozen=True)
 
 
 class OpenCTIConfig(ConfigBaseModel):
@@ -183,7 +183,7 @@ class ConfigLoader(BaseSettings):
 
     # Setup model config and env vars parsing
     model_config = SettingsConfigDict(
-        extra="ignore",
+        extra="allow",
         frozen=True,
         env_nested_delimiter="_",
         env_nested_max_split=1,

--- a/external-import/socradar/src/lib/config_loader.py
+++ b/external-import/socradar/src/lib/config_loader.py
@@ -92,7 +92,7 @@ class ConfigBaseModel(BaseModel):
     Base class for frozen config models, i.e. not alter-able after `model_post_init()`.
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
 
 class OpenCTIConfig(ConfigBaseModel):
@@ -222,6 +222,7 @@ class ConfigLoader(BaseSettings):
 
     # Setup model config and env vars parsing
     model_config = SettingsConfigDict(
+        extra="ignore",
         frozen=True,
         env_nested_delimiter="_",
         env_nested_max_split=1,

--- a/external-import/socradar/src/lib/config_loader.py
+++ b/external-import/socradar/src/lib/config_loader.py
@@ -117,9 +117,14 @@ class ConnectorConfig(ConfigBaseModel):
     Define config specific to this type of connector, e.g. an `external-import`.
     """
 
-    id: str = Field(description="A UUID v4 to identify the connector in OpenCTI.")
-    name: str = Field(description="The name of the connector.")
     type: Literal["EXTERNAL_IMPORT"] = "EXTERNAL_IMPORT"
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+    )
+    name: str = Field(
+        description="The name of the connector.",
+        default="SOCRadar",
+    )
     scope: ListFromString = Field(
         description="The scope of the connector, e.g. 'socradar'.",
         default=["socradar"],
@@ -128,7 +133,6 @@ class ConnectorConfig(ConfigBaseModel):
         description="The period of time to await between two runs of the connector.",
         default=timedelta(minutes=10),
     )
-
     log_level: Literal[
         "debug",
         "info",
@@ -138,6 +142,7 @@ class ConnectorConfig(ConfigBaseModel):
         description="The minimum level of logs to display.",
         default="error",
     )
+
     expose_metrics: bool = Field(
         description="Whether to expose metrics or not.",
         default=False,

--- a/external-import/socradar/src/lib/config_loader.py
+++ b/external-import/socradar/src/lib/config_loader.py
@@ -137,6 +137,7 @@ class ConnectorConfig(ConfigBaseModel):
         "debug",
         "info",
         "warn",
+        "warning",  # warn and warning are aliases
         "error",
     ] = Field(
         description="The minimum level of logs to display.",

--- a/external-import/socradar/src/lib/config_loader.py
+++ b/external-import/socradar/src/lib/config_loader.py
@@ -177,9 +177,9 @@ class ConfigLoader(BaseSettings):
         - radar: the config specific to SOCRadar
     """
 
-    opencti: OpenCTIConfig
-    connector: ConnectorConfig
-    radar: RadarConfig
+    opencti: OpenCTIConfig = Field(default_factory=OpenCTIConfig)
+    connector: ConnectorConfig = Field(default_factory=ConnectorConfig)
+    radar: RadarConfig = Field(default_factory=RadarConfig)
 
     # Setup model config and env vars parsing
     model_config = SettingsConfigDict(

--- a/external-import/socradar/src/lib/converter_to_stix.py
+++ b/external-import/socradar/src/lib/converter_to_stix.py
@@ -1,0 +1,149 @@
+import re
+from datetime import timedelta
+from functools import lru_cache
+
+import pycti
+import stix2
+import stix2.exceptions
+from lib.api_client import RadarFeedItem
+
+REGEX_PATTERNS = {
+    "md5": r"^[a-fA-F\d]{32}$",
+    "sha1": r"^[a-fA-F\d]{40}$",
+    "sha256": r"^[a-fA-F\d]{64}$",
+    "ipv4": r"^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$",
+    "ipv6": r"^(?:[a-fA-F\d]{1,4}:){7}[a-fA-F\d]{1,4}$",
+    "domain": r"^(?=.{1,255}$)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,6}$",
+    "url": r"^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$",
+}
+
+
+class ConverterError(Exception):
+    """Custom wrapper for exceptions raised in ConverterToStix"""
+
+
+class ConverterToStix:
+    """
+    Provides methods for converting various types of input data into STIX 2.1 objects.
+
+    REQUIREMENTS:
+    - generate_id() for each entity from OpenCTI pycti library except observables to create
+    """
+
+    def __init__(self):
+        self.tlp_marking = stix2.TLP_WHITE
+
+    @lru_cache
+    def _create_organization_author(
+        self, name: str, description: str
+    ) -> stix2.Identity:
+        """
+        Create an author of type 'organization'. Uses `lru_cache` for performance.
+        :return: Author as STIX2.1 Identity
+        """
+        author = stix2.Identity(
+            id=pycti.Identity.generate_id(
+                name=name,
+                identity_class="organization",
+            ),
+            name=name,
+            identity_class="organization",
+            description=description,
+        )
+        return author
+
+    def _is_pattern(self, value: str, pattern_name: str) -> bool:
+        """
+        Check if a value match a pattern type.
+        :param value: Value to check
+        :param pattern_name: Type of pattern
+        :return: True if the value is of `pattern_name` type, otherwise False
+        """
+        return bool(re.match(REGEX_PATTERNS[pattern_name], value))
+
+    def _create_stix_pattern(self, value: str, feed_type: str) -> str:
+        """
+        Build a STIX pattern from feed_type or fallback detection (handles ip, domain, url, hash, etc.).
+        :param value: Indicator's value
+        :param feed_type: Type of value
+        :return: A STIX pattern
+        """
+        value_type = feed_type.lower()
+        if value_type == "ip":
+            if self._is_pattern(value, "ipv4"):
+                return f"[ipv4-addr:value = '{value}']"
+            elif self._is_pattern(value, "ipv6"):
+                return f"[ipv6-addr:value = '{value}']"
+
+        known_patterns = {
+            "url": lambda v: f"[url:value = '{v}']",
+            "domain": lambda v: f"[domain-name:value = '{v}']",
+            "ipv4": lambda v: f"[ipv4-addr:value = '{v}']",
+            "ipv6": lambda v: f"[ipv6-addr:value = '{v}']",
+            "md5": lambda v: f"[file:hashes.'MD5' = '{v}']",
+            "sha1": lambda v: f"[file:hashes.'SHA-1' = '{v}']",
+            "sha256": lambda v: f"[file:hashes.'SHA-256' = '{v}']",
+        }
+
+        if value_type in known_patterns:
+            return known_patterns[value_type](value)
+
+        # Fallback detection
+        for pattern_type, regex in REGEX_PATTERNS.items():
+            if re.match(regex, value):
+                # e.g. pattern_type == md5 -> "[file:hashes.'MD5' = '...']"
+                if pattern_type in known_patterns:
+                    return known_patterns[pattern_type](value)
+
+        # Otherwise, custom
+        return f"[x-custom:value = '{value}']"
+
+    def process_on(
+        self, feed_item: RadarFeedItem
+    ) -> list[stix2.Identity | stix2.Indicator]:
+        """
+        Process a feed's item to create STIX2.1 Identity and Indicator.
+        :param feed_item: SOCRadar feed's item to process
+        :return: STIX2.1 Identity and Indicator
+        """
+        value = feed_item.feed
+        if not value:
+            raise ConverterError(
+                "Missing required 'feed' value to create indicator",
+                {"feed_item": feed_item},
+            )
+
+        feed_type = feed_item.feed_type or "ip"
+        maintainer = feed_item.maintainer_name or "Unknown"
+
+        valid_from = feed_item.first_seen_date
+        valid_until = feed_item.latest_seen_date
+        if valid_until <= valid_from:
+            valid_until = valid_from + timedelta(hours=1)
+
+        try:
+            pattern = self._create_stix_pattern(value, feed_type)
+
+            creator = self._create_organization_author(
+                name=maintainer,
+                description=f"Feed Provider: {maintainer}",
+            )
+            indicator = stix2.Indicator(
+                id=pycti.Indicator.generate_id(pattern),
+                name=f"{feed_type.upper()}: {value}",
+                description=f"Source: {maintainer}\nValue: {value}",
+                pattern=pattern,
+                pattern_type="stix",
+                valid_from=valid_from,
+                valid_until=valid_until,
+                created_by_ref=creator.id,
+                object_marking_refs=[self.tlp_marking],
+                labels=["malicious-activity", feed_type],
+            )
+
+            return [creator, indicator]
+        except stix2.exceptions.STIXError as err:
+            raise ConverterError(
+                "Error converting feed's item: {err}",
+                {"feed_item": feed_item, "error": err},
+            ) from err

--- a/external-import/socradar/src/lib/converter_to_stix.py
+++ b/external-import/socradar/src/lib/converter_to_stix.py
@@ -118,7 +118,7 @@ class ConverterToStix:
 
         valid_from = feed_item.first_seen_date
         valid_until = feed_item.latest_seen_date
-        if valid_until <= valid_from:
+        if (valid_from and valid_until) and valid_until <= valid_from:
             valid_until = valid_from + timedelta(hours=1)
 
         try:
@@ -136,9 +136,11 @@ class ConverterToStix:
                 pattern_type="stix",
                 valid_from=valid_from,
                 valid_until=valid_until,
-                created_by_ref=creator.id,
-                object_marking_refs=[self.tlp_marking.id],
                 labels=["malicious-activity", feed_type],
+                object_marking_refs=[self.tlp_marking.id],
+                created_by_ref=creator.id,
+                created=valid_from,
+                modified=valid_from,
             )
 
             return (self.tlp_marking, creator, indicator)

--- a/external-import/socradar/src/lib/converter_to_stix.py
+++ b/external-import/socradar/src/lib/converter_to_stix.py
@@ -100,7 +100,7 @@ class ConverterToStix:
 
     def process_on(
         self, feed_item: RadarFeedItem
-    ) -> list[stix2.Identity | stix2.Indicator]:
+    ) -> tuple[stix2.MarkingDefinition, stix2.Identity, stix2.Indicator]:
         """
         Process a feed's item to create STIX2.1 Identity and Indicator.
         :param feed_item: SOCRadar feed's item to process
@@ -137,11 +137,11 @@ class ConverterToStix:
                 valid_from=valid_from,
                 valid_until=valid_until,
                 created_by_ref=creator.id,
-                object_marking_refs=[self.tlp_marking],
+                object_marking_refs=[self.tlp_marking.id],
                 labels=["malicious-activity", feed_type],
             )
 
-            return [creator, indicator]
+            return (self.tlp_marking, creator, indicator)
         except stix2.exceptions.STIXError as err:
             raise ConverterError(
                 "Error converting feed's item: {err}",

--- a/external-import/socradar/src/lib/converter_to_stix.py
+++ b/external-import/socradar/src/lib/converter_to_stix.py
@@ -131,7 +131,7 @@ class ConverterToStix:
             indicator = stix2.Indicator(
                 id=pycti.Indicator.generate_id(pattern),
                 name=f"{feed_type.upper()}: {value}",
-                description=f"Source: {maintainer}\nValue: {value}",
+                description=f"Source: {maintainer}\n  Value: {value}",
                 pattern=pattern,
                 pattern_type="stix",
                 valid_from=valid_from,

--- a/external-import/socradar/src/lib/radar.py
+++ b/external-import/socradar/src/lib/radar.py
@@ -235,10 +235,8 @@ class RadarConnector:
 
                     # If we reached a batch boundary
                     if idx % BATCH_SIZE == 0:
-                        bundle = Bundle(objects=stix_batch, allow_custom=True)
-                        self.helper.send_stix2_bundle(
-                            bundle.serialize(), work_id=work_id
-                        )
+                        bundle = self.helper.stix2_create_bundle(stix_batch)
+                        self.helper.send_stix2_bundle(bundle, work_id=work_id)
                         total_sent += len(stix_batch)
                         self.helper.connector_logger.info(
                             f"Sent batch of {len(stix_batch)} objects (total: {total_sent})"
@@ -247,8 +245,8 @@ class RadarConnector:
 
                 # Final leftover
                 if stix_batch:
-                    bundle = Bundle(objects=stix_batch, allow_custom=True)
-                    self.helper.send_stix2_bundle(bundle.serialize(), work_id=work_id)
+                    bundle = self.helper.stix2_create_bundle(stix_batch)
+                    self.helper.send_stix2_bundle(bundle, work_id=work_id)
                     total_sent += len(stix_batch)
                     self.helper.connector_logger.info(
                         f"Sent final batch of {len(stix_batch)} objects (total: {total_sent})"

--- a/external-import/socradar/src/lib/radar.py
+++ b/external-import/socradar/src/lib/radar.py
@@ -1,15 +1,14 @@
-import re
 import sys
-from datetime import datetime, timedelta, timezone
-from typing import Dict
+from datetime import datetime, timezone
+from typing import Generator
 
 import pycti
 import stix2
 from lib.api_client import RadarAPIClient, RadarAPIError, RadarFeedItem
 from lib.config_loader import ConfigLoader, FeedList
+from lib.converter_to_stix import ConverterError, ConverterToStix
 
-BATCH_MAX_SIZE = 10_000
-TLP_MARKING = stix2.TLP_WHITE.id
+BATCH_MAX_SIZE = 1_000
 
 
 class RadarConnector:
@@ -29,18 +28,7 @@ class RadarConnector:
             api_base_url=self.config.radar.base_feed_url,
             api_key=self.config.radar.socradar_key,
         )
-
-        self.identity_cache: dict[str, stix2.Identity] = {}
-        self.identity_cache: Dict[str, stix2.Identity] = {}
-        self.regex_patterns = {
-            "md5": r"^[a-fA-F\d]{32}$",
-            "sha1": r"^[a-fA-F\d]{40}$",
-            "sha256": r"^[a-fA-F\d]{64}$",
-            "ipv4": r"^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$",
-            "ipv6": r"^(?:[a-fA-F\d]{1,4}:){7}[a-fA-F\d]{1,4}$",
-            "domain": r"^(?=.{1,255}$)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,6}$",
-            "url": r"^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$",
-        }
+        self.converter_to_stix = ConverterToStix()
 
         self.work_id: str | None = None
 
@@ -118,159 +106,30 @@ class RadarConnector:
             },
         )
 
-        return items
+        return feed_items
 
-    def _matches_pattern(self, value: str, pattern_name: str) -> bool:
-        """Match value against regex pattern"""
-        return bool(re.match(self.regex_patterns[pattern_name], value))
-
-    def _validate_dates(self, first_seen: str, last_seen: str):
-        """Validate and convert date strings to datetime objects"""
-        # Step 1.0: Set datetime format
-        dt_format = "%Y-%m-%d %H:%M:%S"
-
-        # Step 1.1: Convert strings to datetime objects
-        valid_from = datetime.strptime(first_seen, dt_format)
-        valid_until = datetime.strptime(last_seen, dt_format)
-
-        # Step 1.2: Ensure valid time range
-        if valid_until <= valid_from:
-            valid_until = valid_from + timedelta(hours=1)
-
-        return valid_from, valid_until
-
-    def _create_stix_pattern(self, value: str, feed_type: str) -> str:
+    def _convert_feed_items(
+        self, feed_items: list[RadarFeedItem]
+    ) -> Generator[list[stix2.Identity | stix2.Indicator], None, None]:
         """
-        Build a STIX pattern from feed_type or fallback detection
-        (handles ip, domain, url, hash, etc.)
+        Process collection's feed items into STIX Indicator.
         """
-        # If feed_type is "ip", check IPv4 or IPv6
-        if feed_type == "ip":
-            if self._matches_pattern(value, "ipv4"):
-                return f"[ipv4-addr:value = '{value}']"
-            elif self._matches_pattern(value, "ipv6"):
-                return f"[ipv6-addr:value = '{value}']"
+        for feed_item in feed_items:
+            try:
+                author, indicator = self.converter_to_stix.process_on(feed_item)
 
-        known_patterns = {
-            "url": lambda v: f"[url:value = '{v}']",
-            "domain": lambda v: f"[domain-name:value = '{v}']",
-            "ipv4": lambda v: f"[ipv4-addr:value = '{v}']",
-            "ipv6": lambda v: f"[ipv6-addr:value = '{v}']",
-            "md5": lambda v: f"[file:hashes.'MD5' = '{v}']",
-            "sha1": lambda v: f"[file:hashes.'SHA-1' = '{v}']",
-            "sha256": lambda v: f"[file:hashes.'SHA-256' = '{v}']",
-        }
+                self.helper.connector_logger.debug(
+                    f"Indicator successfully created",
+                    {"author": author, "indicator": indicator},
+                )
 
-        if feed_type in known_patterns:
-            return known_patterns[feed_type](value)
-
-        # Fallback detection
-        for ptype, regex in self.regex_patterns.items():
-            if re.match(regex, value):
-                # e.g. ptype=md5 => "[file:hashes.'MD5' = '...']"
-                if ptype in known_patterns:
-                    return known_patterns[ptype](value)
-
-        # Otherwise, custom
-        return f"[x-custom:value = '{value}']"
-
-    def _get_or_create_identity(self, maintainer_name: str):
-        """
-        Use pycti.Identity.generate_id(...) for stable dedup
-        Return a stix2.Identity w/ that ID
-        """
-        if maintainer_name in self.identity_cache:
-            return self.identity_cache[maintainer_name]
-
-        try:
-            now = datetime.now(tz=timezone.utc)
-            identity = stix2.Identity(
-                id=pycti.Identity.generate_id(
-                    name=maintainer_name,
-                    identity_class="organization",
-                ),
-                name=maintainer_name,
-                identity_class="organization",
-                description=f"Feed Provider: {maintainer_name}",
-                created=now,
-                modified=now,
-            )
-            self.identity_cache[maintainer_name] = identity
-            return identity
-        except stix2.exceptions.STIXError as err:
-            self.helper.connector_logger.error(
-                f"Error creating Identity for {maintainer_name}", {"error": err}
-            )
-            return None
-
-    def _process_feed_item(self, item: dict):
-        """Process single feed item into STIX objects"""
-        # Step 1.0: Initialize empty list for STIX objects
-        stix_objects = []
-
-        # Step 2.0: Extract core fields from feed item
-        # Step 2.1: Get primary indicator value
-        value = item.get("feed")
-        # Step 2.2: Get indicator type (default to IP if not specified)
-        feed_type = item.get("feed_type", "ip").lower()
-        # Step 2.3: Get source/maintainer information
-        maintainer = item.get("maintainer_name", "Unknown")
-
-        # Step 3.0: Extract and validate timestamp fields
-        # Step 3.1: Get first seen date
-        first_seen_str = item.get("first_seen_date")
-        # Step 3.2: Get last seen date
-        last_seen_str = item.get("latest_seen_date")
-        # Step 3.3: Validate required fields exist
-        if not (value and first_seen_str and last_seen_str):
-            self.helper.connector_logger.error(f"Item missing fields: {item}")
-            return stix_objects
-
-        # Step 4.0: Convert and validate dates
-        valid_from, valid_until = self._validate_dates(first_seen_str, last_seen_str)
-
-        # Step 5.0: Create or get cached identity object
-        identity_obj = self._get_or_create_identity(maintainer)
-        if not identity_obj:
-            return stix_objects
-
-        # Step 6.0: Generate STIX pattern for indicator
-        pattern = self._create_stix_pattern(value, feed_type)
-        if not pattern:
-            self.helper.connector_logger.error(
-                f"Could not determine pattern for: {value} / {feed_type}"
-            )
-            return stix_objects
-
-        try:
-            # Step 8.0: Create STIX2 Indicator object
-            indicator = stix2.Indicator(
-                id=pycti.Indicator.generate_id(pattern),
-                name=f"{feed_type.upper()}: {value}",
-                description=f"Source: {maintainer}\nValue: {value}",
-                pattern=pattern,
-                pattern_type="stix",
-                valid_from=valid_from,
-                valid_until=valid_until,
-                created_by_ref=identity_obj.id,
-                object_marking_refs=[stix2.TLP_WHITE.id],
-                labels=["malicious-activity", feed_type],
-                created=valid_from,
-                modified=valid_from,
-            )
-
-            # Step 9.0: Combine all STIX objects
-            stix_objects.extend([identity_obj, indicator])
-            # Step 9.1: Log success
-            self.helper.connector_logger.info(
-                f"Created {feed_type} indicator => {value} from {maintainer}"
-            )
-        except stix2.exceptions.STIXError as err:
-            self.helper.connector_logger.error(
-                f"Indicator ID generation error", {"error": err}
-            )
-
-        return stix_objects
+                yield [author, indicator]
+            except ConverterError as err:
+                self.helper.connector_logger.error(
+                    f"Skipping item due to STIX2 Identity conversion error: {err}",
+                    {"error": err},
+                )
+                continue
 
     def process(self):
         """
@@ -295,8 +154,7 @@ class RadarConnector:
                 stix_batch = []
                 stix_objects_count = 0
 
-                for feed_item in feed_items:
-                    stix_objects = self._process_feed_item(feed_item)
+                for stix_objects in self._convert_feed_items(feed_items):
                     stix_batch.extend(stix_objects)
 
                     # If we reached a batch boundary

--- a/external-import/socradar/src/lib/radar.py
+++ b/external-import/socradar/src/lib/radar.py
@@ -119,7 +119,7 @@ class RadarConnector:
                 author, indicator = self.converter_to_stix.process_on(feed_item)
 
                 self.helper.connector_logger.debug(
-                    f"Indicator successfully created",
+                    "Indicator successfully created",
                     {"author": author, "indicator": indicator},
                 )
 

--- a/external-import/socradar/src/lib/radar.py
+++ b/external-import/socradar/src/lib/radar.py
@@ -259,12 +259,6 @@ class RadarConnector:
                     f"Failed to process {collection_name}", {"error", err}
                 )
 
-    #
-    #
-    #
-    #
-    #
-
     def process(self):
         """
         Run main process to collect, process and send intelligence to OpenCTI.
@@ -327,17 +321,17 @@ class RadarConnector:
 
     def run(self):
         """
-        Run in start-up.
-        Mainly runs with OpenCTI's schedule_iso.
+        Run the main process encapsulated in a scheduler
+        It allows you to schedule the process to run at a certain intervals
+        This specific scheduler from the pycti connector helper will also check the queue size of a connector
+        If `CONNECTOR_QUEUE_THRESHOLD` is set, if the connector's queue size exceeds the queue threshold,
+        the connector's main process will not run until the queue is ingested and reduced sufficiently,
+        allowing it to restart during the next scheduler check. (default is 500MB)
+        It requires the `duration_period` connector variable in ISO-8601 standard format
+
+        Example: `CONNECTOR_DURATION_PERIOD=PT5M` => Will run the process every 5 minutes
         """
-        # Step 1.0: Run immediately on startup
-        self.helper.log_info("Running initial collection...")
-        self.process_message()
-
-        # Step 2.0: Schedule recurring runs
-        duration_period = f"PT{self.interval}S"  # e.g., PT600S for 10 minutes
-        self.helper.log_info(f"Scheduling recurring runs every {self.interval} seconds")
-
-        self.helper.schedule_iso(
-            message_callback=self.process_message, duration_period=duration_period
+        self.helper.schedule_process(
+            message_callback=self.process,
+            duration_period=self.config.connector.duration_period.total_seconds(),
         )

--- a/external-import/socradar/src/lib/radar.py
+++ b/external-import/socradar/src/lib/radar.py
@@ -109,20 +109,20 @@ class RadarConnector:
 
     def _convert_feed_items(
         self, feed_items: list[RadarFeedItem]
-    ) -> Generator[list[stix2.Identity | stix2.Indicator], None, None]:
+    ) -> Generator[list[stix2.v21._STIXBase21], None, None]:
         """
         Process collection's feed items into STIX Indicator.
         """
         for feed_item in feed_items:
             try:
-                author, indicator = self.converter_to_stix.process_on(feed_item)
+                tlp, author, indicator = self.converter_to_stix.process_on(feed_item)
 
                 self.helper.connector_logger.debug(
                     "Indicator successfully created",
-                    {"author": author, "indicator": indicator},
+                    {"indicator": indicator, "tlp": tlp, "author": author},
                 )
 
-                yield [author, indicator]
+                yield [tlp, author, indicator]
             except ConverterError as err:
                 self.helper.connector_logger.error(
                     f"Skipping item due to STIX2 Identity conversion error: {err}",

--- a/external-import/socradar/src/lib/radar.py
+++ b/external-import/socradar/src/lib/radar.py
@@ -76,11 +76,6 @@ class RadarConnector:
         Handle a batch of STIX objects (create work, create and send bundle, then close work).
         :param stix_objects: STIX objects batch to handle (length must be lower than BATCH_MAX_SIZE)
         """
-        if len(stix_objects) > BATCH_MAX_SIZE:
-            raise ValueError(
-                f"STIX objects count exceeds max batch size ({BATCH_MAX_SIZE})"
-            )
-
         self._initiate_work()
         self._send_bundle(stix_objects)
         self._finalize_work()

--- a/external-import/socradar/src/lib/radar.py
+++ b/external-import/socradar/src/lib/radar.py
@@ -64,7 +64,11 @@ class RadarConnector:
         :param stix_objects: List of STIX2 objects to send to ingestion
         """
         bundle = self.helper.stix2_create_bundle(stix_objects)
-        sent_bundles = self.helper.send_stix2_bundle(bundle, work_id=self.work_id)
+        sent_bundles = self.helper.send_stix2_bundle(
+            bundle,
+            work_id=self.work_id,
+            cleanup_inconsistent_bundle=True,
+        )
 
         self.helper.connector_logger.info(
             "Sending STIX bundles to OpenCTI",

--- a/external-import/socradar/src/main.py
+++ b/external-import/socradar/src/main.py
@@ -1,8 +1,21 @@
-from lib.radar import RadarConnector
+from lib import ConfigLoader, RadarConnector
+from pycti import OpenCTIConnectorHelper
 
 if __name__ == "__main__":
+    """
+    Entry point of the script
+
+    - traceback.print_exc(): This function prints the traceback of the exception to the standard error (stderr).
+    The traceback includes information about the point in the program where the exception occurred,
+    which is very useful for debugging purposes.
+    - exit(1): effective way to terminate a Python program when an error is encountered.
+    It signals to the operating system and any calling processes that the program did not complete successfully.
+    """
     try:
-        connector = RadarConnector()
+        config = ConfigLoader()
+        helper = OpenCTIConnectorHelper(config=config.model_dump_pycti())
+
+        connector = RadarConnector(config, helper)
         connector.run()
     except Exception as e:
         print(f"Error running connector: {str(e)}")

--- a/external-import/socradar/src/main.py
+++ b/external-import/socradar/src/main.py
@@ -1,3 +1,5 @@
+import traceback
+
 from lib import ConfigLoader, RadarConnector
 from pycti import OpenCTIConnectorHelper
 
@@ -17,6 +19,6 @@ if __name__ == "__main__":
 
         connector = RadarConnector(config, helper)
         connector.run()
-    except Exception as e:
-        print(f"Error running connector: {str(e)}")
+    except Exception:
+        traceback.print_exc()
         exit(1)


### PR DESCRIPTION
### Proposed changes

- Update config:
  * remove 'radar_' suffix of config vars (from _config.yml_) 
  * add runtime validation (with `pydantic_settings` lib)
  * deprecate `RADAR_RUN_INTERVAL` (replaced by `CONNECTOR_DURATION_PERIOD`)
  * deprecate `RADAR_COLLECTIONS_UUID` (replace by `RADAR_FEED_LISTS` - flat version)
  * update _config.yml.sample_ / add _.env.sample_
  * update README
- Update Docker files:
  * add files from templates
  * add env vars examples in _docker-compose.yml_
  * update _Dockerfile_
- Replace deprecated code:
  * use `self.helper.schedule_process` method
  * use `self.helper.connector_logger` log methods
  * use `self.helper.create_stix2_bundle` method
- Error handling improvement:
  * add traceback in _main.py_
  * add 2 abstraction layers: `RadarAPIClient` and `ConverterToStix`
  * wrap expected errors with `RadarAPIError` and `ConverterError`
  * handle expected errors in application layer
  * close work gracefully in case of unexpected error

### Related issues

* #4193 
* #4194 

### Checklist

- [ ] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

- Conversion to STIX refactor:
  * despite refactor, do _not_ change any mapping, skipping, or ingesting behavior
- Config changes:
  * In order to add config runtime validation, config vars had to follow same format as env vars, meaning that `radar_` suffix has been removed from `radar` config vars.

    _config.yml_ **before**
    ```yaml
    opencti:
      ...
    connector:
      ...
    radar:
      radar_base_feed_url: "http://example.com"
      radar_socradar_key: "api_key"
    ```
    _config.yml_ **now**
    ```yaml
    opencti:
      ...
    connector:
      ...
    radar:
      base_feed_url: "http://example.com"
      socradar_key: "api_key"
    ```
    It creates **breaking changes in development mode only**. cc @romain-filigran 
  * For sake of simplicity, I introduced a new env/config var, `RADAR_FEED_LISTS`, which is a flat version of `RADAR_COLLECTIONS_UUID` (now deprecated - but still handled).
    
    _config.yml_ **before**
    ```yaml
    opencti:
      ...
    connector:
      ...
    radar:
      radar_collections_uuid:
        collection_1:
          id: ["COLLECTION_UUID"]
          name: ["COLLECTION_NAME"]
        collection_2:
          id: ["COLLECTION_UUID"]
          name: ["COLLECTION_NAME"]
    ```
    _config.yml_ **now**
    ```yaml
    opencti:
      ...
    connector:
      ...
    radar:
      feed_lists:
        collection_name_1: id_1
        collection_name_2: id_2
    ```
    See #4194 for more explanations. cc @romain-filigran 



