### PR TITLE
[CVE] Add proxy certificate support for HTTPS connections

### DIFF
--- a/external-import/cve/Dockerfile
+++ b/external-import/cve/Dockerfile
@@ -3,6 +3,7 @@ ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
 
 # Copy the connector
 COPY src /opt/opencti-connector-cve/src
+COPY entrypoint.sh /opt/opencti-connector-cve/entrypoint.sh
 WORKDIR /opt/opencti-connector-cve
 
 # Install Python modules
@@ -15,4 +16,8 @@ RUN cd /opt/opencti-connector-cve/src && \
     apk del git build-base && \
     rm -rf /var/cache/apk/*
 
-CMD ["python", "-m", "src"]
+# Make entrypoint executable
+RUN chmod +x /opt/opencti-connector-cve/entrypoint.sh
+
+# Use the entrypoint script
+ENTRYPOINT ["/opt/opencti-connector-cve/entrypoint.sh"]

--- a/external-import/cve/entrypoint.sh
+++ b/external-import/cve/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# Convert HTTPS_CA_CERTIFICATES to REQUESTS_CA_BUNDLE if present
+if [ -n "$HTTPS_CA_CERTIFICATES" ]; then
+    echo "[ENTRYPOINT] Processing HTTPS_CA_CERTIFICATES environment variable"
+    
+    # Create directory for certificates
+    mkdir -p /tmp/certs
+    
+    # Write the certificate to a file
+    echo "$HTTPS_CA_CERTIFICATES" > /tmp/certs/proxy-ca-bundle.crt
+    
+    # Check if system certificates exist and combine them
+    if [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+        echo "[ENTRYPOINT] Combining proxy certificate with system certificates"
+        cat /etc/ssl/certs/ca-certificates.crt >> /tmp/certs/proxy-ca-bundle.crt
+    elif [ -f /etc/pki/tls/certs/ca-bundle.crt ]; then
+        echo "[ENTRYPOINT] Combining proxy certificate with system certificates"
+        cat /etc/pki/tls/certs/ca-bundle.crt >> /tmp/certs/proxy-ca-bundle.crt
+    fi
+    
+    # Export REQUESTS_CA_BUNDLE for the requests library
+    export REQUESTS_CA_BUNDLE=/tmp/certs/proxy-ca-bundle.crt
+    export SSL_CERT_FILE=/tmp/certs/proxy-ca-bundle.crt
+    export CURL_CA_BUNDLE=/tmp/certs/proxy-ca-bundle.crt
+    
+    echo "[ENTRYPOINT] Certificate bundle configured at: $REQUESTS_CA_BUNDLE"
+fi
+
+# Execute the connector
+exec python -m src "$@"


### PR DESCRIPTION
### Proposed changes

* Add custom entrypoint script to CVE connector to handle proxy certificate configuration
* Modify Dockerfile to use entrypoint script instead of direct CMD execution
* Process HTTPS_CA_CERTIFICATES environment variable and combine with system certificates
* Set appropriate SSL environment variables (REQUESTS_CA_BUNDLE, SSL_CERT_FILE, CURL_CA_BUNDLE) for Python requests library

### Related issues

* OpenCTI #12177 
* HTTPS_CA_CERTIFICATES is not handled by lib request used in CVE

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This change enables the CVE connector to work properly in environments that use HTTPS proxies with custom certificates. The entrypoint script automatically detects the presence of the HTTPS_CA_CERTIFICATES environment variable and configures the appropriate certificate bundle for the Python requests library used by the connector.

The implementation:
1. Creates a temporary certificate bundle combining proxy certificates with system certificates
2. Exports the necessary environment variables for SSL verification
3. Maintains backward compatibility when no proxy certificates are provided