### PR TITLE
[connector-sdk] Standardize Pydantic model syntax

### DIFF
--- a/connectors-sdk/connectors_sdk/models/octi/_common.py
+++ b/connectors-sdk/connectors_sdk/models/octi/_common.py
@@ -104,20 +104,20 @@ class BaseEntity(BaseModel):
 class BaseIdentifiedEntity(BaseEntity):
     """Base class that can be identified thanks to a stix-like id."""
 
-    _stix2_id: Optional[str] = PrivateAttr(None)
+    _stix2_id: str | None = PrivateAttr(default=None)
 
-    author: Optional["Author"] = Field(
-        None,
+    author: "Author" | None = Field(
+        default=None,
         description="The Author reporting this Observable.",
     )
 
-    markings: Optional[list["TLPMarking"]] = Field(
-        None,
+    markings: list["TLPMarking"] | None = Field(
+        default=None,
         description="References for object marking.",
     )
 
-    external_references: Optional[list["ExternalReference"]] = Field(
-        None,
+    external_references: list["ExternalReference"] | None = Field(
+        default=None,
         description="External references of the observable.",
     )
 
@@ -255,25 +255,25 @@ class AssociatedFile(BaseEntity):
     name: str = Field(
         description="The name of the file.",
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="Description of the file.",
-        default=None,
     )
-    content: Optional[bytes] = Field(
+    content: bytes | None = Field(
+        default=None,
         description="The file content.",
-        default=None,
     )
-    mime_type: Optional[str] = Field(
+    mime_type: str | None = Field(
+        default=None,
         description="File mime type.",
-        default=None,
     )
-    markings: Optional[list["TLPMarking"]] = Field(
+    markings: list["TLPMarking"] | None = Field(
+        default=None,
         description="References for object marking.",
-        default=None,
     )
-    version: Optional[str] = Field(
-        description="Version of the file.",
+    version: str | None = Field(
         default=None,
+        description="Version of the file.",
     )
 
     def to_stix2_object(self) -> AssociatedFileStix:
@@ -363,17 +363,17 @@ class ExternalReference(BaseEntity):
     source_name: str = Field(
         description="The name of the source of the external reference.",
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="Description of the external reference.",
-        default=None,
     )
-    url: Optional[str] = Field(
+    url: str | None = Field(
+        default=None,
         description="URL of the external reference.",
-        default=None,
     )
-    external_id: Optional[str] = Field(
-        description="An identifier for the external reference content.",
+    external_id: str | None = Field(
         default=None,
+        description="An identifier for the external reference content.",
     )
 
     def to_stix2_object(self) -> stix2.v21.ExternalReference:

--- a/connectors-sdk/connectors_sdk/models/octi/_common.py
+++ b/connectors-sdk/connectors_sdk/models/octi/_common.py
@@ -106,7 +106,7 @@ class BaseIdentifiedEntity(BaseEntity):
 
     _stix2_id: str | None = PrivateAttr(default=None)
 
-    author: "Author" | None = Field(
+    author: "Author | None" = Field(
         default=None,
         description="The Author reporting this Observable.",
     )

--- a/connectors-sdk/connectors_sdk/models/octi/activities/analyses.py
+++ b/connectors-sdk/connectors_sdk/models/octi/activities/analyses.py
@@ -8,7 +8,6 @@ Notes:
 """
 
 from collections import OrderedDict
-from typing import Optional
 
 import stix2.properties
 from connectors_sdk.models.octi._common import (
@@ -49,25 +48,25 @@ class Note(BaseIdentifiedEntity):
     publication_date: AwareDatetime = Field(
         description="Publication date of the note.",
     )
-    abstract: Optional[str] = Field(
+    abstract: str | None = Field(
+        default=None,
         description="A brief summary of the note content.",
-        default=None,
     )
-    note_types: Optional[list[NoteType]] = Field(
+    note_types: list[NoteType] | None = Field(
+        default=None,
         description="Types of the note.",
-        default=None,
     )
-    labels: Optional[list[str]] = Field(
+    labels: list[str] | None = Field(
+        default=None,
         description="Labels of the note.",
-        default=None,
     )
-    authors: Optional[list[str]] = Field(
+    authors: list[str] | None = Field(
+        default=None,
         description="The name of the author(s) of this note (e.g., the analyst(s) that created it).",
-        default=None,
     )
-    objects: Optional[list[BaseIdentifiedEntity]] = Field(
-        description="OCTI objects this note applies to.",
+    objects: list[BaseIdentifiedEntity] | None = Field(
         default=None,
+        description="OCTI objects this note applies to.",
     )
 
     def to_stix2_object(self) -> Stix2Note:
@@ -124,29 +123,29 @@ class Report(BaseIdentifiedEntity):
     publication_date: AwareDatetime = Field(
         description="Publication date of the report.",
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="Description of the report.",
-        default=None,
     )
-    report_types: Optional[list[ReportType]] = Field(
+    report_types: list[ReportType] | None = Field(
+        default=None,
         description="Report types.",
-        default=None,
     )
-    labels: Optional[list[str]] = Field(
+    labels: list[str] | None = Field(
+        default=None,
         description="Labels of the report",
-        default=None,
     )
-    reliability: Optional[Reliability] = Field(
+    reliability: Reliability | None = Field(
+        default=None,
         description="Reliability of the report.",
-        default=None,
     )
-    objects: Optional[list[BaseIdentifiedEntity]] = Field(
+    objects: list[BaseIdentifiedEntity] | None = Field(
+        default=None,
         description="Objects of the report.",
-        default=None,
     )
-    files: Optional[list[AssociatedFile]] = Field(
-        description="Files to upload with the report, e.g. report as a PDF.",
+    files: list[AssociatedFile] | None = Field(
         default=None,
+        description="Files to upload with the report, e.g. report as a PDF.",
     )
 
     def to_stix2_object(self) -> Stix2Report:

--- a/connectors-sdk/connectors_sdk/models/octi/activities/observations.py
+++ b/connectors-sdk/connectors_sdk/models/octi/activities/observations.py
@@ -2,7 +2,7 @@
 
 import ipaddress
 from abc import ABC, abstractmethod
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from connectors_sdk.models.octi._common import (
     MODEL_REGISTRY,
@@ -30,28 +30,28 @@ class Observable(ABC, BaseIdentifiedEntity):
     This class must be subclassed to create specific observable types.
     """
 
-    score: Optional[int] = Field(
+    score: int | None = Field(
+        default=None,
         description="Score of the observable.",
         ge=0,
         le=100,
-        default=None,
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="Description of the observable.",
-        default=None,
     )
-    labels: Optional[list[str]] = Field(
-        description="Labels of the observable.",
+    labels: list[str] | None = Field(
         default=None,
+        description="Labels of the observable.",
     )
 
-    associated_files: Optional[list["AssociatedFile"]] = Field(
+    associated_files: list["AssociatedFile"] | None = Field(
+        default=None,
         description="Associated files for the observable.",
-        default=None,
     )
-    create_indicator: Optional[bool] = Field(
-        description="If True, an indicator and a `based-on` relationship will be created for this observable. (Delegated to OpenCTI Platform).",
+    create_indicator: bool | None = Field(
         default=None,
+        description="If True, an indicator and a `based-on` relationship will be created for this observable. (Delegated to OpenCTI Platform).",
     )
 
     def _custom_properties_to_stix(self) -> dict[str, Any]:
@@ -114,8 +114,7 @@ class Indicator(BaseIdentifiedEntity):
         "See : See https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_9lfdvxnyofxw",
         min_length=1,
     )
-    main_observable_type: Optional[
-        Literal[
+    main_observable_type: Literal[
             "Stix-Cyber-Observable",
             "Artifact",
             "Autonomous-System",
@@ -148,55 +147,54 @@ class Indicator(BaseIdentifiedEntity):
             "User-Agent",
             "Windows-Registry-Key",
             "X509-Certificate",
-        ]
-    ] = Field(
+        ] | None = Field(
+        default=None,
         description="Observable type. "
         "See: https://github.com/OpenCTI-Platform/opencti/blob/master/opencti-platform/opencti-graphql/src/schema/stixCyberObservable.ts#L4",
-        default=None,
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="Description of the indicator.",
-        default=None,
     )
-    indicator_types: Optional[list[str]] = Field(
+    indicator_types: list[str] | None = Field(
+        default=None,
         description="Indicator types. The default OpenCTI types are: "
         "'anomalous-activity', 'anonymization', 'attribution', 'benign', 'compromised', 'malicious-activity', 'unknown'. "
         "See: https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_cvhfwe3t9vuo",
-        default=None,
     )
-    platforms: Optional[list[str]] = Field(
+    platforms: list[str] | None = Field(
+        default=None,
         description="Platforms. The default OpenCTI platforms are: 'windows', 'macos', 'linux', 'android'. "
         "See: https://github.com/OpenCTI-Platform/opencti/blob/master/opencti-platform/opencti-graphql/src/modules/vocabulary/vocabulary-utils.ts#L797",
-        default=None,
     )
-    valid_from: Optional[AwareDatetime] = Field(
+    valid_from: AwareDatetime | None = Field(
+        default=None,
         description="Valid from.",
-        default=None,
     )
-    valid_until: Optional[AwareDatetime] = Field(
+    valid_until: AwareDatetime | None = Field(
+        default=None,
         description="Valid until.",
-        default=None,
     )
-    kill_chain_phases: Optional[list[KillChainPhase]] = Field(
+    kill_chain_phases: list[KillChainPhase] | None = Field(
+        default=None,
         description="Kill chain phases.",
-        default=None,
     )
-    score: Optional[int] = Field(
+    score: int | None = Field(
+        default=None,
         description="Score of the indicator.",
         ge=0,
         le=100,
-        default=None,
     )
-    associated_files: Optional[list[AssociatedFile]] = Field(
-        description="Associated files for the indicator.",
+    associated_files: list[AssociatedFile] | None = Field(
         default=None,
+        description="Associated files for the indicator.",
     )
 
-    create_observables: Optional[bool] = Field(
+    create_observables: bool | None = Field(
+        default=None,
         description="If True, observables and `based-on` relationships will be created for this "
         "indicator (Delegated to OpenCTI Platform). You can also manually define the Observable objects "
         "and use BasedOnRelationship for more granularity.",
-        default=None,
     )
 
     def to_stix2_object(self) -> Stix2Indicator:
@@ -269,46 +267,46 @@ class File(Observable):
           It must be replaced by explicit `____________________` relationships.
     """
 
-    hashes: Optional[dict[HashAlgorithm, str]] = Field(
-        description="A dictionary of hashes for the file.",
+    hashes: dict[HashAlgorithm, str] | None = Field(
         default=None,
+        description="A dictionary of hashes for the file.",
         min_length=1,
     )
-    size: Optional[PositiveInt] = Field(
+    size: PositiveInt | None = Field(
+        default=None,
         description="The size of the file in bytes.",
-        default=None,
     )
-    name: Optional[str] = Field(
+    name: str | None = Field(
+        default=None,
         description="The name of the file.",
-        default=None,
     )
-    name_enc: Optional[str] = Field(
+    name_enc: str | None = Field(
+        default=None,
         description="The observed encoding for the name of the file.",
-        default=None,
     )
-    magic_number_hex: Optional[str] = Field(
+    magic_number_hex: str | None = Field(
+        default=None,
         description="The hexadecimal constant ('magic number') associated with the file format.",
-        default=None,
     )
-    mime_type: Optional[str] = Field(
+    mime_type: str | None = Field(
+        default=None,
         description="The MIME type name specified for the file, e.g., application/msword.",
-        default=None,
     )
-    ctime: Optional[AwareDatetime] = Field(
+    ctime: AwareDatetime | None = Field(
+        default=None,
         description="Date/time the directory was created.",
-        default=None,
     )
-    mtime: Optional[AwareDatetime] = Field(
+    mtime: AwareDatetime | None = Field(
+        default=None,
         description="Date/time the directory was last writtend to or modified.",
-        default=None,
     )
-    atime: Optional[AwareDatetime] = Field(
+    atime: AwareDatetime | None = Field(
+        default=None,
         description="Date/time the directory was last accessed.",
-        default=None,
     )
-    additional_names: Optional[list[str]] = Field(
-        description="Additional names of the file.",
+    additional_names: list[str] | None = Field(
         default=None,
+        description="Additional names of the file.",
     )
 
     @model_validator(mode="before")
@@ -450,25 +448,25 @@ class Software(Observable):
         description="Name of the software.",
         min_length=1,
     )
-    version: Optional[str] = Field(
+    version: str | None = Field(
+        default=None,
         description="Version of the software.",
-        default=None,
     )
-    vendor: Optional[str] = Field(
+    vendor: str | None = Field(
+        default=None,
         description="Vendor of the software.",
-        default=None,
     )
-    swid: Optional[str] = Field(
+    swid: str | None = Field(
+        default=None,
         description="SWID of the software.",
-        default=None,
     )
-    cpe: Optional[str] = Field(
+    cpe: str | None = Field(
+        default=None,
         description="CPE of the software.",
-        default=None,
     )
-    languages: Optional[list[str]] = Field(
-        description="Languages of the software.",
+    languages: list[str] | None = Field(
         default=None,
+        description="Languages of the software.",
     )
 
     def to_stix2_object(self) -> Stix2Software:

--- a/connectors-sdk/connectors_sdk/models/octi/activities/observations.py
+++ b/connectors-sdk/connectors_sdk/models/octi/activities/observations.py
@@ -114,7 +114,8 @@ class Indicator(BaseIdentifiedEntity):
         "See : See https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_9lfdvxnyofxw",
         min_length=1,
     )
-    main_observable_type: Literal[
+    main_observable_type: (
+        Literal[
             "Stix-Cyber-Observable",
             "Artifact",
             "Autonomous-System",
@@ -147,7 +148,9 @@ class Indicator(BaseIdentifiedEntity):
             "User-Agent",
             "Windows-Registry-Key",
             "X509-Certificate",
-        ] | None = Field(
+        ]
+        | None
+    ) = Field(
         default=None,
         description="Observable type. "
         "See: https://github.com/OpenCTI-Platform/opencti/blob/master/opencti-platform/opencti-graphql/src/schema/stixCyberObservable.ts#L4",

--- a/connectors-sdk/connectors_sdk/models/octi/knowledge/arsenal.py
+++ b/connectors-sdk/connectors_sdk/models/octi/knowledge/arsenal.py
@@ -1,7 +1,5 @@
 """Offer arsenal OpenCTI entities."""
 
-from typing import Optional
-
 from connectors_sdk.models.octi._common import MODEL_REGISTRY, BaseIdentifiedEntity
 from connectors_sdk.models.octi.enums import (
     CvssSeverity,
@@ -29,41 +27,41 @@ class Malware(BaseIdentifiedEntity):
     is_family: bool = Field(
         description="Is the malware a family?",
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="Description of the malware.",
-        default=None,
     )
-    aliases: Optional[list[str]] = Field(
+    aliases: list[str] | None = Field(
+        default=None,
         description="Alternative names used to identify this malware or malware family.",
-        default=None,
     )
-    types: Optional[list[MalwareType]] = Field(
+    types: list[MalwareType] | None = Field(
+        default=None,
         description="Types of the malware.",
-        default=None,
     )
-    first_seen: Optional[AwareDatetime] = Field(
+    first_seen: AwareDatetime | None = Field(
+        default=None,
         description="The time that this Malware was first seen.",
-        default=None,
     )
-    last_seen: Optional[AwareDatetime] = Field(
+    last_seen: AwareDatetime | None = Field(
+        default=None,
         description="The time that this Malware was last seen.",
-        default=None,
     )
-    architecture_execution_envs: Optional[list[ProcessorArchitecture]] = Field(
+    architecture_execution_envs: list[ProcessorArchitecture] | None = Field(
+        default=None,
         description="Architecture execution environment of the malware.",
-        default=None,
     )
-    implementation_languages: Optional[list[ImplementationLanguage]] = Field(
+    implementation_languages: list[ImplementationLanguage] | None = Field(
+        default=None,
         description="Implementation languages of the malware.",
-        default=None,
     )
-    kill_chain_phases: Optional[list[KillChainPhase]] = Field(
+    kill_chain_phases: list[KillChainPhase] | None = Field(
+        default=None,
         description="Kill chain phases of the malware.",
-        default=None,
     )
-    capabilities: Optional[list[MalwareCapability]] = Field(
-        description="Any of the capabilities identified for the malware instance or family.",
+    capabilities: list[MalwareCapability] | None = Field(
         default=None,
+        description="Any of the capabilities identified for the malware instance or family.",
     )
 
     def to_stix2_object(self) -> Stix2Malware:
@@ -103,201 +101,201 @@ class Vulnerability(BaseIdentifiedEntity):
         description="Name of the vulnerability.",
         min_length=1,
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="Description of the vulnerability.",
-        default=None,
     )
-    labels: Optional[list[str]] = Field(
+    labels: list[str] | None = Field(
+        default=None,
         description="Labels of the vulnerability.",
-        default=None,
     )
-    aliases: Optional[list[str]] = Field(
+    aliases: list[str] | None = Field(
+        default=None,
         description="Vulnerability aliases",
-        default=None,
     )
-    score: Optional[int] = Field(
-        description="Score of the vulnerability.",
+    score: int | None = Field(
         default=None,
+        description="Score of the vulnerability.",
         ge=0,
         le=100,
     )
-    epss_score: Optional[float] = Field(
+    epss_score: float | None = Field(
+        default=None,
         description="EPSS score.",
-        default=None,
         ge=0,
         le=1,
     )
-    epss_percentile: Optional[float] = Field(
+    epss_percentile: float | None = Field(
+        default=None,
         description="EPSS percentile.",
-        default=None,
         ge=0,
         le=1,
     )
-    is_cisa_kev: Optional[bool] = Field(
+    is_cisa_kev: bool | None = Field(
+        default=None,
         description="Whether vulnerability is a CISA Known Exploited Vulnerability.",
-        default=None,
     )
-    cvss_v2_vector_string: Optional[str] = Field(
+    cvss_v2_vector_string: str | None = Field(
+        default=None,
         description="CVSS v2 vector string.",
-        default=None,
     )
-    cvss_v2_base_score: Optional[float] = Field(
+    cvss_v2_base_score: float | None = Field(
+        default=None,
         description="Reflects the severity score of a vulnerability according to its intrinsic characteristics.",
-        default=None,
     )
-    cvss_v2_access_vector: Optional[str] = Field(
+    cvss_v2_access_vector: str | None = Field(
+        default=None,
         description="Reflects how the vulnerability is exploited. Abbreviation: AV",
-        default=None,
     )
-    cvss_v2_access_complexity: Optional[str] = Field(
+    cvss_v2_access_complexity: str | None = Field(
+        default=None,
         description="Measures the complexity of the attack required to exploit the vulnerability "
         "once an attacker has gained access to the target system. Abbreviation: AC",
-        default=None,
     )
-    cvss_v2_authentication: Optional[str] = Field(
+    cvss_v2_authentication: str | None = Field(
+        default=None,
         description="Measures the number of times an attacker must authenticate "
         "to a target in order to exploit a vulnerability. Abbreviation: Au",
-        default=None,
     )
-    cvss_v2_confidentiality_impact: Optional[str] = Field(
+    cvss_v2_confidentiality_impact: str | None = Field(
+        default=None,
         description="Measures the impact on confidentiality of a successfully exploited vulnerability. Abbreviation: C",
-        default=None,
     )
-    cvss_v2_integrity_impact: Optional[str] = Field(
+    cvss_v2_integrity_impact: str | None = Field(
+        default=None,
         description="Measures the impact to integrity of a successfully exploited vulnerability. Abbreviation: I",
-        default=None,
     )
-    cvss_v2_availability_impact: Optional[str] = Field(
+    cvss_v2_availability_impact: str | None = Field(
+        default=None,
         description="Measures the impact to availability of a successfully exploited vulnerability. Abbreviation: A",
-        default=None,
     )
-    cvss_v2_exploitability: Optional[str] = Field(
+    cvss_v2_exploitability: str | None = Field(
+        default=None,
         description="Measures the current state of exploit techniques or code availability. Abbreviation: E",
-        default=None,
     )
-    cvss_v3_vector_string: Optional[str] = Field(
+    cvss_v3_vector_string: str | None = Field(
+        default=None,
         description="CVSS v3 vector string.",
-        default=None,
     )
-    cvss_v3_base_score: Optional[float] = Field(
+    cvss_v3_base_score: float | None = Field(
+        default=None,
         description="Reflects the severity score of a vulnerability according to its intrinsic characteristics.",
-        default=None,
     )
-    cvss_v3_base_severity: Optional[CvssSeverity] = Field(
+    cvss_v3_base_severity: CvssSeverity | None = Field(
+        default=None,
         description="Reflects the severity level of a vulnerability according to its intrinsic characteristics.",
-        default=None,
     )
-    cvss_v3_attack_vector: Optional[str] = Field(
+    cvss_v3_attack_vector: str | None = Field(
+        default=None,
         description="Reflects the context by which vulnerability exploitation is possible. Abbreviation: AV",
-        default=None,
     )
-    cvss_v3_attack_complexity: Optional[str] = Field(
+    cvss_v3_attack_complexity: str | None = Field(
+        default=None,
         description="Describes the conditions beyond the attacker's control that must "
         "exist in order to exploit the vulnerability. Abbreviation: AC",
-        default=None,
     )
-    cvss_v3_privileges_required: Optional[str] = Field(
+    cvss_v3_privileges_required: str | None = Field(
+        default=None,
         description="Describes the level of privileges an attacker must possess before "
         "successfully exploiting the vulnerability. Abbreviation: PR",
-        default=None,
     )
-    cvss_v3_user_interaction: Optional[str] = Field(
+    cvss_v3_user_interaction: str | None = Field(
+        default=None,
         description="Captures the requirement for a user, other than the attacker, "
         "to participate in the successful compromise of the vulnerable component. Abbreviation: UI",
-        default=None,
     )
-    cvss_v3_integrity_impact: Optional[str] = Field(
+    cvss_v3_integrity_impact: str | None = Field(
+        default=None,
         description="Measures the impact to integrity of a successfully exploited vulnerability. Abbreviation: I",
-        default=None,
     )
-    cvss_v3_availability_impact: Optional[str] = Field(
+    cvss_v3_availability_impact: str | None = Field(
+        default=None,
         description="Measures the impact to the availability of the impacted component "
         "resulting from a successfully exploited vulnerability. Abbreviation: A",
-        default=None,
     )
-    cvss_v3_confidentiality_impact: Optional[str] = Field(
+    cvss_v3_confidentiality_impact: str | None = Field(
+        default=None,
         description="Measures the impact to the confidentiality of the information "
         "resources managed by a software component due to a successfully exploited vulnerability. Abbreviation: C",
-        default=None,
     )
-    cvss_v3_scope: Optional[str] = Field(
+    cvss_v3_scope: str | None = Field(
+        default=None,
         description="The ability for a vulnerability in one software component "
         "to impact resources beyond its means, or privileges. Abbreviation: S",
-        default=None,
     )
-    cvss_v3_exploit_code_maturity: Optional[str] = Field(
+    cvss_v3_exploit_code_maturity: str | None = Field(
+        default=None,
         description="Measures the likelihood of the vulnerability being attacked, and is typically "
         "based on the current state of exploit techniques, exploit code availability, or active, 'in-the-wild' exploitation. Abbreviation: E",
-        default=None,
     )
-    cvss_v4_vector_string: Optional[str] = Field(
+    cvss_v4_vector_string: str | None = Field(
+        default=None,
         description="CVSS v4 vector string.",
-        default=None,
     )
-    cvss_v4_base_score: Optional[float] = Field(
+    cvss_v4_base_score: float | None = Field(
+        default=None,
         description="Reflects the severity score of a vulnerability according to its intrinsic characteristics.",
-        default=None,
     )
-    cvss_v4_base_severity: Optional[CvssSeverity] = Field(
+    cvss_v4_base_severity: CvssSeverity | None = Field(
+        default=None,
         description="Reflects the severity level of a vulnerability according to its intrinsic characteristics.",
-        default=None,
     )
-    cvss_v4_attack_vector: Optional[str] = Field(
+    cvss_v4_attack_vector: str | None = Field(
+        default=None,
         description="Reflects the context by which vulnerability exploitation is possible. Abbreviation: AV",
-        default=None,
     )
-    cvss_v4_attack_complexity: Optional[str] = Field(
+    cvss_v4_attack_complexity: str | None = Field(
+        default=None,
         description="Captures measurable actions that must be taken by the attacker to actively evade or circumvent "
         "existing built-in security-enhancing conditions in order to obtain a working exploit. Abbreviation: AC",
-        default=None,
     )
-    cvss_v4_attack_requirements: Optional[str] = Field(
+    cvss_v4_attack_requirements: str | None = Field(
+        default=None,
         description="Captures the prerequisite deployment and execution conditions or variables "
         "of the vulnerable system that enable the attack. Abbreviation: AT",
-        default=None,
     )
-    cvss_v4_privileges_required: Optional[str] = Field(
+    cvss_v4_privileges_required: str | None = Field(
+        default=None,
         description="Describes the level of privileges an attacker must possess prior to "
         "successfully exploiting the vulnerability. Abbreviation: PR",
-        default=None,
     )
-    cvss_v4_user_interaction: Optional[str] = Field(
+    cvss_v4_user_interaction: str | None = Field(
+        default=None,
         description="Captures the requirement for a human user, other than the attacker, to participate "
         "in the successful compromise of the vulnerable system. Abbreviation: UI",
-        default=None,
     )
-    cvss_v4_vs_confidentiality_impact: Optional[str] = Field(
+    cvss_v4_vs_confidentiality_impact: str | None = Field(
+        default=None,
         description="Measures the impact to the confidentiality of the information managed by "
         "the system due to a successfully exploited vulnerability. Abbreviation: VC",
-        default=None,
     )
-    cvss_v4_ss_confidentiality_impact: Optional[str] = Field(
+    cvss_v4_ss_confidentiality_impact: str | None = Field(
+        default=None,
         description="Measures the impact to the confidentiality of the information managed by "
         "the system due to a successfully exploited vulnerability. Abbreviation: SC",
-        default=None,
     )
-    cvss_v4_vs_integrity_impact: Optional[str] = Field(
+    cvss_v4_vs_integrity_impact: str | None = Field(
+        default=None,
         description="Measures the impact to integrity of a successfully exploited vulnerability. Abbreviation: VI",
-        default=None,
     )
-    cvss_v4_ss_integrity_impact: Optional[str] = Field(
+    cvss_v4_ss_integrity_impact: str | None = Field(
+        default=None,
         description="Measures the impact to integrity of a successfully exploited vulnerability. Abbreviation: SI",
-        default=None,
     )
-    cvss_v4_vs_availability_impact: Optional[str] = Field(
+    cvss_v4_vs_availability_impact: str | None = Field(
+        default=None,
         description="Measures the impact to the availability of the impacted system resulting "
         "from a successfully exploited vulnerability. Abbreviation: VA",
-        default=None,
     )
-    cvss_v4_ss_availability_impact: Optional[str] = Field(
+    cvss_v4_ss_availability_impact: str | None = Field(
+        default=None,
         description="Measures the impact to the availability of the impacted system resulting "
         "from a successfully exploited vulnerability. Abbreviation: SA",
-        default=None,
     )
-    cvss_v4_exploit_maturity: Optional[str] = Field(
+    cvss_v4_exploit_maturity: str | None = Field(
+        default=None,
         description="Measures the likelihood of the vulnerability being attacked, and is based on the current state of "
         "exploit techniques, exploit code availability, or active, “in-the-wild” exploitation. Abbreviation: E",
-        default=None,
     )
 
     def to_stix2_object(self) -> Stix2Vulnerability:

--- a/connectors-sdk/connectors_sdk/models/octi/knowledge/entities.py
+++ b/connectors-sdk/connectors_sdk/models/octi/knowledge/entities.py
@@ -1,7 +1,5 @@
 """Offer OpenCTI entities."""
 
-from typing import Optional
-
 from connectors_sdk.models.octi._common import MODEL_REGISTRY, BaseIdentifiedEntity
 from connectors_sdk.models.octi.enums import (
     IndustrySector,
@@ -26,21 +24,21 @@ class Individual(BaseIdentifiedEntity):
         description="Name of the organization.",
         min_length=1,
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="Description of the organization.",
-        default=None,
     )
-    contact_information: Optional[str] = Field(
+    contact_information: str | None = Field(
+        default=None,
         description="Contact information for the organization.",
-        default=None,
     )
-    reliability: Optional[Reliability] = Field(
+    reliability: Reliability | None = Field(
+        default=None,
         description="OpenCTI Reliability of the organization.",
-        default=None,
     )
-    aliases: Optional[list[str]] = Field(
-        description="Aliases of the organization.",
+    aliases: list[str] | None = Field(
         default=None,
+        description="Aliases of the organization.",
     )
 
     def to_stix2_object(self) -> Stix2Identity:
@@ -86,25 +84,25 @@ class Organization(BaseIdentifiedEntity):
         description="Name of the organization.",
         min_length=1,
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="Description of the organization.",
-        default=None,
     )
-    contact_information: Optional[str] = Field(
+    contact_information: str | None = Field(
+        default=None,
         description="Contact information for the organization.",
-        default=None,
     )
-    organization_type: Optional[OrganizationType] = Field(
+    organization_type: OrganizationType | None = Field(
+        default=None,
         description="OpenCTI Type of the organization.",
-        default=None,
     )
-    reliability: Optional[Reliability] = Field(
+    reliability: Reliability | None = Field(
+        default=None,
         description="OpenCTI Reliability of the organization.",
-        default=None,
     )
-    aliases: Optional[list[str]] = Field(
-        description="Aliases of the organization.",
+    aliases: list[str] | None = Field(
         default=None,
+        description="Aliases of the organization.",
     )
 
     def to_stix2_object(self) -> Stix2Identity:
@@ -146,21 +144,21 @@ class Sector(BaseIdentifiedEntity):
         description="Name of the sector.",
         min_length=1,
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="Description of the sector.",
-        default=None,
     )
-    sectors: Optional[list[IndustrySector]] = Field(
+    sectors: list[IndustrySector] | None = Field(
+        default=None,
         description="The list of industry sectors that this Identity belongs to.",
-        default=None,
     )
-    reliability: Optional[Reliability] = Field(
+    reliability: Reliability | None = Field(
+        default=None,
         description="OpenCTI Reliability of the sector.",
-        default=None,
     )
-    aliases: Optional[list[str]] = Field(
-        description="Aliases of the sector.",
+    aliases: list[str] | None = Field(
         default=None,
+        description="Aliases of the sector.",
     )
 
     def to_stix2_object(self) -> Stix2Identity:

--- a/connectors-sdk/connectors_sdk/models/octi/knowledge/locations.py
+++ b/connectors-sdk/connectors_sdk/models/octi/knowledge/locations.py
@@ -1,7 +1,5 @@
 """Offer locations OpenCTI entities."""
 
-from typing import Optional
-
 from connectors_sdk.models.octi._common import MODEL_REGISTRY, BaseIdentifiedEntity
 from connectors_sdk.models.octi.enums import LocationType
 from pycti import Location as PyctiLocation
@@ -34,17 +32,17 @@ class City(BaseIdentifiedEntity):
     name: str = Field(
         description="A name used to identify the City.",
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="A textual description of the City.",
-        default=None,
     )
-    latitude: Optional[float] = Field(
+    latitude: float | None = Field(
+        default=None,
         description="The latitude of the City in decimal degrees.",
-        default=None,
     )
-    longitude: Optional[float] = Field(
-        description="The longitude of the City in decimal degrees.",
+    longitude: float | None = Field(
         default=None,
+        description="The longitude of the City in decimal degrees.",
     )
 
     def to_stix2_object(self) -> Stix2Location:
@@ -80,9 +78,9 @@ class Country(BaseIdentifiedEntity):
     name: str = Field(
         description="A name used to identify the Country.",
     )
-    description: Optional[str] = Field(
-        description="A textual description of the Country.",
+    description: str | None = Field(
         default=None,
+        description="A textual description of the Country.",
     )
 
     def to_stix2_object(self) -> Stix2Location:

--- a/connectors-sdk/connectors_sdk/models/octi/knowledge/techniques.py
+++ b/connectors-sdk/connectors_sdk/models/octi/knowledge/techniques.py
@@ -1,7 +1,5 @@
 """Offer techniques OpenCTI entities."""
 
-from typing import Optional
-
 from connectors_sdk.models.octi._common import MODEL_REGISTRY, BaseIdentifiedEntity
 from connectors_sdk.models.octi.enums import Permission, Platform
 from connectors_sdk.models.octi.settings.taxonomies import KillChainPhase
@@ -18,37 +16,37 @@ class AttackPattern(BaseIdentifiedEntity):
         description="Name of the attack pattern.",
         min_length=1,
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="Description of the attack pattern.",
-        default=None,
     )
-    labels: Optional[list[str]] = Field(
+    labels: list[str] | None = Field(
+        default=None,
         description="Labels of the attack pattern.",
-        default=None,
     )
-    aliases: Optional[list[str]] = Field(
+    aliases: list[str] | None = Field(
+        default=None,
         description="Vulnerability aliases",
-        default=None,
     )
-    kill_chain_phases: Optional[list[KillChainPhase]] = Field(
+    kill_chain_phases: list[KillChainPhase] | None = Field(
+        default=None,
         description="Kill chain phases associated with the attack pattern.",
-        default=None,
     )
-    mitre_id: Optional[str] = Field(
+    mitre_id: str | None = Field(
+        default=None,
         description="MITRE ATT&CK ID of the attack pattern.",
-        default=None,
     )
-    mitre_detection: Optional[str] = Field(
+    mitre_detection: str | None = Field(
+        default=None,
         description="MITRE ATT&CK detection of the attack pattern.",
-        default=None,
     )
-    mitre_platforms: Optional[list[Platform]] = Field(
+    mitre_platforms: list[Platform] | None = Field(
+        default=None,
         description="MITRE ATT&CK platforms of the attack pattern.",
-        default=None,
     )
-    mitre_required_permissions: Optional[list[Permission]] = Field(
-        description="MITRE ATT&CK required permissions of the attack pattern.",
+    mitre_required_permissions: list[Permission] | None = Field(
         default=None,
+        description="MITRE ATT&CK required permissions of the attack pattern.",
     )
 
     def to_stix2_object(self) -> Stix2AttackPattern:

--- a/connectors-sdk/connectors_sdk/models/octi/knowledge/threats.py
+++ b/connectors-sdk/connectors_sdk/models/octi/knowledge/threats.py
@@ -1,7 +1,5 @@
 """Offer threats OpenCTI entities."""
 
-from typing import Optional
-
 from connectors_sdk.models.octi._common import MODEL_REGISTRY, BaseIdentifiedEntity
 from connectors_sdk.models.octi.enums import (
     AttackMotivation,
@@ -25,37 +23,37 @@ class IntrusionSet(BaseIdentifiedEntity):
         description="A name used to identify this Intrusion Set.",
         min_length=1,
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="A description that provides more details and context about the Intrusion Set.",
-        default=None,
     )
-    aliases: Optional[list[str]] = Field(
+    aliases: list[str] | None = Field(
+        default=None,
         description="Alternative names used to identify this Intrusion Set.",
-        default=None,
     )
-    first_seen: Optional[AwareDatetime] = Field(
+    first_seen: AwareDatetime | None = Field(
+        default=None,
         description="The time that this Intrusion Set was first seen.",
-        default=None,
     )
-    last_seen: Optional[AwareDatetime] = Field(
+    last_seen: AwareDatetime | None = Field(
+        default=None,
         description="The time that this Intrusion Set was last seen.",
-        default=None,
     )
-    goals: Optional[list[str]] = Field(
+    goals: list[str] | None = Field(
+        default=None,
         description="The high-level goals of this Intrusion Set, namely, what are they trying to do.",
-        default=None,
     )
-    resource_level: Optional[AttackResourceLevel] = Field(
+    resource_level: AttackResourceLevel | None = Field(
+        default=None,
         description="The organizational level at which this Intrusion Set typically works.",
-        default=None,
     )
-    primary_motivation: Optional[AttackMotivation] = Field(
+    primary_motivation: AttackMotivation | None = Field(
+        default=None,
         description="The primary reason, motivation, or purpose behind this Intrusion Set.",
-        default=None,
     )
-    secondary_motivations: Optional[list[AttackMotivation]] = Field(
-        description="The secondary reasons, motivations, or purposes behind this Intrusion Set.",
+    secondary_motivations: list[AttackMotivation] | None = Field(
         default=None,
+        description="The secondary reasons, motivations, or purposes behind this Intrusion Set.",
     )
 
     def to_stix2_object(self) -> Stix2IntrusionSet:
@@ -88,53 +86,53 @@ class ThreatActorGroup(BaseIdentifiedEntity):
         description="A name used to identify this Threat Actor.",
         min_length=1,
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="A description that provides more details and context about the Threat Actor.",
-        default=None,
     )
-    threat_actor_types: Optional[list[ThreatActorTypes]] = Field(
+    threat_actor_types: list[ThreatActorTypes] | None = Field(
+        default=None,
         description="The type(s) of this threat actor.",
-        default=None,
     )
-    aliases: Optional[list[str]] = Field(
+    aliases: list[str] | None = Field(
+        default=None,
         description="Alternative names used to identify this Threat Actor.",
-        default=None,
     )
-    first_seen: Optional[AwareDatetime] = Field(
+    first_seen: AwareDatetime | None = Field(
+        default=None,
         description="The time that this Threat Actor was first seen.",
-        default=None,
     )
-    last_seen: Optional[AwareDatetime] = Field(
+    last_seen: AwareDatetime | None = Field(
+        default=None,
         description="The time that this Threat Actor was last seen.",
-        default=None,
     )
-    roles: Optional[list[ThreatActorRole]] = Field(
+    roles: list[ThreatActorRole] | None = Field(
+        default=None,
         description="A list of roles the Threat Actor plays.",
-        default=None,
     )
-    goals: Optional[list[str]] = Field(
+    goals: list[str] | None = Field(
+        default=None,
         description="The high-level goals of this Threat Actor, namely, what are they trying to do.",
-        default=None,
     )
-    sophistication: Optional[ThreatActorSophistication] = Field(
+    sophistication: ThreatActorSophistication | None = Field(
+        default=None,
         description="The skill, specific knowledge, special training, or expertise a Threat Actor must have to perform the attack.",
-        default=None,
     )
-    resource_level: Optional[AttackResourceLevel] = Field(
+    resource_level: AttackResourceLevel | None = Field(
+        default=None,
         description="The organizational level at which this Threat Actor typically works.",
-        default=None,
     )
-    primary_motivation: Optional[AttackMotivation] = Field(
+    primary_motivation: AttackMotivation | None = Field(
+        default=None,
         description="The primary reason, motivation, or purpose behind this Threat Actor.",
-        default=None,
     )
-    secondary_motivations: Optional[list[AttackMotivation]] = Field(
+    secondary_motivations: list[AttackMotivation] | None = Field(
+        default=None,
         description="The secondary reasons, motivations, or purposes behind this Threat Actor.",
-        default=None,
     )
-    personal_motivations: Optional[list[AttackMotivation]] = Field(
-        description="The personal reasons, motivations, or purposes of the Threat Actor regardless of organizational goals.",
+    personal_motivations: list[AttackMotivation] | None = Field(
         default=None,
+        description="The personal reasons, motivations, or purposes of the Threat Actor regardless of organizational goals.",
     )
 
     def to_stix2_object(self) -> Stix2ThreatActor:

--- a/connectors-sdk/connectors_sdk/models/octi/relationships.py
+++ b/connectors-sdk/connectors_sdk/models/octi/relationships.py
@@ -1,6 +1,6 @@
 """Define Relationships handled by OpenCTI platform."""
 
-from typing import Literal, Optional
+from typing import Literal
 
 from connectors_sdk.models.octi._common import MODEL_REGISTRY, BaseIdentifiedEntity
 from pycti import StixCoreRelationship as PyctiStixCoreRelationship
@@ -27,17 +27,17 @@ class Relationship(BaseIdentifiedEntity):
     target: BaseIdentifiedEntity = Field(
         description="The target entity of the relationship.",
     )
-    description: Optional[str] = Field(
+    description: str | None = Field(
+        default=None,
         description="Description of the relationship.",
-        default=None,
     )
-    start_time: Optional[AwareDatetime] = Field(
+    start_time: AwareDatetime | None = Field(
+        default=None,
         description="Start time of the relationship in ISO 8601 format.",
-        default=None,
     )
-    stop_time: Optional[AwareDatetime] = Field(
-        description="End time of the relationship in ISO 8601 format.",
+    stop_time: AwareDatetime | None = Field(
         default=None,
+        description="End time of the relationship in ISO 8601 format.",
     )
 
     def to_stix2_object(self) -> Stix2Relationship:

--- a/connectors-sdk/connectors_sdk/models/octi/settings/taxonomies.py
+++ b/connectors-sdk/connectors_sdk/models/octi/settings/taxonomies.py
@@ -14,8 +14,8 @@ class KillChainPhase(BaseEntity):
         >>> entity = phase.to_stix2_object()
     """
 
-    chain_name: str = Field(..., description="Name of the kill chain.")
-    phase_name: str = Field(..., description="Name of the kill chain phase.")
+    chain_name: str = Field(description="Name of the kill chain.")
+    phase_name: str = Field(description="Name of the kill chain phase.")
 
     def to_stix2_object(self) -> stix2.v21.KillChainPhase:
         """Make stix object."""


### PR DESCRIPTION
### Proposed changes

* Consistency in `Field` definitions (e.g., use of explicit default values, remove ellipsis (...), etc.).
* Order of field arguments (preferably alphabetical).
* Migration from `Optional[<type>]` to `<type> | None` for optional fields, in line with [Pydantic v2](https://docs.pydantic.dev/latest/concepts/fields/#default-values). 

### Related issues

* #4889

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
