### PR TITLE
[PGL-YoYo] Fix Dockerfile

### DIFF
--- a/external-import/pgl-yoyo/Dockerfile
+++ b/external-import/pgl-yoyo/Dockerfile
@@ -1,15 +1,16 @@
 FROM python:3.12-alpine
 ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
 
-# Install system dependencies required by some python packages (libmagic/file)
-# - update and install file (provides libmagic) and any build deps if needed
-RUN apk add --no-cache file
-
 COPY src /opt/opencti-connector
-WORKDIR /opt/opencti-connector
 
-# Install Python requirements
-RUN pip3 install --no-cache-dir -r requirements.txt
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk update && apk upgrade && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN cd /opt/opencti-connector && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
 
 # Expose and entrypoint
 COPY --chmod=0755 entrypoint.sh /


### PR DESCRIPTION
The building of the rolling images fails in the CI, due to missing git binary

### Proposed changes

* follow templates and add git libmagic etc...

### Related issues

* #4823

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

