### PR TITLE
[TeamT5] time data does not match format '%Y-%m-%d %H:%M:%S

### DIFF
--- a/external-import/teamt5/src/teamt5/connector.py
+++ b/external-import/teamt5/src/teamt5/connector.py
@@ -129,9 +129,7 @@ class TeamT5Connector:
                 self.helper.connector_logger.info(
                     "Connector last run", {"last_run_datetime": last_run}
                 )
-                last_run_timestamp = int(
-                    datetime.strptime(last_run, "%Y-%m-%d %H:%M:%S").timestamp()
-                )
+                last_run_timestamp = int(datetime.fromisoformat(last_run).timestamp())
 
             # If the connector has never run, we should retrieve from the timestamp specified in configs
             else:


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

* Closes #5144
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
