### PR TITLE
[cve] Add CVSS v2 & v4.0 support

### DIFF
--- a/external-import/cve/README.md
+++ b/external-import/cve/README.md
@@ -163,9 +163,36 @@ graph LR
 | Description          | Vulnerability.description | CVE description                                |
 | Published Date       | Vulnerability.created   | Date CVE was published                           |
 | Last Modified        | Vulnerability.modified  | Last modification date                           |
-| CVSS v3.1 Score      | Vulnerability.x_opencti_cvss_base_score | CVSS base score              |
-| CVSS v3.1 Severity   | Vulnerability.x_opencti_cvss_base_severity | CRITICAL/HIGH/MEDIUM/LOW |
-| CVSS v3.1 Vector     | Vulnerability.x_opencti_cvss_attack_vector | Attack vector            |
+| CVSS v2 baseScore    | Vulnerability.x_opencti_cvss_v2_base_score | CVSS v2 Base Score            |
+| CVSS v2 accessVector | Vulnerability.x_opencti_cvss_v2_access_vector | CVSS v2 Access Vector      |
+| CVSS v2 accessComplexity| Vulnerability.x_opencti_cvss_v2_access_complexity | CVSS v2 Access Complexity |
+| CVSS v2 authentication | Vulnerability.x_opencti_cvss_v2_authentication | CVSS v2 Authentication  |
+| CVSS v2 confidentialityImpact | Vulnerability.x_opencti_cvss_v2_confidentiality_impact | CVSS v2 Confidentiality Impact |
+| CVSS v2 integrityImpact | Vulnerability.x_opencti_cvss_v2_integrity_impact | CVSS v2 Integrity Impact |
+| CVSS v2 availabilityImpact | Vulnerability.x_opencti_cvss_v2_availability_impact | CVSS v2 Availability Impact |
+| CVSS v3.1 baseScore  | Vulnerability.x_opencti_cvss_base_score | CVSS v3.1 base score             |
+| CVSS v3.1 baseSeverity | Vulnerability.x_opencti_cvss_base_severity | CVSS v3.1 Base Severity: CRITICAL/HIGH/MEDIUM/LOW |
+| CVSS v3.1 attackVector | Vulnerability.x_opencti_cvss_attack_vector | CVSS v3.1 Attack Vector     |
+| CVSS v3.1 attackComplexity | Vulnerability.x_opencti_cvss_attack_complexity | CVSS v3.1 Attack Complexity |
+| CVSS v3.1 privilegesRequired | Vulnerability.x_opencti_cvss_privileges_required | CVSS v3.1 Privileges Required |
+| CVSS v3.1 userInteraction | Vulnerability.x_opencti_cvss_user_interaction | CVSS v3.1 User Interaction |
+| CVSS v3.1 scope | Vulnerability.x_opencti_cvss_scope | CVSS v3.1 Scope                            |
+| CVSS v3.1 confidentialityImpact | Vulnerability.x_opencti_confidentiality_impact | CVSS v3.1 Confidentiality Impact |
+| CVSS v3.1 integrityImpact | Vulnerability.x_opencti_integrity_impact | CVSS v3.1 Integrity Impact |
+| CVSS v3.1 availabilityImpact | Vulnerability.x_opencti_availability_impact | CVSS v3.1 Availability Impact |
+| CVSS v4.0 baseScore | Vulnerability.x_opencti_cvss_v4_base_score | CVSS v4.0 Base Score           |
+| CVSS v4.0 baseSeverity | Vulnerability.x_opencti_cvss_v4_base_severity | CVSS v4.0 Base Severity  |
+| CVSS v4.0 attackVector | Vulnerability.x_opencti_cvss_v4_attack_vector | CVSS v4.0 Attack Vector (AV) |
+| CVSS v4.0 attackComplexity | Vulnerability.x_opencti_cvss_v4_attack_complexity | CVSS v4.0 Attack Complexity (AC)|
+| CVSS v4.0 attackRequirements | Vulnerability.x_opencti_cvss_v4_attack_requirements | CVSS v4.0 Attack Requirements (AT) |
+| CVSS v4.0 privilegesRequired | Vulnerability.x_opencti_cvss_v4_privileges_required | CVSS v4.0 Privileges Required (PR)|
+| CVSS v4.0 userInteraction | Vulnerability.x_opencti_cvss_v4_user_interaction | CVSS v4.0 User Interaction (UI) |
+| CVSS v4.0 vulnConfidentialityImpact | Vulnerability.x_opencti_cvss_v4_confidentiality_impact_v | CVSS v4.0 Confidentiality (VC) |
+| CVSS v4.0 subConfidentialityImpact | Vulnerability.x_opencti_cvss_v4_confidentiality_impact_s | CVSS v4.0 Confidentiality (SC) |
+| CVSS v4.0 vulnIntegrityImpact | Vulnerability.x_opencti_cvss_v4_integrity_impact_v | CVSS v4.0 Integrity  (VI)|
+| CVSS v4.0 subIntegrityImpact | Vulnerability.x_opencti_cvss_v4_integrity_impact_s | CVSS v4.0 Integrity  (SI)|
+| CVSS v4.0 vulnAvailabilityImpact | Vulnerability.x_opencti_cvss_v4_availability_impact_v | CVSS v4.0 Availability (VA) |
+| CVSS v4.0 subAvailabilityImpact | Vulnerability.x_opencti_cvss_v4_availability_impact_s | CVSS v4.0 Availability (SA) |
 | CWE IDs              | Labels                  | Weakness classifications                         |
 | References           | External References     | Links to advisories and patches                  |
 
