### PR TITLE
[shadowtrackr]: put api key to secret string

### DIFF
--- a/internal-enrichment/shadowtrackr/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/shadowtrackr/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -8,7 +8,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
 | OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
-| SHADOWTRACKR_API_KEY | `string` | ✅ | string |  | API key for authentication. |
+| SHADOWTRACKR_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | API key for authentication. |
 | CONNECTOR_NAME | `string` |  | string | `"ShadowTrackr"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["IPv4-Addr", "IPv6-Addr", "Indicator"]` | The scope of the connector, e.g. 'IPv4-Addr,IPv6-Addr,Indicator'. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/internal-enrichment/shadowtrackr/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/shadowtrackr/__metadata__/connector_config_schema.json
@@ -63,7 +63,9 @@
     },
     "SHADOWTRACKR_API_KEY": {
       "description": "API key for authentication.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "SHADOWTRACKR_MAX_TLP": {
       "default": "TLP:AMBER",

--- a/internal-enrichment/shadowtrackr/src/connector/connector.py
+++ b/internal-enrichment/shadowtrackr/src/connector/connector.py
@@ -54,7 +54,7 @@ class ShadowTrackrConnector:
         self.client = ShadowTrackrClient(
             self.helper,
             base_url=self.config.shadowtrackr.base_url,
-            api_key=self.config.shadowtrackr.api_key,
+            api_key=self.config.shadowtrackr.api_key.get_secret_value(),
         )
         self.converter_to_stix = ConverterToStix(
             self.helper,

--- a/internal-enrichment/shadowtrackr/src/connector/settings.py
+++ b/internal-enrichment/shadowtrackr/src/connector/settings.py
@@ -6,7 +6,7 @@ from connectors_sdk import (
     BaseInternalEnrichmentConnectorConfig,
     ListFromString,
 )
-from pydantic import Field, HttpUrl
+from pydantic import Field, HttpUrl, SecretStr
 
 
 class InternalEnrichmentConnectorConfig(BaseInternalEnrichmentConnectorConfig):
@@ -34,7 +34,7 @@ class ShadowTrackrConfig(BaseConfigModel):
         description="Base URL of the ShadowTrackr API.",
         default="https://shadowtrackr.com/api/v3",
     )
-    api_key: str = Field(description="API key for authentication.")
+    api_key: SecretStr = Field(description="API key for authentication.")
     max_tlp: Literal[
         "TLP:WHITE",
         "TLP:CLEAR",


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change api key type from str to SecretStr
*

### Related issues

* Closes #5467 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
