### PR TITLE
[Recorded-Future] Taking different aliases into account for variables

### DIFF
--- a/external-import/recorded-future/src/models/configs/config_loader.py
+++ b/external-import/recorded-future/src/models/configs/config_loader.py
@@ -12,7 +12,7 @@ from models.configs.recorded_future_configs import (
     _ConfigLoaderPlaybookAlert,
     _ConfigLoaderRecordedFuture,
 )
-from pydantic import Field, AliasChoices
+from pydantic import AliasChoices, Field
 from pydantic_settings import (
     BaseSettings,
     DotEnvSettingsSource,

--- a/external-import/recorded-future/src/models/configs/config_loader.py
+++ b/external-import/recorded-future/src/models/configs/config_loader.py
@@ -12,7 +12,7 @@ from models.configs.recorded_future_configs import (
     _ConfigLoaderPlaybookAlert,
     _ConfigLoaderRecordedFuture,
 )
-from pydantic import Field
+from pydantic import Field, AliasChoices
 from pydantic_settings import (
     BaseSettings,
     DotEnvSettingsSource,
@@ -65,7 +65,7 @@ class ConfigLoader(ConfigBaseSettings):
     recorded_future: _ConfigLoaderRecordedFuture = Field(
         default_factory=_ConfigLoaderRecordedFuture,
         description="Recorded Future configurations.",
-        alias="rf",
+        validation_alias=AliasChoices("rf", "recorded_future"),
     )
     alert: _ConfigLoaderAlert = Field(
         default_factory=_ConfigLoaderAlert,


### PR DESCRIPTION
### Proposed changes

* Correct retrieval of environment variables that begin with `RF` or `RECORDED_FUTURE`

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4871

### Checklist

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Problem already identified in the GitHub repository: https://github.com/pydantic/pydantic-settings/issues/689

