### PR TITLE
[Crowdstrike] Create and link IOCs when import and ingest an Intrusion Set (#5017)

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/actor/builder.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/actor/builder.py
@@ -51,6 +51,7 @@ class ActorBundleBuilder:
         source_name: str,
         object_markings: List[MarkingDefinition],
         confidence_level: int,
+        related_indicators: Optional[List] = None,
     ) -> None:
         """Initialize actor bundle builder."""
         self.actor = actor
@@ -58,6 +59,7 @@ class ActorBundleBuilder:
         self.source_name = source_name
         self.object_markings = object_markings
         self.confidence_level = confidence_level
+        self.related_indicators = related_indicators or []
 
         first_seen = timestamp_to_datetime(self.actor["first_activity_date"])
         last_seen = timestamp_to_datetime(self.actor["last_activity_date"])
@@ -283,5 +285,8 @@ class ActorBundleBuilder:
             intrusion_sets, target_sectors
         )
         bundle_objects.extend(intrusion_sets_target_sectors)
+
+        # Add related indicators and their entities to bundle
+        bundle_objects.extend(self.related_indicators)
 
         return Bundle(objects=bundle_objects, allow_custom=True)

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/actor/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/actor/importer.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 """OpenCTI CrowdStrike actor importer module."""
 
+from collections import Counter
 from datetime import datetime
 from typing import Any, Dict, Generator, List, Optional
 
 from crowdstrike_feeds_services.client.actors import ActorsAPI
