### PR TITLE
Update client python repository following migration to opencti repo

### DIFF
--- a/.circleci/templates/dynamic.yml.j2
+++ b/.circleci/templates/dynamic.yml.j2
@@ -39,13 +39,15 @@ jobs:
 
             {% if pycti.replace -%}
                 {% if "prerelease" in tags %}
-            find . -name requirements.txt -exec sed "s|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/client-python@$CIRCLE_BRANCH|" -i {} \;
-            find . -name pyproject.toml -exec sed "s|pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/client-python@$CIRCLE_BRANCH\",|" -i {} \;
+                git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python
+
+            find . -name requirements.txt -exec sed "s|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@$CIRCLE_BRANCH#subdirectory=client-python|" -i {} \;
+            find . -name pyproject.toml -exec sed "s|pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@$CIRCLE_BRANCH#subdirectory=client-python\",|" -i {} \;
             find . -name requirements.txt -exec sed "s|^connectors-sdk.*$|connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@$CIRCLE_BRANCH#subdirectory=connectors-sdk|" -i {} \;
             find . -name pyproject.toml -exec sed "s|connectors-sdk.*$|connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@$CIRCLE_BRANCH#subdirectory=connectors-sdk\",|" -i {} \;
                 {% elif "rolling" in tags %}
-            find . -name requirements.txt -exec sed "s|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/client-python@master|" -i {} \;
-            find . -name pyproject.toml -exec sed "s|pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/client-python@master\",|" -i {} \;
+            find . -name requirements.txt -exec sed "s|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|" -i {} \;
+            find . -name pyproject.toml -exec sed "s|pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python\",|" -i {} \;
             find . -name requirements.txt -exec sed "s|^connectors-sdk.*$|connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk|" -i {} \;
             find . -name pyproject.toml -exec sed "s|connectors-sdk.*$|connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk\",|" -i {} \;
                 {% endif %}

--- a/run_test.sh
+++ b/run_test.sh
@@ -78,8 +78,7 @@ do
 
   echo 'Installing latest version of pycti'
   python -m pip uninstall -y pycti
-  python -m pip install -q git+https://github.com/OpenCTI-Platform/client-python.git@master
-
+  python -m pip install -q git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python
   python -m pip freeze | grep "connectors-sdk\|pycti" || true
 
   python -m pip check || exit 1  # exit if dependencies are broken


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Following migration of client-python to opencti repository, update client-python reference in 
* Circle CI for rolling and prerelease build 
* In run_test.sh

### Related issues

Main issue for migration of client-python: https://github.com/OpenCTI-Platform/opencti/issues/12446

Related issues:
https://github.com/OpenCTI-Platform/client-python/issues/1031
https://github.com/OpenCTI-Platform/opencti/pull/12672
https://github.com/OpenCTI-Platform/release/pull/9

