### PR TITLE
[Google TI Feeds] indicators in future

### DIFF
--- a/external-import/google-ti-feeds/README.md
+++ b/external-import/google-ti-feeds/README.md
@@ -1,5 +1,9 @@
 # Google Threat Intelligence Connector
 
+| Status            | Date       | Comment |
+| ----------------- |------------| ------- |
+| Filigran Verified | 2025-06-20 |    -    |
+
 ---
 
 ## Introduction

--- a/external-import/google-ti-feeds/connector/src/custom/configs/batch_processor_config.py
+++ b/external-import/google-ti-feeds/connector/src/custom/configs/batch_processor_config.py
@@ -105,7 +105,7 @@ def log_batch_completion(stix_objects: List[Any], work_id: str) -> None:
 
 BATCH_PROCESSOR_CONFIG = GenericBatchProcessorConfig(
     batch_size=500,
-    work_name_template="Google Threat Intel - Batch #{batch_num} (0/0 reports)",
+    work_name_template="Google Threat Intel - Batch #{batch_num} (~ 0/0 reports)",
     state_key="next_cursor_start_date",
     entity_type="stix_objects",
     display_name="STIX objects",

--- a/external-import/google-ti-feeds/connector/src/custom/mappers/gti_reports/gti_file_to_stix_file.py
+++ b/external-import/google-ti-feeds/connector/src/custom/mappers/gti_reports/gti_file_to_stix_file.py
@@ -62,6 +62,13 @@ class GTIFileToSTIXFile(BaseMapper):
         if self.file.attributes and self.file.attributes.size:
             file_size = self.file.attributes.size
 
+        ctime = None
+        if self.file.attributes:
+            if self.file.attributes.creation_date:
+                ctime = datetime.fromtimestamp(
+                    self.file.attributes.creation_date, tz=timezone.utc
+                )
+
         file_model = OctiFileModel.create(
             organization_id=self.organization.id,
             marking_ids=[self.tlp_marking.id],
@@ -70,6 +77,7 @@ class GTIFileToSTIXFile(BaseMapper):
             additional_names=additional_names,
             size=file_size,
             score=score,
+            ctime=ctime,
         )
 
         return file_model
@@ -158,13 +166,13 @@ class GTIFileToSTIXFile(BaseMapper):
         modified = datetime.now(timezone.utc)
 
         if self.file.attributes:
-            if self.file.attributes.creation_date:
+            if self.file.attributes.first_submission_date:
                 created = datetime.fromtimestamp(
-                    self.file.attributes.creation_date, tz=timezone.utc
+                    self.file.attributes.first_submission_date, tz=timezone.utc
                 )
-            if self.file.attributes.last_modification_date:
+            if self.file.attributes.last_submission_date:
                 modified = datetime.fromtimestamp(
-                    self.file.attributes.last_modification_date, tz=timezone.utc
+                    self.file.attributes.last_submission_date, tz=timezone.utc
                 )
 
         return {"created": created, "modified": modified}

--- a/external-import/google-ti-feeds/pyproject.toml
+++ b/external-import/google-ti-feeds/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "pydantic_settings ~=2.9.1",
     "python-dotenv ~=1.0.1",
     "stix2 ~=3.0.1",
-    "aiohttp ~=3.11.13",
     "isodate ~=0.7.2",
     "dotenv ~= 0.9.9",
 ]


### PR DESCRIPTION

### Proposed changes

GTI’s `creation-date` can sometimes point to the future/past trick pulled by malware authors to forge file timestamps, aiming to bypass SIEMs and other detection solutions.
While this timestamp is valuable for EDR, YARA, and other detection mechanisms, it's currently mapped to the wrong field in STIX 2.1.

I'm going to correct this based on the following mapping rules:

|        GTI Field        |   STIX 2.1 Mapping  |
| :---------------------: | :-----------------: |
|     `creation-date`     |   File SCO `ctime`  |
| `first_submission_date` | Indicator `created` |

And adding verified in readme + small increment bug in work name

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4201

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


### Further comments
After fix only the ctime on file is in the future, and not the creation date of the indicator.
![Screenshot 2025-06-27 113324](https://github.com/user-attachments/assets/628d6887-d319-4c58-9dc8-40a4832428b8)
![Screenshot 2025-06-27 113335](https://github.com/user-attachments/assets/2147669e-4994-4f8d-91ad-750c192a1e2f)

Work name increment and start well from zero on new run.
![Screenshot 2025-06-27 173416](https://github.com/user-attachments/assets/b7c35276-bb1a-4e45-b2ad-14db43130b9c)