@@ -183,7 +210,7 @@ graph LR
 
 ### Processing Details
 
-- **CVSS v3.1**: Connector uses CVSS v3.1 scores (available from 2019+)
+- **CVSS Support**: Connector supports CVSS v2, v3.1, and v4.0
 - **Rate Limiting**: NVD API has rate limits; connector handles pagination
 - **Date Range**: Maximum 120-day range per API query
 - **API Key Required**: Unauthenticated requests are heavily rate-limited

--- a/external-import/cve/src/services/client/vulnerability.py
+++ b/external-import/cve/src/services/client/vulnerability.py
@@ -22,9 +22,7 @@ class CVEVulnerability(CVEClient):
         cve_vulnerabilities_total = cve_collection["vulnerabilities"]
         total_items = cve_collection["totalResults"]
 
-        filtered_vulnerabilities = self._filter_cvss31(
-            cve_collection["vulnerabilities"]
-        )
+        filtered_vulnerabilities = self._filter_cvss(cve_collection["vulnerabilities"])
 
         if page_size == 0:
             msg = "[API] No Vulnerabilities to retrieve..."
@@ -60,7 +58,7 @@ class CVEVulnerability(CVEClient):
                 msg = f"[API] Received next {page_size} items, currently received {start_index} items of {total_items} total items."
                 self.helper.connector_logger.info(msg)
 
-                filtered_vulnerabilities = self._filter_cvss31(
+                filtered_vulnerabilities = self._filter_cvss(
                     cve_collection["vulnerabilities"]
                 )
                 yield filtered_vulnerabilities
@@ -71,17 +69,22 @@ class CVEVulnerability(CVEClient):
         )
         self.helper.connector_logger.info(info_msg)
 
-    def _filter_cvss31(self, cve_vulnerabilities) -> list:
+    def _filter_cvss(self, cve_vulnerabilities) -> list:
         cve_vulnerabilities_filtered = []
         for cve_vulnerability in cve_vulnerabilities:
             metric_exist = cve_vulnerability["cve"]["metrics"]
             if metric_exist:
                 for key, value in metric_exist.items():
