### PR TITLE
[import-file-yara] avoid crashing if no metadata

### DIFF
--- a/internal-import-file/import-file-yara/src/import-file-yara.py
+++ b/internal-import-file/import-file-yara/src/import-file-yara.py
@@ -98,7 +98,7 @@ class ImportFileYARA:
             )
             for rule in parsing_result:
                 rule_name = rule.get("rule_name")
-                rule_metadata = rule.get("metadata")
+                rule_metadata = rule.get("metadata", [])
                 self.helper.log_debug(f"Processing rule name : {rule_name}")
                 yara_content = rebuild_yara_rule(rule, condition_indents=True)
                 stix_indicator = self._convert_yara_rule_to_stix_indicator(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

If a rule does not contain metadata, the connector crashes.

### Proposed changes

* If there are no metadatas, use an emtpy list.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/5701

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
