### PR TITLE
[sentinelone-intel] Update default connector name

### DIFF
--- a/stream/sentinelone-intel/src/sentinelone_connector/settings.py
+++ b/stream/sentinelone-intel/src/sentinelone_connector/settings.py
@@ -24,7 +24,7 @@ class StreamConnectorConfig(BaseStreamConnectorConfig):
 
     name: str = Field(
         description="The name of the connector.",
-        default="SentinelOne Intel Stream Connector",
+        default="SentinelOne Intel",
     )
     scope: ListFromString = Field(
         description="The scope of the connector, e.g. 'sentinelone'.",


### PR DESCRIPTION
### Proposed changes

* Update default connector name to "SentinelOne Intel"