### PR TITLE
[recorded-future] fix 'No rules returned from Recorded Future API' error

### DIFF
--- a/external-import/recorded-future/src/rflib/pyrf.py
+++ b/external-import/recorded-future/src/rflib/pyrf.py
@@ -123,7 +123,7 @@ class RecordedFutureApiClient:
         # If the response doesn't contain data, log the error
         if "data" not in data:
             self.helper.connector_logger.error(
-                "No data returned from Recorded Future API"
+                "'data' field is missing from the response returned by Recorded Future API"
             )
             return
 
@@ -131,8 +131,7 @@ class RecordedFutureApiClient:
             # If the response does not contain mandatory fields, log the error
             if "status" not in data:
                 self.helper.connector_logger.error(
-                    "Response does not contain mandatory status field",
-                    {"mandatory_field": "status"},
+                    "'status' field is missing from the response returned by Recorded Future API"
                 )
                 return
 


### PR DESCRIPTION
### Proposed changes

* Fix incorrect response content validation that generate useless error logs

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4219

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
