### PR TITLE
[misp] Fix attribute labels propagation (#4532)

### DIFF
--- a/external-import/misp/src/connector/use_cases/convert_attribute.py
+++ b/external-import/misp/src/connector/use_cases/convert_attribute.py
@@ -520,8 +520,15 @@ class AttributeConverter:
         if is_external_reference or is_attachment:
             return stix_objects
 
-        # Extract STIX indicator's metadata from MISP event's attribute's tag
-        attribute_labels = labels
+        # Extract STIX indicator's metadata from MISP event's attribute's tag.
+        # ``labels`` is owned by the caller (the event converter passes a
+        # ``deepcopy(event_labels)`` per attribute, but the object converter
+        # forwards its own list verbatim). Without making a fresh copy here,
+        # ``attribute_labels.append(label)`` below would mutate the caller's
+        # list, which causes attribute-level tags to bleed into every
+        # subsequent attribute / object processed in the same event
+        # (see OpenCTI-Platform/connectors#4532).
+        attribute_labels = list(labels)
         attribute_markings = []
 
         for tag in attribute.Tag or []:

--- a/external-import/misp/tests/tests_connector/test_attribute_converter.py
+++ b/external-import/misp/tests/tests_connector/test_attribute_converter.py
@@ -1,5 +1,10 @@
 import stix2
-from api_client.models import AttributeCategory, AttributeType, ExtendedAttributeItem
+from api_client.models import (
+    AttributeCategory,
+    AttributeType,
+    ExtendedAttributeItem,
+    TagItem,
+)
 from connector.use_cases.common import ConverterConfig
 from connector.use_cases.convert_attribute import AttributeConverter
 
@@ -49,3 +54,43 @@ class TestThreatActorAttributionConversion:
         intrusion_sets = [obj for obj in result if isinstance(obj, stix2.IntrusionSet)]
         assert len(intrusion_sets) == 1
         assert intrusion_sets[0]["name"] == "APT28"
+
+
+class TestLabelsPropagation:
+    """Regression tests for the label-propagation fix (#4532)."""
+
+    def test_process_does_not_mutate_caller_labels(self):
+        """``AttributeConverter.process`` must never mutate its caller's list.
+
+        Regression test for OpenCTI-Platform/connectors#4532: the previous
+        implementation aliased the caller's ``labels`` list as
+        ``attribute_labels`` and ``append``-ed the attribute tags to it,
+        which made tags bleed into every subsequent attribute / object
+        processed in the same event.
+        """
+        config = _make_config()
+        converter = AttributeConverter(config)
+        author = _make_author()
+        attribute = ExtendedAttributeItem(
+            type=AttributeType.domain,
+            category=AttributeCategory.Network_activity,
+            value="foo.bar",
+            comment="",
+            Tag=[TagItem(name="phishing")],
+        )
+
+        shared_labels = ["tlp:clear", "campaign:Alpha"]
+        snapshot_before = list(shared_labels)
+
+        converter.process(
+            attribute,
+            labels=shared_labels,
+            score=50,
+            author=author,
+            markings=[],
+            external_references=[],
+        )
+
+        # The caller's list must be untouched. ``snapshot_before`` is the
+        # exact same content as ``shared_labels`` had at call time.
+        assert shared_labels == snapshot_before


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project!
-->

### Proposed changes

Fixes the long-standing tag/label cross-attribute bleed in the MISP connector reported as [#4532](https://github.com/OpenCTI-Platform/connectors/issues/4532).

`AttributeConverter.process` aliased the caller's `labels` list as `attribute_labels` and then `append`-ed each MISP attribute's own tags to it. Because the MISP-Object processor forwards the same list to `AttributeConverter.process` for every attribute it contains, the shared list accumulates the union of every previous attribute's tags and OpenCTI ends up merging that bag onto each observable / indicator. The symptom reported in #4532:

```
event tags: tlp:clear, campaign:Alpha
attribute domain foo.bar (tag phishing)
attribute ip 1.2.3.4 (tag c2)
```

leaves `foo.bar` labelled `[phishing, c2, tlp:clear, campaign:Alpha]` instead of the documented `[phishing]`.

### Why this rebase

The PR was originally written against the legacy monolithic `external-import/misp/src/misp.py`. That file has been refactored away on master into `external-import/misp/src/connector/use_cases/` modules, so the patch needs to be applied to the new `convert_attribute.py`. The event converter already calls `deepcopy(event_labels)` once per attribute, so the event -> attribute hop is safe, but the bug remains in the object -> attribute hop where `ObjectConverter.process` passes its own `labels` argument verbatim.

### Fix

Take a `list(labels)` copy inside `AttributeConverter.process` before any `.append` happens, so the converter never mutates the caller's list regardless of how labels were plumbed in. The minimal, defensive fix at the leaf is preferable to fixing every call-site, and the comment documents the contract for future maintainers.

A regression test (`TestLabelsPropagation::test_process_does_not_mutate_caller_labels` under `external-import/misp/tests/tests_connector/test_attribute_converter.py`) is added to lock the behaviour in.

Closes [#4532](https://github.com/OpenCTI-Platform/connectors/issues/4532).

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation
- [x] Where necessary I refactored code to improve the overall quality