### PR TITLE
Add initial version of Doppel external import connector

### DIFF
--- a/external-import/doppel/.dockerignore
+++ b/external-import/doppel/.dockerignore
@@ -1,0 +1,21 @@
+# Ignore compiled Python files and virtual env
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Ignore sample config
+src/config.yml.sample
+
+# Ignore logs (if created later)
+src/logs/
+*.log
+
+# Ignore virtual environments (if any)
+.venv/
+venv/
+
+# Git and editor-specific ignores
+.git/
+.gitignore
+*.swp

--- a/external-import/doppel/.gitignore
+++ b/external-import/doppel/.gitignore
@@ -1,0 +1,2 @@
+venv/
+src/config.yml

--- a/external-import/doppel/Dockerfile
+++ b/external-import/doppel/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-alpine
+ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
+
+# Set working directory and copy code
+WORKDIR /opt/doppel
+COPY src /opt/doppel
+
+# Install required OS packages and Python dependencies
+RUN apk update && apk upgrade && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Copy entrypoint and make executable
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/doppel/README.md
+++ b/external-import/doppel/README.md
@@ -1,0 +1,170 @@
+# OpenCTI Doppel Connector
+
+The Doppel connector integrates OpenCTI with the Doppel Threat Intelligence platform by ingesting alerts as STIX 2.1 Indicators.
+
+## Table of Contents
+
+- [OpenCTI Doppel Connector](#opencti-doppel-connector)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Installation](#installation)
+    - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenCTI environment variables](#opencti-environment-variables)
+    - [Base connector environment variables](#base-connector-environment-variables)
+    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
+
+## Introduction
+
+This connector fetches alerts from the Doppel API and imports them into OpenCTI as Indicators. Each alert is mapped to a STIX 2.1 Indicator object, enriched with metadata such as severity, entity state, platform, audit logs, etc.
+
+## Installation
+
+### Requirements
+
+- OpenCTI Platform version >= 6.x
+- Doppel API access (URL + API Key)
+
+## Configuration variables
+
+There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or in `config.yml` (for manual deployment).
+
+### OpenCTI environment variables
+
+| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
+|---------------|------------|-----------------------------|-----------|------------------------------------------------------|
+| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
+| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+
+### Base connector environment variables
+
+| Parameter             | config.yml        | Docker environment variable     | Default | Mandatory | Description                                                                              |
+|----------------------|-------------------|----------------------------------|---------|-----------|------------------------------------------------------------------------------------------|
+| Connector ID         | id                | `CONNECTOR_ID`                  |         | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
+| Connector Name       | name              | `CONNECTOR_NAME`                |         | Yes       | Name of the connector.                                                                   |
+| Connector Scope      | scope             | `CONNECTOR_SCOPE`               |         | Yes       | The scope or type of data the connector is importing (e.g., `Indicator`).                |
+| Log Level            | log_level         | `CONNECTOR_LOG_LEVEL`           | info    | No        | Determines the verbosity of logs: `debug`, `info`, `warn`, or `error`.                   |
+| Polling Interval     | duration_period   | `CONNECTOR_DURATION_PERIOD`     | PT1H    | Yes       | ISO-8601 interval string (e.g., `PT5M`, `PT1H`) for the polling schedule.                |
+| TLP Level            | tlp_level         | `CONNECTOR_TEMPLATE_TLP_LEVEL`  | clear   | No        | TLP marking for created STIX objects.                                                    |
+
+### Connector extra parameters environment variables
+
+| Parameter               | config.yml                      | Docker environment variable           | Default | Mandatory | Description                            |
+|------------------------|----------------------------------|----------------------------------------|---------|-----------|----------------------------------------|
+| API base URL           | connector_template.api_base_url | `CONNECTOR_TEMPLATE_API_BASE_URL`     |         | Yes       | Doppel API base URL                    |
+| API key                | connector_template.api_key      | `CONNECTOR_TEMPLATE_API_KEY`          |         | Yes       | Doppel API key                         |
+| Alerts endpoint        | doppel.alerts_endpoint          | `DOPPEL_ALERTS_ENDPOINT`              |         | Yes       | API endpoint for fetching alerts       |
+| Historical polling days| doppel.historical_polling_days  | `DOPPEL_HISTORICAL_POLLING_DAYS`      | 30      | No        | Days of data to fetch on first run     |
+| Max retries            | doppel.max_retries              | `DOPPEL_MAX_RETRIES`                  | 3       | No        | Retry attempts on API errors           |
+| Retry delay (seconds) | doppel.retry_delay              | `DOPPEL_RETRY_DELAY`                  | 30      | No        | Delay between retry attempts           |
+
+## Deployment
+
+### Docker Deployment
+
+1. Ensure `pycti` version in `requirements.txt` matches your OpenCTI version (e.g., `pycti==6.8.5`).
+
+2. Build Docker image:
+
+```bash
+docker build -t opencti/connector-doppel:6.7.4 .
+```
+
+3. Register connector in the **main** OpenCTI `docker-compose.yml`:
+
+```yaml
+  connector-doppel:
+    image: doppel-connector:latest
+    environment:
+      - OPENCTI_URL=http://opencti:8080
+      - OPENCTI_TOKEN=changeme
+      - CONNECTOR_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+      - CONNECTOR_NAME=Doppel Threat Intelligence
+      - CONNECTOR_SCOPE=Indicator
+      - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_DURATION_PERIOD=PT1H
+      - CONNECTOR_TEMPLATE_API_BASE_URL=https://api.doppel.com
+      - CONNECTOR_TEMPLATE_API_KEY=changeme
+      - DOPPEL_ALERTS_ENDPOINT=/v1/alerts
+      - DOPPEL_HISTORICAL_POLLING_DAYS=30
+      - DOPPEL_MAX_RETRIES=3
+      - DOPPEL_RETRY_DELAY=30
+      - CONNECTOR_TEMPLATE_TLP_LEVEL=green
+    restart: always
+```
+
+4. Start the connector:
+
+```bash
+docker compose up -d
+```
+
+> 🔁 Do not use the local `docker-compose.yml`. Always integrate the connector in OpenCTI’s main `docker-compose.yml`.
+
+### Manual Deployment
+
+1. Copy and configure `config.yml` from the provided `config.yml.sample`
+2. Install dependencies:
+
+```bash
+pip3 install -r requirements.txt
+```
+
+3. Start the connector:
+
+```bash
+python3 main.py
+```
+
+## Usage
+
+The connector runs automatically at the interval set by `duration_period`. You can also manually trigger it from:
+
+**OpenCTI → Data Management → Ingestion → Connectors**
+
+Find the connector, and click on the refresh button to reset the connector's state and force a new
+download of data by re-running the connector.
+
+## Behavior
+
+- Fetches alerts from Doppel API paginated by `last_activity_timestamp`
+- Converts each alert into a STIX 2.1 Indicator object
+- Bundles and sends the STIX objects to OpenCTI
+- Includes platform, score, brand, audit logs, notes, etc. as `custom_properties`
+- On first run, fetches up to `HISTORICAL_POLLING_DAYS`; subsequent runs are delta-based
+
+## Debugging
+
+Enable verbose logging by setting:
+
+```env
+CONNECTOR_LOG_LEVEL=debug
+```
+
+Log output includes:
+- API call details and retry behavior
+- Alert count fetched per run
+- STIX conversion trace per alert
+- Connector and bundle send status
+
+You can also use:
+
+```python
+self.helper.connector_logger.debug("message")
+```
+
+...for custom log messages.
+
+## Additional information
+
+- This connector strictly follows OpenCTI's standard STIX schema.
+- Only `Indicator` objects are created (no ObservedData or Incidents).
+- Custom properties like `x_opencti_brand`, `x_mitre_platforms`, `x_opencti_source` are preserved.
+- Supports safe reprocessing with unique `indicator_id` generation to avoid duplication.

--- a/external-import/doppel/docker-compose.yml
+++ b/external-import/doppel/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  connector-doppel:
+    image: opencti/connector-doppel:6.7.4
+    environment:
+      # OpenCTI connection
+      - OPENCTI_URL=http://opencti:8080
+      - OPENCTI_TOKEN=changeMe
+
+      # Connector required config
+      - CONNECTOR_ID=changeMe
+      - CONNECTOR_NAME=Doppel Threat Intelligence
+      - CONNECTOR_SCOPE=doppel
+      - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_DURATION_PERIOD=PT1H
+
+      # Connector template config
+      - CONNECTOR_TEMPLATE_API_BASE_URL=https://api.doppel.com/v1
+      - CONNECTOR_TEMPLATE_API_KEY=changeMe
+      - CONNECTOR_TEMPLATE_TLP_LEVEL=clear
+
+      # Doppel-specific config
+      - DOPPEL_ALERTS_ENDPOINT=/alerts
+      - DOPPEL_HISTORICAL_POLLING_DAYS=30
+      - DOPPEL_MAX_RETRIES=3
+      - DOPPEL_RETRY_DELAY=30
+
+    restart: always

--- a/external-import/doppel/entrypoint.sh
+++ b/external-import/doppel/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Ensure correct working directory
+cd /opt/doppel
+
+# Start the connector
+python3 main.py

--- a/external-import/doppel/src/config.yml.sample
+++ b/external-import/doppel/src/config.yml.sample
@@ -1,0 +1,22 @@
+opencti:
+  url: 'http://opencti:8080'
+  token: 'changeMe'
+
+connector:
+  id: 'changeMe'      # Valid UUIDv4
+  type: 'EXTERNAL_IMPORT'
+  name: 'Doppel Threat Intelligence'
+  scope: 'doppel'
+  log_level: 'info'
+  duration_period: 'PT1H'  # ISO-8601 format for 1 hour
+
+connector_template:
+  api_base_url: 'https://api.doppel.com/v1'
+  api_key: 'changeMe'
+  tlp_level: 'clear'  # Options: clear, white, green, amber, amber+strict, red
+
+doppel:
+  alerts_endpoint: '/alerts'
+  historical_polling_days: 30
+  max_retries: 3
+  retry_delay: 30

--- a/external-import/doppel/src/external_import_connector/__init__.py
+++ b/external-import/doppel/src/external_import_connector/__init__.py
@@ -1,0 +1,3 @@
+from .connector import DoppelConnector
+
+__all__ = ["DoppelConnector"]

--- a/external-import/doppel/src/external_import_connector/client_api.py
+++ b/external-import/doppel/src/external_import_connector/client_api.py
@@ -1,0 +1,57 @@
+import requests
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+
+class ConnectorClient:
+    def __init__(self, helper, config):
+        self.helper = helper
+        self.config = config
+
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"x-api-key": self.config.api_key, "accept": "application/json"}
+        )
+
+    @retry(wait=wait_fixed(5), stop=stop_after_attempt(3))  # Default fallback values
+    def _request_data(self, api_url, params=None):
+        try:
+            response = self.session.get(api_url, params=params)
+            self.helper.connector_logger.info("[API] Requesting data", {"url": api_url})
+            response.raise_for_status()
+            return response
+        except requests.HTTPError as http_err:
+            error_msg = ""
+            try:
+                error_json = http_err.response.json()
+                error_msg = error_json.get("message", http_err.response.text)
+            except Exception:
+                error_msg = http_err.response.text or str(http_err)
+
+            self.helper.connector_logger.error(
+                "[API] HTTP error during fetch",
+                {
+                    "url": api_url,
+                    "status_code": http_err.response.status_code,
+                    "error": error_msg,
+                },
+            )
+            raise
+        except requests.RequestException as err:
+            self.helper.connector_logger.error(
+                "[API] Request error during fetch",
+                {
+                    "url": api_url,
+                    "error": str(err),
+                },
+            )
+            raise
+
+    def get_alerts(self, last_activity_timestamp, page=0):
+        url = f"{self.config.api_base_url}{self.config.alerts_endpoint}"
+        params = {"last_activity_timestamp": last_activity_timestamp, "page": page}
+
+        # Dynamically set retry settings
+        self._request_data.retry.wait = wait_fixed(self.config.retry_delay)
+        self._request_data.retry.stop = stop_after_attempt(self.config.max_retries)
+
+        return self._request_data(url, params=params)

