### PR TITLE
[sentinelone-intel] Fixed naming convention in config_loader.py

### DIFF
--- a/stream/sentinelone-intel/src/sentinelone_connector/config_loader.py
+++ b/stream/sentinelone-intel/src/sentinelone_connector/config_loader.py
@@ -39,16 +39,16 @@ class ConfigConnector:
 
         # Handle existence of suffix / by removing for consistency
         self.api_url = get_config_variable(
-            "SENTINELONE-INTEL_API_URL",
-            ["sentinelone-intel", "api_url"],
+            "SENTINELONE_INTEL_URL",
+            ["sentinelone_intel", "url"],
             self.load,
             default=None,
             required=True,
         ).strip("/")
 
         self.api_key = get_config_variable(
-            "SENTINELONE-INTEL_API_KEY",
-            ["sentinelone-intel", "api_key"],
+            "SENTINELONE_INTEL_API_KEY",
+            ["sentinelone_intel", "api_key"],
             self.load,
             default=None,
             required=True,
@@ -61,8 +61,8 @@ class ConfigConnector:
         # SentinelOne API Filtering Parameters:
 
         self.account_id = get_config_variable(
-            "SENTINELONE-INTEL_ACCOUNT_ID",
-            ["sentinelone-intel", "account_id"],
+            "SENTINELONE_INTEL_ACCOUNT_ID",
+            ["sentinelone_intel", "account_id"],
             self.load,
             default=None,
         )
@@ -70,8 +70,8 @@ class ConfigConnector:
             self.account_id = int(self.account_id)
 
         self.site_id = get_config_variable(
-            "SENTINELONE-INTEL_SITE_ID",
-            ["sentinelone-intel", "site_id"],
+            "SENTINELONE_INTEL_SITE_ID",
+            ["sentinelone_intel", "site_id"],
             self.load,
             default=None,
         )
@@ -79,8 +79,8 @@ class ConfigConnector:
             self.site_id = int(self.site_id)
 
         self.group_id = get_config_variable(
-            "SENTINELONE-INTEL_GROUP_ID",
-            ["sentinelone-intel", "group_id"],
+            "SENTINELONE_INTEL_GROUP_ID",
+            ["sentinelone_intel", "group_id"],
             self.load,
             default=None,
         )


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* config_loader.py used the naming convention SENTINELONE-INTEL whereas configurations adhered to SENTINELONE_INTEL, thus config_loader.py has been changed to update this. This is the only change. 
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