-                    if key == "cvssMetricV31":
+                    # Filter on CVSS 2, 3.1, and 4.0. Don't include 3.0
+                    if (
+                        key == "cvssMetricV31"
+                        or key == "cvssMetricV40"
+                        or key == "cvssMetricV2"
+                    ):
                         cve_vulnerabilities_filtered.append(cve_vulnerability)
 
         info_msg = (
-            f"[API] Filter for only CVSS 3.1 CVEs. "
+            f"[API] Filter for only CVSS 2, 3.1, or 4.0 CVEs. "
             f"Got {len(cve_vulnerabilities_filtered)} vulnerabilities in total"
         )
         self.helper.connector_logger.info(info_msg)

--- a/external-import/cve/src/services/converter/vulnerability_to_stix2.py
+++ b/external-import/cve/src/services/converter/vulnerability_to_stix2.py
@@ -89,14 +89,98 @@ class CVEConverter:
                 )
                 external_references.append(external_reference)
 
-        # Getting metrics based on CVSS V3.1
-        cvss_metrics = vulnerability["cve"]["metrics"]["cvssMetricV31"][0]["cvssData"]
-        attack_vector = cvss_metrics["attackVector"]
-        availability_impact = cvss_metrics["availabilityImpact"]
-        base_score = cvss_metrics["baseScore"]
-        base_severity = cvss_metrics["baseSeverity"]
-        confidentiality_impact = cvss_metrics["confidentialityImpact"]
-        integrity_impact = cvss_metrics["integrityImpact"]
+        cvss_properties = {}
+
+        # Getting CVSS 3.1 metrics
+        if "cvssMetricV31" in vulnerability["cve"]["metrics"]:
+            selected_cvss_entry = None
+            cvss31_entries = vulnerability["cve"]["metrics"]["cvssMetricV31"]
+
+            # Some CVEs have Primary (from NVD) and Secondary (vendor) scores.
+            # Try to find the Primary CVSS rating from NVD, otherwise default to a Secondary one.
+            if len(cvss31_entries) > 1:
+                for index, value in enumerate(cvss31_entries):
+                    if value["type"] == "Primary":
+                        selected_cvss_entry = index
+                    elif value["type"] == "Secondary" and selected_cvss_entry == None:
+                        # Only set the index if a primary source hasn't already been found
+                        selected_cvss_entry = index
+
+            # Default to first score if no primary or secondary scores were found
+            if selected_cvss_entry == None:
+                selected_cvss_entry = 0
+
+            cvss31_metrics = cvss31_entries[selected_cvss_entry]["cvssData"]
+            cvss31_mapping = {
+                "x_opencti_base_score": "baseScore",
+                "x_opencti_base_severity": "baseSeverity",
+                "x_opencti_attack_vector": "attackVector",
+                "x_opencti_cvss_attack_complexity": "attackComplexity",
+                "x_opencti_cvss_privileges_required": "privilegesRequired",
+                "x_opencti_cvss_user_interaction": "userInteraction",
+                "x_opencti_cvss_scope": "scope",
+                "x_opencti_confidentiality_impact": "confidentialityImpact",
+                "x_opencti_integrity_impact": "integrityImpact",
+                "x_opencti_availability_impact": "availabilityImpact",
+            }
+
+            cvss_properties.update(
+                {
+                    opencti_key: cvss31_metrics[metric]
+                    for opencti_key, metric in cvss31_mapping.items()
+                    if metric in cvss31_metrics
+                }
+            )
+
+        # Get CVSS v2 metrics
+        if "cvssMetricV2" in vulnerability["cve"]["metrics"]:
+            cvss2_entries = vulnerability["cve"]["metrics"]["cvssMetricV2"]
+            cvss2_metrics = cvss2_entries[0]["cvssData"]
+            cvss2_mapping = {
+                "x_opencti_cvss_v2_base_score": "baseScore",
+                "x_opencti_cvss_v2_access_vector": "accessVector",
+                "x_opencti_cvss_v2_access_complexity": "accessComplexity",
+                "x_opencti_cvss_v2_authentication": "authentication",
+                "x_opencti_cvss_v2_confidentiality_impact": "confidentialityImpact",
+                "x_opencti_cvss_v2_integrity_impact": "integrityImpact",
+                "x_opencti_cvss_v2_availability_impact": "availabilityImpact",
+            }
+
+            cvss_properties.update(
+                {
+                    opencti_key: cvss2_metrics[metric]
+                    for opencti_key, metric in cvss2_mapping.items()
+                    if metric in cvss2_metrics
+                }
+            )
+
+        # Get CVSS v4.0 metrics
+        if "cvssMetricV40" in vulnerability["cve"]["metrics"]:
+            cvss40_entries = vulnerability["cve"]["metrics"]["cvssMetricV40"]
+            cvss40_metrics = cvss40_entries[0]["cvssData"]
+            cvss40_mapping = {
+                "x_opencti_cvss_v4_base_score": "baseScore",
+                "x_opencti_cvss_v4_base_severity": "baseSeverity",
+                "x_opencti_cvss_v4_attack_vector": "attackVector",
+                "x_opencti_cvss_v4_attack_complexity": "attackComplexity",
+                "x_opencti_cvss_v4_attack_requirements": "attackRequirements",
+                "x_opencti_cvss_v4_privileges_required": "privilegesRequired",
+                "x_opencti_cvss_v4_user_interaction": "userInteraction",
+                "x_opencti_cvss_v4_confidentiality_impact_v": "vulnConfidentialityImpact",
+                "x_opencti_cvss_v4_confidentiality_impact_s": "subConfidentialityImpact",
+                "x_opencti_cvss_v4_integrity_impact_v": "vulnIntegrityImpact",
+                "x_opencti_cvss_v4_integrity_impact_s": "subIntegrityImpact",
+                "x_opencti_cvss_v4_availability_impact_v": "vulnAvailabilityImpact",
+                "x_opencti_cvss_v4_availability_impact_s": "subAvailabilityImpact",
+            }
+
+            cvss_properties.update(
+                {
+                    opencti_key: cvss40_metrics[metric]
+                    for opencti_key, metric in cvss40_mapping.items()
+                    if metric in cvss40_metrics
+                }
+            )
 
         # Creating the vulnerability with the extracted fields
         vulnerability_to_stix2 = stix2.Vulnerability(
@@ -110,14 +194,7 @@ class CVEConverter:
                 100 if description is not None and len(description) > 0 else 60
             ),
             external_references=external_references,
