### PR TITLE
[CVE] Fix the connector exit(0) when in error

### DIFF
--- a/external-import/cve/src/main.py
+++ b/external-import/cve/src/main.py
@@ -1,6 +1,6 @@
 """OpenCTI CVE connector main module"""
 
-import time
+import traceback
 
 from connector import CVEConnector
 
@@ -11,7 +11,6 @@ if __name__ == "__main__":
     try:
         connector = CVEConnector()
         connector.run()
-    except Exception as err:
-        print(err)
-        time.sleep(10)
-        exit(0)
+    except Exception:
+        traceback.print_exc()
+        exit(1)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix the connector exit(0) when in error using traceback and exit(1)

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4230

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

  - traceback.print_exc(): This function prints the traceback of the exception to the standard error (stderr).
  The traceback includes information about the point in the program where the exception occurred,
  which is very useful for debugging purposes.

  - exit(1): effective way to terminate a Python program when an error is encountered.
  It signals to the operating system and any calling processes that the program did not complete successfully.