### PR TITLE
[crowdstrike] set the default to ignore password and username types

### DIFF
--- a/external-import/crowdstrike/docker-compose.yml
+++ b/external-import/crowdstrike/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - CROWDSTRIKE_REPORT_TARGET_INDUSTRIES= # Can be used to retrieve only reports related to a sector
       - CROWDSTRIKE_REPORT_GUESS_MALWARE=false # Use report tags to guess malware
       - CROWDSTRIKE_INDICATOR_START_TIMESTAMP=0 # BEWARE! A lot of indicators!
-      - CROWDSTRIKE_INDICATOR_EXCLUDE_TYPES=hash_ion,hash_md5,hash_sha1
+      - CROWDSTRIKE_INDICATOR_EXCLUDE_TYPES=hash_ion,hash_md5,hash_sha1,password,username
       - CROWDSTRIKE_DEFAULT_X_OPENCTI_SCORE=50
       - CROWDSTRIKE_INDICATOR_LOW_SCORE=40
       - CROWDSTRIKE_INDICATOR_LOW_SCORE_LABELS=MaliciousConfidence/Low


### PR DESCRIPTION
These types are automatically included in the ingestion but seems to fail and the whole connector stops importing indicators. Since they aren't supported anyway, we might just ignore them here to avoid misbehaviours in user's instances.

### Proposed changes

* Add `username` and `password` to default indicator exclude types in `docker-compose.yml` file to skip them. They were being pulled by the connector and getting invalid type errors, causing the connector to stop importing other indicators.

### Related issues

* Closes #4847

### Checklist

- [X] I consider the submitted work as finished
- [X] I have signed my commits using GPG key.
- [X] I tested the code for its functionality using different use cases
- [X] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

### Further comments