### PR TITLE
[all] Fix connectors-sdk version

### DIFF
--- a/external-import/cisa-known-exploited-vulnerabilities/src/requirements.txt
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/requirements.txt
@@ -2,4 +2,4 @@ pycti==6.9.0
 urllib3==2.6.0
 pydantic>=2.10, <3
 pydantic-settings==2.9.1
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/crowdstrike/src/requirements.txt
+++ b/external-import/crowdstrike/src/requirements.txt
@@ -3,4 +3,4 @@ lxml==5.4.0
 crowdstrike-falconpy==1.5.4
 pydantic>=2.10,<3
 pydantic-settings>=2.0
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/cve/src/requirements.txt
+++ b/external-import/cve/src/requirements.txt
@@ -2,4 +2,4 @@ pycti==6.9.0
 urllib3==2.6.0
 pydantic>=2.10, <3
 pydantic-settings==2.10.1
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/dragos/pyproject.toml
+++ b/external-import/dragos/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "tenacity>=9,<10",
     "markdownify>=1.1.0,<2",
     "pydantic>=2.8.2,<3",
-    "connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk",
+    "connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk",
 ]
 
 

--- a/external-import/feedly/src/requirements.txt
+++ b/external-import/feedly/src/requirements.txt
@@ -4,4 +4,4 @@ schedule==1.2.2
 Markdown==3.9
 pydantic>=2.10, <3
 pydantic-settings==2.9.1
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/ft3/src/requirements.txt
+++ b/external-import/ft3/src/requirements.txt
@@ -2,4 +2,4 @@ pycti==6.9.0
 urllib3==2.6.0
 pydantic>=2.10, <3
 pydantic-settings==2.9.1
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/google-ti-feeds/pyproject.toml
+++ b/external-import/google-ti-feeds/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "python-dotenv~=1.1.1",
     "stix2~=3.0.1",
     "dotenv~= 0.9.9",
-    "connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk",
+    "connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk",
 ]
 
 [project.optional-dependencies]

--- a/external-import/mandiant/src/requirements.txt
+++ b/external-import/mandiant/src/requirements.txt
@@ -1,4 +1,4 @@
 pycti==6.9.0
 pydantic>=2.11.10, <3
 pydantic-settings==2.11.0
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/mitre/src/requirements.txt
+++ b/external-import/mitre/src/requirements.txt
@@ -2,4 +2,4 @@ pycti==6.9.0
 urllib3==2.6.0
 pydantic>=2.10, <3
 pydantic-settings==2.9.1
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/ransomwarelive/requirements.txt
+++ b/external-import/ransomwarelive/requirements.txt
@@ -6,4 +6,4 @@ requests==2.32.5
 stix2==3.0.1
 tldextract==5.3.0
 validators==0.35.0
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/recorded-future/src/requirements.txt
+++ b/external-import/recorded-future/src/requirements.txt
@@ -17,5 +17,5 @@ sseclient
 stix2
 stix2-patterns
 urllib3
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk
 

--- a/external-import/sekoia/src/requirements.txt
+++ b/external-import/sekoia/src/requirements.txt
@@ -2,4 +2,4 @@ pycti==6.9.0
 pydantic>=2.10, <3
 pydantic-settings==2.10.1
 python-dateutil==2.9.0.post0
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/sparta/src/requirements.txt
+++ b/external-import/sparta/src/requirements.txt
@@ -3,4 +3,4 @@ stix2==3.0.1
 urllib3==2.6.0
 pydantic>=2.10, <3
 pydantic-settings==2.11.0
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/threatfox/src/requirements.txt
+++ b/external-import/threatfox/src/requirements.txt
@@ -3,4 +3,4 @@ urllib3==2.5.0
 validators==0.35.0
 pydantic>=2.10, <3
 pydantic-settings==2.9.1
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/abuseipdb/src/requirements.txt
+++ b/internal-enrichment/abuseipdb/src/requirements.txt
@@ -2,4 +2,4 @@ python-dateutil==2.9.0.post0
 pydantic-settings==2.10.1
 pydantic>=2.10, <3
 pycti==6.9.0
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/censys-enrichment/requirements.txt
+++ b/internal-enrichment/censys-enrichment/requirements.txt
@@ -1,5 +1,5 @@
 censys-platform~=0.11.0
 pydantic~=2.12.0
 pydantic-settings~=2.11.0
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk
 pycti==6.9.0

