### PR TITLE
[Recorded Future Enrichment] Fix Notes imported during vulnerability enrichment

### DIFF
--- a/internal-enrichment/recordedfuture-enrichment/src/rflib/use_cases/enrich_vulnerability.py
+++ b/internal-enrichment/recordedfuture-enrichment/src/rflib/use_cases/enrich_vulnerability.py
@@ -379,7 +379,7 @@ class VulnerabilityEnricher:
             # Extract note
             notes = self._convert_vulnerability_risk(vulnerability_enrichment)
             for note in notes:
-                note.objects = [vulnerability] + software_s
+                note.objects = [vulnerability]
                 note.external_references = external_references
                 octi_objects.append(note)
 

--- a/internal-enrichment/recordedfuture-enrichment/src/rflib/use_cases/enrich_vulnerability.py
+++ b/internal-enrichment/recordedfuture-enrichment/src/rflib/use_cases/enrich_vulnerability.py
@@ -380,7 +380,6 @@ class VulnerabilityEnricher:
             notes = self._convert_vulnerability_risk(vulnerability_enrichment)
             for note in notes:
                 note.objects = [vulnerability]
-                note.external_references = external_references
                 octi_objects.append(note)
 
             # Add relationships between entities


### PR DESCRIPTION
### Proposed changes

* keep only Vulnerability in Note's object_refs
* do not extend Note's external_references

### Related issues

* #4863

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
