### PR TITLE
[ConnectorsSDK] Fix AttributeError in base.py due to __main__.__file__ access

### DIFF
--- a/connectors-sdk/connectors_sdk/models/configs/base.py
+++ b/connectors-sdk/connectors_sdk/models/configs/base.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Any, Literal
 
+import __main__
 from connectors_sdk.core.pydantic import ListFromString
 from connectors_sdk.exceptions import (
     ConfigValidationError,
@@ -32,8 +33,6 @@ from pydantic_settings import (
     SettingsConfigDict,
     YamlConfigSettingsSource,
 )
-
-_MAIN_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
 class BaseConfigModel(BaseModel, ABC):
@@ -85,7 +84,6 @@ class _SettingsLoader(BaseSettings):
         env_nested_delimiter="_",
         env_nested_max_split=1,
         enable_decoding=False,
-        env_file=f"{_MAIN_PATH}/../.env",
     )
 
     @classmethod
@@ -110,11 +108,15 @@ class _SettingsLoader(BaseSettings):
             1. If a config.yml file is found, the order will be: `ENV VAR` → config.yml → default value
             2. If a .env file is found, the order will be: `ENV VAR` → .env → default value
         """
+        _main_path = os.path.dirname(os.path.abspath(__main__.__file__))
+
+        settings_cls.model_config["env_file"] = f"{_main_path}/../.env"
+
         if not settings_cls.model_config["yaml_file"]:
-            if Path(f"{_MAIN_PATH}/config.yml").is_file():
-                settings_cls.model_config["yaml_file"] = f"{_MAIN_PATH}/config.yml"
-            if Path(f"{_MAIN_PATH}/../config.yml").is_file():
-                settings_cls.model_config["yaml_file"] = f"{_MAIN_PATH}/../config.yml"
+            if Path(f"{_main_path}/config.yml").is_file():
+                settings_cls.model_config["yaml_file"] = f"{_main_path}/config.yml"
+            if Path(f"{_main_path}/../config.yml").is_file():
+                settings_cls.model_config["yaml_file"] = f"{_main_path}/../config.yml"
 
         if Path(settings_cls.model_config["yaml_file"] or "").is_file():  # type: ignore
             return (


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix AttributeError in base.py due to __main__.__file__ access

Remove the main import and the _MAIN_PATH variable. The _MAIN_PATH variable is defined but never actually used in the configuration loading logic. The configuration loader already handles path resolution properly
through:

Environment variables
YAML config files (checked in multiple locations)
.env files
Default values

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/5055


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