--- a/internal-enrichment/google-dns/src/requirements.txt
+++ b/internal-enrichment/google-dns/src/requirements.txt
@@ -2,4 +2,4 @@ pycti==6.9.0
 responses==0.25.8
 pydantic>=2.10, <3
 pydantic-settings==2.10.1
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/hygiene/src/requirements.txt
+++ b/internal-enrichment/hygiene/src/requirements.txt
@@ -3,4 +3,4 @@ pycti==6.9.0
 pydantic>=2.10, <3
 pydantic-settings==2.10.1
 git+http://github.com/MISP/PyMISPWarningLists.git@main#egg=pymispwarninglists
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/ipinfo/src/requirements.txt
+++ b/internal-enrichment/ipinfo/src/requirements.txt
@@ -2,4 +2,4 @@ pycti==6.9.0
 pycountry==24.6.1
 pydantic>=2.10, <3
 pydantic-settings==2.10.1
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/kaspersky-enrichment/src/requirements.txt
+++ b/internal-enrichment/kaspersky-enrichment/src/requirements.txt
@@ -2,4 +2,4 @@ pycti==6.9.0
 pydantic~= 2.11.3
 pydantic-settings==2.11.0
 requests~=2.32.3
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/recordedfuture-enrichment/src/requirements.txt
+++ b/internal-enrichment/recordedfuture-enrichment/src/requirements.txt
@@ -5,4 +5,4 @@ regex==2024.11.6
 requests==2.32.5
 stix2==3.0.1
 stix2-patterns==2.0.0
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/reversinglabs-spectra-analyze/requirements.txt
+++ b/internal-enrichment/reversinglabs-spectra-analyze/requirements.txt
@@ -1,3 +1,3 @@
 pycti==6.9.0
 reversinglabs-sdk-py3==2.11.4
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/shadowtrackr/src/requirements.txt
+++ b/internal-enrichment/shadowtrackr/src/requirements.txt
@@ -4,4 +4,4 @@ pydantic~=2.11
 validators~=0.35
 requests~=2.32
 
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.8.15#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/tagger/src/requirements.txt
+++ b/internal-enrichment/tagger/src/requirements.txt
@@ -1,4 +1,4 @@
 pycti==6.9.0
 pydantic>=2.10, <3
 pydantic-settings==2.10.1
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/virustotal-downloader/src/requirements.txt
+++ b/internal-enrichment/virustotal-downloader/src/requirements.txt
@@ -1,4 +1,4 @@
 pycti==6.9.0
 pydantic>=2.10, <3
 pydantic-settings==2.10.1
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/virustotal/src/requirements.txt
+++ b/internal-enrichment/virustotal/src/requirements.txt
@@ -1,6 +1,6 @@
 pycti==6.9.0
 pydantic>=2.11, <3
 pydantic-settings==2.11.0
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk
 plyara~=2.2.1
 

--- a/stream/misp-intel/src/requirements.txt
+++ b/stream/misp-intel/src/requirements.txt
@@ -5,5 +5,5 @@ jsonschema==4.25.1
 python-dateutil==2.9.0.post0
 tenacity==9.1.2
 certifi==2025.11.12
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk
 pymisp

--- a/stream/sentinelone-intel/src/requirements.txt
+++ b/stream/sentinelone-intel/src/requirements.txt
@@ -1,4 +1,4 @@
 pycti==6.9.0
 pyyaml==6.0.2
 pydantic~=2.11.3
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/stream/splunk-soar-push/src/requirements.txt
+++ b/stream/splunk-soar-push/src/requirements.txt
@@ -7,4 +7,4 @@ tenacity==9.1.2
 certifi==2025.11.12
 requests==2.32.5
 PyYAML==6.0.3
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.9.0#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/templates/external-import/src/requirements.txt
+++ b/templates/external-import/src/requirements.txt
@@ -2,4 +2,4 @@ pycti==6.9.0
 pydantic~= 2.11.3
 requests~=2.32.3
 validators==0.35.0
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.8.14#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/templates/internal-enrichment/src/requirements.txt
+++ b/templates/internal-enrichment/src/requirements.txt
@@ -2,4 +2,4 @@ pycti==6.9.0
 pydantic~= 2.11.3
 requests~=2.32.3
 validators==0.35.0
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.8.14#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/templates/internal-export-file/src/requirements.txt
+++ b/templates/internal-export-file/src/requirements.txt
@@ -1,3 +1,3 @@
 pycti==6.9.0
 pydantic~= 2.11.3
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.8.14#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/templates/internal-import-file/src/requirements.txt
+++ b/templates/internal-import-file/src/requirements.txt
@@ -1,3 +1,3 @@
 pycti==6.9.0
 pydantic~= 2.11.3
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.8.14#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/templates/stream/src/requirements.txt
+++ b/templates/stream/src/requirements.txt
@@ -1,4 +1,4 @@
 pycti==6.9.0
 pydantic~= 2.11.3
 requests~=2.32.3
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@6.8.14#subdirectory=connectors-sdk
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk


### PR DESCRIPTION
must be 'master' until next release to apply recent sdk updates

### Proposed changes

The version of `connectors-sdk` MUST be `master` until the next release so the connectors get the recent sdk updates. 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] ~~I added/update the relevant documentation (either on github or on notion)~~
- [ ] ~~Where necessary I refactored code to improve the overall quality~~


