### PR TITLE
[misp] remove backward-compat workaround for original_tags_to_keep_as_labels

### DIFF
--- a/external-import/misp/src/connector/use_cases/convert_tag.py
+++ b/external-import/misp/src/connector/use_cases/convert_tag.py
@@ -39,13 +39,6 @@ class TagConverter:
             )
 
     def create_label(self, tag: TagItem) -> str | None:
-        # If no tags are configured to be kept as labels, keep all tags as labels
-        # This is a bug that existed on master before the ConfigLoader was added
-        # For the sake of backward compatibility, we keep this behavior for now (no breaking change)
-        # An issue has been opened: https://github.com/OpenCTI-Platform/connectors/issues/4886
-        if not self.config.original_tags_to_keep_as_labels:
-            self.config.original_tags_to_keep_as_labels = [""]
-
         if tag.name.startswith(tuple(self.config.original_tags_to_keep_as_labels)):
             return tag.name
 

--- a/external-import/misp/tests/tests_connector/test_tag_converter.py
+++ b/external-import/misp/tests/tests_connector/test_tag_converter.py
@@ -1,0 +1,49 @@
+import pytest
+from api_client.models import TagItem
+from connector.use_cases.common import ConverterConfig
+from connector.use_cases.convert_tag import TagConverter
+
+
+@pytest.mark.parametrize(
+    "original_tags_to_keep_as_labels, tag_name, expected",
+    [
+        # GIVEN no prefixes, WHEN tag is generic, THEN label is tag name
+        ([], "sometag", "sometag"),
+        # GIVEN prefix configured, WHEN tag starts with prefix, THEN label is tag name
+        (["keepme"], "keepme:foo", "keepme:foo"),
+        # GIVEN prefix configured, WHEN tag does not start with prefix, THEN label is extracted value
+        (["keepme"], "other:foo", "foo"),
+        # GIVEN no prefixes, WHEN tag is marking, THEN label is None
+        ([], "tlp:amber", None),
+        # GIVEN no prefixes, WHEN tag is entity, THEN label is None
+        ([], 'misp-galaxy:threat-actor=APT28"', None),
+        # GIVEN no prefixes, WHEN tag is in equal-quote format, THEN label is extracted value
+        ([], 'foo="bar"', "bar"),
+        # GIVEN no prefixes, WHEN tag is in colon format, THEN label is extracted value
+        ([], "foo:bar", "bar"),
+        # GIVEN no prefixes, WHEN tag is in digit format, THEN label is extracted value
+        ([], "foo:123", "123"),
+        # GIVEN marking prefix configured, WHEN tag is marking, THEN label is tag name
+        (["tlp:"], "tlp:amber", "tlp:amber"),
+        # GIVEN entity prefix configured, WHEN tag is entity, THEN label is tag name
+        (
+            ["misp-galaxy:threat-actor"],
+            'misp-galaxy:threat-actor=APT28"',
+            'misp-galaxy:threat-actor=APT28"',
+        ),
+    ],
+)
+def test_create_label_parametrized(original_tags_to_keep_as_labels, tag_name, expected):
+    # GIVEN a TagConverter with the specified config
+    config = ConverterConfig(
+        external_reference_base_url="http://dummy",
+        original_tags_to_keep_as_labels=original_tags_to_keep_as_labels,
+    )
+    converter = TagConverter(config)
+    tag = TagItem(name=tag_name)
+
+    # WHEN create_label is called
+    result = converter.create_label(tag)
+
+    # THEN the result matches expected
+    assert result == expected


### PR DESCRIPTION
### Proposed changes

Remove the legacy fallback from the `create_label` function in `TagConverter` and add a few tests.

**Current State**: Previously, if no tag prefixes were configured to be kept as labels, the connector would keep all tags as labels by default. This included marking tags (like tlp:amber) and entity tags (like misp-galaxy:threat-actor=APT28"), which should have been excluded. This behavior was due to a legacy fallback in the code.

Example (Before, with fallback):
- Config: original_tags_to_keep_as_labels = []
  - Tag: "tlp:amber" → Label: "tlp:amber" (incorrect)
  - Tag: "foo:bar" → Label: "foo:bar"
  - Tag: "randomtag" → Label: "randomtag"
- Config: original_tags_to_keep_as_labels = ["tlp:"]
  - Tag: "tlp:amber" → Label: "tlp:amber" (explicitly kept)
  - Tag: "foo:bar" → Label: "foo:bar"

**Target State (After this PR):** The legacy fallback has been removed. Now, only tags that match a configured prefix are kept as labels. Marking and entity tags are excluded by default, unless their prefix is explicitly configured.

Example (After, fallback removed):
- Config: original_tags_to_keep_as_labels = []
  - Tag: "tlp:amber" → Label: None (correct, excluded)
  - Tag: "foo:bar" → Label: "bar" (extracted, if not a marking/entity tag)
  - Tag: "randomtag" → Label: "randomtag"
- Config: original_tags_to_keep_as_labels = ["tlp:"]
  - Tag: "tlp:amber" → Label: "tlp:amber" (explicitly kept)
  - Tag: "foo:bar" → Label: "foo:bar" 
  
**Summary:**
The PR removes the bug where all tags were kept as labels by default.
Marking and entity tags are now correctly excluded unless explicitly configured.
The test suite covers both empty and non-empty prefix configurations to ensure correct behavior in all scenarios.


### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4886

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

