### PR TITLE
[all] Quality Improvement - Chunk 4 (#5539)

### DIFF
--- a/external-import/kaspersky/src/kaspersky/connector.py
+++ b/external-import/kaspersky/src/kaspersky/connector.py
@@ -321,7 +321,8 @@ class KasperskyConnector:
         if not os.path.isfile(config_file_path):
             return {}
 
-        return yaml.load(open(config_file_path), Loader=yaml.FullLoader)
+        with open(config_file_path, encoding="utf-8") as f:
+            return yaml.load(f, Loader=yaml.FullLoader)
 
     @classmethod
     def _get_configuration(

--- a/external-import/kaspersky/src/kaspersky/publication/builder.py
+++ b/external-import/kaspersky/src/kaspersky/publication/builder.py
@@ -174,13 +174,13 @@ class PublicationBundleBuilder:
         return intrusion_sets
 
     def _create_intrusion_set(self, name: str) -> IntrusionSet:
-        create_by = self.author
+        created_by = self.author
         object_markings = self.object_markings
         confidence = self.confidence_level
 
         return create_intrusion_set(
             name,
-            created_by=create_by,
+            created_by=created_by,
             confidence=confidence,
             object_markings=object_markings,
         )

--- a/external-import/kaspersky/src/kaspersky/utils/common.py
+++ b/external-import/kaspersky/src/kaspersky/utils/common.py
@@ -97,4 +97,8 @@ def is_ip_address(address: str) -> bool:
 
 def is_ipv4_address(ip_address_value: str) -> bool:
     """Return True if given IP address is IPv4, otherwise False."""
-    return len(ip_address_value) <= 16
+    try:
+        ip = ipaddress.ip_address(ip_address_value)
+        return ip.version == 4
+    except ValueError:
+        return False

--- a/external-import/kaspersky/src/kaspersky/utils/indicators.py
+++ b/external-import/kaspersky/src/kaspersky/utils/indicators.py
@@ -219,7 +219,7 @@ def create_indicator_pattern_x509_certificate_issuer(value: str) -> IndicatorPat
 
 
 def create_indicator_pattern_user_agent(value: str) -> IndicatorPattern:
-    """Create an indicator pattern for an user-agent."""
+    """Create an indicator pattern for a user-agent."""
     return _create_indicator_pattern_with_value(_OBJECT_TYPE_USER_AGENT, value)
 
 

--- a/external-import/kaspersky/src/kaspersky/utils/observables.py
+++ b/external-import/kaspersky/src/kaspersky/utils/observables.py
@@ -311,7 +311,7 @@ def create_observable_x509_certificate_issuer(
 def create_observable_user_agent(
     properties: ObservableProperties,
 ) -> CustomObservableUserAgent:
-    """Create an observable representing an user-agent."""
+    """Create an observable representing a user-agent."""
     return CustomObservableUserAgent(
         value=properties.value,
         object_marking_refs=properties.object_markings,

--- a/external-import/kaspersky/src/kaspersky/utils/stix2.py
+++ b/external-import/kaspersky/src/kaspersky/utils/stix2.py
@@ -366,7 +366,7 @@ def create_intrusion_set(
     external_references: Optional[List[stix2.ExternalReference]] = None,
     object_markings: Optional[List[stix2.MarkingDefinition]] = None,
 ) -> stix2.IntrusionSet:
-    """Create a intrusion set."""
+    """Create an intrusion set."""
     if intrusion_set_id is None:
         intrusion_set_id = IntrusionSet.generate_id(name)
 

--- a/external-import/kaspersky/src/kaspersky/utils/yara.py
+++ b/external-import/kaspersky/src/kaspersky/utils/yara.py
@@ -142,7 +142,7 @@ class YaraRuleUpdater:
     def _needs_updating(self, current_rule: YaraRule, new_rule: YaraRule) -> bool:
         if current_rule.name != new_rule.name:
             self._error(
-                "Current ({0}) and new ({1}) YARA rules names do no match",
+                "Current ({0}) and new ({1}) YARA rules names do not match",
                 current_rule.name,
                 new_rule.name,
             )

--- a/external-import/lia-file-feed/src/main.py
+++ b/external-import/lia-file-feed/src/main.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import os
+import sys
 import time
 import traceback
 from datetime import datetime
@@ -20,12 +21,11 @@ from pycti import (
 class LIAFileFeed:
     def __init__(self):
         config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
-
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
+        if os.path.isfile(config_file_path):
+            with open(config_file_path, encoding="utf-8") as f:
+                config = yaml.load(f, Loader=yaml.FullLoader)
+        else:
+            config = {}
 
         self.helper = OpenCTIConnectorHelper(config)
 
@@ -90,12 +90,12 @@ class LIAFileFeed:
             sha256 = item.get("sha256")
             filetype = item.get("filetype")
             first_seen = item.get("first_seen")
-            source_family = item.get("source_family").capitalize()
+            source_family = (item.get("source_family") or "").capitalize()
             source_botnet = item.get("source_botnet")
             size = item.get("size")
             source_url = item.get("source_url")
-            detected_as = item.get("detected_as").capitalize()
-            external_link = item["external_link"]
+            detected_as = (item.get("detected_as") or "").capitalize()
+            external_link = item.get("external_link")
 
             valid_from = parse(first_seen).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -133,6 +133,10 @@ class LIAFileFeed:
                 name=f"{detected_as} malware downloaded by {source_family}",
                 size=size,
                 mime_type=filetype,
+                custom_properties={
+                    "x_opencti_created_by_ref": self.identity["standard_id"],
+                    "x_opencti_score": 80,
+                },
             )
 
             pattern = f"[file:hashes.'SHA-256'='{sha256}']"
@@ -145,7 +149,10 @@ class LIAFileFeed:
                 description=f"This indicator represents a file hash observed from downloaded by {source_family}. The payload is detected as {detected_as}",
                 labels=["malicious", "file", source_family, source_botnet, detected_as],
                 created_by_ref=self.identity["standard_id"],
-                custom_properties={"x_opencti_main_observable_type": "File"},
+                custom_properties={
+                    "x_opencti_main_observable_type": "StixFile",
+                    "x_opencti_score": 80,
+                },
                 external_references=[
                     {
                         "source_name": "Loader Insight Agency",
@@ -166,10 +173,19 @@ class LIAFileFeed:
                 labels=["malicious", "url", source_family, source_botnet, detected_as],
                 created_by_ref=self.identity["standard_id"],
                 external_references=[lia_external_reference],
-                custom_properties={"x_opencti_main_observable_type": "Url"},
+                custom_properties={
+                    "x_opencti_main_observable_type": "Url",
+                    "x_opencti_score": 80,
+                },
             )
 
-            url_object = stix2.URL(value=source_url)
+            url_object = stix2.URL(
+                value=source_url,
+                custom_properties={
+                    "x_opencti_created_by_ref": self.identity["standard_id"],
+                    "x_opencti_score": 80,
+                },
+            )
 
             stix_objects.extend(
                 [file_observable, file_indicator, url_indicator, url_object]
@@ -250,7 +266,7 @@ class LIAFileFeed:
 
             self.helper.connector_logger.debug("Fetching external data...")
             data = self.get_feed_data()
-            if "results" in data.keys():
+            if data and "results" in data:
                 self.process_data(data)
             else:
                 self.helper.connector_logger.info(
@@ -282,6 +298,6 @@ if __name__ == "__main__":
     try:
         connector = LIAFileFeed()
         connector.run()
-    except:
+    except Exception:
         traceback.print_exc()
-        exit(1)
+        sys.exit(1)

--- a/external-import/luminar/README.md
+++ b/external-import/luminar/README.md
@@ -85,7 +85,7 @@ Below are the parameters you'll need to set for the connector:
 | Luminar Account ID    | account_id                   | `LUMINAR_ACCOUNT_ID`                   | /       | Yes       | Luminar Account ID                                                                                      |
 | Luminar Client ID     | client_id                   | `LUMINAR_CLIENT_ID`               | /       | Yes       | Luminar Client ID                                                                           |
 | Luminar Client Secret        | client_secret                   | `LUMINAR_CLIENT_SECRET`                  | /       | Yes       | Luminar Client Secret                                                                               |
-| Inititla Fetch Date                  | initial_fetch_date                  | `LUMINAR_INITIAL_FETCH_DATE`           | YYYY-MM-DD   | Yes       | Fetch feeds from date (ex: 2025-01-01) |
+| Initial Fetch Date                  | initial_fetch_date                  | `LUMINAR_INITIAL_FETCH_DATE`           | YYYY-MM-DD   | Yes       | Fetch feeds from date (ex: 2025-01-01) |
 | Create Observable| create_observable | `LUMINAR_CREATE_OBSERVABLE` | True    | Yes       | Whether to create observables in OpenCTI Platform.                       |
 
 ## Deployment

--- a/external-import/luminar/src/luminar_connector/config_loader.py
+++ b/external-import/luminar/src/luminar_connector/config_loader.py
@@ -28,13 +28,10 @@ class ConfigConnector:
         :return: Configuration dictionary
         """
         config_file_path = Path(__file__).parents[1].joinpath("config.yml")
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
-
-        return config
+        if os.path.isfile(config_file_path):
+            with open(config_file_path, encoding="utf-8") as f:
+                return yaml.load(f, Loader=yaml.FullLoader)
+        return {}
 
     def _initialize_configurations(self) -> None:
         """

--- a/external-import/luminar/src/luminar_connector/connector.py
+++ b/external-import/luminar/src/luminar_connector/connector.py
@@ -101,8 +101,7 @@ class ConnectorLuminar:
         404: "Not Found. The server can not find the requested resource.",
         408: "Request Timeout. The server would like to shut down this unused connection.",
         429: "Too Many Requests. The user has sent too many requests in a given amount of time.",
-        500: "Internal Server Error. The server has encountered a situation it doesn't "
-        " know how to handle.",
+        500: "Internal Server Error. The server has encountered a situation it doesn't know how to handle.",
         502: "Bad Gateway. The server was acting as a gateway or proxy and received an invalid "
         "response from the upstream server.",
         503: "Service Unavailable. The server is not ready to handle the request.",
@@ -173,7 +172,7 @@ class ConnectorLuminar:
             return access_token, "Luminar API Connected successfully"
         return False, "Access token not found in response"
 
-    def get_taxi_collections(self, headers: Dict[str, str]) -> Dict[str, str]:
+    def get_taxii_collections(self, headers: Dict[str, str]) -> Dict[str, str]:
         """
         Fetches TAXII collections from the Luminar API and returns a mapping of
         collection aliases to their IDs.
@@ -930,7 +929,7 @@ class ConnectorLuminar:
                 return
 
             headers = {"Authorization": f"Bearer {access_token}"}
-            taxii_collection = self.get_taxi_collections(headers)
+            taxii_collection = self.get_taxii_collections(headers)
             if not taxii_collection:
                 return
 

--- a/external-import/luminar/src/main.py
+++ b/external-import/luminar/src/main.py
@@ -1,3 +1,4 @@
+import sys
 import traceback
 
 from luminar_connector import ConnectorLuminar
@@ -9,7 +10,7 @@ if __name__ == "__main__":
     - traceback.print_exc(): This function prints the traceback of the exception to the standard error (stderr).
     The traceback includes information about the point in the program where the exception occurred,
     which is very useful for debugging purposes.
-    - exit(1): effective way to terminate a Python program when an error is encountered.
+    - sys.exit(1): effective way to terminate a Python program when an error is encountered.
     It signals to the operating system and any calling processes that the program did not complete successfully.
     """
     try:
@@ -17,4 +18,4 @@ if __name__ == "__main__":
         connector.run()
     except Exception:
         traceback.print_exc()
-        exit(1)
+        sys.exit(1)


### PR DESCRIPTION
# fix(external-import): Comprehensive fixes for J-L connectors

## Summary

Comprehensive review and fix of all external-import connectors from J to L, addressing deprecated API usage, file handling issues, code quality improvements, OpenCTI modeling standards, and documentation accuracy.

**Note:** There are no external-import connectors starting with the letter "J". The J-L range includes:
- **J**: *None*
- **K**: kaspersky
- **L**: lastinfosec, lia-file-feed, luminar

## 📊 Statistics

| Metric | Count |
|--------|-------|
| Connectors Reviewed | 4 |
| Connectors Modified | 4 |
| Files Changed | 13 |
| Bug Fixes | 9 |
| Spelling/Grammar Fixes | 10 |
| Code Quality Improvements | 7 |
| Naming Convention Fixes | 1 |
| OpenCTI Modeling Fixes | 4 |

## 🚨 Critical Fixes

### Bug Fixes

| Connector | Issue | Fix |
|-----------|-------|-----|
| **kaspersky** | `is_ipv4_address()` incorrect implementation using length check | Fixed to use `ipaddress.ip_address()` and check `ip.version == 4` |
| **lastinfosec** | Deprecated `datetime.utcfromtimestamp()` | Changed to `datetime.fromtimestamp(timestamp, tz=timezone.utc)` |
| **lastinfosec** | Incorrect exit code `sys.exit(0)` in exception handler | Changed to `sys.exit(1)` |
| **lia-file-feed** | Bare `except:` clause (PEP 8 violation) | Changed to `except Exception:` |
| **lia-file-feed** | Missing `sys` import for `sys.exit(1)` | Added `import sys` |
| **lia-file-feed** | Potential `AttributeError` calling `.capitalize()` on `None` | Added `or ""` before `.capitalize()` |
| **lia-file-feed** | Unsafe dict access `item["external_link"]` | Changed to `item.get("external_link")` |
| **lia-file-feed** | Potential `AttributeError` calling `.keys()` on `None` | Added `data and` check before accessing keys |
| **luminar** | Using `exit(1)` instead of `sys.exit(1)` | Changed to `sys.exit(1)` with proper import |

### OpenCTI Modeling Fixes

| Connector | Issue | Fix |
|-----------|-------|-----|
| **lia-file-feed** | File observable missing OpenCTI custom properties | Added `x_opencti_created_by_ref` and `x_opencti_score` |
| **lia-file-feed** | URL observable missing OpenCTI custom properties | Added `x_opencti_created_by_ref` and `x_opencti_score` |
| **lia-file-feed** | File indicator missing `x_opencti_score` and incorrect type | Added score, changed `"File"` to `"StixFile"` |
| **lia-file-feed** | URL indicator missing `x_opencti_score` | Added score to custom_properties |

## 🐛 Bug Fixes

### Incorrect IPv4 Address Detection (1 connector)
Fixed `is_ipv4_address()` function that was using length-based check instead of proper IP validation in: kaspersky

```python
# Before - INCORRECT: length-based check can give false results
def is_ipv4_address(ip_address_value: str) -> bool:
    """Return True if given IP address is IPv4, otherwise False."""
    return len(ip_address_value) <= 16

# After - CORRECT: uses proper ipaddress module
def is_ipv4_address(ip_address_value: str) -> bool:
    """Return True if given IP address is IPv4, otherwise False."""
    try:
        ip = ipaddress.ip_address(ip_address_value)
        return ip.version == 4
    except ValueError:
        return False
```

### Deprecated DateTime APIs (1 connector)
Replaced `datetime.datetime.utcfromtimestamp()` with timezone-aware alternative in: lastinfosec

### Exit Code Corrections (1 connector)
Changed `sys.exit(0)` to `sys.exit(1)` in exception handlers: lastinfosec

### Bare Except Clause Fix (1 connector)
Changed bare `except:` to `except Exception:` in: lia-file-feed

### Potential AttributeError Fix (1 connector)
Added safety for `.capitalize()` on potentially None values in: lia-file-feed

```python
# Before
source_family = item.get("source_family").capitalize()
detected_as = item.get("detected_as").capitalize()

# After
source_family = (item.get("source_family") or "").capitalize()
detected_as = (item.get("detected_as") or "").capitalize()
```

### Missing Import (1 connector)
Added missing `sys` import in: lia-file-feed

### Safe Dict Access (1 connector)
Changed `item["external_link"]` to `item.get("external_link")` in: lia-file-feed

### Potential AttributeError on None (1 connector)
Fixed potential `AttributeError` when calling `.keys()` on `None` return from `get_feed_data()` in: lia-file-feed

```python
# Before - ERROR: data.keys() fails if data is None
if "results" in data.keys():

# After - CORRECT: checks data is not None first
if data and "results" in data:
```

### Use of `exit()` instead of `sys.exit()` (1 connector)
Changed `exit(1)` to `sys.exit(1)` with proper `sys` import in: luminar

## 🔧 Code Quality

### File Handling Improvements (4 connectors)
Replaced `yaml.load(open(config_file_path), ...)` with proper context manager pattern using `with open(...) as f:` to ensure files are properly closed:

| Connector | File |
|-----------|------|
| kaspersky | `connector.py` |
| lastinfosec | `lastinfosec.py` |
| lia-file-feed | `main.py` |
| luminar | `config_loader.py` |

Example fix:
```python
# Before
config = yaml.load(open(config_file_path), Loader=yaml.FullLoader)

# After
with open(config_file_path, encoding="utf-8") as f:
    config = yaml.load(f, Loader=yaml.FullLoader)
```

### Naming Conventions
- Variable rename: `lastInfoSecConnector` → `connector` (lastinfosec)
- Function rename: `get_taxi_collections` → `get_taxii_collections` (luminar) - TAXII acronym typo fix

### Error Handling
- Replaced `print(e)` with `traceback.print_exc()` (lastinfosec)
- Added `traceback` import (lastinfosec)

### Unused Import Removal (1 connector)
Removed unused `OpenCTIApiClient` import and unused `self.api` assignment in: lastinfosec

## 📝 Spelling & Grammar Fixes

### Docstrings (4 fixes)
| Connector | File | Original | Fixed |
|-----------|------|----------|-------|
| kaspersky | `utils/indicators.py` | "an user-agent" | "a user-agent" |
| kaspersky | `utils/observables.py` | "an user-agent" | "a user-agent" |
| kaspersky | `utils/stix2.py` | "Create a intrusion set" | "Create an intrusion set" |
| kaspersky | `utils/yara.py` | "do no match" | "do not match" |

### README (1 fix)
| Connector | Location | Original | Fixed |
|-----------|----------|----------|-------|
| luminar | README.md | "Inititla Fetch Date" | "Initial Fetch Date" |

### Variable Naming (1 fix)
| Connector | File | Original | Fixed |
|-----------|------|----------|-------|
| kaspersky | `publication/builder.py` | `create_by` | `created_by` |

### Comments (2 fixes)
| Connector | File | Original | Fixed |
|-----------|------|----------|-------|
| lastinfosec | `lastinfosec.py` | "1h in second" | "1h in seconds" |
| lastinfosec | `lastinfosec.py` | "24h in second" | "24h in seconds" |

### Docstring (1 fix)
| Connector | File | Original | Fixed |
|-----------|------|----------|-------|
| luminar | `main.py` | "exit(1):" in docstring | "sys.exit(1):" |

### String Literal (1 fix)
| Connector | File | Issue | Fix |
|-----------|------|-------|-----|
| luminar | `connector.py` | Double space in error message string | Fixed concatenated string literals |

## 📦 Connectors Modified

**K (1):** kaspersky

**L (3):** lastinfosec, lia-file-feed, luminar

### Files Changed Breakdown (13 total)

| Connector | Files Modified |
|-----------|----------------|
| kaspersky | `connector.py`, `utils/common.py`, `utils/indicators.py`, `utils/observables.py`, `utils/stix2.py`, `utils/yara.py`, `publication/builder.py` (7 files) |
| lastinfosec | `lastinfosec.py` (1 file) |
| lia-file-feed | `main.py` (1 file) |
| luminar | `main.py`, `connector.py`, `config_loader.py`, `README.md` (4 files) |

## 🏷️ Naming Convention Review

### K (kaspersky) - Full Review Completed

The kaspersky connector was thoroughly reviewed for naming conventions (20+ files). **Result: Fully compliant with PEP 8.**

| Category | Convention | Status |
|----------|------------|--------|
| File Names | snake_case | ✅ All correct |
| Class Names | PascalCase | ✅ All correct |
| Function Names | snake_case | ✅ All correct |
| Constants | UPPER_SNAKE_CASE | ✅ All correct |
| Private Functions | _leading_underscore | ✅ All correct |

**No naming convention fixes required for kaspersky.**

### L (lastinfosec, lia-file-feed, luminar) - Full Review Completed

All L connectors were thoroughly reviewed for naming conventions.

#### lastinfosec
| Category | Convention | Status |
|----------|------------|--------|
| File Names | snake_case | ✅ `lastinfosec.py` |
| Class Names | PascalCase | ✅ `LastInfoSec` |
| Function Names | snake_case | ✅ All correct |

**No naming convention fixes required.**

#### lia-file-feed
| Category | Convention | Status |
|----------|------------|--------|
| File Names | snake_case | ✅ `main.py` |
| Class Names | PascalCase | ✅ `LIAFileFeed` |
| Function Names | snake_case | ✅ All correct |

**No naming convention fixes required.**

#### luminar
| Category | Convention | Status |
|----------|------------|--------|
| File Names | snake_case | ✅ All correct |
| Class Names | PascalCase | ✅ `ConfigConnector`, `ConnectorLuminar` |
| Function Names | snake_case | ⚠️ 1 fix applied |
| Constants | UPPER_SNAKE_CASE | ✅ All correct |

**1 naming convention fix applied:**

| File | Original | Fixed | Reason |
|------|----------|-------|--------|
| `connector.py` | `get_taxi_collections` | `get_taxii_collections` | TAXII is an acronym (Trusted Automated eXchange of Intelligence Information), not "taxi" |

```python
# Before - INCORRECT: "taxi" is a typo
def get_taxi_collections(self, headers: Dict[str, str]) -> Dict[str, str]:

# After - CORRECT: TAXII acronym properly spelled
def get_taxii_collections(self, headers: Dict[str, str]) -> Dict[str, str]:
```

## 🎯 OpenCTI Modeling Standards Review

### K (kaspersky) - Full Modeling Review Completed

The kaspersky connector was thoroughly reviewed for OpenCTI modeling standards compliance. **Result: Exemplary implementation.**

#### STIX2 ID Generation
| Object Type | pycti Helper Used | Status |
|-------------|-------------------|--------|
| Identity | `Identity.generate_id(name, identity_class)` | ✅ Deterministic |
| Intrusion Set | `IntrusionSet.generate_id(name)` | ✅ Deterministic |
| Location | `Location.generate_id(name, location_type)` | ✅ Deterministic |
| Report | `Report.generate_id(name, published)` | ✅ Deterministic |
| Indicator | `Indicator.generate_id(pattern)` | ✅ Deterministic |
| Relationship | `StixCoreRelationship.generate_id(type, source, target, start, stop)` | ✅ Deterministic |

#### OpenCTI Custom Properties
| Property | Usage | Status |
|----------|-------|--------|
| `x_opencti_score` | Indicators & Observables | ✅ Default 75 |
| `x_opencti_main_observable_type` | Indicators | ✅ Correctly mapped |
| `x_opencti_location_type` | Locations (Region/Country) | ✅ Uses `LocationTypes` enum |
| `x_opencti_report_status` | Reports | ✅ Configurable status |
| `x_opencti_files` | Reports | ✅ PDF attachments |
| `x_opencti_labels` | Observables | ✅ Tag propagation |
| `x_opencti_created_by_ref` | Observables | ✅ Author reference |
| `x_opencti_description` | Observables | ✅ Description propagation |

#### Relationship Types
| Relationship | Source | Target | Status |
|-------------|--------|--------|--------|
| `targets` | Intrusion Set | Sector (Identity) | ✅ Valid |
| `targets` | Intrusion Set | Location | ✅ Valid |
| `indicates` | Indicator | Intrusion Set | ✅ Valid |
| `based-on` | Indicator | Observable | ✅ Valid |

#### TLP Marking Definitions
| TLP Level | STIX2 Object | Status |
|-----------|--------------|--------|
| White | `stix2.TLP_WHITE` | ✅ Standard |
| Green | `stix2.TLP_GREEN` | ✅ Standard |
| Amber | `stix2.TLP_AMBER` | ✅ Standard (Default) |
| Red | `stix2.TLP_RED` | ✅ Standard |

#### Bundle Structure
| Component | Included | Status |
|-----------|----------|--------|
| Author (Identity) | Yes | ✅ |
| Marking Definitions | Yes | ✅ |
| Intrusion Sets | Yes | ✅ |
| Sectors (Identities) | Yes | ✅ |
| Locations | Yes | ✅ |
| Indicators | Yes | ✅ |
| Observables | Yes | ✅ |
| Relationships | Yes | ✅ |
| Report | Yes | ✅ |
| `allow_custom=True` | Yes | ✅ Required for x_opencti_* props |

#### Observable Types Support
| Observable | STIX2 Type | Pattern Type | Status |
|------------|------------|--------------|--------|
| IPv4 Address | `ipv4-addr` | STIX | ✅ |
| IPv6 Address | `ipv6-addr` | STIX | ✅ |
| Domain Name | `domain-name` | STIX | ✅ |
| Hostname | `hostname` (custom) | STIX | ✅ |
| Email Address | `email-addr` | STIX | ✅ |
| Email Message | `email-message` | STIX | ✅ |
| URL | `url` | STIX | ✅ |
| File (MD5/SHA1/SHA256/Name) | `file` | STIX | ✅ |
| Mutex | `mutex` | STIX | ✅ |
| Cryptocurrency Wallet | `cryptocurrency-wallet` (custom) | STIX | ✅ |
| Windows Service | `process` (ext) | STIX | ✅ |
| X509 Certificate | `x509-certificate` | STIX | ✅ |
| User Agent | `user-agent` (custom) | STIX | ✅ |

#### Indicator Types Support
| Indicator Type | Pattern Type | Status |
|----------------|--------------|--------|
| STIX Pattern | `stix` | ✅ |
| YARA Rules | `yara` | ✅ |

#### Known Limitations (Properly Documented)
| Issue | Location | Notes |
|-------|----------|-------|
| Country code hardcoded to "ZZ" | `stix2.py:331` | TODO comment present - STIX2 requires country code |
| Empty report workaround | `builder.py:147-153` | Creates dummy object when no refs exist |

**Summary:** The kaspersky connector is an **exemplary implementation** of OpenCTI modeling standards:
- All STIX2 objects use pycti helpers for deterministic ID generation
- All OpenCTI custom properties are properly implemented
- Relationship types are valid and properly structured
- TLP marking definitions use standard stix2 objects
- Bundle creation follows best practices
- YARA and OpenIOC parsing are well-implemented
- Known limitations are properly documented with TODO comments

**No modeling issues found - this connector can serve as a reference implementation.**

### L (lastinfosec, lia-file-feed, luminar) - Full Modeling Review Completed

#### lastinfosec - Pass-through Connector
The lastinfosec connector fetches pre-made STIX 2.1 bundles directly from the LastInfoSec API and passes them to OpenCTI without modification.

| Aspect | Status |
|--------|--------|
| STIX Bundle Source | External API (pre-made) |
| Local Object Creation | None |
| Modeling Required | No - pass-through connector |

**Result: No modeling changes needed - relies on external API quality.**

#### lia-file-feed - 4 Fixes Applied

| Object | Issue | Fix Applied |
|--------|-------|-------------|
| File Observable | Missing `x_opencti_created_by_ref` and `x_opencti_score` | Added custom properties |
| URL Observable | Missing `x_opencti_created_by_ref` and `x_opencti_score` | Added custom properties |
| File Indicator | Missing `x_opencti_score` + incorrect `x_opencti_main_observable_type` | Added score, changed `"File"` to `"StixFile"` |
| URL Indicator | Missing `x_opencti_score` | Added score to custom_properties |

**Before - File Observable (missing OpenCTI properties):**
```python
file_observable = stix2.File(
    hashes={"SHA-256": sha256},
    name=f"{detected_as} malware downloaded by {source_family}",
    size=size,
    mime_type=filetype,
)
```

**After - File Observable (with OpenCTI properties):**
```python
file_observable = stix2.File(
    hashes={"SHA-256": sha256},
    name=f"{detected_as} malware downloaded by {source_family}",
    size=size,
    mime_type=filetype,
    custom_properties={
        "x_opencti_created_by_ref": self.identity["standard_id"],
        "x_opencti_score": 80,
    },
)
```

**Before - URL Observable (missing OpenCTI properties):**
```python
url_object = stix2.URL(value=source_url)
```

**After - URL Observable (with OpenCTI properties):**
```python
url_object = stix2.URL(
    value=source_url,
    custom_properties={
        "x_opencti_created_by_ref": self.identity["standard_id"],
        "x_opencti_score": 80,
    },
)
```

**Before - File Indicator (incorrect main_observable_type, missing score):**
```python
custom_properties={"x_opencti_main_observable_type": "File"},
```

**After - File Indicator (correct main_observable_type with score):**
```python
custom_properties={
    "x_opencti_main_observable_type": "StixFile",
    "x_opencti_score": 80,
},
```

#### lia-file-feed - Review Summary

| Category | Status |
|----------|--------|
| STIX2 ID Generation | ✅ Uses pycti helpers |
| Identity Creation | ✅ Uses `helper.api.identity.create()` |
| Relationships | ✅ Uses `StixCoreRelationship.generate_id()` |
| Indicators | ✅ Uses `Indicator.generate_id(pattern)` |
| Malware | ✅ Uses `Malware.generate_id(name)` |
| Observables | ✅ Now include `x_opencti_*` properties |
| Bundle | ✅ Uses `allow_custom=True` |

#### luminar - Exemplary Implementation

The luminar connector was reviewed and found to be well-implemented with proper OpenCTI modeling:

| Category | Status |
|----------|--------|
| Author Identity | ✅ `OpenCTIIdentity.generate_id(name, identity_class)` |
| Malware | ✅ `OpenCTIMalware.generate_id(name)` |
| Threat Actors | ✅ `OpenCTIThreatActor.generate_id(name, type)` |
| Incidents | ✅ `OpenCTIIncident.generate_id(name, created)` |
| Indicators | ✅ `OpenCTIIndicator.generate_id(pattern)` |
| Reports | ✅ `OpenCTIReport.generate_id(name, published)` |
| Relationships | ✅ `StixCoreRelationship.generate_id()` |
| Custom Properties | ✅ `x_opencti_score`, `x_opencti_created_by_ref`, `x_opencti_labels`, `x_opencti_description` |
| Relationship Validation | ✅ Uses `stix2-validator` to validate and normalize relationships |
| Bundle | ✅ Uses `helper.stix2_create_bundle()` |

**Notable Features:**
- Validates relationships using `stix2-validator` and normalizes invalid ones to `"related-to"`
- Properly handles IOCs, Leaked Records, and Cyberfeeds collections
- Generates proper `x_opencti_score` (80 default, 90 for Known Malicious IPs)
- Creates observables with full OpenCTI custom properties

**Result: No modeling changes needed - already exemplary.**

## ⚠️ Notes

- No connectors start with "J" in the external-import folder
- All connectors reviewed: kaspersky, lastinfosec, lia-file-feed, luminar
- No breaking changes introduced
- No file renames required
- **Kaspersky connector is a model example of proper OpenCTI integration and Python code structure**

## ✅ Testing Checklist

- [x] All 4 modified connectors initialize without errors
- [x] File handles are properly closed (no resource leaks)
- [x] Datetime handling verified with timezone-aware timestamps
- [x] Error handling produces correct exit codes
- [x] `black .` and `isort --profile=black .` pass

