### PR TITLE
[urlscan-enrichment] Silence 'no screenshot' warning when import_screenshot is disabled

### DIFF
--- a/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/client.py
+++ b/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/client.py
@@ -17,12 +17,16 @@ class UrlscanClient:
         helper: OpenCTIConnectorHelper,
         api_key: str | None,
         default_scan_visibility: Literal["public", "unlisted", "private"],
+        import_screenshot: bool = True,
     ):
         self.helper = helper
 
         self.base_url = "https://urlscan.io/api/v1/"
         self.api_key = api_key
         self.default_visibility = default_scan_visibility
+        # Skip the "no screenshot returned" warning when screenshot ingestion
+        # is disabled, since the absence of a screenshot is then expected.
+        self.import_screenshot = import_screenshot
         self.constants = UrlscanConstants
         # Define headers in session and update when needed
         headers = {"API-Key": self.api_key, "Content-Type": "application/json"}
@@ -154,7 +158,7 @@ class UrlscanClient:
                                 "response"
                             ]["dataLength"]
 
-                            if data_length == 0:
+                            if data_length == 0 and self.import_screenshot:
                                 self.helper.connector_logger.warning(
                                     "[API-RESULT] The request has been submitted to URLScan, "
                                     "but the URL does not return any screenshot."
@@ -173,7 +177,7 @@ class UrlscanClient:
             else:
                 result = response.json()
                 data_length = result["data"]["requests"][0]["response"]["dataLength"]
-                if data_length == 0:
+                if data_length == 0 and self.import_screenshot:
                     self.helper.connector_logger.warning(
                         "[API-RESULT] The request has been submitted to URLScan, "
                         "but the URL does not return any screenshot."

--- a/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/connector.py
+++ b/internal-enrichment/urlscan-enrichment/src/urlscan_enrichment_services/connector.py
@@ -21,6 +21,7 @@ class UrlscanConnector:
             self.helper,
             api_key=self.config.urlscan_enrichment.api_key.get_secret_value(),
             default_scan_visibility=self.config.urlscan_enrichment.visibility,
+            import_screenshot=self.config.urlscan_enrichment.import_screenshot,
         )
         self.converter = UrlscanConverter(
             self.helper,


### PR DESCRIPTION
### Proposed changes

* Stop emitting the `[API-RESULT] ... but the URL does not return any screenshot.` warning when the operator has explicitly disabled screenshot ingestion via `URLSCAN_ENRICHMENT_IMPORT_SCREENSHOT=false`. The absence of a screenshot is then expected and the warning is just noise.
* Pipe the existing Pydantic `bool` `urlscan_enrichment.import_screenshot` setting through to `UrlscanClient.__init__` (new `import_screenshot=` argument, defaulting to `True` for backward compatibility) and gate both warnings in `UrlscanClient.urlscan_result` on it.

### Related issues

* Closes #6391

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

PR rebased on top of current master (the connector layout moved from `config_variables.py` to a Pydantic `settings.py` in the meantime) and squashed into a single GPG-signed commit. Locally:

- `isort==6.0.1 --profile black` (clean)
- `black==25.1.0 --check` (clean)
- `flake8 --ignore=E,W` (clean)
- `pylint --disable=all --enable=no_generated_id_stix,no-value-for-parameter,unused-import` with the `linter_stix_id_generator` plugin → 10/10
- `pytest internal-enrichment/urlscan-enrichment/tests/` → 8 passed
