### PR TITLE
[Shodan InternetDB] Check TLP value to prevent KeyError message

### DIFF
--- a/internal-enrichment/shodan-internetdb/src/shodan_internetdb/config.py
+++ b/internal-enrichment/shodan-internetdb/src/shodan_internetdb/config.py
@@ -10,6 +10,8 @@ __all__ = [
     "ConfigConnector",
 ]
 
+TLP_MARKING_OPTIONS = ["TLP:WHITE", "TLP:GREEN", "TLP:AMBER", "TLP:RED", "TLP:CLEAR"]
+
 
 class ConfigConnector:
     def __init__(self) -> None:
@@ -20,6 +22,7 @@ class ConfigConnector:
         # Load configuration file
         self.load = self._load_config()
         self._initialize_configurations()
+        self._check_configuration()
 
     @staticmethod
     def _load_config() -> dict[str, Any]:
@@ -29,6 +32,16 @@ class ConfigConnector:
             if config_file_path.is_file()
             else {}
         )
+
+    def _check_configuration(self) -> None:
+        """
+        Run configuration additional checks not handled by get_config_variables function.
+        """
+        if self.shodan_max_tlp not in TLP_MARKING_OPTIONS:
+            raise ValueError(
+                "Incorrect value for configuration parameter 'max_tlp'. "
+                "Permitted values are: 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:RED' or 'TLP:CLEAR'"
+            )
 
     def _initialize_configurations(self) -> None:
         """

--- a/internal-enrichment/shodan-internetdb/src/shodan_internetdb/config.py
+++ b/internal-enrichment/shodan-internetdb/src/shodan_internetdb/config.py
@@ -10,7 +10,14 @@ __all__ = [
     "ConfigConnector",
 ]
 
-TLP_MARKING_OPTIONS = ["TLP:WHITE", "TLP:GREEN", "TLP:AMBER", "TLP:RED", "TLP:CLEAR"]
+TLP_MARKING_OPTIONS = [
+    "TLP:WHITE",
+    "TLP:GREEN",
+    "TLP:AMBER",
+    "TLP:RED",
+    "TLP:CLEAR",
+    "TLP:AMBER+STRICT",
+]
 
 
 class ConfigConnector:
@@ -40,7 +47,7 @@ class ConfigConnector:
         if self.shodan_max_tlp not in TLP_MARKING_OPTIONS:
             raise ValueError(
                 "Incorrect value for configuration parameter 'max_tlp'. "
-                "Permitted values are: 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:RED' or 'TLP:CLEAR'"
+                f"Permitted values are: {', '.join(TLP_MARKING_OPTIONS)}"
             )
 
     def _initialize_configurations(self) -> None:


### PR DESCRIPTION
### Proposed changes

* Add TLP validation in check_configuration for ConfigConnector to prevent KeyError 'WHITE'

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4239

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
