### PR TITLE
[MispIntel] Fix configuration defaults to be None on empty env var

### DIFF
--- a/stream/misp-intel/src/config.yml.sample
+++ b/stream/misp-intel/src/config.yml.sample
@@ -21,7 +21,7 @@ misp:
   ssl_verify: true  # Verify SSL certificates
   
   # Organization configuration
-  owner_org: ''  # Optional: Organization that will own the events in MISP (leave empty to use MISP default)
+  # owner_org: 'ChangeMe'  # Optional: Organization that will own the events in MISP
   
   # Event configuration
   distribution_level: 1  # 0: Your organisation only, 1: This community only, 2: Connected communities, 3: All communities

--- a/stream/misp-intel/src/models/configs/base_settings.py
+++ b/stream/misp-intel/src/models/configs/base_settings.py
@@ -9,6 +9,7 @@ class ConfigBaseSettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_nested_delimiter="_",
         env_nested_max_split=1,
+        env_ignore_empty=True,
         frozen=True,
         str_strip_whitespace=True,
         str_min_length=1,

--- a/stream/misp-intel/src/models/configs/config_loader.py
+++ b/stream/misp-intel/src/models/configs/config_loader.py
@@ -84,7 +84,6 @@ class ConfigLoader(ConfigBaseSettings):
                 DotEnvSettingsSource(
                     settings_cls,
                     env_file=env_path,
-                    env_ignore_empty=True,
                     env_file_encoding="utf-8",
                 ),
             )
@@ -100,7 +99,6 @@ class ConfigLoader(ConfigBaseSettings):
             return (
                 EnvSettingsSource(
                     settings_cls,
-                    env_ignore_empty=True,
                 ),
             )
 

--- a/stream/misp-intel/src/models/configs/misp_configs.py
+++ b/stream/misp-intel/src/models/configs/misp_configs.py
@@ -1,6 +1,6 @@
 """MISP-specific configuration models."""
 
-from typing import Any, Optional
+from typing import Optional
 
 from pydantic import Field, SecretStr, field_validator
 
@@ -29,7 +29,7 @@ class _ConfigLoaderMisp(ConfigBaseSettings):
     owner_org: Optional[str] = Field(
         default=None,
         alias="MISP_OWNER_ORG",
-        description="Organization that will own the events in MISP (leave empty to use MISP default).",
+        description="Organization that will own the events in MISP",
     )
 
     # Event configuration
@@ -114,11 +114,3 @@ class _ConfigLoaderProxy(ConfigBaseSettings):
         description="Comma-separated list of hosts to bypass proxy.",
         min_length=0,  # Allow empty strings
     )
-
-    @field_validator("http", "https", "no_proxy", mode="before")
-    @classmethod
-    def empty_str_to_none(cls, v: Any) -> Optional[str]:
-        """Convert empty strings to None for proper optional handling."""
-        if v == "":
-            return None
-        return v


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix configuration defaults to be None on empty env var

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4859

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
