### PR TITLE
[splunk] add detection field to sent events (#5079)

### DIFF
--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -235,7 +235,7 @@ class SplunkConnector:
                     "is_inferred",
                     "main_observable_type",
                     "description",
-                    "detection"
+                    "detection",
                 ]:
                     attribute_value = extension_definition.get(attribute_name)
                     if attribute_value:


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added the `detection` field to the list of attributes parsed from the `extensions` object in the Splunk connector stream.
* This allows the field to be included in the events sent to the Splunk lookup.

### Related issues

* Closes #5079 

### Checklist

- [x] I consider the submitted work as finished  
- [x] I have signed my commits using GPG key  
- [x] I tested the code for its functionality using different use cases  
- [ ] I added/update the relevant documentation (either on github or on notion)  
- [ ] Where necessary I refactored code to improve the overall quality  

### Further comments

This is a minimal but useful change:  
The `detection` field was missing from the parsed list of attributes inside the `extensions` object in the Splunk stream connector.  
This field is useful for improving Splunk lookup content and supports better detection/correlation capabilities.

No breaking changes introduced.  
The new field is simply extracted if present — the rest of the logic is unaffected.
