### PR TITLE
[stream-importer] handle ChannelClosedByBroker exception

### DIFF
--- a/external-import/stream-importer/src/importer/connector.py
+++ b/external-import/stream-importer/src/importer/connector.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 import pika
 from minio import Minio
 from minio.commonconfig import CopySource
-from pika.exceptions import NackError, UnroutableError, ChannelClosedByBroker
+from pika.exceptions import ChannelClosedByBroker, NackError, UnroutableError
 
 from .lib.external_import import ExternalImportConnector
 from .metrics import Metrics
@@ -234,7 +234,9 @@ class StreamImporterConnector(ExternalImportConnector):
             self.helper.metric.inc("bundle_send")
         except (ChannelClosedByBroker, NackError, UnroutableError) as err:
             self.metrics.send_error()
-            self.helper.connector_logger.error(f"Unable to send bundle ({type(err).__name__}): {err}")
+            self.helper.connector_logger.error(
+                f"Unable to send bundle ({type(err).__name__}): {err}"
+            )
             self._send_event(channel, event)
 
 

--- a/external-import/stream-importer/src/importer/connector.py
+++ b/external-import/stream-importer/src/importer/connector.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 import pika
 from minio import Minio
 from minio.commonconfig import CopySource
-from pika.exceptions import NackError, UnroutableError
+from pika.exceptions import NackError, UnroutableError, ChannelClosedByBroker
 
 from .lib.external_import import ExternalImportConnector
 from .metrics import Metrics
@@ -232,9 +232,9 @@ class StreamImporterConnector(ExternalImportConnector):
             )
             self.helper.connector_logger.debug("Event has been sent")
             self.helper.metric.inc("bundle_send")
-        except (UnroutableError, NackError):
+        except (ChannelClosedByBroker, NackError, UnroutableError) as err:
             self.metrics.send_error()
-            self.helper.connector_logger.error("Unable to send bundle, retry...")
+            self.helper.connector_logger.error(f"Unable to send bundle ({type(err).__name__}): {err}")
             self._send_event(channel, event)
 
 

--- a/external-import/stream-importer/src/importer/connector.py
+++ b/external-import/stream-importer/src/importer/connector.py
@@ -232,10 +232,26 @@ class StreamImporterConnector(ExternalImportConnector):
             )
             self.helper.connector_logger.debug("Event has been sent")
             self.helper.metric.inc("bundle_send")
-        except (ChannelClosedByBroker, NackError, UnroutableError) as err:
+        except ChannelClosedByBroker as err:
+            # ``ChannelClosedByBroker`` is raised when the RabbitMQ broker
+            # closes the channel itself (most commonly because the message
+            # exceeds the broker-side ``max_message_size``). The channel
+            # is now permanently closed, so the previous catch-and-recurse
+            # pattern used for ``UnroutableError`` / ``NackError`` would
+            # have looped forever on the very same closed channel — every
+            # subsequent ``basic_publish`` would re-raise the same
+            # exception. Just record the metric, log the error, and drop
+            # this event so the outer per-file loop in :meth:`send_event`
+            # can open a fresh channel for the next file.
             self.metrics.send_error()
             self.helper.connector_logger.error(
-                f"Unable to send bundle ({type(err).__name__}): {err}"
+                f"Unable to send bundle ({type(err).__name__}): {err}; "
+                "channel is closed, skipping retry."
+            )
+        except (NackError, UnroutableError) as err:
+            self.metrics.send_error()
+            self.helper.connector_logger.error(
+                f"Unable to send bundle ({type(err).__name__}): {err}, retrying..."
             )
             self._send_event(channel, event)
 


### PR DESCRIPTION
When a RabbitMQ message is too big, a `ChannelClosedByBroker` exception is raised by RabbitMQ. This PR increments the `sent_errors_total` metric to detect them.

### Proposed changes

* Handle `ChannelClosedByBroker` exception, record metrics.
* `ChannelClosedByBroker` is handled in its own `except` branch and **does not** trigger the existing recursive retry used for `UnroutableError` / `NackError`: when the broker closes the channel itself (e.g. because the message exceeds `max_message_size`), the channel is permanently closed and every subsequent `basic_publish` on it would re-raise the same exception. The retry pattern would have looped forever on the same closed channel and never let the metric increment past the first iteration. The event is now dropped after recording the error so the outer per-file loop in `send_event` opens a fresh channel for the next file.
* Logs now include the exception type and message so operators can tell which error path was taken.

### Related issues

* Closes #6404

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The exception handler was split into two branches: a dedicated `except ChannelClosedByBroker as err:` (record metric, log, do **not** retry) and the existing `except (NackError, UnroutableError) as err:` (record metric, log, retry via the original recursive call). This delivers the metric-counting that motivated the original change without inheriting the recursion bug that adding `ChannelClosedByBroker` to the same `except` tuple would have caused on a closed channel.
