### PR TITLE
[servicenow] Handle null comments and expose sysparm_display_value as a configurable

### DIFF
--- a/external-import/servicenow/docker-compose.yml
+++ b/external-import/servicenow/docker-compose.yml
@@ -41,4 +41,10 @@ services:
       #- SERVICENOW_TLP_LEVEL=red
       #- SERVICENOW_OBSERVABLES_DEFAULT_SCORE=50
       #- SERVICENOW_PROMOTE_OBSERVABLES_AS_INDICATORS=True
+      # Forwards ``sysparm_display_value`` to every ServiceNow Table
+      # API call. Default ``true`` matches ServiceNow's REST default
+      # (human-readable display strings); set to ``false`` on
+      # instances that return non-ISO 8601 datetimes when display
+      # values are enabled, which the connector cannot parse.
+      #- SERVICENOW_SYSPARM_DISPLAY_VALUE=True
     restart: always

--- a/external-import/servicenow/src/connector/models/config_loader.py
+++ b/external-import/servicenow/src/connector/models/config_loader.py
@@ -197,6 +197,18 @@ class _ConfigLoaderServiceNow(ConfigBaseSettings):
         default=True,
         description="Boolean to promote observables into indicators.",
     )
+    sysparm_display_value: Optional[bool] = Field(
+        alias="SERVICENOW_SYSPARM_DISPLAY_VALUE",
+        default=True,
+        description=(
+            "Boolean controlling the ``sysparm_display_value`` query parameter "
+            "sent to ServiceNow on every Table API call. Defaults to ``true`` "
+            "(backwards-compatible — ServiceNow returns human-readable "
+            "display strings). Set to ``false`` on instances that return "
+            "non-ISO 8601 datetimes when ``sysparm_display_value=true`` is "
+            "in effect, which the connector cannot parse."
+        ),
+    )
 
     @field_validator(
         "state_to_exclude",

--- a/external-import/servicenow/src/connector/services/client_api.py
+++ b/external-import/servicenow/src/connector/services/client_api.py
@@ -18,6 +18,15 @@ class ServiceNowClient:
         self.severity_to_exclude = self.config.servicenow.severity_to_exclude
         self.priority_to_exclude = self.config.servicenow.priority_to_exclude
         self.import_start_date = self.config.servicenow.import_start_date
+        # ``sysparm_display_value`` is sent on every ServiceNow Table API
+        # call. Pre-format the bool as the lowercase ``"true"`` / ``"false"``
+        # string ServiceNow expects — interpolating a Python ``bool``
+        # directly in an f-string produces ``"True"`` / ``"False"`` (capitalised),
+        # which some ServiceNow Table API endpoints treat as truthy strings
+        # and which goes against ServiceNow's documented contract.
+        self.sysparm_display_value = (
+            "true" if self.config.servicenow.sysparm_display_value else "false"
+        )
 
         # Limiter config
         self.rate_limiter = Limiter(
@@ -244,7 +253,14 @@ class ServiceNowClient:
         if sysparm_query:
             filter_query_parameters.append(f"sysparm_query={sysparm_query}")
 
-        filter_query_parameters.append("sysparm_display_value=true")
+        # ``sysparm_display_value`` is configurable because forcing it to
+        # ``true`` on some ServiceNow instances returns non-ISO 8601
+        # datetimes that the connector cannot parse. ``self.sysparm_display_value``
+        # is already the lowercase ``"true"`` / ``"false"`` string ServiceNow
+        # expects (see ``__init__``).
+        filter_query_parameters.append(
+            f"sysparm_display_value={self.sysparm_display_value}"
+        )
         filter_query_parameters.append("sysparm_exclude_reference_link=true")
         filter_query_parameters.append(f"sysparm_fields={sysparm_fields}")
 
@@ -278,9 +294,13 @@ class ServiceNowClient:
         ]
         sysparm_fields = ",".join(list_sysparm_fields)
 
+        # Apply the configured ``sysparm_display_value`` here too so the
+        # non-ISO-8601 datetime issue does not resurface on the
+        # observables endpoint when the operator disables display
+        # values to work around it on ``get_security_incidents``.
         query_parameters = (
             f"sysparm_query=task={sys_id}"
-            "&sysparm_display_value=true"
+            f"&sysparm_display_value={self.sysparm_display_value}"
             "&sysparm_exclude_reference_link=true"
             f"&sysparm_fields={sysparm_fields}"
         )
@@ -315,9 +335,12 @@ class ServiceNowClient:
         ]
         sysparm_fields = ",".join(list_sysparm_fields)
 
+        # Same rationale as ``get_observables`` — apply the configured
+        # ``sysparm_display_value`` so all three Table API endpoints stay
+        # consistent on instances that need ``false``.
         query_parameters = (
             f"sysparm_query=parent={security_incident_id}"
-            "&sysparm_display_value=true"
+            f"&sysparm_display_value={self.sysparm_display_value}"
             "&sysparm_exclude_reference_link=true"
             f"&sysparm_fields={sysparm_fields}"
         )

