### PR TITLE
[composer] encode connectors logo in base64 in final manifest (#4627)

### DIFF
--- a/shared/tools/composer/generate_connectors_manifest.py
+++ b/shared/tools/composer/generate_connectors_manifest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import traceback
+import base64
 from pathlib import Path
 from typing import Generator
 
@@ -8,9 +9,9 @@ from typing import Generator
 __OPENCTI_CURRENT_VERSION__ = "rolling"
 __CONNECTOR_METADATA_DIRECTORY__ = "__metadata__"
 __CONNECTOR_MANIFEST_FILENAME__ = "connector_manifest.json"
+__CONNECTOR_LOGO_FILENAME__ = "logo.png"
 __CONNECTOR_CONFIG_JSON_SCHEMA_FILENAME__ = "connector_config_schema.json"
 __CATALOG_ID__ = "filigran-catalog-id"
-
 
 class ManifestGenerator:
     @staticmethod
@@ -38,33 +39,67 @@ class ManifestGenerator:
                         connector_config_json_schema_file_path,
                     )
 
+    def encode_logo_to_base64(self, logo_path: str) -> str:
+        """
+        Read logo file and encode it to base64 string
+        """
+        try:
+            with open(logo_path, "rb") as logo_file:
+                logo_data = logo_file.read()
+                # Get file extension to determine MIME type
+                file_ext = os.path.splitext(logo_path)[1].lower()
+                mime_type = {
+                    '.png': 'image/png',
+                    '.jpg': 'image/jpeg',
+                    '.jpeg': 'image/jpeg',
+                    '.gif': 'image/gif',
+                    '.svg': 'image/svg+xml'
+                }.get(file_ext, 'image/png')  # default to png
+
+                # Encode to base64 and create data URL
+                encoded_logo = base64.b64encode(logo_data).decode('utf-8')
+                return f"data:{mime_type};base64,{encoded_logo}"
+        except Exception as e:
+            print(f"Warning: Could not encode logo {logo_path}: {e}")
+            return None
+
     def get_connectors_contracts(self):
         contracts = []
-
         for __metadata___files_paths in self.get_connector___metadata___files_path():
             manifest_file_path, config_json_schema_file_path = __metadata___files_paths
-
             connector_manifest = None
             connector_config_json_schema = None
-
             if manifest_file_path:
                 with open(manifest_file_path, encoding="utf-8") as file:
                     connector_manifest = json.load(file)
             else:
                 continue  # skip connectors without connector_manifest.json
-
             if config_json_schema_file_path:
                 with open(config_json_schema_file_path, encoding="utf-8") as file:
                     connector_config_json_schema = json.load(file)
 
+            # if a logo is provided, encode it in base64 and add it to the manifest
+            if connector_manifest and "logo" in connector_manifest:
+                metadata_dir = os.path.dirname(manifest_file_path)
+                logo_path = os.path.join(metadata_dir, __CONNECTOR_LOGO_FILENAME__)
+                if os.path.exists(logo_path):
+                    encoded_logo = self.encode_logo_to_base64(logo_path)
+                    if encoded_logo:
+                        connector_manifest.update(
+                            {"logo": encoded_logo }
+                        )
+                    else:
+                        print(f"Warning: Logo for connector [{connector_manifest["title"]}] could not be encoded")
+                else:
+                    print(f"Warning: Logo file for connector [{connector_manifest["title"]}] not found")
+
+            print(f"New contract added for [{connector_manifest["title"]}]")
             connector_contract = connector_manifest
             if connector_config_json_schema:
                 connector_contract.update(
                     {"config_schema": connector_config_json_schema}
                 )
-
             contracts.append(connector_contract)
-
         return contracts
 
     def generate_manifest(self):
@@ -76,14 +111,12 @@ class ManifestGenerator:
             "version": __OPENCTI_CURRENT_VERSION__,
             "contracts": self.get_connectors_contracts(),
         }
-
         # Write and add manifest file in root
         connector_root_path = Path(__file__).parents[3]
         manifest_path = os.path.join(connector_root_path, "manifest.json")
         with open(manifest_path, "w", encoding="utf-8") as manifest_file:
             manifest_json = json.dumps(manifest, indent=2)
             manifest_file.write(manifest_json)
-
 
 if __name__ == "__main__":
     """

--- a/shared/tools/composer/generate_connectors_manifest.py
+++ b/shared/tools/composer/generate_connectors_manifest.py
@@ -1,7 +1,7 @@
+import base64
 import json
 import os
 import traceback
-import base64
 from pathlib import Path
 from typing import Generator
 


### PR DESCRIPTION
If a `logo.png` file is present in the metadata folder of a connector, when generating the catalogue manifest it will be encoded in base64 and put as "logo" field for this connector. 