### PR TITLE
[Kaspersky enrichment] Fix type of zone_octi_score_mapping

### DIFF
--- a/internal-enrichment/kaspersky-enrichment/src/connector/settings.py
+++ b/internal-enrichment/kaspersky-enrichment/src/connector/settings.py
@@ -7,7 +7,7 @@ from connectors_sdk import (
 )
 from connectors_sdk.core.pydantic import ListFromString
 from pydantic import (
-    BeforeValidator,
+    AfterValidator,
     Field,
     HttpUrl,
     PlainSerializer,
@@ -38,8 +38,8 @@ def pycti_list_serializer(v: dict, info: SerializationInfo) -> str:
 
 
 DictFromString = Annotated[
-    dict,
-    BeforeValidator(parse_string_to_dict),
+    str,
+    AfterValidator(parse_string_to_dict),
     PlainSerializer(pycti_list_serializer, when_used="json"),
 ]
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add str instead of dict and call AfterValidation instead of BeforeValidation for zone_octi_score_mapping

### Related issues

* Closing https://github.com/OpenCTI-Platform/connectors/issues/5297

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->
