### PR TITLE
[Sekoia] Load `SEKOIA_LIMIT` env as integer

### DIFF
--- a/external-import/sekoia/README.md
+++ b/external-import/sekoia/README.md
@@ -5,7 +5,7 @@ Collect Sekoia.io CTI data in an existing OpenCTI instance for any operational p
 
 ## Prerequisites
 - An operational OpenCTI on-prem instance with administrator privileges or an OpenCTI Saas version
-- An active Sekoia CTI subscription (Sekoia Intelligence) : https://www.sekoia.io/en/product/cti/. If you want to test Sekoia CTI please contact : contact@sekoia.io 
+- An active Sekoia CTI subscription (Sekoia Intelligence) : https://www.sekoia.io/en/product/cti/. If you want to test Sekoia CTI please contact : contact@sekoia.io
 - [Creating a Sekoia.io API KEY](https://docs.sekoia.io/getting_started/manage_api_keys/) with the "View intelligence" premission (at least)
 
 ## OpenCTI on-prem version configuration
@@ -78,13 +78,13 @@ On this page, you can find the following information:
 2. Navigate the Sekoia Intelligence Feed
 Here are the elements of the Sekoia feed that can be found on OpenCTI after export:
 
-| **OpenCTI**    | 	**Sekoia.io** |
-|----------------|----------------|
-| Reports        | Threat-reports |
-| Observables    | Sightings      |
-| Malwares	      | Malwares       |
-| Intrusion Set	 | Intrusion-sets |
-| Indicators	    | Indicators     |
+| **OpenCTI**   | **Sekoia.io**  |
+|---------------|----------------|
+| Reports       | Threat-reports |
+| Observables   | Sightings      |
+| Malwares      | Malwares       |
+| Intrusion Set | Intrusion-sets |
+| Indicators    | Indicators     |
 
 ## Known behavior
 

--- a/external-import/sekoia/src/sekoia.py
+++ b/external-import/sekoia/src/sekoia.py
@@ -46,7 +46,13 @@ class Sekoia(object):
 
         self.base_url = self.get_config("base_url", config, "https://api.sekoia.io")
         self.start_date: str = self.get_config("start_date", config, None)
-        self.limit = self.get_config("limit", config, 200)
+        self.limit = get_config_variable(
+            "SEKOIA_LIMIT",
+            ["sekoia", "limit"],
+            config,
+            isNumber=True,
+            default=200,
+        )
         self.collection = self.get_config(
             "collection", config, "d6092c37-d8d7-45c3-8aff-c4dc26030608"
         )


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

The environment variable `SEKOIA_LIMIT` needs to be converted to an integer. Currently, using this variable will trigger an error: `if len(items) < self.limit:\nypeError: '<' not supported between instances of 'int' and 'str'` since the variable is loaded as a string.

### Proposed changes

* Load the environment variable `SEKOIA_LIMIT` using the function `get_config_variable` from `pycti` with the parameter `isNumber=True`.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4270

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