--- a/external-import/doppel/src/external_import_connector/config_loader.py
+++ b/external-import/doppel/src/external_import_connector/config_loader.py
@@ -1,0 +1,94 @@
+import os
+import re
+from pathlib import Path
+
+import yaml
+from pycti import get_config_variable
+
+
+class ConfigDoppel:
+    def __init__(self):
+        self.load = self._load_config()
+        self._initialize_configurations()
+
+    @staticmethod
+    def _load_config():
+        config_file_path = Path(__file__).parents[1].joinpath("config.yml")
+        if os.path.isfile(config_file_path):
+            with open(config_file_path, "r", encoding="utf-8") as file:
+                return yaml.safe_load(file) or {}
+        return {}
+
+    @staticmethod
+    def _validate_positive_int(value_str, field_name):
+        try:
+            value = int(value_str)
+            if value <= 0:
+                raise ValueError
+            return value
+        except Exception:
+            raise ValueError(
+                f"{field_name} must be a positive integer (greater than 0)"
+            )
+
+    @staticmethod
+    def _validate_iso8601_duration(value, field_name):
+        # Match format like PT30S, PT1M, PT1H, etc.
+        pattern = re.compile(r"^P(T(\d+H)?(\d+M)?(\d+S)?)?$")
+        if not pattern.match(value):
+            raise ValueError(
+                f"{field_name} must be a valid ISO 8601 duration format (e.g., PT30S, PT5M, PT1H)"
+            )
+        return value
+
+    def _initialize_configurations(self):
+        self.api_base_url = get_config_variable(
+            "CONNECTOR_TEMPLATE_API_BASE_URL",
+            ["connector_template", "api_base_url"],
+            self.load,
+        )
+
+        self.api_key = get_config_variable(
+            "CONNECTOR_TEMPLATE_API_KEY", ["connector_template", "api_key"], self.load
+        )
+
+        self.alerts_endpoint = get_config_variable(
+            "DOPPEL_ALERTS_ENDPOINT", ["doppel", "alerts_endpoint"], self.load
+        )
+
+        self.historical_days = self._validate_positive_int(
+            get_config_variable(
+                "DOPPEL_HISTORICAL_POLLING_DAYS",
+                ["doppel", "historical_polling_days"],
+                self.load,
+            ),
+            "DOPPEL_HISTORICAL_POLLING_DAYS",
+        )
+
+        self.duration_period = self._validate_iso8601_duration(
+            get_config_variable(
+                "CONNECTOR_DURATION_PERIOD", ["connector", "duration_period"], self.load
+            ),
+            "CONNECTOR_DURATION_PERIOD",
+        )
+
+        self.max_retries = self._validate_positive_int(
+            get_config_variable(
+                "DOPPEL_MAX_RETRIES", ["doppel", "max_retries"], self.load
+            ),
+            "DOPPEL_MAX_RETRIES",
+        )
+
+        self.retry_delay = self._validate_positive_int(
+            get_config_variable(
+                "DOPPEL_RETRY_DELAY", ["doppel", "retry_delay"], self.load
+            ),
+            "DOPPEL_RETRY_DELAY",
+        )
+
+        self.tlp_level = get_config_variable(
+            "CONNECTOR_TEMPLATE_TLP_LEVEL",
+            ["connector_template", "tlp_level"],
+            self.load,
+            default="clear",
+        )

