### PR TITLE
[Hatching Triage Sandbox] Added RF url support

### DIFF
--- a/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
+++ b/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
@@ -97,11 +97,18 @@ class HatchingTriageSandboxConnector:
 
         bundle_objects = []
 
+        if "us-sandbox.recordedfuture.com" in self.base_url:
+            report_url = f"https://us-sandbox.recordedfuture.com/{sample_id}/"
+        elif "sandbox.recordedfuture.com" in self.base_url:
+            report_url = f"https://sandbox.recordedfuture.com/{sample_id}/"
+        else:
+            report_url = f"https://triage.ge/{sample_id}/"
+
         # Create external reference
         # Analysis URL
         external_reference = self.helper.api.external_reference.create(
             source_name="Hatching Triage Sandbox Analysis",
-            url=f"https://tria.ge/{sample_id}/",
+            url=report_url,
             description="Hatching Triage Sandbox Analysis",
         )
         self.helper.api.stix_cyber_observable.add_external_reference(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Adds support for Recorded Future URLs as external references after enriching an Artifact with this connector. Base URL configuration will determine which URL is provided as the external reference.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/5625

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I have signed my commits using GPG key.
- [X] I tested the code for its functionality using different use cases
- [X] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
