### PR TITLE
[crowdstrike] Skip unmanaged indicator types

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/importer.py
@@ -60,6 +60,10 @@ class BaseImporter(ABC):
         fmt_msg = msg.format(*args)
         self.helper.log_error(fmt_msg)
 
+    def _warning(self, msg: str, *args: Any) -> None:
+        fmt_msg = msg.format(*args)
+        self.helper.log_warning(fmt_msg)
+
     def _source_name(self) -> str:
         return self.author["name"]
 

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
@@ -205,7 +205,7 @@ class IndicatorImporter(BaseImporter):
 
         indicator_bundle = self._create_indicator_bundle(indicator)
         if indicator_bundle is None:
-            self._error("Discarding indicator {0} bundle", indicator["id"])
+            self._warning("Discarding indicator {0} bundle", indicator["id"])
             return False
 
         # with open(f"indicator_bundle_{indicator_bundle['id']}.json", "w") as f:
@@ -238,7 +238,11 @@ class IndicatorImporter(BaseImporter):
                 indicator_unwanted_labels=self.indicator_unwanted_labels,
             )
 
-            bundle_builder = IndicatorBundleBuilder(self.helper, bundle_builder_config)
+            try:
+                bundle_builder = IndicatorBundleBuilder(self.helper, bundle_builder_config)
+            except Exception as err:
+                self.helper.connector_logger.warning(f"Unable to process indicator value: {indicator['indicator']}, error: {err}")
+                return None
             indicator_bundle_built = bundle_builder.build()
             if indicator_bundle_built:
                 return indicator_bundle_built.get("indicator_bundle")


### PR DESCRIPTION
### Proposed changes

* Skip unmanaged indicator types

### Related issues
 
* https://github.com/OpenCTI-Platform/connectors/issues/4420
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
