### PR TITLE
[Connectors] Issue/4344 conflict dependencies

### DIFF
--- a/external-import/email-intel-imap/src/base_connector/requirements.txt
+++ b/external-import/email-intel-imap/src/base_connector/requirements.txt
@@ -1,3 +1,3 @@
-pycti==6.7.7
+pycti==6.7.6
 pydantic~=2.11.3
 pydantic-settings==2.8.1

--- a/external-import/email-intel-imap/src/requirements.txt
+++ b/external-import/email-intel-imap/src/requirements.txt
@@ -1,10 +1,10 @@
 -r ./base_connector/requirements.txt
 imap-tools==1.11.0
-pycti==6.7.7
+pycti==6.7.6
 pydantic~=2.11.3
 google-api-python-client>=2.169.0
 google-api-core==2.25.0
 google-auth==2.40.3
-google-auth-oauthlib==1.2.2  # prefered to default one by google-auth 
+google-auth-oauthlib==1.2.2  # prefered to default one by google-auth
 google-auth-httplib2==0.2.0  # prefered to default one by google-auth see https://github.com/googleapis/google-auth-library-python-httplib2?tab=readme-ov-file#introduction
 stix2~=3.0.1

--- a/external-import/google-drive/src/requirements.txt
+++ b/external-import/google-drive/src/requirements.txt
@@ -1,3 +1,3 @@
-pycti==6.7.7
+pycti==6.7.6
 google-api-python-client==2.177.0
 google-auth==2.40.3

--- a/stream/chronicle/src/requirements.txt
+++ b/stream/chronicle/src/requirements.txt
@@ -1,4 +1,4 @@
-pycti==6.7.7
+pycti==6.7.6
 google==3.0.0
 google-auth==2.40.3
 google-api-core==2.25.0

--- a/stream/crowdstrike-endpoint-security/src/requirements.txt
+++ b/stream/crowdstrike-endpoint-security/src/requirements.txt
@@ -1,3 +1,3 @@
 pycti==6.7.7
-prometheus-client>=0.20.0,<=0.21.1
+prometheus-client>=0.20.0,<=0.22.1
 crowdstrike-falconpy==1.5.2

--- a/stream/google-secops-siem/src/requirements.txt
+++ b/stream/google-secops-siem/src/requirements.txt
@@ -1,2 +1,2 @@
-pycti==6.7.7
+pycti==6.7.6
 google-auth==2.40.3


### PR DESCRIPTION
based on the issue: https://github.com/OpenCTI-Platform/connectors/issues/4344

I have temporarily downgraded the following connectors to pycti==6.7.6 until the client-python PR is merged and dependencies are updated:
- stream_google-secops-siem
- stream_chronicle
- external-import_google-drive
- external-import_email-intel-imap

Regarding prometheus-client, I have updated the dependency constraint in the stream_crowdstrike-endpoint-security connector accordingly.