### PR TITLE
[RansomwareLive] Fix timezone error and remove useless code

### DIFF
--- a/external-import/ransomwarelive/src/ransomwarelive/ransom_conn.py
+++ b/external-import/ransomwarelive/src/ransomwarelive/ransom_conn.py
@@ -401,16 +401,6 @@ class RansomwareAPIConnector:
         bundles = []
         last_run_datetime = self.last_run_datetime_with_ingested_data or self.last_run
 
-        # Previous last_run was in seconds
-        if isinstance(last_run_datetime, int):
-            last_run_datetime = datetime.fromtimestamp(
-                last_run_datetime, tz=timezone.utc
-            )
-        elif isinstance(last_run_datetime, str):
-            last_run_datetime = datetime.strptime(
-                last_run_datetime, "%Y-%m-%dT%H:%M:%S%z"
-            )
-
         for item in response_json:
             created = datetime.strptime(
                 item.get("discovered"), "%Y-%m-%d %H:%M:%S.%f"
@@ -495,7 +485,9 @@ class RansomwareAPIConnector:
 
             if current_state and "last_run" in current_state:
                 if isinstance(current_state["last_run"], int):
-                    self.last_run = datetime.fromtimestamp(current_state["last_run"])
+                    self.last_run = datetime.fromtimestamp(
+                        current_state["last_run"]
+                    ).replace(tzinfo=timezone.utc)
                 else:
                     self.last_run = datetime.fromisoformat(current_state["last_run"])
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* If last_run is an int (line 487), it's from the previous version of the connector so we add to had timezone to prevent error
* Removed useless code in collect_intelligence

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4443

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
To test, run the [previous version of the connector ](https://github.com/OpenCTI-Platform/connectors/tree/fb8ff02a83b769a7a8c01c5252f584f44c2484ac/external-import/ransomwarelive)or simply add a set_state like `self.helper.set_state({"last_run":1754665431})` in line 483