### PR TITLE
[CrowdStrike] Critical: Unsupported indicator type prevents connector execution #5219

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/actor/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/actor/importer.py
@@ -238,9 +238,22 @@ class ActorImporter(BaseImporter):
                             "indicator_unwanted_labels"
                         ],
                     )
-                    bundle_builder = IndicatorBundleBuilder(
-                        self.helper, bundle_builder_config
-                    )
+                    try:
+                        bundle_builder = IndicatorBundleBuilder(
+                            self.helper, bundle_builder_config
+                        )
+                    except TypeError as err:
+                        self.helper.connector_logger.warning(
+                            "Skipping unsupported indicator type for actor.",
+                            {
+                                "actor_name": actor_name,
+                                "indicator_id": indicator.get("id"),
+                                "indicator_type": indicator.get("type"),
+                                "indicator_value": indicator.get("indicator"),
+                                "error": str(err),
+                            },
+                        )
+                        continue
                     indicator_bundle_built = bundle_builder.build()
                     if indicator_bundle_built:
                         indicator_with_related_entities = indicator_bundle_built[

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
@@ -245,9 +245,22 @@ class ReportImporter(BaseImporter):
                             "indicator_unwanted_labels"
                         ],
                     )
-                    bundle_builder = IndicatorBundleBuilder(
-                        self.helper, bundle_builder_config
-                    )
+                    try:
+                        bundle_builder = IndicatorBundleBuilder(
+                            self.helper, bundle_builder_config
+                        )
+                    except TypeError as err:
+                        self.helper.connector_logger.warning(
+                            "Skipping unsupported indicator type for report.",
+                            {
+                                "report_name": report_name,
+                                "indicator_id": indicator.get("id"),
+                                "indicator_type": indicator.get("type"),
+                                "indicator_value": indicator.get("indicator"),
+                                "error": str(err),
+                            },
+                        )
+                        continue
                     indicator_bundle_built = bundle_builder.build()
                     if indicator_bundle_built:
                         indicator_with_related_entities = indicator_bundle_built[


### PR DESCRIPTION
### Proposed changes

In the response to the issue #5219  this is my fix proposition in favor of #5220 .
The reason is explained in the original issue.

The purpose is to have a better handling of the error of trying to ingest an unsupported indicatior type for a report or actor.

For ease of reproduction, i've simply comment the factory for 'domain' type, who stop the flow before the fix, and skip them properly after the fix:
<img width="1962" height="108" alt="Screenshot 2025-11-24 112255" src="https://github.com/user-attachments/assets/4c238a8b-8e31-442f-9b76-0149dd1f5752" />

### Related issues

#5219

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
