### PR TITLE
[S3] Manage a state per S3 bucket prefix

### DIFF
--- a/external-import/s3/README.md
+++ b/external-import/s3/README.md
@@ -16,18 +16,19 @@ Below are the parameters you'll need to set for running the connector properly:
 | Parameter `connector`       | config.yml                    | Docker environment variable             | Default | Mandatory | Example                                | Description                                                                            |
 |-----------------------------|-------------------------------|-----------------------------------------|---------|-----------|----------------------------------------|----------------------------------------------------------------------------------------|
 | ID                          | `id`                          | `CONNECTOR_ID`                          | /       | Yes       | `fe418972-1b42-42c9-a665-91544c1a9939` | A unique `UUIDv4` identifier for this connector instance.                              |
-| Name                        | `name`                        | `CONNECTOR_NAME`                        | /       | Yes       | `S3 Bucket`                            | Full name of the connector : `S3`.                                     |
+| Name                        | `name`                        | `CONNECTOR_NAME`                        | /       | Yes       | `S3 Bucket`                            | Full name of the connector : `S3`.                                                     |
 | Log Level                   | `log_level`                   | `CONNECTOR_LOG_LEVEL`                   | `error` | No        | `error`                                | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`. |
 
 Below are the parameters you'll need to set for s3 Connector:
 
-| Parameter `s3`    | config.yml          | Docker environment variable | Default        | Mandatory | Example        | Description                                      |
-|-------------------|---------------------|-----------------------------|----------------|-----------|----------------|--------------------------------------------------|
-| Region            | `region`            | `S3_REGION`                 | `us-east-1`    | No        | `us-east-1`    | S3 Region for Amazon                             |
-| Endpoint URL      | `endpoint_url`      | `S3_ENDPOINT_URL`           | /              | No        | /              | S3 Endpoint                                      |
-| Access Key ID     | `access_key_id`     | `S3_ACCESS_KEY_ID`          | /              | Yes       | /              | S3 Access Key ID                                 |
-| Secret Access Key | `secret_access_key` | `S3_SECRET_ACCESS_KEY`      | /              | Yes       | /              | S3 Secret Access Key                             |
-| Bucket name       | `bucket_name`       | `S3_BUCKET_NAME`            | /              | Yes       | /              | S3 Bucket Name                                   |
-| Author            | `author`            | `S3_AUHOR`                  | /              | No        | /              | Put author (created by ref) if not exist in data |
-| Marking           | `marking`           | `S3_MARKING`                | `TLP:GREEN`    | No        | `TLP:AMBER`    | Put marking if not exist in data                 |
-| Interval          | `interval`          | `S3_INTERVAL`               | `5`            | No        | `5`            | Interval to pull files                           |
+| Parameter `s3`    | config.yml          | Docker environment variable | Default           | Mandatory | Example        | Description                                      |
+|-------------------|---------------------|-----------------------------|-------------------|-----------|----------------|--------------------------------------------------|
+| Region            | `region`            | `S3_REGION`                 | `us-east-1`       | No        | `us-east-1`    | S3 Region for Amazon                             |
+| Endpoint URL      | `endpoint_url`      | `S3_ENDPOINT_URL`           | /                 | No        | /              | S3 Endpoint                                      |
+| Access Key ID     | `access_key_id`     | `S3_ACCESS_KEY_ID`          | /                 | Yes       | /              | S3 Access Key ID                                 |
+| Secret Access Key | `secret_access_key` | `S3_SECRET_ACCESS_KEY`      | /                 | Yes       | /              | S3 Secret Access Key                             |
+| Bucket name       | `bucket_name`       | `S3_BUCKET_NAME`            | /                 | Yes       | /              | S3 Bucket Name                                   |
+| Bucket prefixes   | `bucket_prefixes`   | `S3_BUCKET_PREFIXES`        | `ACI_TI,ACI_Vuln` | No        | /              | S3 Bucket Prefixes to process                    |
+| Author            | `author`            | `S3_AUHOR`                  | /                 | No        | /              | Put author (created by ref) if not exist in data |
+| Marking           | `marking`           | `S3_MARKING`                | `TLP:GREEN`       | No        | `TLP:AMBER`    | Put marking if not exist in data                 |
+| Interval          | `interval`          | `S3_INTERVAL`               | `120`             | No        | `5`            | Interval to pull files (in minutes)              |

--- a/external-import/s3/docker-compose.yml
+++ b/external-import/s3/docker-compose.yml
@@ -10,4 +10,5 @@ services:
       - S3_ACCESS_KEY_ID=
       - S3_SECRET_ACCESS_KEY=
       - S3_BUCKET_NAME=
+      - S3_BUCKET_PREFIXES=
     restart: always

--- a/external-import/s3/src/config.yml.sample
+++ b/external-import/s3/src/config.yml.sample
@@ -11,3 +11,4 @@ s3:
   access_key_id: ''
   secret_access_key: ''
   bucket_name: ''
+  bucket_prefixes: ''

--- a/external-import/s3/src/s3.py
+++ b/external-import/s3/src/s3.py
@@ -9,6 +9,7 @@ import boto3
 import pytz
 import stix2
 import yaml
+from dateutil import parser
 from pycti import (
     CourseOfAction,
     Identity,
@@ -108,6 +109,15 @@ class S3Connector:
             "S3_CUTOFF", ["s3", "cutoff"], config, isNumber=True, default=360
         )
 
+        bucket_prefixes = get_config_variable(
+            "S3_BUCKET_PREFIXES",
+            ["s3", "bucket_prefixes"],
+            config,
+            isNumber=False,
+            default="ACI_TI,ACI_Vuln",
+        )
+        self.s3_bucket_prefixes = [x.strip() for x in bucket_prefixes.split(",")]
+
         # Create the identity
         self.identity = None
         if self.s3_author is not None:
@@ -123,10 +133,23 @@ class S3Connector:
             region_name=self.s3_region,
         )
 
+    def set_state_value(self, s3_prefix: str, value: str):
+        """Using this method to set the value of a specific key in the state collection.
+        See Also:
+            get_state_value
+        """
+        try:
+            state = self.helper.get_state()
+            state[s3_prefix] = value
+            self.helper.set_state(state)
+        except (KeyError, TypeError) as err:
+            raise Exception(f"State key {s3_prefix} not found") from err
+
     def get_interval(self):
         return int(self.s3_interval) * 60
 
-    def rewrite_stix_ids(self, objects):
+    @staticmethod
+    def rewrite_stix_ids(objects):
         # First pass: Build ID mapping for objects that need new IDs
         id_mapping = {}
 
@@ -462,60 +485,99 @@ class S3Connector:
         return new_bundle
 
     def process(self):
-        now = datetime.datetime.now(pytz.UTC)
-        # We always re-send 2 days of data before deleting to handle multi instances consuming, we are good with this approach
-        # OpenCTI will de-duplicate / upsert if necessary
-        cutoff = now - datetime.timedelta(minutes=self.s3_cutoff)
-        objects = self.s3_client.list_objects(Bucket=self.s3_bucket_name)
-        if objects.get("Contents") is not None and len(objects.get("Contents")) > 0:
-            friendly_name = "S3 run @ " + now.astimezone(pytz.UTC).isoformat()
-            work_id = self.helper.api.work.initiate_work(
-                self.helper.connect_id, friendly_name
+
+        state = self.helper.get_state()
+        if state is None:
+            state = {}
+
+        for prefix in self.s3_bucket_prefixes:
+
+            prefix_state = state.get(prefix, "")
+            if prefix_state:
+                prefix_state_date = parser.parse(prefix_state)
+            else:
+                prefix_state_date = None
+            self.helper.connector_logger.info(
+                f"Going to process files in S3 Prefix: '{prefix}', Prefix state: '{prefix_state}'"
             )
-            for o in objects.get("Contents"):
-                try:
-                    last_modified = o.get("LastModified")
-                    data = self.s3_client.get_object(
-                        Bucket=self.s3_bucket_name, Key=o.get("Key")
-                    )
-                    content = data["Body"].read()
-                except:
-                    continue
-                self.helper.log_info("Sending file " + o.get("Key"))
-                fixed_bundle = self.fix_bundle(content)
-                if fixed_bundle:
-                    self.helper.send_stix2_bundle(bundle=fixed_bundle, work_id=work_id)
-                else:
-                    self.helper.log_info("No content to ingest")
-                if self.s3_delete_after_import and last_modified < cutoff:
-                    self.helper.log_info(
-                        "Deleting file "
-                        + o.get("Key")
-                        + "(2 days ago="
-                        + str(cutoff)
-                        + ", modified="
-                        + str(last_modified)
-                        + ")"
-                    )
+
+            now = datetime.datetime.now(pytz.UTC)
+            # We always re-send 2 days of data before deleting to handle multi instances consuming, we are good with this approach
+            # OpenCTI will de-duplicate / upsert if necessary
+            cutoff = now - datetime.timedelta(minutes=self.s3_cutoff)
+            objects = self.s3_client.list_objects(
+                Bucket=self.s3_bucket_name, Prefix=prefix
+            )
+            self.helper.log_info(
+                f"{len(objects.get('Contents', []))} files listed in S3 Prefix: '{prefix}'"
+            )
+            if (
+                objects.get("Contents", None) is not None
+                and len(objects.get("Contents")) > 0
+            ):
+                friendly_name = (
+                    f"S3/{prefix} run @ " + now.astimezone(pytz.UTC).isoformat()
+                )
+                work_id = self.helper.api.work.initiate_work(
+                    self.helper.connect_id, friendly_name
+                )
+                updated_files = 0
+                for o in objects.get("Contents"):
                     try:
-                        self.s3_client.delete_object(
-                            Bucket=self.s3_bucket_name, Key=o.get("Key")
-                        )
-                    except:
+                        last_modified = o.get("LastModified")
+                        if (
+                            prefix_state_date is None
+                            or last_modified > prefix_state_date
+                        ):
+                            data = self.s3_client.get_object(
+                                Bucket=self.s3_bucket_name, Key=o.get("Key")
+                            )
+                            content = data["Body"].read()
+                            fixed_bundle = self.fix_bundle(content)
+                            if fixed_bundle:
+                                self.helper.log_info(
+                                    f"Sending STIX bundle from file: '{o.get("Key")}'"
+                                )
+                                self.helper.send_stix2_bundle(
+                                    bundle=fixed_bundle, work_id=work_id
+                                )
+                                state[prefix] = last_modified.strftime(
+                                    "%Y-%m-%d %H:%M:%S%z"
+                                )
+                                self.helper.set_state(state)
+                                updated_files += 1
+                            else:
+                                self.helper.log_info("No content to ingest")
+                    except Exception as ex:
+                        print(ex)
                         continue
-            message = (
-                "Connector successfully run ("
-                + str(len(objects.get("Contents")))
-                + " file(s) have been processed"
-            )
-            self.helper.log_info(message)
-            self.helper.api.work.to_processed(work_id, message)
-        else:
-            self.helper.log_info("Returned 0 files")
+                    if self.s3_delete_after_import and last_modified < cutoff:
+                        self.helper.log_info(
+                            "Deleting file "
+                            + o.get("Key")
+                            + "(2 days ago="
+                            + str(cutoff)
+                            + ", modified="
+                            + str(last_modified)
+                            + ")"
+                        )
+                        try:
+                            self.s3_client.delete_object(
+                                Bucket=self.s3_bucket_name, Key=o.get("Key")
+                            )
+                        except:
+                            continue
+                message = (
+                    f"Connector successfully processed S3 Prefix: '{prefix}' files, "
+                    f"'{updated_files}' file(s) have been ingested"
+                )
+                self.helper.log_info(message)
+                self.helper.api.work.to_processed(work_id, message)
+            else:
+                self.helper.log_info("Returned 0 files")
 
     def run(self):
-        get_run_and_terminate = getattr(self.helper, "get_run_and_terminate", None)
-        if callable(get_run_and_terminate) and self.helper.get_run_and_terminate():
+        if self.helper.get_run_and_terminate():
             self.process()
             self.helper.force_ping()
         else:


### PR DESCRIPTION
### Proposed changes

Currently, the connector re-ingests all the contents of files published in the S3 bucket at each execution. This isn't optimal because it constantly republishes information already ingested into the platform.

Change the connector's operating mode to:

- Configure the S3 prefixes to ingest
- Maintain an ingestion state per S3 prefix. This state must correspond to the "LastModified" date of the most recently ingested file for the S3 prefix.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/5057

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
