### PR TITLE
[Flashpoint] The connector state is not updated correctly, resulting in the multiple re-importing of the same indicators

### DIFF
--- a/external-import/flashpoint/src/flashpoint_connector/connector.py
+++ b/external-import/flashpoint/src/flashpoint_connector/connector.py
@@ -549,6 +549,10 @@ class FlashpointConnector:
                 "Getting current state and update it with last run of the connector",
                 {"current_datetime": now_iso},
             )
+
+            # need to retrieve the current state as it can be updated in the 'import_indicators' function
+            current_state = self._get_state()
+
             current_state["last_run"] = now_iso
             self._set_state(current_state)
 


### PR DESCRIPTION
…le re-importing of the same indicators

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Retrieve state before to update it

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/5163

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
