### PR TITLE
[import-document] Fix the missing git dependency when building rolling (#5430)

### DIFF
--- a/internal-import-file/import-document/Dockerfile
+++ b/internal-import-file/import-document/Dockerfile
@@ -6,9 +6,10 @@ COPY src /opt/opencti-connector-import-document
 
 # Install Python modules
 # hadolint ignore=DL3003
-RUN apk --no-cache add libmagic libffi-dev libxml2-dev libxslt-dev libffi-dev openssl-dev && \
+RUN apk --no-cache add git libmagic libffi-dev libxml2-dev libxslt-dev libffi-dev openssl-dev && \
     cd /opt/opencti-connector-import-document && \
-    pip3 install --no-cache-dir -r requirements.txt
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git
 
 # Expose and entrypoint
 COPY entrypoint.sh /


### PR DESCRIPTION
### Proposed changes

* Fix of #5340 introduce a build regression on rolling, reintroduce git in apk package
* It sill fix the c-ares issue since c-ares was also introduced through cargo, so c-ares was still present after the git package removal. Since cargo dependency has been removed in #5340 , removing git now also remove c-ares

### Related issues

* #5340 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
