### PR TITLE
[CircleCI] build_manifest on diff with origin/master instead forked master in PR

### DIFF
--- a/external-import/threatfox/src/.env.sample
+++ b/external-import/threatfox/src/.env.sample
@@ -1,3 +1,3 @@
 # OpenCTI configuration
 OPENCTI_URL=http://opencti:8080
-OPENCTI_TOKEN=ChangeMe
+OPENCTI_TOKEN=ChangeM

--- a/external-import/threatfox/src/.env.sample
+++ b/external-import/threatfox/src/.env.sample
@@ -1,3 +1,3 @@
 # OpenCTI configuration
 OPENCTI_URL=http://opencti:8080
-OPENCTI_TOKEN=ChangeM
+OPENCTI_TOKEN=ChangeMe

--- a/shared/tools/composer/generate_connectors_config_json_schemas.sh
+++ b/shared/tools/composer/generate_connectors_config_json_schemas.sh
@@ -70,7 +70,7 @@ do
     if [ "$CIRCLE_BRANCH" = "master" ]; then
       directory_has_changed=$(git diff HEAD~1 HEAD -- "$connector_directory_path")
     else
-      directory_has_changed=$(git diff origin/master "$connector_directory_path")
+      directory_has_changed=$(git diff $(git merge-base master HEAD) HEAD "$connector_directory_path")
     fi
 
     if [ -z "$directory_has_changed" ] ; then


### PR DESCRIPTION
When opening a pull request, the CI job build_manifest is started on connectors that have changes from the branch to origin/master regarding if the branch is rebased or no.

This induce the generation of connectors manifest that haven't been changed in the scope the PR.

- This PR is based from the last commit of the 12th of september https://github.com/OpenCTI-Platform/connectors/commit/f2d5e09126949a08edc81fc38931e424f99e263f
- The git diff with origin/master at the time includes a lot of connectors :
<img width="288" height="456" alt="image" src="https://github.com/user-attachments/assets/4a38fd9b-40b0-4dda-98c0-e55467a64d38" />

### Proposed changes

* First commit simulate today's behavior. The CI run the build_manifest on the diff from the branch to `origin/master`
<img width="1612" height="599" alt="image" src="https://github.com/user-attachments/assets/cd6a7aaf-8f16-498b-b306-d61254fde079" />

**5min59s**

https://app.circleci.com/pipelines/github/OpenCTI-Platform/connectors/11869/workflows/7a23e58b-d0d1-4f7c-8bea-8258bea3072e/jobs/208597

* 2nd commit is the CI fix, and run on the threat fox "modification"
<img width="1612" height="599" alt="image" src="https://github.com/user-attachments/assets/a7065ba3-e354-4341-9792-e4ff4dbb2f31" />

**22s**

https://app.circleci.com/pipelines/github/OpenCTI-Platform/connectors/11870/workflows/3d318d98-cbf0-4646-865a-8c90a7fd66c6/jobs/208602

* 3rd commit is the removal of the simulation and no run of build_manifest
<img width="1616" height="595" alt="image" src="https://github.com/user-attachments/assets/887e339b-2332-414a-acac-30bf7f5327ad" />

**0s**

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4766

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
