### PR TITLE
[DIODE-Import|  Fix the bug of filtering by scope lead to no data ingested #4274

### DIFF
--- a/external-import/diode-import/src/diode-import.py
+++ b/external-import/diode-import/src/diode-import.py
@@ -55,7 +55,6 @@ class DiodeImport:
         file_paths = glob.glob(path, recursive=True)
         file_paths.sort(key=os.path.getctime)
         for file_path in file_paths:
-
             # Fetch file content
             file = open(file_path, mode="r")
             file_content = file.read()
@@ -108,7 +107,6 @@ class DiodeImport:
             )
             self.helper.send_stix2_bundle(
                 json.dumps(json_content.get("bundle")),
-                entities_types=self.helper.connect_scope,
                 update=json_content.get("update", False),
                 work_id=work_id,
             )


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

A modification of the default value for the connectors scope from `None` to `not-applicable` introduced a breaking change in the current usage of the DIODE connector.  
As stated in issue #4274 , the connector stopped ingesting data because this change caused entity filtering based on the scoped value.

This was categorized as a bug, and the decision was made to revert to the previous behavior: disabling filtering by scope.

To fix this, I simply removed `entities_types` from the call to `send_stix2_bundle`, allowing it to use the default value `None`, which effectively disables filtering.

### Related issues

#4274 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
