### PR TITLE
[connectors_sdk] Add Country, Sector and IntrusionSet OCTI models and their relationships

### DIFF
--- a/connectors-sdk/connectors_sdk/models/octi/__init__.py
+++ b/connectors-sdk/connectors_sdk/models/octi/__init__.py
@@ -13,31 +13,47 @@ from connectors_sdk.models.octi.activities.observations import (
     Indicator,
     IPV4Address,
 )
-from connectors_sdk.models.octi.knowledge.entities import Organization
+from connectors_sdk.models.octi.knowledge.entities import Organization, Sector
+from connectors_sdk.models.octi.knowledge.locations import Country
+from connectors_sdk.models.octi.knowledge.threats import IntrusionSet
 from connectors_sdk.models.octi.relationships import (
-    AnyRelatedToAny,
-    IndicatorBasedOnObservable,
-    IndicatorDerivedFromIndicator,
+    BasedOn,
+    DerivedFrom,
+    LocatedAt,
+    RelatedTo,
+    Targets,
     based_on,
+    located_at,
     related_to,
+    targets,
 )
 from connectors_sdk.models.octi.settings.taxonomies import KillChainPhase
 
 __all__ = [
-    "AnyRelatedToAny",
+    # Models flat list
     "AssociatedFile",
-    "BaseEntity",  # for typing purpose.
+    "BasedOn",
+    "Country",
+    "DerivedFrom",
     "ExternalReference",
     "Indicator",
-    "IndicatorBasedOnObservable",
-    "IndicatorDerivedFromIndicator",
+    "IntrusionSet",
     "IPV4Address",
     "KillChainPhase",
+    "LocatedAt",
     "Organization",
     "OrganizationAuthor",
+    "RelatedTo",
+    "Sector",
+    "Targets",
     "TLPMarking",
-    "related_to",
+    # Relationship builders
     "based_on",
+    "located_at",
+    "related_to",
+    "targets",
+    # Typing purpose
+    "BaseEntity",
 ]
 
 

--- a/connectors-sdk/connectors_sdk/models/octi/_common.py
+++ b/connectors-sdk/connectors_sdk/models/octi/_common.py
@@ -325,9 +325,13 @@ class Author(ABC, BaseIdentifiedEntity):
 class TLPMarking(BaseIdentifiedEntity):
     """Represent a TLP marking definition."""
 
-    level: Literal["white", "green", "amber", "amber+strict", "red"] = Field(
-        description="The level of the TLP marking.",
-    )
+    level: Literal[
+        "white",
+        "green",
+        "amber",
+        "amber+strict",
+        "red",
+    ] = Field(description="The level of the TLP marking.")
 
     def to_stix2_object(self) -> stix2.v21.MarkingDefinition:
         """Make stix object."""

--- a/connectors-sdk/connectors_sdk/models/octi/activities/observations.py
+++ b/connectors-sdk/connectors_sdk/models/octi/activities/observations.py
@@ -1,7 +1,7 @@
 """Offer observations OpenCTI entities."""
 
 import ipaddress
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Any, Literal, Optional
 
 import pycti  # type: ignore[import-untyped]  # pycti does not provide stubs
@@ -16,7 +16,7 @@ from pydantic import AwareDatetime, Field, field_validator
 
 
 @MODEL_REGISTRY.register
