### PR TITLE
[crowdstrike-endpoint-security] skip metrics validation and initialization when disabled

### DIFF
--- a/stream/crowdstrike-endpoint-security/src/crowdstrike_connector/connector.py
+++ b/stream/crowdstrike-endpoint-security/src/crowdstrike_connector/connector.py
@@ -20,12 +20,14 @@ class CrowdstrikeConnector:
         self.config = config
         self.helper = helper
         self.client = CrowdstrikeClient(config.crowdstrike, helper)
-        self.metrics = Metrics(
-            config.connector.name,
-            str(config.metrics.addr),
-            config.metrics.port,
-        )
         self.metrics_enabled = config.metrics.enable
+        self.metrics = None
+        if self.metrics_enabled:
+            self.metrics = Metrics(
+                config.connector.name,
+                str(config.metrics.addr),
+                config.metrics.port,
+            )
 
     def handle_logger_info(self, action: str, data: dict) -> None:
         """
@@ -46,7 +48,7 @@ class CrowdstrikeConnector:
         :return: None
         """
         try:
-            if self.metrics_enabled:
+            if self.metrics_enabled and self.metrics is not None:
                 self.metrics.handle_metrics(msg)
             data = json.loads(msg.data)["data"]
         except Exception:
@@ -82,7 +84,7 @@ class CrowdstrikeConnector:
         Start main execution loop procedure for connector
         """
         # Start getting metrics if metrics_enabled is true
-        if self.metrics_enabled:
+        if self.metrics_enabled and self.metrics is not None:
             self.metrics.start_server()
 
         # Start listening to the stream

--- a/stream/crowdstrike-endpoint-security/tests/tests_connector/test_settings.py
+++ b/stream/crowdstrike-endpoint-security/tests/tests_connector/test_settings.py
@@ -52,6 +52,33 @@ from crowdstrike_connector import ConnectorSettings
             },
             id="minimal_valid_settings_dict",
         ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "live_stream_id": "E6EA6EE6-14A2-4EF9-B709-7C7524DB2A4F",
+                    "live_stream_listen_delete": True,
+                    "live_stream_no_dependencies": True,
+                },
+                "crowdstrike": {
+                    "api_base_url": "https://api.crowdstrike.com",
+                    "client_id": "test-client-id",
+                    "client_secret": "test-client-secret",
+                    "permanent_delete": False,
+                    "falcon_for_mobile_active": False,
+                },
+                "metrics": {
+                    "enable": False,
+                    "port": "ChangeMe",
+                    "addr": "ChangeMe",
+                },
+            },
+            id="metrics_disabled_with_placeholder_addr_and_port_is_valid",
+        ),
     ],
 )
 def test_settings_should_accept_valid_input(settings_dict):
@@ -145,6 +172,7 @@ def test_settings_should_accept_valid_input(settings_dict):
                     "id": "connector-id",
                     "scope": "test, connector",
                     "log_level": "error",
+                    "live_stream_id": "D5685291-70A3-47D2-AB3A-FEB0F7DA9257",
                 },
                 "crowdstrike": {
                     "api_base_url": "https://api.crowdstrike.com",
@@ -152,11 +180,36 @@ def test_settings_should_accept_valid_input(settings_dict):
                     "client_secret": "test-client-secret",
                 },
                 "metrics": {
+                    "enable": True,
                     "addr": "invalid-ip",
+                    "port": 9113,
                 },
             },
             "metrics.addr",
-            id="invalid_metrics_addr",
+            id="invalid_metrics_addr_when_enabled",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "live_stream_id": "D5685291-70A3-47D2-AB3A-FEB0F7DA9257",
+                },
+                "crowdstrike": {
+                    "api_base_url": "https://api.crowdstrike.com",
+                    "client_id": "test-client-id",
+                    "client_secret": "test-client-secret",
+                },
+                "metrics": {
+                    "enable": True,
+                    "addr": "0.0.0.0",
+                    "port": "invalid-port",
+                },
+            },
+            "metrics.port",
+            id="invalid_metrics_port_when_enabled",
         ),
     ],
 )


### PR DESCRIPTION
### Proposed changes

Make metrics configuration conditional on METRICS_ENABLE in the Crowdstrike Endpoint Security connector:

- Conditional metrics validation: Update MetricsConfig so that addr and port are validated only when enable = true. When metrics are disabled (enable = false), metrics-specific validation is skipped, allowing placeholder values (e.g. "ChangeMe") for METRICS_*. Port is relaxed from int to int | str and is always normalized but only validated when metrics are enabled (with clearer error messages for invalid addr/port).
- Connector initialization: Update the connector initialization to only instantiate the Metrics object when metrics are enabled, and set self.metrics = None otherwise.

- Adjust configuration tests to:
  - Configurations where metrics are disabled and addr or port are placeholders are now accepted. 
  - Configurations with metrics enabled and an invalid addr or port still fail validation as expected.

### Related issues

* Fixes #5573
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->
