### PR TITLE
[Microsoft Sentinel Incident] import incidents based on specific tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
     environment:
       BUILD_TAGS: <<parameters.tags>>
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
   ci_notifications:
     docker:
       - image: "cimg/base:stable"
@@ -123,7 +123,7 @@ jobs:
             fi
   test:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
     working_directory: ~/repo
     parallelism: 4
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
     environment:
       BUILD_TAGS: <<parameters.tags>>
     docker:
-      - image: cimg/python:3.12
+      - image: cimg/python:3.11
   ci_notifications:
     docker:
       - image: "cimg/base:stable"
@@ -123,7 +123,7 @@ jobs:
             fi
   test:
     docker:
-      - image: cimg/python:3.12
+      - image: cimg/python:3.11
     working_directory: ~/repo
     parallelism: 4
     steps:

--- a/external-import/microsoft-sentinel-incidents/README.md
+++ b/external-import/microsoft-sentinel-incidents/README.md
@@ -15,7 +15,6 @@ Table of Contents
         - [Docker Deployment](#docker-deployment)
         - [Manual Deployment](#manual-deployment)
     - [Usage](#usage)
-    - [Behavior](#behavior)
     - [Debugging](#debugging)
     - [Additional information](#additional-information)
 
@@ -85,15 +84,16 @@ Below are the parameters you'll need to set for running the connector properly:
 
 Below are the parameters you'll need to set for the connector:
 
-| Parameter         | config.yml `microsoft_sentinel_incidents` | Docker environment variable                      | Default                                                  | Mandatory | Description                                                                                                            |
-|-------------------|-------------------------------------------|--------------------------------------------------|----------------------------------------------------------|-----------|------------------------------------------------------------------------------------------------------------------------|
-| Tenant ID         | `tenant_id`                               | `MICROSOFT_SENTINEL_INCIDENTS_TENANT_ID`         |                                                          | Yes       | Your Azure App Tenant ID, see the screenshot to help you find this information.                                        |
-| Client ID         | `client_id`                               | `MICROSOFT_SENTINEL_INCIDENTS_CLIENT_ID`         |                                                          | Yes       | Your Azure App Client ID, see the screenshot to help you find this information.                                        |
-| Client Secret     | `client_secret`                           | `MICROSOFT_SENTINEL_INCIDENTS_CLIENT_SECRET`     |                                                          | Yes       | Your Azure App Client secret, See the screenshot to help you find this information.                                    |
-| Subscription ID   | `subscription_id`                         | `MICROSOFT_SENTINEL_INCIDENTS_SUBSCRIPTION_ID`   |                                                          | Yes       | Your Microsoft Sentinel workspace ID.                                                                                  |
-| Resource Group    | `resource_group`                          | `MICROSOFT_SENTINEL_INCIDENTS_RESOURCE_GROUP`    |                                                          | Yes       | Your Microsoft Sentinel workspace ID.                                                                                  |
-| Workspace ID      | `workspace_id`                            | `MICROSOFT_SENTINEL_INCIDENTS_WORKSPACE_ID`      |                                                          | Yes       | Your Microsoft Sentinel workspace ID.                                                                                  |
-| Import start date | `import_start_date`                       | `MICROSOFT_SENTINEL_INCIDENTS_IMPORT_START_DATE` | `2020-01-01T00:00:00Z`                                   | No        | Import starting date (in YYYY-MM-DD format or YYYY-MM-DDTHH:MM:SSZ format) - used only if connector's state is not set |
+| Parameter            | config.yml `microsoft_sentinel_incidents` | Docker environment variable                      | Default                | Mandatory | Description                                                                                                             |
+|----------------------|-------------------------------------------|--------------------------------------------------|------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------|
+| Tenant ID            | `tenant_id`                               | `MICROSOFT_SENTINEL_INCIDENTS_TENANT_ID`         |                        | Yes       | Your Azure App Tenant ID, see the screenshot to help you find this information.                                         |
+| Client ID            | `client_id`                               | `MICROSOFT_SENTINEL_INCIDENTS_CLIENT_ID`         |                        | Yes       | Your Azure App Client ID, see the screenshot to help you find this information.                                         |
+| Client Secret        | `client_secret`                           | `MICROSOFT_SENTINEL_INCIDENTS_CLIENT_SECRET`     |                        | Yes       | Your Azure App Client secret, See the screenshot to help you find this information.                                     |
+| Subscription ID      | `subscription_id`                         | `MICROSOFT_SENTINEL_INCIDENTS_SUBSCRIPTION_ID`   |                        | Yes       | Your Microsoft Sentinel subscription ID.                                                                                |
+| Resource Group       | `resource_group`                          | `MICROSOFT_SENTINEL_INCIDENTS_RESOURCE_GROUP`    |                        | Yes       | Your Microsoft Sentinel resource group.                                                                                 |
+| Workspace ID         | `workspace_id`                            | `MICROSOFT_SENTINEL_INCIDENTS_WORKSPACE_ID`      |                        | Yes       | Your Microsoft Sentinel workspace ID.                                                                                   |
+| Import start date    | `import_start_date`                       | `MICROSOFT_SENTINEL_INCIDENTS_IMPORT_START_DATE` | `2020-01-01T00:00:00Z` | No        | Import starting date (in YYYY-MM-DD format or YYYY-MM-DDTHH:MM:SSZ format) - used only if connector's state is not set. |
+| Incident tags filter | `tags`                                    | `MICROSOFT_SENTINEL_INCIDENTS_TAGS`              |                        | No        | Only incidents containing these specified tag(s) will be retrieved and ingested (comma separated values).               |
 
 ## Deployment
 
@@ -153,7 +153,7 @@ download of data by re-running the connector.
 
 ## Debugging
 
-The connector can be debugged by setting the appropiate log level.
-Note that logging messages can be added using `self.helper.connector_logger,{LOG_LEVEL}("Sample message")`, i.
-e., `self.helper.connector_logger.error("An error message")`.
+The connector can be debugged by setting the appropriate log level.
+Note that logging messages can be added using `self.helper.connector_logger,{LOG_LEVEL}("Sample message")`,
+i.e., `self.helper.connector_logger.error("An error message")`.
 

--- a/external-import/microsoft-sentinel-incidents/README.md
+++ b/external-import/microsoft-sentinel-incidents/README.md
@@ -16,7 +16,6 @@ Table of Contents
         - [Manual Deployment](#manual-deployment)
     - [Usage](#usage)
     - [Debugging](#debugging)
-    - [Additional information](#additional-information)
 
 ## Introduction
 
@@ -84,16 +83,16 @@ Below are the parameters you'll need to set for running the connector properly:
 
 Below are the parameters you'll need to set for the connector:
 
-| Parameter            | config.yml `microsoft_sentinel_incidents` | Docker environment variable                      | Default                | Mandatory | Description                                                                                                             |
-|----------------------|-------------------------------------------|--------------------------------------------------|------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------|
-| Tenant ID            | `tenant_id`                               | `MICROSOFT_SENTINEL_INCIDENTS_TENANT_ID`         |                        | Yes       | Your Azure App Tenant ID, see the screenshot to help you find this information.                                         |
-| Client ID            | `client_id`                               | `MICROSOFT_SENTINEL_INCIDENTS_CLIENT_ID`         |                        | Yes       | Your Azure App Client ID, see the screenshot to help you find this information.                                         |
-| Client Secret        | `client_secret`                           | `MICROSOFT_SENTINEL_INCIDENTS_CLIENT_SECRET`     |                        | Yes       | Your Azure App Client secret, See the screenshot to help you find this information.                                     |
-| Subscription ID      | `subscription_id`                         | `MICROSOFT_SENTINEL_INCIDENTS_SUBSCRIPTION_ID`   |                        | Yes       | Your Microsoft Sentinel subscription ID.                                                                                |
-| Resource Group       | `resource_group`                          | `MICROSOFT_SENTINEL_INCIDENTS_RESOURCE_GROUP`    |                        | Yes       | Your Microsoft Sentinel resource group.                                                                                 |
-| Workspace ID         | `workspace_id`                            | `MICROSOFT_SENTINEL_INCIDENTS_WORKSPACE_ID`      |                        | Yes       | Your Microsoft Sentinel workspace ID.                                                                                   |
-| Import start date    | `import_start_date`                       | `MICROSOFT_SENTINEL_INCIDENTS_IMPORT_START_DATE` | `2020-01-01T00:00:00Z` | No        | Import starting date (in YYYY-MM-DD format or YYYY-MM-DDTHH:MM:SSZ format) - used only if connector's state is not set. |
-| Incident tags filter | `tags`                                    | `MICROSOFT_SENTINEL_INCIDENTS_TAGS`              |                        | No        | Only incidents containing these specified tag(s) will be retrieved and ingested (comma separated values).               |
+| Parameter              | config.yml `microsoft_sentinel_incidents` | Docker environment variable                      | Default                | Mandatory | Description                                                                                                            |
+|------------------------|-------------------------------------------|--------------------------------------------------|------------------------|-----------|------------------------------------------------------------------------------------------------------------------------|
+| Tenant ID              | `tenant_id`                               | `MICROSOFT_SENTINEL_INCIDENTS_TENANT_ID`         |                        | Yes       | Your Azure App Tenant ID, see the screenshot to help you find this information.                                        |
+| Client ID              | `client_id`                               | `MICROSOFT_SENTINEL_INCIDENTS_CLIENT_ID`         |                        | Yes       | Your Azure App Client ID, see the screenshot to help you find this information.                                        |
+| Client Secret          | `client_secret`                           | `MICROSOFT_SENTINEL_INCIDENTS_CLIENT_SECRET`     |                        | Yes       | Your Azure App Client secret, See the screenshot to help you find this information.                                    |
+| Subscription ID        | `subscription_id`                         | `MICROSOFT_SENTINEL_INCIDENTS_SUBSCRIPTION_ID`   |                        | Yes       | Your Microsoft Sentinel subscription ID.                                                                               |
+| Resource Group         | `resource_group`                          | `MICROSOFT_SENTINEL_INCIDENTS_RESOURCE_GROUP`    |                        | Yes       | Your Microsoft Sentinel resource group.                                                                                |
+| Workspace ID           | `workspace_id`                            | `MICROSOFT_SENTINEL_INCIDENTS_WORKSPACE_ID`      |                        | Yes       | Your Microsoft Sentinel workspace ID.                                                                                  |
+| Import start date      | `import_start_date`                       | `MICROSOFT_SENTINEL_INCIDENTS_IMPORT_START_DATE` | `2020-01-01T00:00:00Z` | No        | Import starting date (in YYYY-MM-DD format or YYYY-MM-DDTHH:MM:SSZ format) - used only if connector's state is not set. |
+| Incident filter labels | `filter_labels`                           | `MICROSOFT_SENTINEL_INCIDENTS_FILTER_LABELS`     |                        | No        | Only incidents containing these specified labels will be retrieved and ingested (comma separated values).            |
 
 ## Deployment
 

--- a/external-import/microsoft-sentinel-incidents/docker-compose.yml
+++ b/external-import/microsoft-sentinel-incidents/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - MICROSOFT_SENTINEL_INCIDENTS_RESOURCE_GROUP=ChangeMe # Sentinel Resource Group
       - MICROSOFT_SENTINEL_INCIDENTS_WORKSPACE_ID=ChangeMe # Sentinel Workspace ID
       - MICROSOFT_SENTINEL_INCIDENTS_IMPORT_START_DATE=2025-01-01T00:00:00Z
-      - MICROSOFT_SENTINEL_INCIDENTS_TAGS=ChangeMe,OrDeleteMe # Comma separated list of tags to import
+      - MICROSOFT_SENTINEL_INCIDENTS_FILTER_LABELS=ChangeMe,OrDeleteMe # Comma separated list of labels to import
       # Add proxy parameters below if needed
       # - HTTP_PROXY=CHANGEME
       # - HTTPS_PROXY=CHANGEME

--- a/external-import/microsoft-sentinel-incidents/docker-compose.yml
+++ b/external-import/microsoft-sentinel-incidents/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - MICROSOFT_SENTINEL_INCIDENTS_RESOURCE_GROUP=ChangeMe # Sentinel Resource Group
       - MICROSOFT_SENTINEL_INCIDENTS_WORKSPACE_ID=ChangeMe # Sentinel Workspace ID
       - MICROSOFT_SENTINEL_INCIDENTS_IMPORT_START_DATE=2025-01-01T00:00:00Z
+      - MICROSOFT_SENTINEL_INCIDENTS_TAGS=ChangeMe,OrDeleteMe # Comma separated list of tags to import
       # Add proxy parameters below if needed
       # - HTTP_PROXY=CHANGEME
       # - HTTPS_PROXY=CHANGEME

--- a/external-import/microsoft-sentinel-incidents/src/config.yml.sample
+++ b/external-import/microsoft-sentinel-incidents/src/config.yml.sample
@@ -27,4 +27,4 @@ microsoft_sentinel_incidents:
   resource_group: 'ChangeMe'
   workspace_id: 'ChangeMe'
   import_start_date: '2025-01-01T00:00:00Z'
-  tags: 'ChangeMe,OrDeleteMe'
+  filter_labels: 'ChangeMe,OrDeleteMe'

--- a/external-import/microsoft-sentinel-incidents/src/config.yml.sample
+++ b/external-import/microsoft-sentinel-incidents/src/config.yml.sample
@@ -27,3 +27,4 @@ microsoft_sentinel_incidents:
   resource_group: 'ChangeMe'
   workspace_id: 'ChangeMe'
   import_start_date: '2025-01-01T00:00:00Z'
+  tags: 'ChangeMe,OrDeleteMe'

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/client_api.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/client_api.py
@@ -68,17 +68,20 @@ class ConnectorClient:
             f"{self.log_analytics_url}/workspaces/{self.config.workspace_id}/query"
         )
         body = {
-            "query": f"""SecurityIncident 
+            "query": f"""
+            SecurityIncident 
             | sort by LastModifiedTime asc 
             | where LastModifiedTime > todatetime('"{date_str}"')
             """
         }
         if self.config.tags:
-            body["query"] += (
-                f" | mv-apply Labels on ("
-                f" where Labels.labelName has_any ({', '.join(f'\"{tag}\"' for tag in self.config.tags)})"
-                f" )"
+            body[
+                "query"
+            ] += f"""
+            | mv-apply Labels on (
+                where Labels.labelName has_any ({', '.join(f'"{tag}"' for tag in self.config.tags)})
             )
+            """
         while next_page_url:
             try:
                 response = self.session.post(url=next_page_url, json=body)

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/client_api.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/client_api.py
@@ -74,12 +74,12 @@ class ConnectorClient:
             | where LastModifiedTime > todatetime('"{date_str}"')
             """
         }
-        if self.config.tags:
+        if self.config.filter_labels:
             body[
                 "query"
             ] += f"""
             | mv-apply Labels on (
-                where Labels.labelName has_any ({', '.join(f'"{tag}"' for tag in self.config.tags)})
+                where Labels.labelName has_any ({', '.join(f'"{label}"' for label in self.config.filter_labels)})
             )
             """
         while next_page_url:
@@ -166,7 +166,6 @@ class ConnectorClient:
         collected. If any request results in an error (retry error, HTTP error, timeout, or connection error), it will
         log the issue and halt further pagination.
 
-        :param initial_url: The initial URL for retrieving alerts.
         :return: A list of all alerts as dictionaries containing mixed data types.
         """
         all_alerts = []

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/client_api.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/client_api.py
@@ -72,9 +72,10 @@ class ConnectorClient:
             f"| where LastModifiedTime > todatetime('{date_str}')"
         }
         if self.config.filter_labels:
+            labels = ", ".join(f'"{label}"' for label in self.config.filter_labels)
             body["query"] += (
                 "| mv-apply labelsFiltered=Labels on ("
-                f"where labelsFiltered.labelName has_any ({', '.join(f'"{label}"' for label in self.config.filter_labels)})"
+                f"where labelsFiltered.labelName has_any ({labels})"
                 "| take 1 )"
             )
         while next_page_url:

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/client_api.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/client_api.py
@@ -68,20 +68,15 @@ class ConnectorClient:
             f"{self.log_analytics_url}/workspaces/{self.config.workspace_id}/query"
         )
         body = {
-            "query": f"""
-            SecurityIncident 
-            | sort by LastModifiedTime asc 
-            | where LastModifiedTime > todatetime('"{date_str}"')
-            """
+            "query": "SecurityIncident | sort by LastModifiedTime asc"
+            f"| where LastModifiedTime > todatetime('{date_str}')"
         }
         if self.config.filter_labels:
-            body[
-                "query"
-            ] += f"""
-            | mv-apply Labels on (
-                where Labels.labelName has_any ({', '.join(f'"{label}"' for label in self.config.filter_labels)})
+            body["query"] += (
+                "| mv-apply labelsFiltered=Labels on ("
+                f"where labelsFiltered.labelName has_any ({', '.join(f'"{label}"' for label in self.config.filter_labels)})"
+                "| take 1 )"
             )
-            """
         while next_page_url:
             try:
                 response = self.session.post(url=next_page_url, json=body)

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/config_variables.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/config_variables.py
@@ -39,14 +39,16 @@ class ConfigConnector:
             return default_date
 
     @staticmethod
-    def prepare_tags(tags: str | None) -> list[str]:
+    def prepare_filter_labels(filter_labels: str | None) -> list[str]:
         """
-        Prepare tags from a comma-separated string to a list of trimmed strings.
-        :param tags: Comma-separated string of tags
-        :return: List of trimmed tags
+        Prepare labels from a comma-separated string to a list of trimmed strings.
+        :param filter_labels: Comma-separated string of labels
+        :return: List of trimmed labels
         """
-        if tags is not None and tags.strip():
-            return [tag.strip() for tag in tags.split(",") if tag.strip()]
+        if filter_labels is not None and filter_labels.strip():
+            return [
+                label.strip() for label in filter_labels.split(",") if label.strip()
+            ]
         return []
 
     @staticmethod
@@ -115,9 +117,11 @@ class ConfigConnector:
         self.import_start_date = self.prepare_iso_format(
             microsoft_sentinel_import_start_date_var
         )
-        microsoft_sentinel_incidents_tags = get_config_variable(
-            "MICROSOFT_SENTINEL_INCIDENTS_TAGS",
-            ["microsoft_sentinel_incidents", "tags"],
+        microsoft_sentinel_filter_labels = get_config_variable(
+            "MICROSOFT_SENTINEL_INCIDENTS_FILTER_LABELS",
+            ["microsoft_sentinel_incidents", "filter_labels"],
             self.load,
         )
-        self.tags = self.prepare_tags(microsoft_sentinel_incidents_tags)
+        self.filter_labels = self.prepare_filter_labels(
+            microsoft_sentinel_filter_labels
+        )

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/config_variables.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/config_variables.py
@@ -39,6 +39,17 @@ class ConfigConnector:
             return default_date
 
     @staticmethod
+    def prepare_tags(tags: str | None) -> list[str]:
+        """
+        Prepare tags from a comma-separated string to a list of trimmed strings.
+        :param tags: Comma-separated string of tags
+        :return: List of trimmed tags
+        """
+        if tags is not None and tags.strip():
+            return [tag.strip() for tag in tags.split(",") if tag.strip()]
+        return []
+
+    @staticmethod
     def _load_config() -> dict:
         """
         Load the configuration from the YAML file
@@ -104,3 +115,9 @@ class ConfigConnector:
         self.import_start_date = self.prepare_iso_format(
             microsoft_sentinel_import_start_date_var
         )
+        microsoft_sentinel_incidents_tags = get_config_variable(
+            "MICROSOFT_SENTINEL_INCIDENTS_TAGS",
+            ["microsoft_sentinel_incidents", "tags"],
+            self.load,
+        )
+        self.tags = self.prepare_tags(microsoft_sentinel_incidents_tags)

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
@@ -74,11 +74,14 @@ class ConverterToStix:
 
     @handle_stix2_error
     def create_incident(self, alert: dict) -> stix2.Incident | None:
+        return_key = "\n"
+
         def _get_remediation(remediation_steps: str | None) -> str:
             try:
-                return "  \n" + "  \n".join(
+                steps = "  \n".join(
                     json.loads(remediation_steps) if remediation_steps else []
                 )
+                return f"  {return_key}{steps}"
             except json.JSONDecodeError:
                 self.helper.connector_logger.warning(
                     "Error while decoding remediation steps, RemediationSteps must be a valid JSON list:"
@@ -90,39 +93,19 @@ class ConverterToStix:
         incident_created_at = format_datetime(alert.get("StartTime"))
         incident_modified_at = format_datetime(alert.get("EndTime"))
         incident_labels = [alert.get("AlertType")] if alert.get("AlertType") else None
+        remediation = _get_remediation(alert.get("RemediationSteps"))
         incident_description = (
-            "**Display Name**: "
-            + alert.get("DisplayName")
-            + "  \n"
-            + "**Alert ID**: "
-            + alert.get("SystemAlertId")
-            + "  \n"
-            + "**Status**: "
-            + alert.get("Status")
-            + "  \n"
-            + "**Severity**: "
-            + alert.get("AlertSeverity")
-            + "  \n"
-            + "**Alert Type**: "
-            + alert.get("AlertType")
-            + "  \n"
-            + "**Start Time (UTC)**: "
-            + alert.get("StartTime")
-            + "  \n"
-            + "**End Time (UTC)**: "
-            + alert.get("EndTime")
-            + "  \n"
-            + "**Time Generated (UTC)**: "
-            + alert.get("TimeGenerated")
-            + "  \n"
-            + "**Tactics**: "
-            + alert.get("Tactics")
-            + "  \n"
-            + "**Description**: "
-            + alert.get("Description")
-            + "  \n"
-            + "**Remediation**: "
-            + _get_remediation(alert.get("RemediationSteps"))
+            f"**Display Name**: {alert.get('DisplayName')}  {return_key}"
+            f"**Alert ID**: {alert.get('SystemAlertId')}  {return_key}"
+            f"**Status**: {alert.get('Status')}  {return_key}"
+            f"**Severity**: {alert.get('AlertSeverity')}  {return_key}"
+            f"**Alert Type**: {alert.get('AlertType')}  {return_key}"
+            f"**Start Time (UTC)**: {alert.get('StartTime')}  {return_key}"
+            f"**End Time (UTC)**: {alert.get('EndTime')}  {return_key}"
+            f"**Time Generated (UTC)**: {alert.get('TimeGenerated')}  {return_key}"
+            f"**Tactics**: {alert.get('Tactics')}  {return_key}"
+            f"**Description**: {alert.get('Description')}  {return_key}"
+            f"**Remediation**: {remediation}"
         )
         stix_incident = stix2.Incident(
             id=Incident.generate_id(incident_name, incident_created_at),

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
@@ -76,9 +76,7 @@ class ConverterToStix:
     def create_incident(self, alert: dict) -> stix2.Incident | None:
         def _get_remediation(remediation_steps: str | None) -> str:
             try:
-                return "  \n" + "  \n".join(
-                    json.loads(remediation_steps) if remediation_steps else []
-                )
+                return f"  \n{'  \n'.join(json.loads(remediation_steps) if remediation_steps else [])}"
             except json.JSONDecodeError:
                 self.helper.connector_logger.warning(
                     "Error while decoding remediation steps, RemediationSteps must be a valid JSON list:"
@@ -91,29 +89,17 @@ class ConverterToStix:
         incident_modified_at = format_datetime(alert.get("EndTime"))
         incident_labels = [alert.get("AlertType")] if alert.get("AlertType") else None
         incident_description = (
-            "**Display Name**: {DisplayName}  \n"
-            "**Alert ID**: {SystemAlertId}  \n"
-            "**Status**: {Status}  \n"
-            "**Severity**: {AlertSeverity}  \n"
-            "**Alert Type**: {AlertType}  \n"
-            "**Start Time (UTC)**: {StartTime}  \n"
-            "**End Time (UTC)**: {EndTime}  \n"
-            "**Time Generated (UTC)**: {TimeGenerated}  \n"
-            "**Tactics**: {Tactics}  \n"
-            "**Description**: {Description}  \n"
-            "**Remediation**:{Remediation}"
-        ).format(
-            DisplayName=alert.get("DisplayName"),
-            SystemAlertId=alert.get("SystemAlertId"),
-            Status=alert.get("Status"),
-            AlertSeverity=alert.get("AlertSeverity"),
-            AlertType=alert.get("AlertType"),
-            StartTime=alert.get("StartTime"),
-            EndTime=alert.get("EndTime"),
-            TimeGenerated=alert.get("TimeGenerated"),
-            Tactics=alert.get("Tactics"),
-            Description=alert.get("Description"),
-            Remediation=_get_remediation(alert.get("RemediationSteps")),
+            f"**Display Name**: {alert.get('DisplayName')}  \n"
+            f"**Alert ID**: {alert.get('SystemAlertId')}  \n"
+            f"**Status**: {alert.get('Status')}  \n"
+            f"**Severity**: {alert.get('AlertSeverity')}  \n"
+            f"**Alert Type**: {alert.get('AlertType')}  \n"
+            f"**Start Time (UTC)**: {alert.get('StartTime')}  \n"
+            f"**End Time (UTC)**: {alert.get('EndTime')}  \n"
+            f"**Time Generated (UTC)**: {alert.get('TimeGenerated')}  \n"
+            f"**Tactics**: {alert.get('Tactics')}  \n"
+            f"**Description**: {alert.get('Description')}  \n"
+            f"**Remediation**:{_get_remediation(alert.get("RemediationSteps"))}"
         )
         stix_incident = stix2.Incident(
             id=Incident.generate_id(incident_name, incident_created_at),

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
@@ -76,7 +76,9 @@ class ConverterToStix:
     def create_incident(self, alert: dict) -> stix2.Incident | None:
         def _get_remediation(remediation_steps: str | None) -> str:
             try:
-                return f"  \n{'  \n'.join(json.loads(remediation_steps) if remediation_steps else [])}"
+                return "  \n" + "  \n".join(
+                    json.loads(remediation_steps) if remediation_steps else []
+                )
             except json.JSONDecodeError:
                 self.helper.connector_logger.warning(
                     "Error while decoding remediation steps, RemediationSteps must be a valid JSON list:"
@@ -89,17 +91,29 @@ class ConverterToStix:
         incident_modified_at = format_datetime(alert.get("EndTime"))
         incident_labels = [alert.get("AlertType")] if alert.get("AlertType") else None
         incident_description = (
-            f"**Display Name**: {alert.get('DisplayName')}  \n"
-            f"**Alert ID**: {alert.get('SystemAlertId')}  \n"
-            f"**Status**: {alert.get('Status')}  \n"
-            f"**Severity**: {alert.get('AlertSeverity')}  \n"
-            f"**Alert Type**: {alert.get('AlertType')}  \n"
-            f"**Start Time (UTC)**: {alert.get('StartTime')}  \n"
-            f"**End Time (UTC)**: {alert.get('EndTime')}  \n"
-            f"**Time Generated (UTC)**: {alert.get('TimeGenerated')}  \n"
-            f"**Tactics**: {alert.get('Tactics')}  \n"
-            f"**Description**: {alert.get('Description')}  \n"
-            f"**Remediation**:{_get_remediation(alert.get("RemediationSteps"))}"
+            "**Display Name**: {DisplayName}  \n"
+            "**Alert ID**: {SystemAlertId}  \n"
+            "**Status**: {Status}  \n"
+            "**Severity**: {AlertSeverity}  \n"
+            "**Alert Type**: {AlertType}  \n"
+            "**Start Time (UTC)**: {StartTime}  \n"
+            "**End Time (UTC)**: {EndTime}  \n"
+            "**Time Generated (UTC)**: {TimeGenerated}  \n"
+            "**Tactics**: {Tactics}  \n"
+            "**Description**: {Description}  \n"
+            "**Remediation**:{Remediation}"
+        ).format(
+            DisplayName=alert.get("DisplayName"),
+            SystemAlertId=alert.get("SystemAlertId"),
+            Status=alert.get("Status"),
+            AlertSeverity=alert.get("AlertSeverity"),
+            AlertType=alert.get("AlertType"),
+            StartTime=alert.get("StartTime"),
+            EndTime=alert.get("EndTime"),
+            TimeGenerated=alert.get("TimeGenerated"),
+            Tactics=alert.get("Tactics"),
+            Description=alert.get("Description"),
+            Remediation=_get_remediation(alert.get("RemediationSteps")),
         )
         stix_incident = stix2.Incident(
             id=Incident.generate_id(incident_name, incident_created_at),
@@ -328,7 +342,7 @@ class ConverterToStix:
             return None
 
     @handle_stix2_error
-    def create_evidence_identity_system(self, evidence: dict) -> stix2.Identity:
+    def create_evidence_identity_system(self, evidence: dict) -> stix2.Identity | None:
         """
         Create STIX 2.1 Identity System object
         :param evidence: Evidence to create Identity system from

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/converter_to_stix.py
@@ -76,7 +76,9 @@ class ConverterToStix:
     def create_incident(self, alert: dict) -> stix2.Incident | None:
         def _get_remediation(remediation_steps: str | None) -> str:
             try:
-                return f"  \n{'  \n'.join(json.loads(remediation_steps) if remediation_steps else [])}"
+                return "  \n" + "  \n".join(
+                    json.loads(remediation_steps) if remediation_steps else []
+                )
             except json.JSONDecodeError:
                 self.helper.connector_logger.warning(
                     "Error while decoding remediation steps, RemediationSteps must be a valid JSON list:"
@@ -89,17 +91,38 @@ class ConverterToStix:
         incident_modified_at = format_datetime(alert.get("EndTime"))
         incident_labels = [alert.get("AlertType")] if alert.get("AlertType") else None
         incident_description = (
-            f"**Display Name**: {alert.get('DisplayName')}  \n"
-            f"**Alert ID**: {alert.get('SystemAlertId')}  \n"
-            f"**Status**: {alert.get('Status')}  \n"
-            f"**Severity**: {alert.get('AlertSeverity')}  \n"
-            f"**Alert Type**: {alert.get('AlertType')}  \n"
-            f"**Start Time (UTC)**: {alert.get('StartTime')}  \n"
-            f"**End Time (UTC)**: {alert.get('EndTime')}  \n"
-            f"**Time Generated (UTC)**: {alert.get('TimeGenerated')}  \n"
-            f"**Tactics**: {alert.get('Tactics')}  \n"
-            f"**Description**: {alert.get('Description')}  \n"
-            f"**Remediation**:{_get_remediation(alert.get("RemediationSteps"))}"
+            "**Display Name**: "
+            + alert.get("DisplayName")
+            + "  \n"
+            + "**Alert ID**: "
+            + alert.get("SystemAlertId")
+            + "  \n"
+            + "**Status**: "
+            + alert.get("Status")
+            + "  \n"
+            + "**Severity**: "
+            + alert.get("AlertSeverity")
+            + "  \n"
+            + "**Alert Type**: "
+            + alert.get("AlertType")
+            + "  \n"
+            + "**Start Time (UTC)**: "
+            + alert.get("StartTime")
+            + "  \n"
+            + "**End Time (UTC)**: "
+            + alert.get("EndTime")
+            + "  \n"
+            + "**Time Generated (UTC)**: "
+            + alert.get("TimeGenerated")
+            + "  \n"
+            + "**Tactics**: "
+            + alert.get("Tactics")
+            + "  \n"
+            + "**Description**: "
+            + alert.get("Description")
+            + "  \n"
+            + "**Remediation**: "
+            + _get_remediation(alert.get("RemediationSteps"))
         )
         stix_incident = stix2.Incident(
             id=Incident.generate_id(incident_name, incident_created_at),

--- a/external-import/microsoft-sentinel-incidents/tests/conftest.py
+++ b/external-import/microsoft-sentinel-incidents/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/external-import/microsoft-sentinel-incidents/tests/test-requirements.txt
+++ b/external-import/microsoft-sentinel-incidents/tests/test-requirements.txt
@@ -1,0 +1,3 @@
+# Main dependencies needs to be installed
+-r ../src/requirements.txt
+pytest

--- a/external-import/microsoft-sentinel-incidents/tests/test_config.py
+++ b/external-import/microsoft-sentinel-incidents/tests/test_config.py
@@ -3,7 +3,7 @@ from src.microsoft_sentinel_incidents_connector.config_variables import ConfigCo
 
 
 @pytest.mark.parametrize(
-    "input_tags,expected",
+    "input_filter_labels,expected",
     [
         (None, []),
         ("", []),
@@ -19,5 +19,5 @@ from src.microsoft_sentinel_incidents_connector.config_variables import ConfigCo
         ("tag 1,tag 2", ["tag 1", "tag 2"]),
     ],
 )
-def test_prepare_tags(input_tags, expected):
-    assert ConfigConnector.prepare_tags(input_tags) == expected
+def test_prepare_filter_labels(input_filter_labels, expected):
+    assert ConfigConnector.prepare_filter_labels(input_filter_labels) == expected

--- a/external-import/microsoft-sentinel-incidents/tests/test_config.py
+++ b/external-import/microsoft-sentinel-incidents/tests/test_config.py
@@ -1,0 +1,23 @@
+import pytest
+from src.microsoft_sentinel_incidents_connector.config_variables import ConfigConnector
+
+
+@pytest.mark.parametrize(
+    "input_tags,expected",
+    [
+        (None, []),
+        ("", []),
+        ("   ", []),
+        ("tag1", ["tag1"]),
+        ("tag1,tag2", ["tag1", "tag2"]),
+        ("tag1, tag2 ,tag3", ["tag1", "tag2", "tag3"]),
+        ("tag1,,tag2", ["tag1", "tag2"]),
+        (",tag1,", ["tag1"]),
+        ("tag1, , tag2", ["tag1", "tag2"]),
+        ("tag1,tag2,tag3", ["tag1", "tag2", "tag3"]),
+        ("  tag1  ,  tag2  ", ["tag1", "tag2"]),
+        ("tag 1,tag 2", ["tag 1", "tag 2"]),
+    ],
+)
+def test_prepare_tags(input_tags, expected):
+    assert ConfigConnector.prepare_tags(input_tags) == expected


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add new config option to filter incidents based on comma-separated tags

### Related issues

* Closes #4594 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