-class Observable(BaseIdentifiedEntity):
+class Observable(ABC, BaseIdentifiedEntity):
     """Base class for OpenCTI Observables.
 
     This class must be subclassed to create specific observable types.
@@ -186,7 +186,7 @@ class Indicator(BaseIdentifiedEntity):
 
     create_observables: Optional[bool] = Field(
         None,
-        description="If True, observables and `based-on` relationships will be created for this indicator (Delegated to OpenCTI Platform). You can also manually define the Observable objects and use IndicatorBasedOnObservableRelationship for more granularity.",
+        description="If True, observables and `based-on` relationships will be created for this indicator (Delegated to OpenCTI Platform). You can also manually define the Observable objects and use BasedOnRelationship for more granularity.",
     )
 
     def to_stix2_object(self) -> stix2.v21.Indicator:

--- a/connectors-sdk/connectors_sdk/models/octi/knowledge/locations.py
+++ b/connectors-sdk/connectors_sdk/models/octi/knowledge/locations.py
@@ -1,1 +1,88 @@
 """Offer locations OpenCTI entities."""
+
+from typing import Optional
+
+import pycti  # type: ignore[import-untyped]  # pycti does not provide stubs
+import stix2  # type: ignore[import-untyped] # stix2 does not provide stubs
+from connectors_sdk.models.octi._common import MODEL_REGISTRY, BaseIdentifiedEntity
+from pydantic import Field
+
+
+class OCTIStixLocation(stix2.Location):  # type: ignore[misc]  # stix2 does not provide stubs
+    """Override stix2 Location to skip some constraints incompatible with OpenCTI Location entities."""
+
+    def _check_object_constraints(self) -> None:
+        """Override _check_object_constraints method."""
+        location_type = (self.x_opencti_location_type or "").lower()
+        if location_type in ["administrative-area", "city", "position"]:
+            if self.get("precision") is not None:
+                self._check_properties_dependency(
+                    ["longitude", "latitude"], ["precision"]
+                )
+
+            self._check_properties_dependency(["latitude"], ["longitude"])
+            self._check_properties_dependency(["longitude"], ["latitude"])
+
+            # Skip region/country/latitude/longitude presence check because all of them are optional on OpenCTI
+            # even though at least one of them is required in the STIX2.1 spec
+        else:
+            super()._check_object_constraints()
+
+
+@MODEL_REGISTRY.register
+class Country(BaseIdentifiedEntity):
+    """Represent a Country on OpenCTI."""
+
+    name: str = Field(
+        description="A name used to identify the Location.",
+    )
+    description: Optional[str] = Field(
+        None,
+        description="A textual description of the Location.",
+    )
+
+    def to_stix2_object(self) -> stix2.Location:
+        """Make stix object.
+
+        Notes:
+            - OpenCTI maps STIX Location SDO to OCTI Country entity based on `x_opencti_location_type`.
+            - To create a Country entity on OpenCTI, `x_opencti_location_type` MUST be 'Country'.
+        """
+        location_type = "Country"
+
+        return OCTIStixLocation(
+            id=pycti.Location.generate_id(
+                name=self.name,
+                x_opencti_location_type=location_type,
+            ),
+            name=self.name,
+            country=self.name,
+            description=self.description,
+            custom_properties=dict(  # noqa: C408  # No literal dict for maintainability
+                x_opencti_location_type=location_type,
+            ),
+            latitude=None,
+            longitude=None,
+            precision=None,
+            region=None,
+            administrative_area=None,
+            city=None,
+            street_address=None,
+            postal_code=None,
+            created=None,
+            modified=None,
+            revoked=None,
+            labels=None,
+            confidence=None,
+            lang=None,
+            granular_markings=None,
+            extensions=None,
+        )
+
+
+MODEL_REGISTRY.rebuild_all()
+
+if __name__ == "__main__":  # pragma: no cover  # Do not run coverage on doctest
+    import doctest
+
+    doctest.testmod()

--- a/connectors-sdk/connectors_sdk/models/octi/knowledge/threats.py
+++ b/connectors-sdk/connectors_sdk/models/octi/knowledge/threats.py
@@ -1,1 +1,87 @@
 """Offer threats OpenCTI entities."""
+
+from typing import Optional
+
+import pycti  # type: ignore[import-untyped]  # pycti does not provide stubs
+import stix2  # type: ignore[import-untyped] # stix2 does not provide stubs
+from connectors_sdk.models.octi._common import MODEL_REGISTRY, BaseIdentifiedEntity
+from pydantic import AwareDatetime, Field
+
+
+@MODEL_REGISTRY.register
+class IntrusionSet(BaseIdentifiedEntity):
+    """Define an Intrusion Set on OpenCTI."""
+
+    name: str = Field(
+        description="A name used to identify this Intrusion Set.",
+        min_length=1,
+    )
+    description: Optional[str] = Field(
+        description="A description that provides more details and context about the Intrusion Set.",
+        default=None,
+    )
+    aliases: Optional[list[str]] = Field(
+        description="Alternative names used to identify this Intrusion Set.",
+        default=None,
+    )
+    first_seen: Optional[AwareDatetime] = Field(
+        description="The time that this Intrusion Set was first seen.",
+        default=None,
+    )
+    last_seen: Optional[AwareDatetime] = Field(
+        description="The time that this Intrusion Set was last seen.",
+        default=None,
+    )
+    goals: Optional[list[str]] = Field(
+        description="The high-level goals of this Intrusion Set, namely, what are they trying to do.",
+        default=None,
+    )
+    resource_level: Optional[str] = Field(
+        description="The organizational level at which this Intrusion Set typically works.",
+        default=None,
+    )
+    primary_motivation: Optional[str] = Field(
+        description="The primary reason, motivation, or purpose behind this Intrusion Set.",
+        default=None,
+    )
+    secondary_motivations: Optional[str] = Field(
+        description="The secondary reasons, motivations, or purposes behind this Intrusion Set.",
+        default=None,
+    )
+
+    def to_stix2_object(self) -> stix2.v21.IntrusionSet:
+        """Make stix object."""
+        return stix2.IntrusionSet(
+            id=pycti.IntrusionSet.generate_id(name=self.name),
+            name=self.name,
+            description=self.description,
+            aliases=self.aliases,
+            first_seen=self.first_seen,
+            last_seen=self.last_seen,
+            goals=self.goals,
+            resource_level=self.resource_level,
+            primary_motivation=self.primary_motivation,
+            secondary_motivations=self.secondary_motivations,
+            created_by_ref=self.author.id if self.author else None,
+            external_references=[
+                external_reference.to_stix2_object()
+                for external_reference in self.external_references or []
+            ],
+            object_marking_refs=[marking.id for marking in self.markings or []],
+            # unused
+            created=None,
+            modified=None,
+            labels=None,
+            confidence=None,
+            lang=None,
+            granular_markings=None,
+            extensions=None,
+        )
+
+
+MODEL_REGISTRY.rebuild_all()
+
+if __name__ == "__main__":  # pragma: no cover  # Do not run coverage on doctest
+    import doctest
+
+    doctest.testmod()

--- a/connectors-sdk/connectors_sdk/models/octi/relationships.py
+++ b/connectors-sdk/connectors_sdk/models/octi/relationships.py
@@ -13,6 +13,9 @@ from connectors_sdk.models.octi.activities.observations import (
     Indicator,
     Observable,
 )
+from connectors_sdk.models.octi.knowledge.entities import Organization, Sector
+from connectors_sdk.models.octi.knowledge.locations import Country
+from connectors_sdk.models.octi.knowledge.threats import IntrusionSet
 from pydantic import (
     AwareDatetime,
     ConfigDict,
@@ -132,7 +135,7 @@ class Relationship(ABC, BaseIdentifiedEntity):
 
 
 @MODEL_REGISTRY.register
-class AnyRelatedToAny(Relationship):
+class RelatedTo(Relationship):
     """Represent a relationship indicating that an entity is related to another entity.
 
     This is a generic relationship that can be used for any two entities.
