### PR TITLE
[Google TI] Optimize API calls by setting explicit pagination limit on relationship queries

### DIFF
--- a/external-import/google-ti-feeds/build/lib/connector/src/custom/client_api/client_api_base.py
+++ b/external-import/google-ti-feeds/build/lib/connector/src/custom/client_api/client_api_base.py
@@ -290,7 +290,7 @@ class BaseClientAPI:
         """Calculate total pages based on count and limit."""
         if count is None:
             return None
-        limit = params.get("limit", 10)
+        limit = params.get("limit", 40)
         return (count + limit - 1) // limit
 
     def _build_log_message(

--- a/external-import/google-ti-feeds/build/lib/connector/src/custom/client_api/client_api_shared.py
+++ b/external-import/google-ti-feeds/build/lib/connector/src/custom/client_api/client_api_shared.py
@@ -45,7 +45,7 @@ class ClientAPIShared(BaseClientAPI):
             for subentity_type in subentity_types:
                 all_ids = []
 
-                params = {entity_name: entity_id, "entity_type": subentity_type}
+                params = {entity_name: entity_id, "entity_type": subentity_type, "limit": 40}
 
                 try:
                     async for page_data in self._paginate_with_cursor(


### PR DESCRIPTION
### Proposed changes

- Add `limit=40` parameter to relationship queries in `ClientAPIShared.fetch_subentities_ids()`, aligning with the limit already used by all main entity queries
- This reduces the number of API round-trips needed to fetch relationship data by up to 4x (pages of 40 instead of the API default of 10)

All main entity fetching paths (`_build_filter_configurations` and entity-specific fallbacks) already set `limit=40`. Only the relationship/subentity ID fetching in `client_api_shared.py` was missing this parameter, causing it to fall back to the Google TI API default of 10 results per page.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/5790

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
