### PR TITLE
Update docker-compose.yml for missing connector- prefix in image name

### DIFF
--- a/external-import/montysecurity-c2-tracker/docker-compose.yml
+++ b/external-import/montysecurity-c2-tracker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   connector-c2tracker:
-    image: opencti/montysecurity-c2-tracker:6.7.7
+    image: opencti/connector-montysecurity-c2-tracker:6.7.7
     environment:
       - OPENCTI_URL=http://opencti:8080
       - OPENCTI_C2TRACKER_TOKEN=${OPENCTI_C2TRACKER_TOKEN}


### PR DESCRIPTION
Missing "connector-" prefix in image name to match image name on Docker Hub.

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add missing "connector-" prefix string to image-name in docker-compose.yaml to align with image-name on Docker Hub.

### Related issues

* Unrelated but this change allowed the image to pull ok but still has configuration errors (cant connect to OpenCTI API), although i'm still troubleshooting that.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
