### PR TITLE
[MISP] Add publish_timestamp as allowed value for date_filter_field

### DIFF
--- a/external-import/misp/src/connector/config_loader.py
+++ b/external-import/misp/src/connector/config_loader.py
@@ -244,7 +244,11 @@ class _MISPConfig(_ConfigBaseModel):
         default="timestamp",
     )
     # TODO: check if Literal is correct
-    date_filter_field: Literal["date_from", "timestamp"] = Field(
+    date_filter_field: Literal[
+        "date_from",
+        "timestamp",
+        "publish_timestamp",
+    ] = Field(
         description="The attribute to use as filter to query new MISP events by date.",
         default="timestamp",
     )


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add publish_timestamp as allowed value for date_filter_field

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/5291

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
