### PR TITLE
[Mandiant] Skip indicator if its value is invalid

### DIFF
--- a/external-import/mandiant/src/connector/indicators.py
+++ b/external-import/mandiant/src/connector/indicators.py
@@ -1,4 +1,5 @@
 import stix2
+import stix2.exceptions
 from pycti import Indicator
 
 from . import utils
@@ -97,7 +98,15 @@ def process(connector, indicator):
         "Processing indicator", {"indicator_id": indicator_id}
     )
 
-    stix_indicator = create_indicator(connector, indicator)
+    try:
+        stix_indicator = create_indicator(connector, indicator)
+    except stix2.exceptions.InvalidValueError as e:
+        connector.helper.connector_logger.warning(
+            f"Skipping indicator due to invalid value: {e}",
+            {"indicator_id": indicator_id, "indicator_value": indicator.get("value")},
+        )
+        return None
+
     items = [stix_indicator]
 
     for attribution in indicator.get("attributed_associations", []):


### PR DESCRIPTION
### Proposed changes

* add error handling to log and skip indicator in case of invalid value

### Related issues

* #5192 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

I decided on purpose to not try to sanitize the data returned by Mandiant. For now, invalid indicators are logged and skipped.
Once we'll have more insights we could decide if it's worth trying to clean Mandiant data.
