### PR TITLE
[Flashpoint] Remove ExternalReference causing a blacklisting on flashpoint side

### DIFF
--- a/external-import/flashpoint/src/flashpoint_connector/misp_converter_to_stix.py
+++ b/external-import/flashpoint/src/flashpoint_connector/misp_converter_to_stix.py
@@ -1642,16 +1642,8 @@ class MISPConverterToStix:
         if "Tag" in event["Event"]:
             event_tags = self._resolve_tags(event["Event"]["Tag"])
 
-        event_external_reference = stix2.ExternalReference(
-            source_name=self.helper.connect_name,
-            description=event["Event"]["info"],
-            external_id=event["Event"]["uuid"],
-            url="https://app.flashpoint.io/cti/malware/iocs?query="
-            + event["Event"]["uuid"],
-        )
-
         # Get indicators
-        event_external_references = [event_external_reference]
+        event_external_references = []
         indicators = []
         # Get attributes of event
         create_relationships = len(event["Event"].get("Attribute", [])) < 10000


### PR DESCRIPTION
### Proposed changes

* [Flashpoint] Remove URL from ExternalReference causing a blacklisting on flashpoint side

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4453

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
