### PR TITLE
[MicrosoftSentinelIncidents] Fix CaseIncidents ingestion

### DIFF
--- a/external-import/microsoft-defender-incidents/src/microsoft_defender_incidents_connector/converter_to_stix.py
+++ b/external-import/microsoft-defender-incidents/src/microsoft_defender_incidents_connector/converter_to_stix.py
@@ -160,15 +160,19 @@ class ConverterToStix:
             )
             return None
 
-        user_account = stix2.UserAccount(
-            account_login=user_account_dict.get("accountName"),
-            display_name=user_account_dict.get("displayName"),
-            object_marking_refs=[self.tlp_marking],
-            custom_properties={
-                "created_by_ref": self.author["id"],
-            },
-        )
-        return user_account
+        user_account_account_name = user_account_dict.get("accountName")
+        user_account_display_name = user_account_dict.get("displayName")
+        if user_account_account_name or user_account_display_name:
+            # stix2 lib does not check fields constraints (at least one field must be provided)
+            user_account = stix2.UserAccount(
+                account_login=user_account_account_name,
+                display_name=user_account_display_name,
+                object_marking_refs=[self.tlp_marking],
+                custom_properties={
+                    "created_by_ref": self.author["id"],
+                },
+            )
+            return user_account
 
     @handle_stix2_error
     def create_evidence_ipv4(self, evidence: dict) -> stix2.IPv4Address | None:

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/connector.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/connector.py
@@ -379,11 +379,6 @@ class MicrosoftSentinelIncidentsConnector:
                     "[CONNECTOR] Connector has never run..."
                 )
 
-            # Initiate a new work
-            work_id = self.helper.api.work.initiate_work(
-                self.helper.connect_id, self.helper.connect_name
-            )
-
             self.helper.connector_logger.info(
                 "[CONNECTOR] Running connector...",
                 {"connector_name": self.helper.connect_name},
@@ -401,6 +396,18 @@ class MicrosoftSentinelIncidentsConnector:
                 )
                 stix_objects.extend(incident_stix_objects)
                 last_incident_timestamp = format_date(incident["LastModifiedTime"])
+
+            if not incidents:
+                self.helper.connector_logger.info(
+                    f"{self.helper.connect_name} connector successfully run, no new data to send."
+                )
+                self._set_last_incident_date(last_incident_timestamp)
+                return
+
+            # Initiate a new work
+            work_id = self.helper.api.work.initiate_work(
+                self.helper.connect_id, self.helper.connect_name
+            )
 
             if stix_objects:
                 # Add author and default TLP marking for consistent bundle

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
@@ -197,14 +197,16 @@ class ConverterToStix:
         :param evidence: Evidence to create User Account from
         :return: User Account in STIX 2.1 format
         """
-        user_account = stix2.UserAccount(
-            account_login=evidence.get("Name"),
-            object_marking_refs=[self.tlp_marking],
-            custom_properties={
-                "created_by_ref": self.author["id"],
-            },
-        )
-        return user_account
+        if evidence.get("Name"):
+            # stix2 lib does not check fields constraints (at least one field must be provided)
+            user_account = stix2.UserAccount(
+                account_login=evidence.get("Name"),
+                object_marking_refs=[self.tlp_marking],
+                custom_properties={
+                    "created_by_ref": self.author["id"],
+                },
+            )
+            return user_account
 
     @handle_stix2_error
     def create_evidence_ipv4(self, evidence: dict) -> stix2.IPv4Address | None:


### PR DESCRIPTION
### Proposed changes

Microsoft Sentinel Incidents:
* merge same `CaseIncident` before creating a bundle (fix)
* do not init work if bundle is empty (best practice)
* do not create empty UserAccount

Microsoft Defender Incidents:
* do not init work if bundle is empty (best practice)
* do not create empty UserAccount

### Related issues

* #4220 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Seems to solve the issue with missing/inconsistent Incident responses' related entities on OCTI (to confirm)
