### PR TITLE
[Sekoia] Remove filter on `x_inthreat_sources_refs` to use as label as other entities

### DIFF
--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -203,7 +203,11 @@ class Sekoia(object):
         items = self._clean_ic_fields(items)
         self._add_files_to_items(items)
 
+        # Getting source refs and add as labels in entity
+        self._add_sources_to_items(items)
+
         if self.import_ioc_relationships:
+            # Retrieve all related object to IOC and relationship
             [all_related_objects, all_relationships] = (
                 self._retrieve_related_objects_and_relationships(items)
             )
@@ -269,10 +273,8 @@ class Sekoia(object):
             "x_ic_impacted_locations",
             "x_ic_impacted_sectors",
         ]
-        return (
-            (field.startswith("x_ic") or field.startswith("x_inthreat"))
-            and (field.endswith("ref") or field.endswith("refs"))
-        ) or field in to_ignore
+
+        return (field.startswith("x_ic")) or field in to_ignore
 
     def _retrieve_related_objects_and_relationships(self, indicators: List[Dict]):
         all_related_objects = []


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove filter on `x_inthreat_sources_refs` on IOC which is a source but also used as labels for other entities
* Add some comments

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/3870

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
