### PR TITLE
[ci] Add root pyproject.toml so isort behaves identically from any working directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,27 @@
 #
 # Pinning ``src_paths`` here keeps ``isort`` output identical no matter
 # whether the command is invoked from the repository root, from a
-# connector subdirectory, or via the pre-commit hook. Without this file
-# ``isort`` resolves first-party imports relative to its current working
-# directory, so the same file ends up with a different ordering
-# depending on where the contributor (or CI) happens to run from.
-# See OpenCTI-Platform/connectors#4798 for the original bug report.
+# connector subdirectory that does **not** ship its own
+# ``[tool.isort]`` section, or via the pre-commit hook. Without this
+# file ``isort`` resolves first-party imports relative to its current
+# working directory, so the same file ends up with a different
+# ordering depending on where the contributor (or CI) happens to run
+# from. See OpenCTI-Platform/connectors#4798 for the original bug
+# report.
+#
+# A handful of connectors ship their own ``pyproject.toml`` with a
+# ``[tool.isort]`` section (``external-import/dragos``,
+# ``external-import/proofpoint-tap``,
+# ``external-import/tenable-security-center``). ``isort`` walks up the
+# tree looking for the *closest* config and stops at the first
+# ``[tool.isort]`` it finds, so when ``isort`` is run from inside one
+# of those connector directories the connector-level section takes
+# precedence over this file. Those connectors keep their existing
+# self-contained config on purpose (separate ``black`` / ``ruff`` /
+# ``mypy`` settings, source layouts that already produce the desired
+# isort output); the repository-wide CI invocation
+# ``isort --profile black --check .`` is always run from the repo
+# root and therefore picks up this file.
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+# Repository-wide tooling configuration.
+#
+# Pinning ``src_paths`` here keeps ``isort`` output identical no matter
+# whether the command is invoked from the repository root, from a
+# connector subdirectory, or via the pre-commit hook. Without this file
+# ``isort`` resolves first-party imports relative to its current working
+# directory, so the same file ends up with a different ordering depending
+# on where the contributor (or CI) happens to run from
+# (see OpenCTI-Platform/connectors#4798).
+
+[tool.isort]
+profile = "black"
+src_paths = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@
 # whether the command is invoked from the repository root, from a
 # connector subdirectory, or via the pre-commit hook. Without this file
 # ``isort`` resolves first-party imports relative to its current working
-# directory, so the same file ends up with a different ordering depending
-# on where the contributor (or CI) happens to run from
-# (see OpenCTI-Platform/connectors#4798).
+# directory, so the same file ends up with a different ordering
+# depending on where the contributor (or CI) happens to run from.
+# See OpenCTI-Platform/connectors#4798 for the original bug report.
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
- fixes: isort non-deterministic behavior across repo root vs connector subdirectories
- Fixes #4798

### Proposed changes

* Add a project-wide `pyproject.toml` that pins `isort` configuration.
* Configure `isort` to consistently treat `.` as the source root (`src_paths = [.]`), ensuring identical results whether `isort` is run from the repository root or within a connector subdirectory.
* Align settings with OpenCTI's existing code style guidelines: `profile = black` matches the existing CI invocation (`isort --profile black --check .`) and the pre-commit hook (`isort --profile black --line-length 88`); `line_length = 88` is implied by the `black` profile and therefore not set explicitly.

### Verification

- `isort --profile black --check .` from the repository root produces zero diffs against current master.
- `isort --profile black --check src/main.py` from `external-import/pgl-yoyo/` (the example flagged in #4798) also produces zero diffs once the new config is in place. Without the config, the same command produces the spurious `from pycti import OpenCTIConnectorHelper` reorder diff documented in the issue.

### Related issues

* #4798

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This change ensures that developers, CI, and pre-commit hooks all get deterministic `isort` behavior regardless of where in the repo the command is invoked. Without this, contributors see spurious diffs depending on their working directory, which complicates code reviews and wastes CI cycles.