### PR TITLE
[ci] Automate the verification about signed commit in PRs. (#4802)

### DIFF
--- a/.github/workflows/check-verified-commit.yml
+++ b/.github/workflows/check-verified-commit.yml
@@ -1,0 +1,19 @@
+name: Check signed commits in PR
+on: [pull_request,pull_request_target]
+jobs:
+  check-signed-commits:
+    name: Check signed commits in PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Information about how to sign commits see https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
+        # "with comment" below does not work for forks.
+        run: |
+          echo "If you need to sign commits, Please see https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits"
+      - name: Check signed commits in PR on fail see above information.
+        uses: 1Password/check-signed-commits-action@v1
+        with:
+          comment: |
+            Thank you for your contribution, but we need you to sign your commits. Please see https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

* Closes #4802
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