--- a/external-import/servicenow/src/connector/services/utils.py
+++ b/external-import/servicenow/src/connector/services/utils.py
@@ -64,7 +64,9 @@ class Utils:
 
     @staticmethod
     def transform_description_to_markdown(
-        comment_to_exclude: list[str], description: str, comments: str
+        comment_to_exclude: list[str],
+        description: str,
+        comments: str | None,
     ) -> str:
         """This method allows you to structure the entity's description in OpenCTI, starting with a description and then
         adding a Markdown table to list the comments written in ServiceNow. The description field can be empty, just
@@ -77,11 +79,19 @@ class Utils:
         Args:
             comment_to_exclude (list[str]): A list of comment types to exclude (e.g., ["private", "auto"]).
             description (str): The original description content to include at the top.
-            comments (str): The raw comment string from ServiceNow to parse and format.
+            comments (str | None): The raw comment string from ServiceNow to parse and format.
+                ServiceNow's REST API returns ``null`` (``None``) when no comments are
+                present on the security incident; the helper accepts both ``None`` and
+                an empty / whitespace-only string and renders the description-only
+                Markdown in those cases (no Markdown table is emitted).
 
         Returns:
             str: A formatted string containing the description and comments in the form of a Markdown table.
         """
+
+        if comments is None:
+            comments = ""
+
         pattern = r"(?=\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} - )"
         blocks = re.split(pattern, comments.strip())
         list_comments = [block.strip() for block in blocks if block.strip()]

--- a/external-import/servicenow/src/env.sample
+++ b/external-import/servicenow/src/env.sample
@@ -36,3 +36,9 @@ SERVICENOW_API_KEY=CHANGEME
 # SERVICENOW_TLP_LEVEL=red
 # SERVICENOW_OBSERVABLES_DEFAULT_SCORE=50
 # SERVICENOW_PROMOTE_OBSERVABLES_AS_INDICATORS=True
+# Forwards ``sysparm_display_value`` to every ServiceNow Table API
+# call. Default ``true`` matches ServiceNow's REST default
+# (human-readable display strings); set to ``false`` on instances
+# that return non-ISO 8601 datetimes when display values are
+# enabled, which the connector cannot parse.
+# SERVICENOW_SYSPARM_DISPLAY_VALUE=True

--- a/external-import/servicenow/tests/test_client_api.py
+++ b/external-import/servicenow/tests/test_client_api.py
@@ -15,6 +15,10 @@ def mock_client():
 
     config.servicenow.api_leaky_bucket_rate = 10
     config.servicenow.api_leaky_bucket_capacity = 10
+    # ``sysparm_display_value`` is forwarded on every ServiceNow Table
+    # API call; the client coerces it to the lowercase ``"true"`` /
+    # ``"false"`` string ServiceNow expects.
+    config.servicenow.sysparm_display_value = True
 
     return ServiceNowClient(helper=helper, config=config)
 
@@ -107,3 +111,39 @@ async def test_list_matched(config_labels, mock_response, expected_result):
     )
     # Then the results should be in the values matching the labels
     assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    ("configured_value", "expected_query_value"),
+    [
+        (True, "true"),
+        (False, "false"),
+    ],
+    ids=[
+        "true is sent as the lowercase 'true' ServiceNow expects",
+        "false is sent as the lowercase 'false' ServiceNow expects",
+    ],
+)
+def test_sysparm_display_value_is_serialized_as_lowercase(
+    configured_value, expected_query_value
+):
+    """Pin the bool → lowercase string coercion the ServiceNow API expects.
+
+    A naive ``f"sysparm_display_value={bool}"`` produces the
+    capitalised Python ``"True"`` / ``"False"`` representation,
+    which goes against ServiceNow's documented contract (the
+    parameter is documented as accepting the lowercase strings
+    ``"true"`` / ``"false"``). The client normalises the value
+    once at init so every Table API call site emits the correct
+    payload.
+    """
+    helper = Mock()
+    config = Mock()
+    config.servicenow.api_leaky_bucket_rate = 10
+    config.servicenow.api_leaky_bucket_capacity = 10
+    config.servicenow.sysparm_display_value = configured_value
+
+    client = ServiceNowClient(helper=helper, config=config)
+
+    assert client.sysparm_display_value == expected_query_value
+    assert isinstance(client.sysparm_display_value, str)

