### PR TITLE
[recordedfuture-enrichment] fix enrichment if risk option is not enabled

### DIFF
--- a/internal-enrichment/recordedfuture-enrichment/docker-compose.yml
+++ b/internal-enrichment/recordedfuture-enrichment/docker-compose.yml
@@ -1,7 +1,6 @@
-version: "3"
 services:
   connector-recordedfuture-enrichment:
-    image: opencti/connector-recordedfuture-enrichment:6.8.8
+    image: opencti/connector-recordedfuture-enrichment:rolling
     environment:
       - OPENCTI_URL=http://opencti:4000
       - OPENCTI_TOKEN=CHANGME

--- a/internal-enrichment/recordedfuture-enrichment/src/rf_client/api_client.py
+++ b/internal-enrichment/recordedfuture-enrichment/src/rf_client/api_client.py
@@ -159,6 +159,9 @@ class RFClient:
             if not data:
                 raise RFClientError("RecordedFuture API response does not include data")
 
+            if not data.get("nvdDescription"):
+                data.pop("nvdDescription")
+
             return VulnerabilityEnrichment(**data)
         except ValidationError as err:
             raise RFClientError("Invalid vulnerability enrichment data") from err

--- a/internal-enrichment/recordedfuture-enrichment/src/rf_client/models.py
+++ b/internal-enrichment/recordedfuture-enrichment/src/rf_client/models.py
@@ -366,8 +366,9 @@ class VulnerabilityEnrichment(RecordedFutureBaseModel):
     lifecycleStage: str = Field(
         description="Lifecycle stage of the vulnerability.",
     )
-    nvdDescription: str = Field(
+    nvdDescription: Optional[str] = Field(
         description="NVD description of the vulnerability.",
+        default=None,
     )
     nvdReferences: list[NvdReference] = Field(
         description="NVD advisory references and tools.",

--- a/internal-enrichment/recordedfuture-enrichment/src/rflib/use_cases/enrich_vulnerability.py
+++ b/internal-enrichment/recordedfuture-enrichment/src/rflib/use_cases/enrich_vulnerability.py
@@ -120,12 +120,18 @@ class VulnerabilityEnricher:
                 if source_description not in vulnerability_description:
                     vulnerability_description += f"  \n{source_description}"
 
+        vulnerability_score = (
+            vulnerability_enrichment.risk.score
+            if vulnerability_enrichment.risk
+            else None
+        )
+
         return Vulnerability(
             name=octi_vulnerability_data.get("name"),
             description=vulnerability_description,
             labels=[vulnerability_enrichment.lifecycleStage],
             aliases=vulnerability_enrichment.commonNames,
-            score=vulnerability_enrichment.risk.score,
+            score=vulnerability_score,
             cvss_v2_vector_string=cvss_v2.vectorString,
             cvss_v2_base_score=cvss_v2.score,
             cvss_v2_access_vector=cvss_v2.accessVector,
@@ -341,7 +347,9 @@ class VulnerabilityEnricher:
             octi_objects.extend(software_s)
 
             # Extract note
-            notes = self._convert_vulnerability_risk(vulnerability_enrichment)
+            notes = []
+            if vulnerability_enrichment.risk:
+                notes = self._convert_vulnerability_risk(vulnerability_enrichment)
             for note in notes:
                 note.objects = [vulnerability]
                 octi_objects.append(note)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Check if risk option is enabled before enriching
*

### Related issues

* Closes #5090
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