--- a/external-import/doppel/src/external_import_connector/connector.py
+++ b/external-import/doppel/src/external_import_connector/connector.py
@@ -1,0 +1,56 @@
+from .client_api import ConnectorClient
+from .converter_to_stix import ConverterToStix
+from .utils import get_last_run, set_last_run
+
+
+class DoppelConnector:
+    def __init__(self, config, helper):
+        self.helper = helper
+        self.config = config
+        self.client = ConnectorClient(self.helper, self.config)
+        self.converter = ConverterToStix(self.helper, self.config)
+
+    def _collect_alerts(self):
+        last_timestamp = get_last_run(self.helper, self.config.historical_days)
+
+        all_alerts = []
+        page = 0
+        while True:
+            response = self.client.get_alerts(last_timestamp, page)
+            if not response:
+                break
+
+            alerts = response.json().get("alerts", [])
+            if not alerts:
+                break
+
+            all_alerts.extend(alerts)
+            page += 1
+
+        self.helper.connector_logger.info("Fetched alerts", {"count": len(all_alerts)})
+        return all_alerts
+
+    def process_message(self):
+        self.helper.connector_logger.info("[DoppelConnector] Running scheduled fetch")
+
+        try:
+            alerts = self._collect_alerts()
+            if alerts:
+                bundle = self.converter.convert_alerts_to_stix(alerts)
+                bundle_sent = self.helper.send_stix2_bundle(bundle)
+                self.helper.connector_logger.info(
+                    "STIX bundle sent", {"objects": len(bundle_sent)}
+                )
+                set_last_run(self.helper)
+        except Exception as err:
+            self.helper.connector_logger.error(
+                f"[DoppelConnector] Error in process_message: {str(err)}"
+            )
+            raise
+
+    def run(self):
+        self.helper.connector_logger.info("[DoppelConnector] Starting scheduler")
+        self.helper.schedule_iso(
+            message_callback=self.process_message,
+            duration_period=self.config.duration_period,
+        )

