### PR TITLE
[recorded-future] Support of Vulnerabilities playbooks alerts and opt…

### DIFF
--- a/external-import/recorded-future/docker-compose.yml
+++ b/external-import/recorded-future/docker-compose.yml
@@ -32,8 +32,10 @@ services:
       - ALERT_DEFAULT_OPENCTI_SEVERITY=low # OPTIONAL - default: low
       - ALERT_PRIORITY_ALERTS_ONLY=False # OPTIONAL - default: False
       - PLAYBOOK_ALERT_ENABLE=False # REQUIRED
+      - PLAYBOOK_ALERT_CATEGORIES=domain_abuse,identity_novel_exposures,code_repo_leakage # REQUIRED
       - PLAYBOOK_ALERT_SEVERITY_THRESHOLD_DOMAIN_ABUSE=Informational # OPTIONAL - default: Informational
       - PLAYBOOK_ALERT_SEVERITY_THRESHOLD_IDENTITY_NOVEL_EXPOSURES=Informational # OPTIONAL - default: Informational
       - PLAYBOOK_ALERT_SEVERITY_THRESHOLD_CODE_REPO_LEAKAGE=Informational # OPTIONAL - default: Informational
+      - PLAYBOOK_ALERT_SEVERITY_THRESHOLD_CYBER_VULNERABILITIES=Informational # OPTIONAL - default: Informational
       - PLAYBOOK_ALERT_DEBUG=False # OPTIONAL - default: False
     restart: always

--- a/external-import/recorded-future/src/config.yml.sample
+++ b/external-import/recorded-future/src/config.yml.sample
@@ -40,7 +40,9 @@ alert:
 
 playbook_alert:
   enable: False # required
+  categories: 'domain_abuse,identity_novel_exposures,code_repo_leakage'
   severity_threshold_domain_abuse: 'Informational' # optional
   severity_threshold_identity_novel_exposures: 'Informational' # optional
   severity_threshold_code_repo_leakage: 'Informational' # optional
+  severity_threshold_cyber_vulnerability: 'Informational' # optional
   debug: False # optional

--- a/external-import/recorded-future/src/main.py
+++ b/external-import/recorded-future/src/main.py
@@ -99,6 +99,9 @@ class BaseRFConnector:
         self.rf_alert_enable = self.config.alert.enable
         self.opencti_default_severity = self.config.alert.default_opencti_severity
         self.rf_playbook_alert_enable = self.config.playbook_alert.enable
+
+        self.playbook_alert_categories = self.config.playbook_alert.categories
+
         self.severity_threshold_domain_abuse = (
             self.config.playbook_alert.severity_threshold_domain_abuse
         )
@@ -107,6 +110,9 @@ class BaseRFConnector:
         )
         self.severity_threshold_code_repo_leakage = (
             self.config.playbook_alert.severity_threshold_code_repo_leakage
+        )
+        self.severity_threshold_cyber_vulnerability = (
+            self.config.playbook_alert.severity_threshold_cyber_vulnerability
         )
         self.debug_var = self.config.playbook_alert.debug
 
@@ -138,9 +144,11 @@ class RFConnector:
             self.alerts_playbook = RecordedFuturePlaybookAlertConnector(
                 self.RF.helper,
                 self.RF.rf_alerts_api,
+                self.RF.playbook_alert_categories,
                 self.RF.severity_threshold_domain_abuse,
                 self.RF.severity_threshold_identity_novel_exposures,
                 self.RF.severity_threshold_code_repo_leakage,
+                self.RF.severity_threshold_cyber_vulnerability,
                 self.RF.debug_var,
                 self.RF.tlp,
             )

--- a/external-import/recorded-future/src/models/configs/recorded_future_configs.py
+++ b/external-import/recorded-future/src/models/configs/recorded_future_configs.py
@@ -133,6 +133,13 @@ class _ConfigLoaderPlaybookAlert(ConfigBaseSettings):
         default=False,
         description="Whether to enable fetching Recorded Future playbook alerts.",
     )
