### PR TITLE
[connectors] Remove strict check of pip audit

### DIFF
--- a/connectors-sdk/tests/conftest.py
+++ b/connectors-sdk/tests/conftest.py
@@ -95,7 +95,7 @@ def pytest_sessionfinish(session, exitstatus):
         subprocess.run(  # noqa: S603
             [sys.executable, "-m", "pip_audit", "--skip-editable"],
             cwd=repo_root,
-            check=True,
+            check=False,
         )
     except subprocess.CalledProcessError as e:
         pytest.exit(f"Post-check failed: {e}", returncode=1)

--- a/external-import/tenable-security-center/tests/conftest.py
+++ b/external-import/tenable-security-center/tests/conftest.py
@@ -33,7 +33,7 @@ def pytest_sessionstart(session):
         subprocess.run(
             [sys.executable, "-m", "pip_audit", ".", "--strict"],
             cwd=repo_root,
-            check=True,
+            check=False,
         )
     except subprocess.CalledProcessError as e:
         pytest.exit(f"Pre-check failed: {e}", returncode=1)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove strict check of pip audit

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4325

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

`check=False` (safe default)
This will let the process run and print any pip-audit errors, but it won’t raise an exception or stop your script.
