### PR TITLE
[Unpac Me] Rename unpac connector

### DIFF
--- a/internal-enrichment/unpac-me/docker-compose.yml
+++ b/internal-enrichment/unpac-me/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  connector-hatching-triage-sandbox:
+  connector-unpac-me:
     image: opencti/connector-unpac-me:rolling
     environment:
       - OPENCTI_URL=ChangeMe


### PR DESCRIPTION
Seems like the wrong connector name was used for unpac.me. I don't assume there would be negative impact of this change. FYI @YungBinary

## Related issue
- https://github.com/OpenCTI-Platform/connectors/issues/5044
