### PR TITLE
[SEKOIA.IO] add dynamic revocation in stream connector

### DIFF
--- a/external-import/sekoia/src/connector/sekoia.py
+++ b/external-import/sekoia/src/connector/sekoia.py
@@ -296,6 +296,8 @@ class SekoiaConnector(object):
                 item["x_opencti_main_observable_type"] = (
                     OpenCTIStix2Utils.stix_observable_opencti_type(stix_type)
                 )
+                if item.get("revoked") is not None and item.get("revoked") is True:
+                    item["valid_until"] = item.get("modified")
 
     def _retrieve_references(
         self, items: List[Dict], current_depth: int = 0


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add dynamic revocation when an IOC is revoked in Sekoia.io

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
