### PR TITLE
[Google TI] Fix increment number in work description #4810

### DIFF
--- a/external-import/google-ti-feeds/connector/src/custom/client_api/client_api_base.py
+++ b/external-import/google-ti-feeds/connector/src/custom/client_api/client_api_base.py
@@ -360,7 +360,7 @@ class BaseClientAPI:
                 data_count = len(data) if isinstance(data, list) else 1
                 cursor, count = self._extract_meta_info(meta)
 
-                if total_items is None and count is not None:
+                if count is not None:
                     total_items = count
                     total_pages = self._calculate_pagination_info(count, params)
 

--- a/external-import/google-ti-feeds/connector/src/custom/configs/campaign/batch_processor_config_campaign.py
+++ b/external-import/google-ti-feeds/connector/src/custom/configs/campaign/batch_processor_config_campaign.py
@@ -34,7 +34,7 @@ def campaign_extract_stix_date(stix_object: Any) -> Optional[Any]:
 
 
 CAMPAIGN_BATCH_PROCESSOR_CONFIG = GenericBatchProcessorConfig(
-    batch_size=5000,
+    batch_size=9999,
     work_name_template="Google Threat Intel - Batch #{batch_num} (~ 0/0 campaigns)",
     state_key="campaign_next_cursor_start_date",
     entity_type="stix_objects",

--- a/external-import/google-ti-feeds/connector/src/custom/configs/report/batch_processor_config_report.py
+++ b/external-import/google-ti-feeds/connector/src/custom/configs/report/batch_processor_config_report.py
@@ -34,7 +34,7 @@ def report_extract_stix_date(stix_object: Any) -> Optional[Any]:
 
 
 REPORT_BATCH_PROCESSOR_CONFIG = GenericBatchProcessorConfig(
-    batch_size=500,
+    batch_size=9999,
     work_name_template="Google Threat Intel - Batch #{batch_num} (~ 0/0 reports)",
     state_key="report_next_cursor_start_date",
     entity_type="stix_objects",

--- a/external-import/google-ti-feeds/connector/src/custom/configs/vulnerability/batch_processor_config_vulnerability.py
+++ b/external-import/google-ti-feeds/connector/src/custom/configs/vulnerability/batch_processor_config_vulnerability.py
@@ -34,7 +34,7 @@ def vulnerability_extract_stix_date(stix_object: Any) -> Optional[Any]:
 
 
 VULNERABILITY_BATCH_PROCESSOR_CONFIG = GenericBatchProcessorConfig(
-    batch_size=5000,
+    batch_size=9999,
     work_name_template="Google Threat Intel - Batch #{batch_num} (~ 0/0 vulnerabilities)",
     state_key="vulnerability_next_cursor_start_date",
     entity_type="stix_objects",

--- a/external-import/google-ti-feeds/connector/src/custom/orchestrators/base_orchestrator.py
+++ b/external-import/google-ti-feeds/connector/src/custom/orchestrators/base_orchestrator.py
@@ -107,7 +107,7 @@ class BaseOrchestrator:
         """
         if (
             batch_processor.get_current_batch_size() + len(all_entities)
-        ) >= batch_processor.config.batch_size:
+        ) >= batch_processor.config.batch_size * 2:
             self.logger.info(
                 "Need to Flush before adding next items to preserve consistency of the bundle",
                 {"prefix": LOG_PREFIX},

--- a/external-import/google-ti-feeds/connector/src/custom/orchestrators/campaign/orchestrator_campaign.py
+++ b/external-import/google-ti-feeds/connector/src/custom/orchestrators/campaign/orchestrator_campaign.py
@@ -93,6 +93,7 @@ class OrchestratorCampaign(BaseOrchestrator):
             async for gti_campaigns in self.client_api.fetch_campaigns(initial_state):
                 total_campaigns = len(gti_campaigns)
                 for campaign_idx, campaign in enumerate(gti_campaigns):
+                    self._update_index_inplace()
                     campaign_entities = self.converter.convert_campaign_to_stix(
                         campaign
                     )
@@ -179,7 +180,6 @@ class OrchestratorCampaign(BaseOrchestrator):
                     )
 
                     self._check_batch_size_and_flush(self.batch_processor, all_entities)
-                    self._update_index_inplace()
                     self._add_entities_to_batch(
                         self.batch_processor, all_entities, self.converter
                     )

--- a/external-import/google-ti-feeds/connector/src/custom/orchestrators/malware/orchestrator_malware.py
+++ b/external-import/google-ti-feeds/connector/src/custom/orchestrators/malware/orchestrator_malware.py
@@ -90,6 +90,7 @@ class OrchestratorMalware(BaseOrchestrator):
                 for malware_family_idx, malware_family in enumerate(
                     gti_malware_families
                 ):
+                    self._update_index_inplace()
                     malware_family_entities = (
                         self.converter.convert_malware_family_to_stix(malware_family)
                     )
@@ -176,7 +177,6 @@ class OrchestratorMalware(BaseOrchestrator):
                     )
 
                     self._check_batch_size_and_flush(self.batch_processor, all_entities)
-                    self._update_index_inplace()
                     self._add_entities_to_batch(
                         self.batch_processor, all_entities, self.converter
                     )

--- a/external-import/google-ti-feeds/connector/src/custom/orchestrators/report/orchestrator_report.py
+++ b/external-import/google-ti-feeds/connector/src/custom/orchestrators/report/orchestrator_report.py
@@ -90,6 +90,7 @@ class OrchestratorReport(BaseOrchestrator):
             async for gti_reports in self.client_api.fetch_reports(initial_state):
                 total_reports = len(gti_reports)
                 for report_idx, report in enumerate(gti_reports):
+                    self._update_index_inplace()
                     report_entities = self.converter.convert_report_to_stix(report)
                     subentities_ids = await self.client_api.fetch_subentities_ids(
                         entity_name="entity_id",
@@ -174,7 +175,6 @@ class OrchestratorReport(BaseOrchestrator):
                     )
 
                     self._check_batch_size_and_flush(self.batch_processor, all_entities)
-                    self._update_index_inplace()
                     self._add_entities_to_batch(
                         self.batch_processor, all_entities, self.converter
                     )

--- a/external-import/google-ti-feeds/connector/src/custom/orchestrators/threat_actor/orchestrator_threat_actor.py
+++ b/external-import/google-ti-feeds/connector/src/custom/orchestrators/threat_actor/orchestrator_threat_actor.py
@@ -95,6 +95,7 @@ class OrchestratorThreatActor(BaseOrchestrator):
             ):
                 total_threat_actors = len(gti_threat_actors)
                 for threat_actor_idx, threat_actor in enumerate(gti_threat_actors):
+                    self._update_index_inplace()
                     threat_actor_entities = self.converter.convert_threat_actor_to_stix(
                         threat_actor
                     )
@@ -181,7 +182,6 @@ class OrchestratorThreatActor(BaseOrchestrator):
                     )
 
                     self._check_batch_size_and_flush(self.batch_processor, all_entities)
-                    self._update_index_inplace()
                     self._add_entities_to_batch(
                         self.batch_processor, all_entities, self.converter
                     )

--- a/external-import/google-ti-feeds/connector/src/custom/orchestrators/vulnerability/orchestrator_vulnerability.py
+++ b/external-import/google-ti-feeds/connector/src/custom/orchestrators/vulnerability/orchestrator_vulnerability.py
@@ -95,6 +95,7 @@ class OrchestratorVulnerability(BaseOrchestrator):
             ):
                 total_vulnerabilities = len(gti_vulnerabilities)
                 for vulnerability_idx, vulnerability in enumerate(gti_vulnerabilities):
+                    self._update_index_inplace()
                     vulnerability_entities = (
                         self.converter.convert_vulnerability_to_stix(vulnerability)
                     )
@@ -181,7 +182,6 @@ class OrchestratorVulnerability(BaseOrchestrator):
                     )
 
                     self._check_batch_size_and_flush(self.batch_processor, all_entities)
-                    self._update_index_inplace()
                     self._add_entities_to_batch(
                         self.batch_processor, all_entities, self.converter
                     )


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

 - [x] Fix entity increment issues in the connector’s work screen (counter exceeds estimated total).

This PR is part of the umbrella PR #4810 to solve the issues identified in #4801

Before:
<img width="432" height="64" alt="Screenshot 2025-09-24 144555" src="https://github.com/user-attachments/assets/24eab171-a5ef-45dc-ac41-04cef2eb368f" />

After:
<img width="411" height="57" alt="Screenshot 2025-09-24 154737" src="https://github.com/user-attachments/assets/7cdb4156-dc24-4727-b912-b9809e9506ae" />

### Related issues

Umbrella PR: https://github.com/OpenCTI-Platform/connectors/pull/4810
Base Issue: https://github.com/OpenCTI-Platform/connectors/issues/4801

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Sometimes, you can see the number overshot the total slightly, this is due to the api sending new data in the last page while processing them.
