### PR TITLE
Fix: Handle missing indicator scope permission gracefully in CrowdStrike Report Connector

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
@@ -208,7 +208,7 @@ class ReportImporter(BaseImporter):
             response = self.indicators_api_cs.get_combined_indicator_entities(
                 limit=_limit, sort=_sort, fql_filter=_fql_filter, deep_pagination=True
             )
-            
+
             # Check if response has resources or if it's an error response
             if "resources" in response:
                 related_indicators.extend(response["resources"])
@@ -216,15 +216,27 @@ class ReportImporter(BaseImporter):
                 # API returned an error (e.g., 403 permission denied)
                 error_code = response.get("errors", [{}])[0].get("code")
                 if error_code == 403:
-                    self._warning("Skipping IOC fetching for report {0} - no indicator scope permission", report_name)
-                    return related_indicators_with_related_entities  # Return what we have
+                    self._warning(
+                        "Skipping IOC fetching for report {0} - no indicator scope permission",
+                        report_name,
+                    )
+                    return (
+                        related_indicators_with_related_entities  # Return what we have
+                    )
                 else:
                     # Other errors should be logged
-                    self._warning("Error fetching related IOCs for report {0}: {1}", report_name, str(response))
+                    self._warning(
+                        "Error fetching related IOCs for report {0}: {1}",
+                        report_name,
+                        str(response),
+                    )
                     return related_indicators_with_related_entities
             else:
                 # Unexpected response format
-                self._warning("Unexpected response format when fetching indicators for report {0}", report_name)
+                self._warning(
+                    "Unexpected response format when fetching indicators for report {0}",
+                    report_name,
+                )
                 return related_indicators_with_related_entities
 
             if related_indicators is not None:

--- a/external-import/crowdstrike/src/crowdstrike_feeds_services/client/base_api.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_services/client/base_api.py
@@ -31,7 +31,7 @@ class BaseCrowdstrikeClient:
         if response["status_code"] >= 400:
             error_message = response["body"]["errors"][0]["message"]
             status_code = response["status_code"]
-            
+
             # Log 403 (permission denied) as warning since it's often expected/handled gracefully
             if status_code == 403:
                 self.helper.connector_logger.warning(


### PR DESCRIPTION
## Problem
CrowdStrike connector crashes with `KeyError: 'resources'` when users lack the "indicator" API scope, preventing import of reports and actors.

## Root Cause
API returns a 403 error response without a `"resources"` field, but code tried to access it directly without validation.

## Solution
- Added defensive check for response structure before accessing 'resources'
- Handle 403 errors gracefully with warnings instead of crashing
- Changed 403 logging from ERROR to WARNING level
- Applied Black formatting

## Testing
- ✅ Actors imported successfully
- ✅ Reports imported successfully
- ✅ No KeyError crashes
- ✅ Backward compatible

## Impact
- Fixes crash for users without "indicator" scope
- No breaking changes
- No configuration changes needed

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
