### PR TITLE
[abuseipdb-ipblacklist] fix discrepancy between observable and indicator scores (#4783)

### DIFF
--- a/external-import/abuseipdb-ipblacklist/src/external_import_connector/connector.py
+++ b/external-import/abuseipdb-ipblacklist/src/external_import_connector/connector.py
@@ -91,14 +91,6 @@ class ConnectorAbuseIPDB:
 
             stix_objects.append(obs)
 
-            if self.config.create_indicator:
-                indicator = self.converter_to_stix.create_indicator(obs)
-                stix_objects.append(indicator)
-                rel = self.converter_to_stix.create_relationship(
-                    indicator.id, "based-on", obs.id
-                )
-                stix_objects.append(rel)
-
         if len(stix_objects):
             stix_objects.append(self.converter_to_stix.author)
             stix_objects.append(self.converter_to_stix.tlp_marking)

--- a/external-import/abuseipdb-ipblacklist/tests/conftest.py
+++ b/external-import/abuseipdb-ipblacklist/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/external-import/abuseipdb-ipblacklist/tests/conftest.py
+++ b/external-import/abuseipdb-ipblacklist/tests/conftest.py
@@ -1,4 +1,75 @@
 import os
 import sys
 
+import pytest
+from pycti import OpenCTIApiClient, OpenCTIApiConnector
+from src.external_import_connector.config_variables import ConfigConnector
+
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+@pytest.fixture(autouse=True)
+def mock_env(monkeypatch):
+    monkeypatch.setenv("ABUSEIPDB_SCORE", "90")
+    monkeypatch.setenv("ABUSEIPDB_CREATE_INDICATOR", "true")
+
+
+@pytest.fixture(autouse=True)
+def mock_config(monkeypatch):
+    monkeypatch.setattr(
+        ConfigConnector,
+        "_load_config",
+        lambda self: {
+            "opencti": {
+                "url": "http://localhost:8080",
+                "token": "changeme",
+                "ssl_verify": False,
+            },
+            "connector": {
+                "id": "CHANGEME",
+                "name": "AbuseIPDB Connector",
+                "type": "EXTERNAL_IMPORT",
+            },
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_health_check(monkeypatch):
+    monkeypatch.setattr(OpenCTIApiClient, "health_check", lambda self: True)
+
+
+@pytest.fixture(autouse=True)
+def mock_ping(monkeypatch):
+    monkeypatch.setattr(
+        OpenCTIApiConnector,
+        "ping",
+        lambda self, connector_id, initial_state, connector_info: {
+            "id": "CHANGEME",
+            "connector_user_id": "1",
+            "connector_state": "{}",
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_register(monkeypatch):
+    monkeypatch.setattr(
+        OpenCTIApiConnector,
+        "register",
+        lambda self, connector: {
+            "id": "CHANGEME",
+            "connector_user_id": "1",
+            "connector_state": "{}",
+            "config": {
+                "connection": {
+                    "host": "rabbitmq",
+                    "vhost": "/",
+                    "use_ssl": False,
+                    "port": 5672,
+                    "user": "opencti",
+                    "pass": "changeme",
+                }
+            },
+        },
+    )

--- a/external-import/abuseipdb-ipblacklist/tests/test-requirements.txt
+++ b/external-import/abuseipdb-ipblacklist/tests/test-requirements.txt
@@ -1,0 +1,4 @@
+# Main dependencies needs to be installed
+-r ../src/requirements.txt
+pytest
+pytest-mock

--- a/external-import/abuseipdb-ipblacklist/tests/test_connector.py
+++ b/external-import/abuseipdb-ipblacklist/tests/test_connector.py
@@ -1,67 +1,9 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
-from pycti import OpenCTIApiClient, OpenCTIApiConnector
-from src.external_import_connector.config_variables import ConfigConnector
 from src.external_import_connector.connector import ConnectorAbuseIPDB
 
 
-@patch.dict(
-    "os.environ",
-    {
-        "ABUSEIPDB_SCORE": "90",
-        "ABUSEIPDB_CREATE_INDICATOR": "true",
-    },
-)
-@patch.object(
-    ConfigConnector,
-    "_load_config",
-    return_value={
-        "opencti": {
-            "url": "http://localhost:8080",
-            "token": "changeme",
-            "ssl_verify": False,
-        },
-        "connector": {
-            "id": "CHANGEME",
-            "name": "AbuseIPDB Connector",
-            "type": "EXTERNAL_IMPORT",
-        },
-    },
-)
-@patch.object(
-    OpenCTIApiClient,
-    "health_check",
-    return_value=True,
-)
-@patch.object(
-    OpenCTIApiConnector,
-    "ping",
-    return_value={
-        "id": "CHANGEME",
-        "connector_user_id": "1",
-        "connector_state": "{}",
-    },
-)
-@patch.object(
-    OpenCTIApiConnector,
-    "register",
-    return_value={
-        "id": "CHANGEME",
-        "connector_user_id": "1",
-        "connector_state": "{}",
-        "config": {
-            "connection": {
-                "host": "rabbitmq",
-                "vhost": "/",
-                "use_ssl": False,
-                "port": 5672,
-                "user": "opencti",
-                "pass": "changeme",
-            }
-        },
-    },
-)
-def test_should_create_indicator_with_same_score(_, __, ___, ____):
+def test_should_create_indicator_with_same_score():
     connector = ConnectorAbuseIPDB()
 
     connector.helper.api.work.initiate_work = lambda x, y: "work_id_123"
@@ -77,16 +19,9 @@ def test_should_create_indicator_with_same_score(_, __, ___, ____):
         ]
     )
 
-    indictor_tag_exists = False
+    def mocked_stix2_create_bundle(stix_objects):
+        assert stix_objects[0].x_opencti_create_indicator
 
-    def check_if_indicator_tag_exists(stix_objects):
-        nonlocal indictor_tag_exists
-        indictor_tag_exists = stix_objects[0].x_opencti_create_indicator
-
-    connector.helper.stix2_create_bundle = Mock(
-        side_effect=check_if_indicator_tag_exists
-    )
+    connector.helper.stix2_create_bundle = mocked_stix2_create_bundle
 
     connector.process_message()
-
-    assert indictor_tag_exists

--- a/external-import/abuseipdb-ipblacklist/tests/test_connector.py
+++ b/external-import/abuseipdb-ipblacklist/tests/test_connector.py
@@ -1,0 +1,92 @@
+from unittest.mock import Mock, patch
+
+from pycti import OpenCTIApiClient, OpenCTIApiConnector
+from src.external_import_connector.config_variables import ConfigConnector
+from src.external_import_connector.connector import ConnectorAbuseIPDB
+
+
+@patch.dict(
+    "os.environ",
+    {
+        "ABUSEIPDB_SCORE": "90",
+        "ABUSEIPDB_CREATE_INDICATOR": "true",
+    },
+)
+@patch.object(
+    ConfigConnector,
+    "_load_config",
+    return_value={
+        "opencti": {
+            "url": "http://localhost:8080",
+            "token": "changeme",
+            "ssl_verify": False,
+        },
+        "connector": {
+            "id": "CHANGEME",
+            "name": "AbuseIPDB Connector",
+            "type": "EXTERNAL_IMPORT",
+        },
+    },
+)
+@patch.object(
+    OpenCTIApiClient,
+    "health_check",
+    return_value=True,
+)
+@patch.object(
+    OpenCTIApiConnector,
+    "ping",
+    return_value={
+        "id": "CHANGEME",
+        "connector_user_id": "1",
+        "connector_state": "{}",
+    },
+)
+@patch.object(
+    OpenCTIApiConnector,
+    "register",
+    return_value={
+        "id": "CHANGEME",
+        "connector_user_id": "1",
+        "connector_state": "{}",
+        "config": {
+            "connection": {
+                "host": "rabbitmq",
+                "vhost": "/",
+                "use_ssl": False,
+                "port": 5672,
+                "user": "opencti",
+                "pass": "changeme",
+            }
+        },
+    },
+)
+def test_should_create_indicator_with_same_score(_, __, ___, ____):
+    connector = ConnectorAbuseIPDB()
+
+    connector.helper.api.work.initiate_work = lambda x, y: "work_id_123"
+
+    connector.client.get_entities = Mock(
+        return_value=[
+            {
+                "value": "8.8.8.8",
+                "country_code": "US",
+                "confidence_score": "95",
+                "last_reported": "2024-01-01 00:00:00",
+            },
+        ]
+    )
+
+    indictor_tag_exists = False
+
+    def check_if_indicator_tag_exists(stix_objects):
+        nonlocal indictor_tag_exists
+        indictor_tag_exists = stix_objects[0].x_opencti_create_indicator
+
+    connector.helper.stix2_create_bundle = Mock(
+        side_effect=check_if_indicator_tag_exists
+    )
+
+    connector.process_message()
+
+    assert indictor_tag_exists


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add `x_opencti_create_indicator` instead of manually creating indicator
*

### Related issues

* Closes #4783 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