--- a/external-import/doppel/src/external_import_connector/converter_to_stix.py
+++ b/external-import/doppel/src/external_import_connector/converter_to_stix.py
@@ -1,0 +1,109 @@
+import json
+
+from pycti import Identity as PyCTIIdentity
+from pycti import Indicator as PyCTIIndicator
+from stix2 import Bundle, Identity, Indicator
+
+from .utils import parse_iso_datetime
+
+
+class ConverterToStix:
+    def __init__(self, helper, config):
+        self.helper = helper
+        self.config = config
+        self.author = self._create_identity()
+
+    def _create_identity(self):
+        return Identity(
+            id=PyCTIIdentity.generate_id(name="Doppel", identity_class="organization"),
+            name="Doppel",
+            identity_class="organization",
+            description="Threat Intelligence Provider",
+            allow_custom=True,
+        )
+
+    def convert_alerts_to_stix(self, alerts):
+        stix_objects = [self.author]
+        created_by_ref = self.author.id
+
+        for alert in alerts:
+            entity = alert.get("entity", "Unknown")
+            pattern = f"[entity:value ='{entity}']"
+            alert_id = alert.get("id", "unknown")
+
+            # Corrected: Removed invalid keyword argument `pattern_type`
+            indicator_id = PyCTIIndicator.generate_id(pattern=pattern)
+
+            self.helper.log_info(f"Processing alert ID: {alert_id}")
+
+            created_at = parse_iso_datetime(
+                alert.get("created_at", ""), "created_at", alert_id, self.helper
+            )
+            modified = parse_iso_datetime(
+                alert.get("last_activity_timestamp", ""),
+                "last_activity_timestamp",
+                alert_id,
+                self.helper,
+            )
+
+            audit_logs = alert.get("audit_logs", [])
+            audit_log_text = "\n".join(
+                [
+                    f"{log['timestamp']}: {log['type']} - {log['value']}"
+                    for log in audit_logs
+                ]
+            )
+
+            entity_content = alert.get("entity_content", {})
+            formatted_entity_content = json.dumps(entity_content, indent=2)
+            platform = alert.get("platform", "unknown")
+            platform_value = alert.get("product", "Unknown")
+
+            entity_state = alert.get("entity_state", "unknown")
+            queue_state = alert.get("queue_state", "unknown")
+            raw_severity = alert.get("severity", "unknown")
+            severity = f"{raw_severity} severity"
+
+            description = (
+                f"Platform: {platform},\n"
+                f"Entity State: {entity_state},\n"
+                f"Queue State: {queue_state},\n"
+                f"Severity: {severity},\n"
+                f"Entity Content:\n{formatted_entity_content}"
+            )
+
+            raw_score = alert.get("score")
+            try:
+                score = int(float(raw_score) * 100) if raw_score is not None else 0
+            except (ValueError, TypeError):
+                score = 0
+
+            indicator = Indicator(
+                id=indicator_id,
+                name=entity,
+                pattern=pattern,
+                pattern_type="stix",
+                description=description,
+                created=created_at,
+                modified=modified,
+                created_by_ref=created_by_ref,
+                external_references=[
+                    {
+                        "source_name": self.author.name,
+                        "url": alert.get("doppel_link"),
+                        "external_id": alert.get("id"),
+                    }
+                ],
+                custom_properties={
+                    "x_opencti_score": score,
+                    "x_opencti_brand": alert.get("brand", "Unknown"),
+                    "x_mitre_platforms": platform_value,
+                    "x_opencti_source": alert.get("source", "Unknown"),
+                    "x_opencti_notes": alert.get("notes", ""),
+                    "x_opencti_audit_logs": audit_log_text,
+                },
+                allow_custom=True,
+            )
+            stix_objects.append(indicator)
+
+        return Bundle(objects=stix_objects, allow_custom=True).serialize()

