### PR TITLE
[Crowdstrike] fix latest_indicator_timestamp misbehaviour for indicators related to actors

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/actor/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/actor/importer.py
@@ -185,16 +185,16 @@ class ActorImporter(BaseImporter):
                 fetch_datetime = fetch_datetime.replace(tzinfo=timezone.utc)
 
             delta_days = (now_utc - fetch_datetime).days
-            if delta_days > 30:
-                thirty_days_ago = now_utc - timedelta(days=30)
-                fetch_timestamp = datetime_to_timestamp(thirty_days_ago)
+            if delta_days > 15:
+                fifteen_days_ago = now_utc - timedelta(days=15)
+                fetch_timestamp = datetime_to_timestamp(fifteen_days_ago)
                 self._warning(
-                    "Fetch timestamp is more than 30 days old ({0} days). "
-                    "Falling back to 30 days ago: {1}",
+                    "Fetch timestamp is more than 15 days old ({0} days). "
+                    "Falling back to 15 days ago: {1}",
                     delta_days,
-                    thirty_days_ago,
+                    fifteen_days_ago,
                 )
-                timestamp_source = "30d gated"
+                timestamp_source = "15d gated"
 
             _fql_filter = f"actors:['{actor_name}']+last_updated:>{fetch_timestamp}"
 


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

In some case, when retrieving indicators related in threat actors, we ended in retrieving a large amount of old data.
Causing really long ingest works.
To leverage that, we added a new gate to ensure if the delta between now and the state is more than 30d, we limit it to the past 30days.

Before:
<img width="1708" height="312" alt="Screenshot 2025-11-27 194358" src="https://github.com/user-attachments/assets/1ac41489-dd76-4869-a368-fde4525b62cf" />

After:
<img width="1954" height="362" alt="Screenshot 2025-11-27 194856" src="https://github.com/user-attachments/assets/89d9419d-b1d6-4852-8146-54c20b55e16d" />


### Related issues

* 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
