### PR TITLE
[Shadowserver] Replace deprecated call report #5426

### DIFF
--- a/external-import/shadowserver/src/shadowserver/constants.py
+++ b/external-import/shadowserver/src/shadowserver/constants.py
@@ -3,6 +3,7 @@ import stix2
 from stix2 import TLP_AMBER, TLP_GREEN, TLP_RED, TLP_WHITE
 
 BASE_URL = "https://transform.shadowserver.org/api2/"
+DOWNLOAD_URL = "https://dl.shadowserver.org/"
 TIMEOUT = 500
 
 REQUEST_DATE_FORMAT = "%Y-%m-%d"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Replace deprecated call when downloading reports
* Fix tests related as a csv is parsed now instead of a json

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/5426

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
