### PR TITLE
[CISA/Google TI Feeds] fix proxy support

### DIFF
--- a/external-import/cisa-known-exploited-vulnerabilities/src/main.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/main.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import os
 import ssl
 import sys
 import time
@@ -52,10 +53,20 @@ class Cisa:
             A string with the content or None in case of failure.
         """
         try:
+            # Check if SSL verification should be disabled for testing
+            ssl_context = ssl.create_default_context()
+            reject_unauthorized = os.environ.get(
+                "HTTPS_PROXY_REJECT_UNAUTHORIZED", ""
+            ).lower()
+            if reject_unauthorized == "false":
+                # Disable SSL verification
+                ssl_context.check_hostname = False
+                ssl_context.verify_mode = ssl.CERT_NONE
+
             return (
                 urllib.request.urlopen(
                     url,
-                    context=ssl.create_default_context(),
+                    context=ssl_context,
                 )
                 .read()
                 .decode("utf-8")


### PR DESCRIPTION
### Proposed changes

* Add support for `HTTPS_PROXY_REJECT_UNAUTHORIZED` environment variable in CISA Known Exploited Vulnerabilities connector to allow disabling SSL certificate verification for proxy testing environments
* Add support for `HTTPS_PROXY_REJECT_UNAUTHORIZED` environment variable in Google TI Feeds connector to allow disabling SSL certificate verification for proxy testing environments

### Related issues

* Fix proxy of connectors in environments with self-signed proxy certificates
* OCTI [#12177](https://github.com/OpenCTI-Platform/opencti/issues/12177)

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

 When the environment variable `HTTPS_PROXY_REJECT_UNAUTHORIZED` is set to `"false"`, the connectors will disable SSL certificate verification, allowing them to work with self-signed certificates in proxy environments.

This is particularly useful for:
- Development and testing environments with self-signed proxy certificates
- Internal corporate environments where custom CA certificates are used
- Maintaining consistency with the platform's proxy handling capabilities