+from crowdstrike_feeds_services.client.indicators import IndicatorsAPI
 from crowdstrike_feeds_services.utils import (
     datetime_to_timestamp,
     paginate,
@@ -16,6 +18,7 @@ from pycti.connector.opencti_connector_helper import (  # type: ignore  # noqa: 
 from stix2 import Bundle, Identity, MarkingDefinition  # type: ignore
 
 from ..importer import BaseImporter
+from ..indicator.builder import IndicatorBundleBuilder, IndicatorBundleBuilderConfig
 from .builder import ActorBundleBuilder
 
 
@@ -25,6 +28,7 @@ class ActorImporter(BaseImporter):
     _NAME = "Actor"
 
     _LATEST_ACTOR_TIMESTAMP = "latest_actor_timestamp"
+    _LATEST_INDICATOR_TIMESTAMP = "latest_indicator_timestamp"
 
     def __init__(
         self,
@@ -32,11 +36,14 @@ class ActorImporter(BaseImporter):
         author: Identity,
         default_latest_timestamp: int,
         tlp_marking: MarkingDefinition,
+        indicator_config: Dict[str, Any],
     ) -> None:
         """Initialize CrowdStrike actor importer."""
         super().__init__(helper, author, tlp_marking)
         self.actors_api_cs = ActorsAPI(helper)
+        self.indicators_api_cs = IndicatorsAPI(helper)
         self.default_latest_timestamp = default_latest_timestamp
+        self.indicator_config = indicator_config
 
     def run(self, state: Dict[str, Any]) -> Dict[str, Any]:
         """Run importer."""
@@ -45,6 +52,8 @@ class ActorImporter(BaseImporter):
         fetch_timestamp = state.get(
             self._LATEST_ACTOR_TIMESTAMP, self.default_latest_timestamp
         )
+
+        self.current_state = state.copy()
 
         new_state = state.copy()
 
@@ -147,13 +156,155 @@ class ActorImporter(BaseImporter):
 
         self._send_bundle(actor_bundle)
 
+    def _get_related_iocs(self, actor_name: str) -> List[Any]:
+        """Get IOCs associated with the specified actor."""
+        try:
+            related_indicators = []
+            related_indicators_with_related_entities = []
+            _limit = 10000
+            _sort = "last_updated|asc"
+
+            fetch_timestamp = self.indicator_config.get(
+                "default_latest_timestamp", self.default_latest_timestamp
+            )
+            timestamp_source = "config_default"
+
+            if self.current_state.get(self._LATEST_INDICATOR_TIMESTAMP):
+                fetch_timestamp = self.current_state.get(
+                    self._LATEST_INDICATOR_TIMESTAMP
+                )
+                timestamp_source = "indicator"
+            elif self.current_state.get(self._LATEST_ACTOR_TIMESTAMP):
+                fetch_timestamp = self.current_state.get(self._LATEST_ACTOR_TIMESTAMP)
+                timestamp_source = "actor"
+
+            _fql_filter = f"actors:['{actor_name}']+last_updated:>{fetch_timestamp}"
+
+            exclude_types = self.indicator_config.get("exclude_types", [])
+            if exclude_types:
+                _fql_filter = f"{_fql_filter}+type:!{exclude_types}"
+
+            self._info(
+                "Fetching IOCs for actor {0} with timestamp filter {1} (using {2} timestamp)",
+                actor_name,
+                timestamp_to_datetime(fetch_timestamp),
+                timestamp_source,
+            )
+
+            response = self.indicators_api_cs.get_combined_indicator_entities(
+                limit=_limit, sort=_sort, fql_filter=_fql_filter, deep_pagination=True
+            )
+            related_indicators.extend(response["resources"])
+
+            self._info(
+                "Retrieved {0} raw IOCs from CrowdStrike for actor: {1}",
+                len(related_indicators),
+                actor_name,
+            )
+
+            if related_indicators is not None:
+                for indicator in related_indicators:
+                    bundle_builder_config = IndicatorBundleBuilderConfig(
+                        indicator=indicator,
+                        author=self.author,
+                        source_name=self._source_name(),
+                        object_markings=[self.tlp_marking],
+                        confidence_level=self._confidence_level(),
+                        create_observables=self.indicator_config["create_observables"],
+                        create_indicators=self.indicator_config["create_indicators"],
+                        default_x_opencti_score=self.indicator_config[
+                            "default_x_opencti_score"
+                        ],
+                        indicator_low_score=self.indicator_config[
+                            "indicator_low_score"
+                        ],
+                        indicator_low_score_labels=self.indicator_config[
+                            "indicator_low_score_labels"
+                        ],
+                        indicator_medium_score=self.indicator_config[
+                            "indicator_medium_score"
+                        ],
+                        indicator_medium_score_labels=self.indicator_config[
+                            "indicator_medium_score_labels"
+                        ],
+                        indicator_high_score=self.indicator_config[
+                            "indicator_high_score"
+                        ],
+                        indicator_high_score_labels=self.indicator_config[
+                            "indicator_high_score_labels"
+                        ],
+                        indicator_unwanted_labels=self.indicator_config[
+                            "indicator_unwanted_labels"
+                        ],
+                    )
+                    bundle_builder = IndicatorBundleBuilder(
+                        self.helper, bundle_builder_config
+                    )
+                    indicator_bundle_built = bundle_builder.build()
+                    if indicator_bundle_built:
+                        indicator_with_related_entities = indicator_bundle_built[
+                            "object_refs"
+                        ]
+                        related_indicators_with_related_entities.extend(
+                            indicator_with_related_entities
+                        )
+                    else:
+                        self.helper.connector_logger.debug(
+                            "[DEBUG] The construction of the indicator has been skipped in the actor.",
+                            {
+                                "indicator_id": indicator.get("id"),
+                                "indicator_type": indicator.get("type"),
+                            },
+                        )
+                        continue
+
+            return related_indicators_with_related_entities
+        except Exception as err:
+            self.helper.connector_logger.error(
+                "[ERROR] An unexpected error occurred when retrieving indicators for the actor.",
+                {
+                    "error": err,
+                    "actor_name": actor_name,
+                },
+            )
+            raise
+
     def _create_actor_bundle(self, actor) -> Bundle:
         author = self.author
         source_name = self._source_name()
         object_marking_refs = [self.tlp_marking]
         confidence_level = self._confidence_level()
+        related_indicators_with_related_entities = []
+
+        actor_name = actor["name"]
+        if actor_name is not None:
+            self._info("Fetching related IOCs for actor: {0}", actor_name)
+            related_indicators_with_related_entities = self._get_related_iocs(
+                actor_name
+            )
+            if len(related_indicators_with_related_entities) > 0:
+                counts = Counter(
+                    s["type"]
+                    for s in {
+                        (stix["type"], stix["id"]): stix
+                        for stix in related_indicators_with_related_entities
+                        if stix["type"] not in ["relationship", "indicator"]
+                    }.values()
+                )
+
+                summary = ", ".join(f"{t}:{n}" for t, n in counts.items())
+                self._info(
+                    "Creating {0} stix objects for the IOCs and related entities for actor: {1}",
+                    summary,
+                    actor_name,
+                )
 
         bundle_builder = ActorBundleBuilder(
-            actor, author, source_name, object_marking_refs, confidence_level
+            actor,
+            author,
+            source_name,
+            object_marking_refs,
+            confidence_level,
+            related_indicators_with_related_entities,
         )
         return bundle_builder.build()

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/core.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/core.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """OpenCTI CrowdStrike connector core module."""
+
 import os
 import sys
 import time
@@ -183,11 +184,27 @@ class CrowdStrike:
         importers: List[BaseImporter] = []
 
         if self._CONFIG_SCOPE_ACTOR in scopes:
+            actor_indicator_config = {
+                "default_latest_timestamp": actor_start_timestamp,
+                "create_observables": create_observables,
+                "create_indicators": create_indicators,
+                "exclude_types": indicator_exclude_types,
+                "default_x_opencti_score": default_x_opencti_score,
+                "indicator_low_score": indicator_low_score,
+                "indicator_low_score_labels": set(indicator_low_score_labels),
+                "indicator_medium_score": indicator_medium_score,
+                "indicator_medium_score_labels": set(indicator_medium_score_labels),
+                "indicator_high_score": indicator_high_score,
+                "indicator_high_score_labels": set(indicator_high_score_labels),
+                "indicator_unwanted_labels": set(indicator_unwanted_labels),
+            }
+
             actor_importer = ActorImporter(
                 self.helper,
                 author,
                 actor_start_timestamp,
                 tlp_marking,
+                actor_indicator_config,
             )
 
             importers.append(actor_importer)


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

As stated in the linked issue #5017 , the objectives of this new feature was to enable the fetching of IoCs related with actor when retrieving actors.

Some screen to show the changes:
Before we only retrieved Actors:
<img width="422" height="943" alt="before" src="https://github.com/user-attachments/assets/ed38461c-5882-4a2d-899d-e610479d96d5" />

Now when retrieving Actor, we got recent related IoCs and relationships:
<img width="1291" height="981" alt="after_overview" src="https://github.com/user-attachments/assets/e5dea51a-7272-47fb-8696-2b5f7f0ca8b1" />
<img width="1293" height="622" alt="after_rel" src="https://github.com/user-attachments/assets/5726c8f9-e446-4226-906b-479cb5d31fe7" />

By recent, i mean, if no state exist, we retrieved the IoCs since the configuration 'actor_start_timestamp'.
<img width="1729" height="287" alt="after_log_default" src="https://github.com/user-attachments/assets/70de4a8f-7bc6-4afa-8ad8-8360d04efae7" />

If no indicator state, but actor state, we use this one:
<img width="1585" height="27" alt="after_log_actor" src="https://github.com/user-attachments/assets/05910d27-e98c-45fc-a640-29935cbaec69" />

And if an indicator state, we use this one:
<img width="1638" height="23" alt="after_log_indicator" src="https://github.com/user-attachments/assets/3377351b-7909-485e-8d24-34a48a0423ba" />

This should prevents dupe retrieved from the IoCs collections if enabled, and allow us to retrieve 'recent' data and not the whole history.

And if you look closely at this screen of log:
<img width="1729" height="287" alt="after_log_default" src="https://github.com/user-attachments/assets/f791bf58-46d7-407e-9a45-993624953059" />
You will see that for 'Recess Spider' we have retrieved 2IoCs updated since 2025-10-15T16:09:14Z, and we can confirm this on the Crowdstrike UI:
<img width="2436" height="397" alt="cs_ui" src="https://github.com/user-attachments/assets/aa233774-9b3c-492e-aa70-483ee019466a" />

You also see 2Malware, because those are directly related to the retrieved IoCs.

### Related issues

#5017 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
