### PR TITLE
[recorded-future] Infinite loop processing analyst notes

### DIFF
--- a/external-import/recorded-future/src/rflib/rf_client.py
+++ b/external-import/recorded-future/src/rflib/rf_client.py
@@ -146,7 +146,9 @@ class RFClient:
                     )
                     res.raise_for_status()
                     lookup_data = res.json()
-                    if lookup_data.get("attributes") and lookup_data["attributes"].get("events"):
+                    if lookup_data.get("attributes") and lookup_data["attributes"].get(
+                        "events"
+                    ):
                         note["events"] = lookup_data["attributes"]["events"]
 
                     notes.append(note)


### PR DESCRIPTION
…ten when retrieving the analyst note details. This therefore causes an infinite loop.

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Bug identified when processing large volume of analystes notes. 
* The 'next_offset' is always empty as the main 'data' response is overwritten when retrieving the analyst note details. This therefore causes an infinite loop.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4121
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
