### PR TITLE
TheHive connector : Add a whitelist TAG to optionnaly filter transmited cases to OpenCTI

### DIFF
--- a/external-import/thehive/README.md
+++ b/external-import/thehive/README.md
@@ -28,6 +28,7 @@ Setting up TheHive Connector is straightforward. The following table provides de
 | `thehive.alert_status_mapping`  | `THEHIVE_ALERT_STATUS_MAPPING`| No        | Status mapping for alerts. e.g., `hive_status_1:opencti_status_id_2,hive_status_2:opencti_status_id_2`                                            |
 | `thehive.user_mapping`          | `THEHIVE_USER_MAPPING`        | No        | Mapping of TheHive assignees to OpenCTI users. e.g., `user@contoso.com:opencti_user_id,user2@contoso.com:opencti_user_id_2`                 |
 | `thehive.interval`              | `THEHIVE_INTERVAL`            | Yes       | Frequency of running the connector in minutes.                  |
+| `thehive.case_tag_whitelist`    | `THEHIVE_CASE_TAG_WHITELIST`  | No        | Whitelist to accept only case with configurated TAGS (if not empty)           |
 
 ## Supported Indicator Field Names
 The following is a list of indicator Field Names supported by this integration and the prescribed value types. Indicators of this field name will be imported into OpenCTI as the STIX object defined. Please ensure that the field names are receiving standardized values to avoid potential import errors (e.g., and IP is an IP).

--- a/external-import/thehive/docker-compose.yml
+++ b/external-import/thehive/docker-compose.yml
@@ -22,4 +22,5 @@ services:
       - THEHIVE_ALERT_STATUS_MAPPING= # TheHive_ExtStatus_Text1:OpenCTI_Status_ID1,TheHive_ExtStatus_Text2:OpenCTI_Status_ID2
       - THEHIVE_USER_MAPPING= # Format: TheHive_Assignee_Email1:OpenCTI_User_ID1,TheHive_Assignee_Email2:OpenCTI_User_ID2
       - THEHIVE_INTERVAL=5 # In minutes
+      - THEHIVE_CASE_TAG_WHITELIST= # TAG_OK,TAG_GOOD
     restart: always

--- a/external-import/thehive/src/config.yml.sample
+++ b/external-import/thehive/src/config.yml.sample
@@ -24,3 +24,4 @@ thehive:
   alert_status_mapping: '' # TheHive_ExtStatus_Text1:OpenCTI_Status_ID1,TheHive_ExtStatus_Text2:OpenCTI_Status_ID2
   user_mapping: '' # Format: TheHive_Assignee_Email1:OpenCTI_User_ID1,TheHive_Assignee_Email2:OpenCTI_User_ID2
   interval: 5 # In minutes
+  case_tag_whitelist: '' # TAG_OK,TAG_GOOD

--- a/external-import/thehive/src/thehive.py
+++ b/external-import/thehive/src/thehive.py
@@ -25,7 +25,7 @@ from pycti import (
     get_config_variable,
 )
 from thehive4py import TheHiveApi
-from thehive4py.query import Gt
+from thehive4py.query import Gt, In
 from thehive4py.query.page import Paginate
 from thehive4py.query.sort import Asc
 from thehive4py.types.alert import OutputAlert
@@ -87,6 +87,13 @@ class TheHive:
             ["thehive", "case_status_mapping"],
             config,
             False,
+			"",
+        ).split(",")
+        self.thehive_case_tag_whitelist = get_config_variable(
+            "THEHIVE_CASE_TAG_WHITELIST",
+            ["thehive", "case_tag_whitelist"],
+            config,
+            False,
             "",
         ).split(",")
         self.thehive_task_status_mapping = get_config_variable(
@@ -133,7 +140,10 @@ class TheHive:
             f"Constructing query with last date: {format_datetime(last_date, DEFAULT_UTC_DATETIME)}"
         )
         if type == "case":
-            return Gt("_updatedAt", int(last_date * 1000)) | Gt(
+            if len(self.thehive_case_tag_whitelist) > 0:
+                return In("tags", self.thehive_case_tag_whitelist) & ( Gt("_updatedAt", int(last_date * 1000)) | Gt("_createdAt", int(last_date * 1000)))
+            else:
+                return Gt("_updatedAt", int(last_date * 1000)) | Gt(
                 "_createdAt", int(last_date * 1000)
             )
         elif type == "alert":
@@ -381,6 +391,7 @@ class TheHive:
 
         # check if type is case or alert, run search based on provided type.
         if type == "case":
+            self.helper.log_debug(f"query: {query}")
             items: list["OutputCase"] = self.thehive_api.case.find(
                 filters=query,
                 sortby=Asc("_updatedAt"),


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
Introduce an optional whitelist feature, enabling the transfer of cases from TheHive to OpenCTI only if they have at least one tag matching those specified in a configured list.
* If no whitelist is set, the current behavior remains unchanged.
* The corresponding configuration parameter is called `thehive.case_tag_whitelist`.
* The related Docker environment variable is `THEHIVE_CASE_TAG_WHITELIST`.


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This new feature allows you to selectively transfer only relevant cases from TheHive to OpenCTI by pre-filtering them based on their tags in TheHive.

