### PR TITLE
[composer] Fix Parsing configuration error

### DIFF
--- a/external-import/cisa-known-exploited-vulnerabilities/src/models/configs/base_settings.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/models/configs/base_settings.py
@@ -11,6 +11,7 @@ class ConfigBaseSettings(BaseSettings):
         str_strip_whitespace=True,
         str_min_length=1,
         extra="allow",
+        enable_decoding=False,
         # Allow both alias and field name for input
         validate_by_name=True,
         validate_by_alias=True,

--- a/external-import/cve/src/models/configs/base_settings.py
+++ b/external-import/cve/src/models/configs/base_settings.py
@@ -11,6 +11,7 @@ class ConfigBaseSettings(BaseSettings):
         str_strip_whitespace=True,
         str_min_length=1,
         extra="allow",
+        enable_decoding=False,
         # Allow both alias and field name for input
         validate_by_name=True,
         validate_by_alias=True,

--- a/external-import/greynoise-feed/src/connector/config_loader.py
+++ b/external-import/greynoise-feed/src/connector/config_loader.py
@@ -7,9 +7,7 @@ from typing import Annotated, Literal, Optional
 import __main__
 from pydantic import (
     AliasChoices,
-    BaseModel,
     BeforeValidator,
-    ConfigDict,
     Field,
     HttpUrl,
     PlainSerializer,
@@ -119,15 +117,20 @@ DatetimeFromIsoString = Annotated[
 ]
 
 
-class ConfigBaseModel(BaseModel):
-    """
-    Base class for frozen config models, i.e. not alter-able after `model_post_init()`.
-    """
+class ConfigBaseModel(BaseSettings):
+    """Base class for global config models. To prevent attributes from being modified after initialization."""
 
-    model_config = ConfigDict(
-        extra="allow",
-        validate_default=True,
+    model_config = SettingsConfigDict(
+        env_nested_delimiter="_",
+        env_nested_max_split=1,
         frozen=True,
+        str_strip_whitespace=True,
+        str_min_length=1,
+        extra="allow",
+        enable_decoding=False,
+        # Allow both alias and field name for input
+        validate_by_name=True,
+        validate_by_alias=True,
     )
 
 

--- a/external-import/mitre/src/models/configs/base_settings.py
+++ b/external-import/mitre/src/models/configs/base_settings.py
@@ -11,6 +11,7 @@ class ConfigBaseSettings(BaseSettings):
         str_strip_whitespace=True,
         str_min_length=1,
         extra="allow",
+        enable_decoding=False,
         # Allow both alias and field name for input
         validate_by_name=True,
         validate_by_alias=True,

--- a/external-import/ransomwarelive/src/models/configs/base_settings.py
+++ b/external-import/ransomwarelive/src/models/configs/base_settings.py
@@ -11,6 +11,7 @@ class ConfigBaseSettings(BaseSettings):
         str_strip_whitespace=True,
         str_min_length=1,
         extra="allow",
+        enable_decoding=False,
         # Allow both alias and field name for input
         validate_by_name=True,
         validate_by_alias=True,

--- a/external-import/sekoia/src/connector/models/configs/base_settings.py
+++ b/external-import/sekoia/src/connector/models/configs/base_settings.py
@@ -11,6 +11,7 @@ class ConfigBaseSettings(BaseSettings):
         str_strip_whitespace=True,
         str_min_length=1,
         extra="allow",
+        enable_decoding=False,
         # Allow both alias and field name for input
         validate_by_name=True,
         validate_by_alias=True,

--- a/external-import/threatfox/src/models/configs/base_settings.py
+++ b/external-import/threatfox/src/models/configs/base_settings.py
@@ -11,6 +11,7 @@ class ConfigBaseSettings(BaseSettings):
         str_strip_whitespace=True,
         str_min_length=1,
         extra="allow",
+        enable_decoding=False,
         # Allow both alias and field name for input
         validate_by_name=True,
         validate_by_alias=True,

--- a/internal-enrichment/abuseipdb/src/connector/models/configs/base_settings.py
+++ b/internal-enrichment/abuseipdb/src/connector/models/configs/base_settings.py
@@ -11,6 +11,7 @@ class ConfigBaseSettings(BaseSettings):
         str_strip_whitespace=True,
         str_min_length=1,
         extra="allow",
+        enable_decoding=False,
         # Allow both alias and field name for input
         validate_by_name=True,
         validate_by_alias=True,

--- a/internal-enrichment/google-dns/src/models/configs/base_settings.py
+++ b/internal-enrichment/google-dns/src/models/configs/base_settings.py
@@ -11,6 +11,7 @@ class ConfigBaseSettings(BaseSettings):
         str_strip_whitespace=True,
         str_min_length=1,
         extra="allow",
+        enable_decoding=False,
         # Allow both alias and field name for input
         validate_by_name=True,
         validate_by_alias=True,

--- a/internal-enrichment/hygiene/src/connector/models/configs/base_settings.py
+++ b/internal-enrichment/hygiene/src/connector/models/configs/base_settings.py
@@ -11,6 +11,7 @@ class ConfigBaseSettings(BaseSettings):
         str_strip_whitespace=True,
         str_min_length=1,
         extra="allow",
+        enable_decoding=False,
         # Allow both alias and field name for input
         validate_by_name=True,
         validate_by_alias=True,

--- a/internal-enrichment/ipinfo/src/models/configs/base_settings.py
+++ b/internal-enrichment/ipinfo/src/models/configs/base_settings.py
@@ -11,6 +11,7 @@ class ConfigBaseSettings(BaseSettings):
         str_strip_whitespace=True,
         str_min_length=1,
         extra="allow",
+        enable_decoding=False,
         # Allow both alias and field name for input
         validate_by_name=True,
         validate_by_alias=True,

--- a/internal-enrichment/virustotal-downloader/src/connector/models/configs/base_settings.py
+++ b/internal-enrichment/virustotal-downloader/src/connector/models/configs/base_settings.py
@@ -11,6 +11,7 @@ class ConfigBaseSettings(BaseSettings):
         str_strip_whitespace=True,
         str_min_length=1,
         extra="allow",
+        enable_decoding=False,
         # Allow both alias and field name for input
         validate_by_name=True,
         validate_by_alias=True,


### PR DESCRIPTION
### Proposed changes

* Having a custom Field like ListFromString, needs to have the pydantic property enable_decoding=False in order to have the custom serializers instead of the default

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4741

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