@@ -143,17 +146,17 @@ class AnyRelatedToAny(Relationship):
         >>> from connectors_sdk.models.octi.activities.observations import IPV4Address
         >>> organization = Organization(name="Example Corp")
         >>> ip = IPV4Address(value="127.0.0.1")
-        >>> relationship = AnyRelatedToAny(source=ip, target=organization)
+        >>> relationship = RelatedTo(source=ip, target=organization)
     """
 
     _relationship_type: Literal["related-to"] = "related-to"
 
 
-related_to = AnyRelatedToAny._builder
+related_to = RelatedTo._builder
 
 
 @MODEL_REGISTRY.register
-class IndicatorBasedOnObservable(Relationship):
+class BasedOn(Relationship):
     """Represent a relationship indicating that an indicator is based on an observable.
 
     Notes:
@@ -165,28 +168,28 @@ class IndicatorBasedOnObservable(Relationship):
         >>> from connectors_sdk.models.octi.activities.observations import Indicator, IPV4Address
         >>> indicator = Indicator(name="Test Indicator", pattern="[ipv4-addr:value = '127.0.0.1']", pattern_type="stix")
         >>> observable = IPV4Address(value="127.0.0.1")
-        >>> relationship = IndicatorBasedOnObservable(source=indicator, target=observable)
+        >>> relationship = BasedOn(source=indicator, target=observable)
 
     """
 
     _relationship_type: Literal["based-on"] = "based-on"
 
-    source: "Indicator" = Field(
+    source: Indicator = Field(
         ...,
         description="Reference to the source entity of the relationship. Here an Indicator.",
     )
-    target: "Observable" = Field(
+    target: Observable = Field(
         ...,
         description="Reference to the target entity of the relationship. Here an Observable.",
     )
 
 
-based_on = IndicatorBasedOnObservable._builder
+based_on = BasedOn._builder
 
 
 # Demonstrate how to dynamically create a Relationship
-IndicatorDerivedFromIndicator = create_model(
-    "IndicatorDerivedFromIndicator",
+DerivedFrom = create_model(
+    "DerivedFrom",
     __base__=Relationship,
     source=Indicator,
     target=Indicator,
@@ -201,13 +204,99 @@ IndicatorDerivedFromIndicator = create_model(
         >>> from connectors_sdk.models.octi.activities.observations import Indicator
         >>> url = Indicator(name="Url", pattern="[url:value = 'http://example.com/test']", pattern_type="stix")
         >>> domain = Indicator(name="Domain", pattern="[domain-name:value = 'example.com']", pattern_type="stix")
-        >>> relationship = IndicatorDerivedFromIndicator(source=domain, target=url)
+        >>> relationship = DerivedFrom(source=domain, target=url)
     """,
 )
