### PR TITLE
[Recorded Future] crash since 6.8.1 (#4871)

### DIFF
--- a/external-import/recorded-future/docker-compose.yml
+++ b/external-import/recorded-future/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   connector-recorded-future:
     image: opencti/connector-recorded-future:rolling
@@ -16,7 +16,7 @@ services:
       - RECORDED_FUTURE_PULL_ANALYST_NOTES=True
       - RECORDED_FUTURE_LAST_PUBLISHED_NOTES=24 #required, in hours
       - RECORDED_FUTURE_TOPIC=ChangeMe #optional, can remove
-      - RECORDED_FUTURE_TLP=Red # required
+      - RECORDED_FUTURE_TLP=red # required
       - RECORDED_FUTURE_INSIKT_ONLY=True #optional, can remove
       - RECORDED_FUTURE_PULL_SIGNATURES=False #optional, can remove
       - RECORDED_FUTURE_PERSON_TO_TA=False #optional, can remove

--- a/external-import/recorded-future/src/config.yml.sample
+++ b/external-import/recorded-future/src/config.yml.sample
@@ -10,7 +10,7 @@ connector:
   log_level: 'info'
   duration_period: 'PT1H' # ISO8601 Format starting with "P" for Period ex: "PT24H" // Period time of 5 minutes
 
-recorded_future:
+rf:
   token: 'ChangeMe' # Required
   initial_lookback: 240 # Required, in hours
   pull_analyst_notes: True

--- a/external-import/recorded-future/src/config.yml.sample
+++ b/external-import/recorded-future/src/config.yml.sample
@@ -10,7 +10,7 @@ connector:
   log_level: 'info'
   duration_period: 'PT1H' # ISO8601 Format starting with "P" for Period ex: "PT24H" // Period time of 5 minutes
 
-rf:
+recorded_future:
   token: 'ChangeMe' # Required
   initial_lookback: 240 # Required, in hours
   pull_analyst_notes: True

--- a/external-import/recorded-future/src/main.py
+++ b/external-import/recorded-future/src/main.py
@@ -34,22 +34,26 @@ class BaseRFConnector:
         self.helper = OpenCTIConnectorHelper(self.config.model_dump_pycti())
 
         # Extract configuration values from the loaded config
-        self.rf_token = self.config.rf.token.get_secret_value()
-        self.rf_initial_lookback = self.config.rf.initial_lookback
-        self.tlp = self.config.rf.tlp.lower()
-        self.rf_pull_signatures = self.config.rf.pull_signatures
-        self.rf_pull_risk_list = self.config.rf.pull_risk_list
-        self.rf_riskrules_as_label = self.config.rf.riskrules_as_label
-        self.rf_insikt_only = self.config.rf.insikt_only
+        self.rf_token = self.config.recorded_future.token.get_secret_value()
+        self.rf_initial_lookback = self.config.recorded_future.initial_lookback
+        self.tlp = self.config.recorded_future.tlp.lower()
+        self.rf_pull_signatures = self.config.recorded_future.pull_signatures
+        self.rf_pull_risk_list = self.config.recorded_future.pull_risk_list
+        self.rf_riskrules_as_label = self.config.recorded_future.riskrules_as_label
+        self.rf_insikt_only = self.config.recorded_future.insikt_only
 
         # Handle topics - convert list to comma-separated string if needed
-        self.rf_topics = self.config.rf.topic if self.config.rf.topic else [None]
+        self.rf_topics = (
+            self.config.recorded_future.topic
+            if self.config.recorded_future.topic
+            else [None]
+        )
 
-        self.rf_person_to_TA = self.config.rf.person_to_ta
-        self.rf_TA_to_intrusion_set = self.config.rf.ta_to_intrusion_set
-        self.risk_as_score = self.config.rf.risk_as_score
-        self.risk_threshold = self.config.rf.risk_threshold
-        self.risk_list_threshold = self.config.rf.risk_list_threshold
+        self.rf_person_to_TA = self.config.recorded_future.person_to_ta
+        self.rf_TA_to_intrusion_set = self.config.recorded_future.ta_to_intrusion_set
+        self.risk_as_score = self.config.recorded_future.risk_as_score
+        self.risk_threshold = self.config.recorded_future.risk_threshold
+        self.risk_list_threshold = self.config.recorded_future.risk_list_threshold
 
         self.rfapi = RFClient(
             self.rf_token,
@@ -60,22 +64,26 @@ class BaseRFConnector:
         # In a crisis, smash glass and uncomment this line of code
         # self.helper.config['uri'] = self.helper.config['uri'].replace('rabbitmq', '172.19.0.6')
 
-        self.rf_pull_threat_maps = self.config.rf.pull_threat_maps
+        self.rf_pull_threat_maps = self.config.recorded_future.pull_threat_maps
 
         # Handle risk list related entities
-        if self.config.rf.risklist_related_entities is None:
+        if self.config.recorded_future.risklist_related_entities is None:
             if self.rf_pull_risk_list:
                 raise ValueError(
                     "Missing or incorrect value in configuration parameter 'Risk List Related Entities'"
                 )
             self.risklist_related_entities = []
         else:
-            self.risklist_related_entities = self.config.rf.risklist_related_entities
+            self.risklist_related_entities = (
+                self.config.recorded_future.risklist_related_entities
+            )
 
-        self.rf_pull_analyst_notes = self.config.rf.pull_analyst_notes
-        self.last_published_notes_interval = self.config.rf.last_published_notes
+        self.rf_pull_analyst_notes = self.config.recorded_future.pull_analyst_notes
+        self.last_published_notes_interval = (
+            self.config.recorded_future.last_published_notes
+        )
         self.duration_period = self.config.connector.duration_period
-        self.rf_interval = self.config.rf.interval
+        self.rf_interval = self.config.recorded_future.interval
         self.priority_alerts_only = self.config.alert.priority_alerts_only
 
         self.rf_alerts_api = RecordedFutureApiClient(

--- a/external-import/recorded-future/src/models/configs/config_loader.py
+++ b/external-import/recorded-future/src/models/configs/config_loader.py
@@ -62,7 +62,7 @@ class ConfigLoader(ConfigBaseSettings):
         default_factory=ConfigLoaderConnector,
         description="Connector configurations.",
     )
-    rf: _ConfigLoaderRecordedFuture = Field(
+    recorded_future: _ConfigLoaderRecordedFuture = Field(
         default_factory=_ConfigLoaderRecordedFuture,
         description="Recorded Future configurations.",
     )

--- a/external-import/recorded-future/src/models/configs/config_loader.py
+++ b/external-import/recorded-future/src/models/configs/config_loader.py
@@ -65,6 +65,7 @@ class ConfigLoader(ConfigBaseSettings):
     recorded_future: _ConfigLoaderRecordedFuture = Field(
         default_factory=_ConfigLoaderRecordedFuture,
         description="Recorded Future configurations.",
+        alias="rf",
     )
     alert: _ConfigLoaderAlert = Field(
         default_factory=_ConfigLoaderAlert,

--- a/external-import/recorded-future/src/models/configs/recorded_future_configs.py
+++ b/external-import/recorded-future/src/models/configs/recorded_future_configs.py
@@ -2,7 +2,7 @@ from typing import Literal, Optional
 
 from connectors_sdk.core.pydantic import ListFromString
 from models.configs.base_settings import ConfigBaseSettings
-from pydantic import Field, PositiveInt, SecretStr
+from pydantic import Field, PositiveInt, SecretStr, field_validator
 
 
 class _ConfigLoaderRecordedFuture(ConfigBaseSettings):
@@ -20,6 +20,13 @@ class _ConfigLoaderRecordedFuture(ConfigBaseSettings):
         default="red",
         description="Default Traffic Light Protocol (TLP) marking for imported data.",
     )
+
+    @field_validator("tlp", mode="before")
+    @classmethod
+    def validate_tlp_lowercase(cls, v: str) -> str:
+        """Convert TLP value to lowercase."""
+        return v.lower()
+
     interval: PositiveInt = Field(
         default=1,
         description="Polling interval in hours for fetching Recorded Future data.",


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

I was able to reproduce the bug straight forward by launching the connector with docker and .env (work with actual config.yml.sample):
<img width="1117" height="547" alt="Screenshot 2025-10-01 111044" src="https://github.com/user-attachments/assets/01340344-89dc-4666-9482-67658b8f2f7b" />

This one is due to the fact that in the ConfigLoader the conf for the connector is loaded under `rf`:
<img width="397" height="88" alt="Screenshot 2025-10-01 111050" src="https://github.com/user-attachments/assets/8c1ed04d-e14e-4518-aca4-5db845282cd4" />

This mean it will look for a variable starting with `rf_` which is the case in the sample config in yml:
<img width="61" height="112" alt="Screenshot 2025-10-01 111121" src="https://github.com/user-attachments/assets/760b6ff1-1c55-4b6b-bcc2-6c0b05ba0f95" />

but not in the readme and docker one:
<img width="174" height="102" alt="Screenshot 2025-10-01 111111" src="https://github.com/user-attachments/assets/f84f7d1b-0ba3-4802-bffe-be07a9b1cdd0" />
<img width="327" height="289" alt="Screenshot 2025-10-01 111135" src="https://github.com/user-attachments/assets/a94544f7-a022-4312-9a39-0a726e8aa0de" />

So the fix consist to set back to recorded_future:
<img width="450" height="81" alt="Screenshot 2025-10-01 111233" src="https://github.com/user-attachments/assets/98f1a3a7-8508-4baf-81cb-d38bf2e547f7" />

And after that the connector launch but with a new error:
<img width="1117" height="445" alt="Screenshot 2025-10-01 111239" src="https://github.com/user-attachments/assets/1957a382-f9fe-4b8f-98c6-e0e6109559d6" />

The TLP provided in the doc are not lowercase and so don't match our Literal.
I've created a small validator to convert it to lower:
<img width="472" height="215" alt="Screenshot 2025-10-01 114512" src="https://github.com/user-attachments/assets/39a142d0-7f61-44f4-a571-2c9b7ece36e1" />

And then the connector start without trouble:
<img width="1753" height="403" alt="Screenshot 2025-10-01 112200" src="https://github.com/user-attachments/assets/6448f47b-2f37-405f-a921-06c5568a561e" />
<img width="1185" height="850" alt="Screenshot 2025-10-01 112206" src="https://github.com/user-attachments/assets/f6cc3f84-3ce4-428d-95ff-c8f3cac79891" />


### Related issues

#4871 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

The manifest for the connector is generated with the key prefix "RF_" so we need to check back the good regeneration after the merge with "RECORDED_FUTURE_".
