### PR TITLE
[Crowdstrike Endpoint Security] Fix Wrong placement of ignore_types and unused variable consumer_count

### DIFF
--- a/stream/crowdstrike-endpoint-security/docker-compose.yml
+++ b/stream/crowdstrike-endpoint-security/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       # - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=true
       # - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true
       # - CONNECTOR_LOG_LEVEL=error
-      # - CONNECTOR_CONSUMER_COUNT=10
       # - CONNECTOR_IGNORE_TYPES=label,marking-definition,identity
       # - CROWDSTRIKE_API_BASE_URL=https://api.crowdstrike.com
       - CROWDSTRIKE_CLIENT_ID=ChangeMe

--- a/stream/crowdstrike-endpoint-security/src/config.yml.sample
+++ b/stream/crowdstrike-endpoint-security/src/config.yml.sample
@@ -10,7 +10,6 @@ connector:
 #   live_stream_listen_delete: true
 #   live_stream_no_dependencies: true
 #   log_level: 'error'
-#   consumer_count: 10
 #   ignore_types: label,marking-definition,identity
 
 crowdstrike:

--- a/stream/crowdstrike-endpoint-security/src/crowdstrike_connector/settings.py
+++ b/stream/crowdstrike-endpoint-security/src/crowdstrike_connector/settings.py
@@ -27,6 +27,10 @@ class StreamConnectorConfig(BaseStreamConnectorConfig):
     live_stream_id: str = Field(
         description="The ID of the live stream to connect to.",
     )
+    ignore_types: ListFromString = Field(
+        description="Ignoring types from OpenCTI",
+        default=["label", "marking-definition", "identity"],
+    )
 
 
 class CrowdstrikeEndpointSecurityConfig(BaseConfigModel):
@@ -51,14 +55,6 @@ class CrowdstrikeEndpointSecurityConfig(BaseConfigModel):
     falcon_for_mobile_active: bool = Field(
         description="Crowdstrike client secret used to connect to the API.",
         default=False,
-    )
-    consumer_count: int = Field(
-        description="Number of consumer/worker used to push data",
-        default=10,
-    )
-    ignore_types: ListFromString = Field(
-        description="Ignoring types from OpenCTI",
-        default=["label", "marking-definition", "identity"],
     )
 
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- Fixed ignore_types implementation → now filters stream data correctly
- Removed consumer_count variable → unused dead code

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/5555

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