+    categories: Optional[ListFromString] = Field(
+        default=["domain_abuse", "identity_novel_exposures", "code_repo_leakage"],
+        description=(
+            "Comma-separated list of Playbook Alert categories to import. Leave blank to fetch all categories available to your licence."
+            "Supported values: 'domain_abuse', 'identity_novel_exposures', 'code_repo_leakage'."
+        ),
+    )
     severity_threshold_domain_abuse: Literal["Informational", "Moderate", "High"] = (
         Field(
             default="Informational",
@@ -150,6 +157,12 @@ class _ConfigLoaderPlaybookAlert(ConfigBaseSettings):
     ] = Field(
         default="Informational",
         description="Minimum severity threshold for code repository leakage playbook alerts.",
+    )
+    severity_threshold_cyber_vulnerability: Literal[
+        "Informational", "Moderate", "High"
+    ] = Field(
+        default="Informational",
+        description="Minimum severity threshold for cyber vulnerabilities playbook alerts.",
     )
     debug: bool = Field(
         default=False,

--- a/external-import/recorded-future/src/rflib/constants.py
+++ b/external-import/recorded-future/src/rflib/constants.py
@@ -40,3 +40,10 @@ TLP_MAP = {
     ),
     "red": stix2.TLP_RED,
 }
+
+SUPPORTED_PLAYBOOK_ALERT_CATEGORIES = [
+    "domain_abuse",
+    "identity_novel_exposures",
+    "code_repo_leakage",
+    "cyber_vulnerability",
+]

--- a/external-import/recorded-future/src/rflib/pyrf.py
+++ b/external-import/recorded-future/src/rflib/pyrf.py
@@ -3,6 +3,8 @@ from datetime import datetime, timedelta, timezone
 import requests
 from pycti import OpenCTIConnectorHelper
 
+from .constants import SUPPORTED_PLAYBOOK_ALERT_CATEGORIES
+
 
 class RecordedFutureApiError(Exception):
     """Wrap exceptions emitted in RecordedFutureApiClient"""
@@ -334,7 +336,7 @@ class RecordedFutureApiClient:
 
         except requests.exceptions.RequestException as e:
             self.helper.connector_logger.error(
-                "Exception occured when trying to reach RecordedFuture's API : ",
+                "Exception occurred when trying to reach RecordedFuture's API : ",
                 {"error": str(e)},
             )
         except Exception as err:
@@ -349,31 +351,48 @@ class RecordedFutureApiClient:
                 )
 
             # If playbook_alert.category is not one of: domain_abuse, identity_novel_exposures, code_repo_leakage, log the error
-            playbook_alert_categories = [
-                "domain_abuse",
-                "identity_novel_exposures",
-                "code_repo_leakage",
-            ]
-            if playbook_alert_summary.category not in playbook_alert_categories:
+            if (
+                playbook_alert_summary.category
+                not in SUPPORTED_PLAYBOOK_ALERT_CATEGORIES
+            ):
                 self.helper.connector_logger.error(
-                    "You must provide an playbook alert whose category is among : domain_abuse, identity_novel_exposures, code_repo_leakage"
+                    f"You must provide an playbook alert whose category is among: {SUPPORTED_PLAYBOOK_ALERT_CATEGORIES}"
                 )
 
-            response = requests.post(
-                str(
-                    self.base_url
-                    + "playbook-alert/"
-                    + playbook_alert_summary.category
-                    + "/"
-                    + playbook_alert_summary.playbook_alert_id
-                ),
-                headers={
-                    "X-RFToken": self.x_rf_token,
-                    "Content-Type": "application/json",
-                    "accept": "application/json",
-                },
-                json={"panels": ["status", "action", "summary", "dns", "whois", "log"]},
-            )
+            # for vulnerability, the endpoint doesn't correspond to alert category
+            if playbook_alert_summary.category == "cyber_vulnerability":
+                response = requests.post(
+                    str(
+                        self.base_url
+                        + "playbook-alert/"
+                        + "vulnerability/"
+                        + playbook_alert_summary.playbook_alert_id
+                    ),
+                    headers={
+                        "X-RFToken": self.x_rf_token,
+                        "Content-Type": "application/json",
+                        "accept": "application/json",
+                    },
+                    json={"panels": ["status", "summary", "log"]},
+                )
+            else:
+                response = requests.post(
+                    str(
+                        self.base_url
+                        + "playbook-alert/"
+                        + playbook_alert_summary.category
+                        + "/"
+                        + playbook_alert_summary.playbook_alert_id
+                    ),
+                    headers={
+                        "X-RFToken": self.x_rf_token,
+                        "Content-Type": "application/json",
+                        "accept": "application/json",
+                    },
+                    json={
+                        "panels": ["status", "action", "summary", "dns", "whois", "log"]
+                    },
+                )
 
             # If there is an error during the request, the method raise the error
             response.raise_for_status()

--- a/external-import/recorded-future/src/rflib/utils.py
+++ b/external-import/recorded-future/src/rflib/utils.py
@@ -19,7 +19,6 @@ def make_markdown_table(array):
             markdown += f"| {' | '.join(entry)} |{nl}"
 
     markdown += nl
-    markdown += "> "
 
     return markdown
 


### PR DESCRIPTION
Duplicate of PR [5442 ](https://github.com/OpenCTI-Platform/connectors/pull/5593) to address the unsigned commit issue

------------------

> ### Proposed changes
> 
> * Support of ingestion of Vulnerability playbook alerts
> * Introduce a connector option allowing users to choose which Playbook Alerts categories to import
> 
> ### Related issues
> 
> * [[recorded-future] Introduce a connector option allowing users to choose which Playbook Alerts categories to import #5442](https://github.com/OpenCTI-Platform/connectors/issues/5442)
> * [[recorded-future] Support of "vulnerabilities" playbook alerts #5403](https://github.com/OpenCTI-Platform/connectors/issues/5403)
> 
> ### Checklist
> 
> * [x]  I consider the submitted work as finished
> * [x]  I have signed my commits using GPG key.
> * [x]  I tested the code for its functionality using different use cases
> * [x]  I added/update the relevant documentation (either on github or on notion)
> * [x]  Where necessary I refactored code to improve the overall quality
