### PR TITLE
[URLHausRecentPayloads] Add required API key authentication

### DIFF
--- a/external-import/urlhaus-recent-payloads/docker-compose.yml
+++ b/external-import/urlhaus-recent-payloads/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "CONNECTOR_NAME=URLhaus Recent Payloads"
       - CONNECTOR_LOG_LEVEL=error
       - URLHAUS_RECENT_PAYLOADS_API_URL=https://urlhaus-api.abuse.ch/v1/
+      - URLHAUS_RECENT_PAYLOADS_API_KEY=ChangeMe # Required, issued for free by URLHaus - https://urlhaus-api.abuse.ch/#auth_key
       - URLHAUS_RECENT_PAYLOADS_COOLDOWN_SECONDS=300 # Time to wait in seconds between subsequent requests
       - URLHAUS_RECENT_PAYLOADS_INCLUDE_FILETYPES=exe,dll,docm,docx,doc,xls,xlsx,xlsm,js,xll # (Optional) Only download files if any tag matches. (Comma separated)
       - URLHAUS_RECENT_PAYLOADS_INCLUDE_SIGNATURES= # (Optional) Only download files matching these Yara rules. (Comma separated)

--- a/external-import/urlhaus-recent-payloads/src/config.yml.sample
+++ b/external-import/urlhaus-recent-payloads/src/config.yml.sample
@@ -14,6 +14,7 @@ connector:
 
 urlhaus_recent_payloads:
   api_url: 'https://urlhaus-api.abuse.ch/v1/'
+  api_key: 'ChangeMe' # Required, issued for free by URLHaus - https://urlhaus-api.abuse.ch/#auth_key
   cooldown_seconds: 300 # Time to wait in seconds between subsequent requests
   include_filetypes: 'exe,zip,dll,docm,docx,doc,xls,xlsx,xlsm,js,xll' # (Optional) Only download files if file type matches. (Comma separated)
   include_signatures: '' # (Optional) Only download files if match these Yara rules. (Comma separated)

--- a/external-import/urlhaus-recent-payloads/src/urlhaus-recent-payloads.py
+++ b/external-import/urlhaus-recent-payloads/src/urlhaus-recent-payloads.py
@@ -36,6 +36,13 @@ class URLHausRecentPayloads:
             default="https://urlhaus-api.abuse.ch/v1/",
         )
 
+        self.api_key = get_config_variable(
+            "URLHAUS_RECENT_PAYLOADS_API_KEY",
+            ["urlhaus_recent_payloads", "api_key"],
+            config,
+            default="",
+        )
+
         self.cooldown_seconds = get_config_variable(
             "URLHAUS_RECENT_PAYLOADS_COOLDOWN_SECONDS",
             ["urlhaus_recent_payloads", "cooldown_seconds"],
@@ -264,7 +271,7 @@ class URLHausRecentPayloads:
         """
 
         url = self.api_url + "payloads/recent/"
-        resp = requests.get(url)
+        resp = requests.get(url, headers={"Auth-Key": self.api_key})
 
         # Handle the response data
 
@@ -279,7 +286,7 @@ class URLHausRecentPayloads:
         returns: a bytes object containing the contents of the file
         """
 
-        resp = requests.get(download_url)
+        resp = requests.get(download_url, headers={"Auth-Key": self.api_key})
         return resp.content
 
     def artifact_exists_opencti(self, sha256):


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add required auth key to URLHaus Recent Payloads connector.

### Related issues

* [4329](https://github.com/OpenCTI-Platform/connectors/issues/4329)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
