### PR TITLE
[VirusTotal] Raise if no SHA in the entity

### DIFF
--- a/internal-enrichment/virustotal/src/virustotal/virustotal.py
+++ b/internal-enrichment/virustotal/src/virustotal/virustotal.py
@@ -112,6 +112,9 @@ class VirusTotalConnector:
             return stix_entity["hashes"]["SHA-1"]
         if "hashes" in stix_entity and "MD5" in stix_entity["hashes"]:
             return stix_entity["hashes"]["MD5"]
+        raise ValueError(
+            "Unable to enrich the observable, the observable does not have an SHA256, SHA1, or MD5"
+        )
 
     def _retrieve_yara_ruleset(self, ruleset_id: str) -> dict:
         """


### PR DESCRIPTION
### Description

The issue occurred when a StixFile observable did not contain any hash values. The connector logic was designed to resolve files only based on their hashes (SHA-256, SHA-1, or MD5). As a result, when no hash was present, or when the API could not resolve the given hash, the connector returned a 404.

The fix improves this behavior by making the error message more explicit, clarifying that the lookup requires a hash and that files cannot be resolved by name alone. This ensures that users understand why the lookup failed and how to provide the correct data.

### Proposed changes

* Raise if the entity to enrich has no SHA

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4236

