### PR TITLE
[TheHive] add comment

### DIFF
--- a/external-import/thehive/src/thehive.py
+++ b/external-import/thehive/src/thehive.py
@@ -124,9 +124,7 @@ class TheHive:
             self.severity_mapping[int(mapping.split(":")[0])] = mapping.split(":")[1]
 
         self.thehive_api = TheHiveApi(
-            self.thehive_url,
-            self.thehive_api_key,
-            verify=self.thehive_check_ssl
+            self.thehive_url, self.thehive_api_key, verify=self.thehive_check_ssl
         )
 
     def construct_query(self, type, last_date):


### PR DESCRIPTION
**Summary**
This PR adds support for importing case comments from TheHive into OpenCTI.

**Details**
Introduced a new method process_comments() that retrieves and processes all comments related to a TheHive case.
Each comment is converted into a STIX note object.
The notes are linked to the corresponding case using object_refs.
Handles edge cases where _createdAt is missing by falling back to case creation date or current timestamp.

Case comments in TheHive often contain useful context and investigation insights. Bringing them into OpenCTI helps improve collaboration and enriches case history.

**Impact**
This does not break existing functionality.
Controlled via the case import logic and fits into the existing connector structure.

### Related issue
- https://github.com/OpenCTI-Platform/connectors/issues/4543

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