--- a/external-import/servicenow/tests/test_utils.py
+++ b/external-import/servicenow/tests/test_utils.py
@@ -1,0 +1,57 @@
+# isort: skipfile
+"""Tests for ``connector.services.utils.Utils``."""
+
+import pytest
+from src.connector.services.utils import Utils
+
+
+class TestTransformDescriptionToMarkdownNullComments:
+    """``transform_description_to_markdown`` must handle ``comments=None``.
+
+    ServiceNow's REST API returns the ``comments`` field as ``null``
+    when no comments are present. Passing that ``None`` through to
+    ``comments.strip()`` / the ``re.split`` call raised
+    ``AttributeError: 'NoneType' object has no attribute 'strip'`` and
+    crashed the enrichment. The helper now coerces ``None`` to an
+    empty string before the regex split so the description still
+    renders cleanly with only the original ``description`` block.
+    """
+
+    def test_none_comments_yields_description_only(self):
+        result = Utils.transform_description_to_markdown(
+            comment_to_exclude=[],
+            description="Original description",
+            comments=None,
+        )
+        assert result.startswith("Original description")
+        # No "Date | Author | Comments" markdown table header is
+        # emitted when there are no comments to render.
+        assert "| Date |" not in result
+
+    @pytest.mark.parametrize("blank_comments", ["", "   ", "\n\n"])
+    def test_blank_comments_yield_description_only(self, blank_comments):
+        # A pre-existing-empty / whitespace-only ``comments`` value
+        # behaves the same way as ``None`` (the previous code path).
+        result = Utils.transform_description_to_markdown(
+            comment_to_exclude=[],
+            description="Original description",
+            comments=blank_comments,
+        )
+        assert result.startswith("Original description")
+        assert "| Date |" not in result
+
+    def test_none_comments_does_not_raise_attribute_error(self):
+        # Regression guard: the previous code path crashed with
+        # ``AttributeError`` on ``comments.strip()`` when ``comments``
+        # was ``None``. Make sure the helper now succeeds.
+        try:
+            Utils.transform_description_to_markdown(
+                comment_to_exclude=["private"],
+                description="",
+                comments=None,
+            )
+        except AttributeError as exc:  # pragma: no cover - regression guard
+            pytest.fail(
+                f"transform_description_to_markdown raised AttributeError "
+                f"on comments=None: {exc}"
+            )


### PR DESCRIPTION
### Proposed changes

Two fixes for the ServiceNow external-import connector, plus the follow-on hardening applied during the Copilot review pass.

- When ServiceNow returns `comments=None` (no comments on a security incident), the connector now treats it as an empty string instead of raising `AttributeError` on `comments.strip()`. An incident with no comments now ingests cleanly.
- The hard-coded `sysparm_display_value=true` query parameter sent on every Table API call is now configurable through a new `SERVICENOW_SYSPARM_DISPLAY_VALUE` env var (default `True`, backwards-compatible). Some ServiceNow instances return non-ISO 8601 datetimes when display values are enabled, which the connector cannot parse — operators on those instances can now set `SERVICENOW_SYSPARM_DISPLAY_VALUE=False` to fall back to raw values.

### Copilot review fixes applied during the pass

- **Lowercase boolean serialisation.** A naive `f"sysparm_display_value={bool}"` produces `"True"` / `"False"` (capitalised), which goes against ServiceNow's documented contract. The client now coerces the bool to the lowercase `"true"` / `"false"` string ServiceNow expects, once at `__init__`, so every call site emits the correct payload.
- **Consistent application across all three Table API endpoints.** The new `sysparm_display_value` setting is now applied to `get_security_incidents`, `get_observables` **and** `get_tasks` — disabling display values on just one of the three would have left the non-ISO 8601 datetime issue on the other two.
- **Naming consistency.** The Python field, the env-var alias and the REST query parameter are all spelled `sysparm_display_value` (no extra `a`) — matching ServiceNow's documented Table API parameter. The docstring typo (`syparam_display_value`) is also fixed.
- **`transform_description_to_markdown(comments)` type annotation widened** from `str` to `str | None` (and docstring updated) so the API contract matches the new behaviour and the regression tests calling it with `None`.
- **Trailing whitespace** stripped from `utils.py` (line 88) and `client_api.py` (line 247). The `ci/circleci: ensure_formatting` check on the old head was failing because of these; `black --check` now passes cleanly.

### Branch sync + signed-commit cleanup

The branch was 732 commits behind master. Merged `origin/master` into the branch so the connector picks up current master's pin cohort (`pycti==7.260515.0`, `requests~=2.33.0`, the `pytest` bumps, the `connectors-sdk` release, `.build.env`, README polish). The merge was clean — no conflicts. Original branch history contained two unsigned commits (the `Check signed commits in PR` workflow was failing); the whole branch is now squashed into a single GPG-signed commit on top of current master, preserving original authorship via a `Co-authored-by:` trailer in the commit body.

### Tests

- `tests/test_client_api.py::test_sysparm_display_value_is_serialized_as_lowercase` (2 parametrised cases) pins the bool → lowercase string coercion so the rendered query parameter is always `"true"` / `"false"` regardless of how the operator configured it.
- `tests/test_utils.py::TestTransformDescriptionToMarkdownNullComments` (new file, 5 cases) pins the original bug fix — `transform_description_to_markdown(comments=None)` returns the description-only Markdown without raising `AttributeError`. Whitespace-only and empty-string inputs behave the same way.
- All 15 pytest cases (8 existing + 7 new) pass locally.

`black --check`, `isort --profile black --check` and `flake8 --select=F` all clean on the connector tree.

### Related issues

Closes #6436.

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation
- [x] Where necessary I refactored code to improve the overall quality
