### PR TITLE
[crowdstrike] remove inferred relation created through indicator #5359

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/builder.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/builder.py
@@ -493,18 +493,6 @@ class IndicatorBundleBuilder:
         vulnerabilities = self._create_vulnerabilities()
         bundle_objects.extend(vulnerabilities)
 
-        # Intrusion sets target vulnerabilities and add to bundle.
-        intrusion_sets_target_vulnerabilities = self._create_targets_relationships(
-            intrusion_sets, vulnerabilities
-        )
-        bundle_objects.extend(intrusion_sets_target_vulnerabilities)
-
-        # Malwares target vulnerabilities and add to bundle.
-        malwares_target_vulnerabilities = self._create_targets_relationships(
-            malwares, vulnerabilities
-        )
-        bundle_objects.extend(malwares_target_vulnerabilities)
-
         # Create observations.
         observation = self._create_observation(kill_chain_phases)
         if observation is None:
@@ -547,13 +535,8 @@ class IndicatorBundleBuilder:
         object_refs = create_object_refs(
             cast(List[_DomainObject], intrusion_sets),
             cast(List[_DomainObject], malwares),
-            cast(List[_RelationshipObject], intrusion_sets_use_malwares),
             cast(List[_DomainObject], target_sectors),
-            cast(List[_RelationshipObject], intrusion_sets_target_sectors),
-            cast(List[_RelationshipObject], malwares_target_sectors),
             cast(List[_DomainObject], vulnerabilities),
-            cast(List[_RelationshipObject], intrusion_sets_target_vulnerabilities),
-            cast(List[_RelationshipObject], malwares_target_vulnerabilities),
             cast(List[_DomainObject], observables),
             cast(List[_DomainObject], indicators),
             cast(List[_RelationshipObject], indicators_based_on_observables),

--- a/external-import/crowdstrike/tests/indicator_kill_chain_isolation/test_indicator_kill_chain_isolation.py
+++ b/external-import/crowdstrike/tests/indicator_kill_chain_isolation/test_indicator_kill_chain_isolation.py
@@ -164,6 +164,7 @@ def _when_indicator_is_ingested(
         indicator_high_score=80,
         indicator_high_score_labels=["high", "Malicious"],
         indicator_unwanted_labels=[],
+        scopes=["malware", "vulnerability", "indicator", "actor"],
     )
 
     builder = IndicatorBundleBuilder(helper=helper, config=builder_config)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

The purpose of that PR is to remove the inferred relation create through indicator for actors, malwares, and sectors.

Before:
<img width="1707" height="431" alt="Screenshot from 2026-01-15 12-36-39" src="https://github.com/user-attachments/assets/f5092b7f-5320-4ef1-9f0b-83022dcc2c8a" />
<img width="448" height="422" alt="Screenshot from 2026-01-15 13-31-35" src="https://github.com/user-attachments/assets/02d74ffe-3d6b-45d0-9e98-bf9ea79882fa" />


After:
<img width="1714" height="119" alt="Screenshot from 2026-01-15 13-13-17" src="https://github.com/user-attachments/assets/56f3d119-4aca-4ef2-841b-337dd834c1c7" />
<img width="448" height="422" alt="Screenshot from 2026-01-15 13-26-36" src="https://github.com/user-attachments/assets/8cef2153-1af8-479f-9e49-abaf40cf841e" />


### Related issues

#5359 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
