### PR TITLE
[ConnectorSDK] Fix conflict in pycti version when used from another version or master branch

### DIFF
--- a/connectors-sdk/pyproject.toml
+++ b/connectors-sdk/pyproject.toml
@@ -14,7 +14,7 @@ packages = [{include = "connectors_sdk"}]
 
 
 [tool.poetry.dependencies]
-pycti = "6.8.0"
+pycti = {version = ">= 6.7.19"}
 
 # Optional dependencies
 # octi-connectors = {path = "../.", extras = ["dev"], optional=true}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Allow connectors-sdk version of pycti being >= 6.7.19 and not fixed

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4808

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
