### PR TITLE
[GithubAction] Fix auto set filigran team label & auto assign pull request

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,15 @@
+# .github/workflows/auto-author-assign.yml
+name: Auto Author Assign
+
+on:
+  pull_request:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.1

--- a/.github/workflows/auto-set-labels.yml
+++ b/.github/workflows/auto-set-labels.yml
@@ -3,6 +3,9 @@ on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Setting labels


### PR DESCRIPTION
### Proposed changes

* fix: Add required permission in the github action to add labels on PRs (cf: https://github.com/OpenCTI-Platform/opencti/pull/12460)
* feat: Add auto author assignation on PR creation

<img width="412" height="82" alt="image" src="https://github.com/user-attachments/assets/e6a4de0e-10d6-482a-a244-2bbb6d87f4e2" />


### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4772

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
