### PR TITLE
[Microsoft sentinel incidents] Fix duplicate alert ingestion

### DIFF
--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
@@ -85,7 +85,7 @@ class ConverterToStix:
                 return "  \n"
 
         incident_name = alert.get("DisplayName")
-        incident_created_at = format_datetime(alert.get("TimeGenerated"))
+        incident_created_at = format_datetime(alert.get("StartTime"))
         incident_modified_at = format_datetime(alert.get("EndTime"))
         incident_labels = [alert.get("AlertType")] if alert.get("AlertType") else None
         incident_description = (


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change value of incident_created_at (used for generate_id) variable from TimeGenerated to StartTime

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4335

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
