### PR TITLE
[NIST CVE] Fixed error : Unknown component value ADJACENT_NETWORK for component AV

### DIFF
--- a/external-import/cve/src/services/converter/vulnerabilityToStix2.py
+++ b/external-import/cve/src/services/converter/vulnerabilityToStix2.py
@@ -87,6 +87,10 @@ class CVEConverter:
         # Getting metrics based on CVSS V3.1
         cvss_metrics = vulnerability["cve"]["metrics"]["cvssMetricV31"][0]["cvssData"]
         attack_vector = cvss_metrics["attackVector"]
+
+        if attack_vector == "ADJACENT_NETWORK" or attack_vector == "adjacent_network" :
+            attack_vector == "ADJACENT"
+        
         availability_impact = cvss_metrics["availabilityImpact"]
         base_score = cvss_metrics["baseScore"]
         base_severity = cvss_metrics["baseSeverity"]


### PR DESCRIPTION
Fixed bug in vulnerabilityToStix2.py that caused the error :

{'name': 'INTERNAL_SERVER_ERROR', 'error_message': 'Unknown component value ADJACENT_NETWORK for component AV'}

In OpenCTI, ADJACENT_NETWORK = ADJACENT

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* verify if the value of attack_vector is "ADJACENT_NETWORK" and replace it with ADJACENT

```
        if attack_vector == "ADJACENT_NETWORK" or attack_vector == "adjacent_network" :
            attack_vector == "ADJACENT"
```
