### PR TITLE
[crowdstrike-endpoint-security] fix 'falcon_for_mobile_active' placeholder

### DIFF
--- a/stream/crowdstrike-endpoint-security/src/crowdstrike_connector/settings.py
+++ b/stream/crowdstrike-endpoint-security/src/crowdstrike_connector/settings.py
@@ -53,7 +53,7 @@ class CrowdstrikeEndpointSecurityConfig(BaseConfigModel):
         default=False,
     )
     falcon_for_mobile_active: bool = Field(
-        description="Crowdstrike client secret used to connect to the API.",
+        description="Enable Android and iOS platform support.",
         default=False,
     )
 


### PR DESCRIPTION
### Proposed changes
 
* fix 'falcon_for_mobile_active' configuration placeholder

