### PR TITLE
[CrowdStrike] Resolves GH-5219

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/actor/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/actor/importer.py
@@ -238,7 +238,10 @@ class ActorImporter(BaseImporter):
                         ],
                     )
                     # Check if the indicator type is supported
-                    if indicator.get("type") not in IndicatorBundleBuilder._INDICATOR_TYPE_TO_OBSERVATION_FACTORY:
+                    if (
+                        indicator.get("type")
+                        not in IndicatorBundleBuilder._INDICATOR_TYPE_TO_OBSERVATION_FACTORY
+                    ):
                         self.helper.connector_logger.warning(
                             (
                                 "[WARNING] The construction of the indicator has been skipped in the actor because "
@@ -250,7 +253,9 @@ class ActorImporter(BaseImporter):
                             },
                         )
                         continue
-                    bundle_builder = IndicatorBundleBuilder(self.helper, bundle_builder_config)
+                    bundle_builder = IndicatorBundleBuilder(
+                        self.helper, bundle_builder_config
+                    )
                     indicator_bundle_built = bundle_builder.build()
                     if indicator_bundle_built:
                         indicator_with_related_entities = indicator_bundle_built[


### PR DESCRIPTION
Resolves GH-5219 for the CrowdStrike connector. 

_Note: A secondary solution could be to attempt the `__init__` of the `IndicatorBundleBuilder` and catch the `TypeError` for unsupported indicator types._