### PR TITLE
[ransomware live] Disable raise_for_status to prevent dns crashes

### DIFF
--- a/external-import/ransomwarelive/src/ransomwarelive/utils.py
+++ b/external-import/ransomwarelive/src/ransomwarelive/utils.py
@@ -103,7 +103,11 @@ def ip_fetcher(domain: str):
         params=params,
         timeout=(20000, 20000),
     )
-    response.raise_for_status()
+    # response.raise_for_status()
+    # Google DNS does not take into account characters with accents.
+    # In this case, a status_code = 400 is raise and stop all the process.
+    # In a first step, we disable raise_for_status
+    # Then we will search to another management instead of dns google
 
     if response.status_code == 200:
         response_json = response.json()


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Disable raise_for_status on call for dns.google/resolve

### Related issues

* github.com/OpenCTI-Platform/connectors/issues/4652

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