--- a/external-import/doppel/src/external_import_connector/utils.py
+++ b/external-import/doppel/src/external_import_connector/utils.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta, timezone
+
+
+def parse_iso_datetime(timestamp_str, field_name, alert_id, helper):
+    if not timestamp_str:
+        return ""
+    try:
+        return (
+            datetime.strptime(timestamp_str, "%Y-%m-%dT%H:%M:%S.%f").isoformat(
+                timespec="seconds"
+            )
+            + "Z"
+        )
+    except ValueError as e:
+        helper.log_error(f"[{alert_id}] Failed to parse '{field_name}': {e}")
+        return ""
+
+
+def get_last_run(helper, historical_days):
+    state = helper.get_state()
+    if state and "last_run" in state:
+        helper.log_info("Resuming from last run timestamp")
+        return state["last_run"]
+
+    default_start = datetime.now(timezone.utc) - timedelta(days=historical_days)
+    formatted = default_start.strftime("%Y-%m-%dT%H:%M:%S")
+    helper.log_info(
+        f"No previous state found. Using historical polling window: {formatted}"
+    )
+    return formatted
+
+
+def set_last_run(helper):
+    current_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    helper.set_state({"last_run": current_time})
+    helper.log_info(f"Updated last run timestamp to: {current_time}")

