### PR TITLE
[urlhaus] Add labels to Indicators  #5186

### DIFF
--- a/external-import/urlhaus/src/external_import_connector/converter_to_stix.py
+++ b/external-import/urlhaus/src/external_import_connector/converter_to_stix.py
@@ -84,6 +84,7 @@ class ConverterToStix:
             custom_properties={
                 "x_opencti_score": self.config.default_x_opencti_score,
                 "x_opencti_main_observable_type": "Url",
+                "labels": [x for x in row[6].split(",") if x],
             },
         )
         return stix_indicator


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

In the same way as it's done for the Observables, i've added labels to the indicators.

Before:
<img width="1265" height="782" alt="Screenshot from 2026-01-12 11-06-38" src="https://github.com/user-attachments/assets/e53467a4-223b-4528-b1fe-014b9fb8153e" />
<img width="1265" height="782" alt="Screenshot from 2026-01-12 11-06-32" src="https://github.com/user-attachments/assets/3135936b-0489-426b-8ebe-1ad0b83715c2" />

And After:
<img width="1265" height="782" alt="Screenshot from 2026-01-12 11-35-47" src="https://github.com/user-attachments/assets/6a461499-e424-4f1b-80de-a9252ed09866" />
<img width="1265" height="782" alt="Screenshot from 2026-01-12 11-36-21" src="https://github.com/user-attachments/assets/6044df7e-976a-404f-afda-8c0b2ab60501" />


### Related issues

https://github.com/OpenCTI-Platform/connectors/issues/5186

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