-            custom_properties={
-                "x_opencti_base_score": base_score,
-                "x_opencti_base_severity": base_severity,
-                "x_opencti_attack_vector": attack_vector,
-                "x_opencti_integrity_impact": integrity_impact,
-                "x_opencti_availability_impact": availability_impact,
-                "x_opencti_confidentiality_impact": confidentiality_impact,
-            },
+            custom_properties=cvss_properties,
         )
 
         return vulnerability_to_stix2


### PR DESCRIPTION
### Proposed changes

* Add ability to parse CVSS v2 and v4.0 data for CVEs in NVD that have those metrics
* Expanded support for the CVSS v3.1 metrics
* Update documentation to reflect new CVSS version support

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4431

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Note 1: This is a cleaned up re-submission of my first pull request. I closed that one in favor of this one.

Note 2: Many of the CVEs in the NVD have multiple scores for CVSS v3.1. Some are from NVD (primary) and others from 3rd parties (secondary). The current connector design selects the first score entry, without considering if the score is from a primary or secondary source. This new code selects a score from a primary source (NVD) if available, otherwise it will default to the first score found.

CVSS v2 & v4.0 screenshots:
<img width="808" height="546" alt="2 0" src="https://github.com/user-attachments/assets/336e546b-9b4d-4e55-abf4-b7ee2571092f" />
<img width="806" height="630" alt="4 0" src="https://github.com/user-attachments/assets/fb77b58b-e316-45bf-920a-e8c6706a3f38" />