### PR TITLE
[Silobreaker] Remove truncation that causes incomplete report content

### DIFF
--- a/external-import/silobreaker/src/silobreaker.py
+++ b/external-import/silobreaker/src/silobreaker.py
@@ -30,13 +30,6 @@ from pycti import (
 )
 
 
-def smart_truncate(content, length=100, suffix="..."):
-    if len(content) <= length:
-        return content
-    else:
-        return " ".join(content[: length + 1].split(" ")[0:-1]) + suffix
-
-
 class Silobreaker:
     def __init__(self):
         # Instantiate the connector helper from config
@@ -588,12 +581,8 @@ class Silobreaker:
                             )
                             objects.append(relationship_stix)
                 if len(objects) > 0:
-                    description = smart_truncate(
-                        self._convert_to_markdown(
-                            item["Extras"]["DocumentTeasers"]["HtmlSnippet"]
-                        ),
-                        200,
-                        "...",
+                    description = self._convert_to_markdown(
+                        item["Extras"]["DocumentTeasers"]["HtmlSnippet"]
                     )
                     content = item["Extras"]["DocumentTeasers"]["HtmlSnippet"]
                     if (
@@ -605,12 +594,8 @@ class Silobreaker:
                             .encode("utf-8")
                             .decode("utf-8")
                         )
-                        description = smart_truncate(
-                            self._convert_to_markdown(
-                                item["Extras"]["DocumentFullText"]["HtmlFullText"]
-                            ),
-                            200,
-                            "...",
+                        description = self._convert_to_markdown(
+                            item["Extras"]["DocumentFullText"]["HtmlFullText"]
                         )
                     file = None
                     if (


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove truncation method that truncate completely the report content

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4478

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Result before changes
<img width="662" height="392" alt="image" src="https://github.com/user-attachments/assets/3b316a18-3f64-403a-9018-31da0ea8df9b" />

After changes
<img width="657" height="672" alt="image" src="https://github.com/user-attachments/assets/eaba9858-a342-464d-a7f1-56d219701047" />

The code should be optimized as today, it can be pretty confusing:

- report name in OCTI is the Description from Silobreaker

https://github.com/OpenCTI-Platform/connectors/blob/5bf9055d182faaa14d16ff04fdf981556859e5ff/external-import/silobreaker/src/silobreaker.py#L631
<img width="559" height="166" alt="image" src="https://github.com/user-attachments/assets/917e7613-f4f3-4b3d-9155-9654266ff30e" />

- report description in OCTI takes the Document Full Text from Silobreaker
https://github.com/OpenCTI-Platform/connectors/blob/5bf9055d182faaa14d16ff04fdf981556859e5ff/external-import/silobreaker/src/silobreaker.py#L608
<img width="646" height="419" alt="image" src="https://github.com/user-attachments/assets/bd463b03-df87-401b-b18e-244f744e12de" />

I've created anissue for this purpose: https://github.com/OpenCTI-Platform/connectors/issues/4502