### PR TITLE
[S3] Mapping of the X_severity field on the OpenCTI score & better modeling of Notes

### DIFF
--- a/external-import/s3/src/s3.py
+++ b/external-import/s3/src/s3.py
@@ -220,7 +220,6 @@ class S3Connector:
             if "object_marking_refs" not in obj:
                 obj["object_marking_refs"] = [self.s3_marking["id"]]
 
-
             if "x_severity" in obj:
                 # handle mapping of "x_severity" on Vulnerability object
                 if obj["type"] == "vulnerability":
@@ -243,7 +242,6 @@ class S3Connector:
                         obj["x_opencti_score"] = 60
                     elif obj["x_severity"] == "low":
                         obj["x_opencti_score"] = 30
-
 
             # Aliases
             if "x_alias" in obj:
@@ -286,7 +284,7 @@ class S3Connector:
             # Title Note
             if obj.get("x_title", None) and obj.get("x_acti_uuid", None):
                 # generate a unique note identifier that don't change in the time even of the obj_name change or x_title change
-                note_key = obj.get("x_acti_uuid")+" - Title"
+                note_key = obj.get("x_acti_uuid") + " - Title"
                 note_abstract = obj.get("name") + " - Title"
                 note = stix2.Note(
                     id=Note.generate_id(obj["created"], note_key),
@@ -306,7 +304,7 @@ class S3Connector:
             # Analysis Note
             if obj.get("x_analysis", None) and obj.get("x_acti_uuid", None):
                 # generate a unique note identifier that don't change in the time even of the obj_name change or x_analysis change
-                note_key = obj.get("x_acti_uuid")+" - Analysis"
+                note_key = obj.get("x_acti_uuid") + " - Analysis"
                 note_abstract = obj.get("name") + " - Analysis"
                 note = stix2.Note(
                     id=Note.generate_id(obj["created"], note_key),
@@ -329,7 +327,7 @@ class S3Connector:
                 for history in obj.get("x_history"):
                     note_content += f"| {history.get('timestamp', '')} | {history.get('comment', '')} |\n"
 
-                note_key = obj.get("x_acti_uuid")+" - History"
+                note_key = obj.get("x_acti_uuid") + " - History"
                 abstract = obj.get("name") + " - History"
                 note = stix2.Note(
                     id=Note.generate_id(obj["created"], note_key),


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Mapping of the X_severity field on the OpenCTI score & better modeling of Notes

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4899

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
