### PR TITLE
[Diode Import] Add missing required positional arguments

### DIFF
--- a/external-import/diode-import/src/diode-import.py
+++ b/external-import/diode-import/src/diode-import.py
@@ -82,13 +82,15 @@ class DiodeImport:
             # region Register the connector in OpenCTI to simulate the real activity if not in cache
             if self.connectors_cache.get(connector_id) is None:
                 connector_registration = OpenCTIConnector(
-                    connector.get("id"),
-                    connector.get("name"),
-                    connector.get("type"),
-                    connector.get("scope"),
-                    connector.get("auto"),
-                    False,
-                    False,
+                    connector_id=connector.get("id"),
+                    connector_name=connector.get("name"),
+                    connector_type=connector.get("type"),
+                    scope=connector.get("scope"),
+                    auto=connector.get("auto"),
+                    only_contextual=False,  # default
+                    playbook_compatible=False,  # default
+                    auto_update=False,  # default
+                    enrichment_resolution="none",  # default
                 )
                 self.helper.api.connector.register(connector_registration)
                 self.connectors_cache[connector_id] = connector_id


### PR DESCRIPTION
As I don't know why this connector does not use `pycti.OpenCTIConnectorHelper` for connectors' registration, I did a fix that doesn't touch the rest of the code.

### Proposed changes

* add missing required positional arguments (default values)
* use keyword args for clarity

### Related issues

* #5150 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

