### PR TITLE
[obstracts] use `show_only_my_feeds` to limit results muchdogesec/obs…

### DIFF
--- a/external-import/dogesec-obstracts/src/obstracts.py
+++ b/external-import/dogesec-obstracts/src/obstracts.py
@@ -51,8 +51,10 @@ class ObstractsConnector:
 
     def list_feeds(self):
         try:
-            feeds = self.retrieve("v1/feeds/", list_key="results", params=dict(show_only_my_feeds=True))
-            return [feed['obstract_feed_metadata'] for feed in feeds]
+            feeds = self.retrieve(
+                "v1/feeds/", list_key="results", params=dict(show_only_my_feeds=True)
+            )
+            return [feed["obstract_feed_metadata"] for feed in feeds]
         except Exception:
             self.helper.log_error("failed to fetch feeds")
         return []


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Match updated schema for feeds endpoint
* Use  `show_only_my_feeds` to limit results

### Related issues

* #4416 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
