### PR TITLE
[Shadowserver] fix: Return empty list instead of None on empty results

### DIFF
--- a/external-import/shadowserver/src/shadowserver/api.py
+++ b/external-import/shadowserver/src/shadowserver/api.py
@@ -3,7 +3,7 @@ import hmac
 import json
 import logging
 from json import JSONDecodeError
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urljoin
 
 import requests
@@ -149,7 +149,7 @@ class ShadowserverAPI:
         limit: int = LIMIT,
         incident: dict = {},
         labels: List[str] = ["Shadowserver"],
-    ) -> Optional[Dict]:
+    ) -> list[Any]:
         """
         Retrieves a STIX report based on the specified report parameters.
 
@@ -160,7 +160,7 @@ class ShadowserverAPI:
             labels (list, optional): Labels to apply to the STIX objects. Defaults to ['Shadowserver'].
 
         Returns:
-            dict or None: The retrieved STIX report in dictionary format, or None if an error occurred.
+            list: A list of STIX objects.
         """
         if not report.get("id") or not report.get("report"):
             raise ValueError(f"Invalid report: {report}")
@@ -184,4 +184,4 @@ class ShadowserverAPI:
             )
             return stix_transformation.get_stix_objects()
         else:
-            return None
+            return []


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/connector/lib/external_import.py", line 98, in process
    self.process_message()
  File "/opt/connector/lib/external_import.py", line 89, in process_message
    self.process_data()
  File "/opt/connector/lib/external_import.py", line 68, in process_data
    if not (bundle_objects := self._collect_intelligence()):
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/connector/shadowserver/connector.py", line 103, in _collect_intelligence
    for stix_object in report_stix_objects:
                       ^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

This error has been retrieved from the connector

### Proposed changes

* fix: Return empty list instead of None on empty results

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4973

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
