### PR TITLE
[CVE] Fixing API key header to follow NIST documentation

### DIFF
--- a/external-import/cpe/src/connector.py
+++ b/external-import/cpe/src/connector.py
@@ -100,7 +100,7 @@ class CPEConnector:
         session = requests.Session()
 
         headers = {
-            "api_key": self.api_key,
+            "apiKey": self.api_key,
             "User-Agent": f"OpenCTI-cpe-connector/{APP_VERSION}",
         }
 
@@ -155,7 +155,7 @@ class CPEConnector:
         session = requests.Session()
 
         headers = {
-            "api_key": self.api_key,
+            "apiKey": self.api_key,
             "User-Agent": f"OpenCTI-cpe-connector/{APP_VERSION}",
         }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change the header in the API request to NIST API from `api_key` to `apiKey` as per NIST documentation [[1](https://nvd.nist.gov/developers/start-here#:~:text=API%20keys%20are,is%20case%20sensitive.)]
* This is now consistent with what is used in the [CVE connector](https://github.com/OpenCTI-Platform/connectors/blob/17d8be603c4bfb9e8d36d42c043188cf83133181/external-import/cve/src/services/client/api.py#L21).
* The API calls still worked, but behaved as if no API key was provided - which the API makes possible, however, there is stricter rate limitation.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4830

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
