### PR TITLE
[CVE] Fix Invalid ISO 8601 date/time format

### DIFF
--- a/external-import/cve/src/connector/cveConnector.py
+++ b/external-import/cve/src/connector/cveConnector.py
@@ -196,8 +196,8 @@ class CVEConnector:
         :return: Dict of CVE params
         """
         return {
-            "lastModStartDate": start_date.isoformat(),
-            "lastModEndDate": end_date.isoformat(),
+            "lastModStartDate": start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "lastModEndDate": end_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
 
     def process_data(self) -> None:


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change datetime format for CVE API parameters `lastModStartDate` and `lastModEndDate`

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4365

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Recommendations given in NVD documentation: https://nvd.nist.gov/developers/vulnerabilities#:~:text=lastModStartDate%20%26%20lastModEndDate