-MODEL_REGISTRY.register(IndicatorDerivedFromIndicator)
+MODEL_REGISTRY.register(DerivedFrom)
+
+
+@MODEL_REGISTRY.register
+class Indicates(Relationship):
+    """Represent a relationship indicating that an indicator can detect evidence of an
+    attack pattern, campaign, infrastructure, intrusion set, malware, threat actor, or tool.
+
+    Examples:
+        >>> from connectors_sdk.models.octi.activities.observations import Indicator
+        >>> from connectors_sdk.models.octi.activities.knowledge import IntrusionSet
+        >>> indicator = Indicator(name="Test Indicator", pattern="[ipv4-addr:value = '127.0.0.1']", pattern_type="stix")
+        >>> intrusion_set = IntrusionSet(name="Test IntrusionSet")
+        >>> relationship = Indicates(source=indicator, target=intrusion_set)
+
+    """
+
+    _relationship_type: Literal["indicates"] = "indicates"
+
+    source: Indicator = Field(
+        ...,
+        description="Reference to the source entity of the relationship. Here an Indicator.",
+    )
+    target: IntrusionSet = Field(
+        ...,
+        description="Reference to the target entity of the relationship. Here an IntrusionSet.",
+    )
+
+
+indicates = Indicates._builder
+
+
+@MODEL_REGISTRY.register
+class Targets(Relationship):
+    """Represent a relationship indicating that an IntrusionSet targets a Country or an Organization.
+
+    Examples:
+        >>> from connectors_sdk.models.octi.knowledge.locations import Country
+        >>> from connectors_sdk.models.octi.knowledge.threats import IntrusionSet
+        >>> intrusion_set = IntrusionSet(name="Test IntrusionSet")
+        >>> country = Country(name="France")
+        >>> relationship = Targets(source=intrusion_set, target=country)
+
+    """
+
+    _relationship_type: Literal["targets"] = "targets"
+
+    source: IntrusionSet = Field(
+        ...,
+        description="Reference to the source entity of the relationship. Here an Intrusion Set.",
+    )
+    target: Country | Organization = Field(
+        ...,
+        description="Reference to the target entity of the relationship. Here a Country or an Organization.",
+    )
+
+
+targets = Targets._builder
+
+
+@MODEL_REGISTRY.register
+class LocatedAt(Relationship):
+    """Represent a relationship indicating that a Sector or an Orgnization is located at a Country.
+
+    Examples:
+        >>> from connectors_sdk.models.octi.knowledge.entities import Sector
+        >>> from connectors_sdk.models.octi.knowledge.locations import Country
+        >>> sector = Sector(name="Test Sector")
+        >>> country = Country(name="France")
+        >>> relationship = LocatedAt(source=sector, target=country)
+
+    """
+
+    _relationship_type: Literal["located-at"] = "located-at"
+
+    source: Organization | Sector = Field(
+        ...,
+        description="Reference to the source entity of the relationship. Here a Sector.",
+    )
+    target: Country = Field(
+        ...,
+        description="Reference to the target entity of the relationship. Here a Country.",
+    )
+
+
+located_at = LocatedAt._builder
 
 
 MODEL_REGISTRY.rebuild_all()
+
 if __name__ == "__main__":  # pragma: no cover # do not run coverage on doctests
     import doctest
 