--- a/external-import/doppel/src/main.py
+++ b/external-import/doppel/src/main.py
@@ -1,0 +1,20 @@
+import traceback
+
+from external_import_connector.config_loader import ConfigDoppel
+from external_import_connector.connector import DoppelConnector
+from pycti import OpenCTIConnectorHelper
+
+if __name__ == "__main__":
+    try:
+        config = ConfigDoppel()
+        helper = OpenCTIConnectorHelper(config=config.load)
+        connector = DoppelConnector(config=config, helper=helper)
+        connector.run()
+
+    except ValueError as ve:
+        print(f"[Config Error] {ve}")
+        exit(1)
+
+    except Exception:
+        traceback.print_exc()
+        exit(1)

--- a/external-import/doppel/src/requirements.txt
+++ b/external-import/doppel/src/requirements.txt
@@ -1,0 +1,7 @@
+pycti==6.7.4              # OpenCTI Python client (latest stable)
+pyyaml~=6.0.2             # YAML config file support
+requests~=2.32.3          # HTTP requests
+stix2~=3.0.1              # STIX 2.1 object creation
+validators==0.35.0        # For domain/IP validation (used in converter)
+tenacity==8.2.3           # Retry logic (used in older implementation, optional now)
+python-dotenv==1.0.0 


### PR DESCRIPTION
**Summary**
This PR introduces a new Doppel Threat Intelligence Connector for OpenCTI. The connector pulls alerts from the Doppel API, transforms them into STIX 2.1 format, and sends the data to OpenCTI for further analysis and correlation.

**Features**

- Fetches alerts from Doppel based on a configurable created_after timestamp.
- Retries failed requests with configurable retry count and delay.
- Transforms Doppel alerts into STIX Indicators and bundles them with a source identity.
- Configurable via environment variables or config.yml.
- Batches and sends STIX bundles using OpenCTI’s asynchronous ingestion.