### PR TITLE
[URLHaus] docs: Fix Urlhaus URL in manifest json

### DIFF
--- a/external-import/urlhaus/__metadata__/connector_manifest.json
+++ b/external-import/urlhaus/__metadata__/connector_manifest.json
@@ -13,7 +13,7 @@
   "max_confidence_level": 50,
   "support_version": ">= 6.5.1",
   "subscription_link": "",
-  "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/oob/connector_manager/external-import/urlhaus",
+  "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/urlhaus",
   "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-urlhaus",


### PR DESCRIPTION
The URL was 
https://github.com/OpenCTI-Platform/connectors/tree/oob/connector_manager/external-import/urlhaus
 
instead of 
https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/urlhaus