### PR TITLE
[recordedfuture] Map the 'last_seen' RF date as OCTI 'valid_from' when creating an Indicator

### DIFF
--- a/external-import/recorded-future/src/rflib/rf_to_stix2.py
+++ b/external-import/recorded-future/src/rflib/rf_to_stix2.py
@@ -45,7 +45,15 @@ class ConversionError(Exception):
 class RFStixEntity:
     """Parent class"""
 
-    def __init__(self, name, _type, author=None, tlp="amber+strict", first_seen=None, last_seen=None):
+    def __init__(
+        self,
+        name,
+        _type,
+        author=None,
+        tlp="amber+strict",
+        first_seen=None,
+        last_seen=None,
+    ):
         self.name = name
         self.type = _type
         self.author = author or self._create_author()
@@ -237,7 +245,9 @@ class Indicator(RFStixEntity):
 
 
 class IPAddress(Indicator):
-    def __init__(self, name, _type, author=None, tlp=None, first_seen=None, last_seen=None):
+    def __init__(
+        self, name, _type, author=None, tlp=None, first_seen=None, last_seen=None
+    ):
         super().__init__(name, _type, author, tlp, first_seen, last_seen)
 
     """Converts IP address to IP indicator and observable"""
@@ -294,7 +304,9 @@ class IPAddress(Indicator):
 class Domain(Indicator):
     """Converts Domain to Domain indicator and observable"""
 
-    def __init__(self, name, _type, author=None, tlp=None, first_seen=None, last_seen=None):
+    def __init__(
+        self, name, _type, author=None, tlp=None, first_seen=None, last_seen=None
+    ):
         super().__init__(name, _type, author, tlp, first_seen, last_seen)
 
     def _create_pattern(self):
@@ -311,7 +323,9 @@ class Domain(Indicator):
 class URL(Indicator):
     """Converts URL to URL indicator and observable"""
 
-    def __init__(self, name, _type, author=None, tlp=None, first_seen=None, last_seen=None):
+    def __init__(
+        self, name, _type, author=None, tlp=None, first_seen=None, last_seen=None
+    ):
         super().__init__(name, _type, author, tlp, first_seen, last_seen)
 
     def _create_pattern(self):
@@ -330,7 +344,9 @@ class URL(Indicator):
 class FileHash(Indicator):
     """Converts Hash to File indicator and observable"""
 
-    def __init__(self, name, _type, author=None, tlp=None, first_seen=None, last_seen=None):
+    def __init__(
+        self, name, _type, author=None, tlp=None, first_seen=None, last_seen=None
+    ):
         super().__init__(name, _type, author, tlp, first_seen, last_seen)
         self.algorithm = self._determine_algorithm()
 

--- a/external-import/recorded-future/src/rflib/risk_list.py
+++ b/external-import/recorded-future/src/rflib/risk_list.py
@@ -78,7 +78,11 @@ class RiskList(threading.Thread):
                     first_seen = row["FirstSeen"] if row["FirstSeen"] else None
                     last_seen = row["LastSeen"] if row["LastSeen"] else None
                     indicator = risk_list_type["class"](
-                        row["Name"], key, tlp=self.tlp, first_seen=first_seen, last_seen=last_seen
+                        row["Name"],
+                        key,
+                        tlp=self.tlp,
+                        first_seen=first_seen,
+                        last_seen=last_seen,
                     )
 
                     rule_criticality_list = (


### PR DESCRIPTION
### Proposed changes

Currently, when creating an indicator from RF risk lists feeds, the connector uses the 'first_seen' date field as the 'valid_from' of the derived indicator.

This behavior currently causes numerous problems related to OpenCTI's Decay engine. Since the 'first_seen' date can be very old, many indicators are immediately revoked and expire in OpenCTI (the decay engine relies on this 'valid_from' field to apply its expiration).

Therefore, using the 'last_seen' field as 'valid_from' with the RF source makes much more sense, as it represents the last time the indicator was observed by RF and should thus allow the indicator's expiration date to be pushed back.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4324

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