--- a/connectors-sdk/tests/test_models/test_octi/test_api.py
+++ b/connectors-sdk/tests/test_models/test_octi/test_api.py
@@ -6,21 +6,27 @@ import inspect
 import connectors_sdk.models.octi as octi
 
 FEATURE_NAMES = [
-    "AnyRelatedToAny",
     "AssociatedFile",
+    "BasedOn",
     "BaseEntity",
+    "Country",
+    "DerivedFrom",
     "ExternalReference",
     "Indicator",
-    "IndicatorBasedOnObservable",
-    "IndicatorDerivedFromIndicator",
+    "IntrusionSet",
     "IPV4Address",
     "KillChainPhase",
+    "LocatedAt",
     "Organization",
     "OrganizationAuthor",
+    "RelatedTo",
+    "Sector",
+    "Targets",
     "TLPMarking",
-    "related_to",
     "based_on",
-    # When adding a new OCTI model or feature, add its name here
+    "located_at",
+    "related_to",
+    "targets",
 ]
 
 

--- a/connectors-sdk/tests/test_models/test_octi/test_relationships.py
+++ b/connectors-sdk/tests/test_models/test_octi/test_relationships.py
@@ -5,10 +5,13 @@ import stix2
 from connectors_sdk.models.octi._common import BaseIdentifiedEntity
 from connectors_sdk.models.octi.activities.observations import Indicator, Observable
 from connectors_sdk.models.octi.relationships import (
-    AnyRelatedToAny,
-    IndicatorBasedOnObservable,
-    IndicatorDerivedFromIndicator,
+    BasedOn,
+    DerivedFrom,
+    Indicates,
+    LocatedAt,
+    RelatedTo,
     Relationship,
+    Targets,
     based_on,
     related_to,
 )
@@ -16,9 +19,12 @@ from pydantic import create_model
 
 # Add the newly implemented relationship in this list
 IMPLEMENTED_RELATIONSHIPS = [
-    AnyRelatedToAny,
-    IndicatorBasedOnObservable,
-    IndicatorDerivedFromIndicator,
+    BasedOn,
+    DerivedFrom,
+    LocatedAt,
+    Indicates,
+    RelatedTo,
+    Targets,
 ]
 
 ### BASE RELATIONSHIP
@@ -101,20 +107,20 @@ def test_implemented_relationship_is_a_subclass_of_relationship(relationship_cls
 
 
 def test_any_related_to_any_can_use_pipe_syntax(fake_valid_organization_author):
-    """Test that AnyRelatedToAny can use pipe syntax."""
-    # Given the AnyRelatedToAny relationship class and a valid BaseIdentifiedEntity instance
+    """Test that RelatedTo can use pipe syntax."""
+    # Given the RelatedTo relationship class and a valid BaseIdentifiedEntity instance
     author = fake_valid_organization_author
     # When using the pipe syntax to create a relationship
     relationship = author | related_to | author
-    # Then it should return an instance of AnyRelatedToAny with the correct source and target
-    assert isinstance(relationship, AnyRelatedToAny)
+    # Then it should return an instance of RelatedTo with the correct source and target
+    assert isinstance(relationship, RelatedTo)
     assert relationship.source == author
     assert relationship.target == author
 
 
-def test_indicator_based_on_observable_can_use_pipe_syntax():
-    """Test that IndicatorBasedOnObservable can use pipe syntax."""
-    # Given the IndicatorBasedOnObservable relationship class and a Indicator and a valid Observable instance
+def test_based_on_can_use_pipe_syntax():
+    """Test that BasedOn can use pipe syntax."""
+    # Given the BasedOn relationship class and a Indicator and a valid Observable instance
     ind = create_model(
         "DummyIndicator",
         __base__=Indicator,
@@ -134,7 +140,7 @@ def test_indicator_based_on_observable_can_use_pipe_syntax():
     obs = DummyObservable()
     # When using the pipe syntax to create a relationship
     relationship = ind | based_on | obs
-    # Then it should return an instance of IndicatorBasedOnObservable with the correct source and target
-    assert isinstance(relationship, IndicatorBasedOnObservable)
+    # Then it should return an instance of BasedOn with the correct source and target
+    assert isinstance(relationship, BasedOn)
     assert relationship.source == ind
     assert relationship.target == obs


### PR DESCRIPTION
### Proposed changes

Added entities:
- Country
- Sector
- IntrusionSet

Added relationships:
- indicates
- targets
- located_at

Renamed relationships (to use same naming convention everywhere):
- related_to
- based_on
- derived_from


### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality


### Further comments

The naming convention of the relationships models is to discuss. IMO its depend whether we need to narrow down source/target types to only one model per relationship or not. cc @helene-nguyen  @Megafredo  @pdamoune @Kakudou  @Ninoxe 
