### PR TITLE
[Kaspersky Enrichment] Create on note for all detections

### DIFF
--- a/internal-enrichment/kaspersky-enrichment/src/connector/connector.py
+++ b/internal-enrichment/kaspersky-enrichment/src/connector/connector.py
@@ -148,11 +148,17 @@ class KasperskyConnector:
                 "[CONNECTOR] Process enrichment from DetectionsInfo data..."
             )
 
+            content = "| Detection Date | Detection Name | Detection Method |\n"
+            content += "|----------------|----------------|------------------|\n"
+
             for obs_detection_info in entity_data["DetectionsInfo"]:
-                obs_note = self.converter_to_stix.create_file_note(
-                    observable["id"], obs_detection_info
-                )
-                self.stix_objects.append(obs_note)
+                detection_name = f"[{obs_detection_info["DetectionName"]}]({obs_detection_info["DescriptionUrl"]})"
+                content += f"| {obs_detection_info["LastDetectDate"]} | {detection_name} | {obs_detection_info["DetectionMethod"]} |\n"
+
+            obs_note = self.converter_to_stix.create_file_note(
+                observable["id"], content
+            )
+            self.stix_objects.append(obs_note)
 
         # Manage FileDownloadedFromUrls data
 

--- a/internal-enrichment/kaspersky-enrichment/src/connector/converter_to_stix.py
+++ b/internal-enrichment/kaspersky-enrichment/src/connector/converter_to_stix.py
@@ -40,17 +40,10 @@ class ConverterToStix:
         )
         return author
 
-    def create_file_note(self, obs_id: str, detection_info: dict) -> stix2.Note:
+    def create_file_note(self, obs_id: str, content: str) -> stix2.Note:
         """
         Create a note associated to the file observable
         """
-        detection_name = (
-            f"[{detection_info["DetectionName"]}]({detection_info["DescriptionUrl"]})"
-        )
-        content = "| Detection Date | Detection Name | Detection Method |\n"
-        content += "|----------------|----------------|------------------|\n"
-        content += f"| {detection_info["LastDetectDate"]} | {detection_name} | {detection_info["DetectionMethod"]} |\n"
-
         note = stix2.Note(
             type="note",
             id=Note.generate_id(datetime.datetime.now().isoformat(), content),


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Creation of a unique note with a single table encompassing every detections instead of one note by detection

### Related issues

* Closing https://github.com/OpenCTI-Platform/connectors/issues/5341

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
