### PR TITLE
Fixed issue in misp-feed that prevented import from S3 bucket

### DIFF
--- a/external-import/misp-feed/src/misp-feed.py
+++ b/external-import/misp-feed/src/misp-feed.py
@@ -2092,11 +2092,14 @@ class MispFeed:
                 else:
                     objects = self.s3.objects.all()
 
+                number_events = 0
+                file_name = None
                 for obj in objects:
                     try:
                         file_name = obj.key.split("/")[-1]
                         self.s3.download_file(obj.key, file_name)
                         events = json.load(open(file_name, "r"))
+                        number_events += len(events)
                         bundle = self._process_event(events)
                         self._send_bundle(work_id, bundle)
                         self.s3.Object(obj.key).delete()
@@ -2106,6 +2109,14 @@ class MispFeed:
 
                     except Exception as e:
                         self.helper.log_error(str(e))
+
+                message = (
+                    "Connector successfully run ("
+                    + str(number_events)
+                    + " events have been processed), storing state (last_file="
+                    + str(file_name)
+                    + ")"
+                )
 
             if self.source_type == "url":
                 if (


### PR DESCRIPTION
### Proposed changes

* Add a log message if misp-feed connector is ran in "s3" mode (as opposed to "url")

### Related issues

There is a bug in misp-feed connector that makes it unable to work if MISP_FEED_SOURCE_TYPE is set to "s3" : on line 2224, a message is logged, but this message is not present in the "s3" processing block.

This PR adds the message in this block – with some informative data – so that the connector does not fail.

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality