### PR TITLE
[MicrosoftSentinelIntel] Remove mistaken set_state

### DIFF
--- a/stream/microsoft-sentinel-intel/src/microsoft_sentinel_intel/connector.py
+++ b/stream/microsoft-sentinel-intel/src/microsoft_sentinel_intel/connector.py
@@ -114,5 +114,4 @@ class Connector:
         The connector have the capability to listen a live stream from the platform.
         The helper provide an easy way to listen to the events.
         """
-        self.helper.set_state({})
         self.helper.listen_stream(message_callback=self.process_message)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* fix: Remove mistaken set_state

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4840

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
