### PR TITLE
[Feedly]Make FEEDLY_STREAM_IDS setting mandatory (#5387)

### DIFF
--- a/external-import/feedly/src/models/configs/feedly_configs.py
+++ b/external-import/feedly/src/models/configs/feedly_configs.py
@@ -15,7 +15,6 @@ class _ConfigLoaderFeedly(ConfigBaseSettings):
         ),
     )
     stream_ids: ListFromString = Field(
-        default=[],
         description=(
             "Comma separated list of Feedly stream IDs to monitor. "
             "Each stream ID represents a specific feed or collection to import from Feedly."

--- a/external-import/feedly/tests/conftest.py
+++ b/external-import/feedly/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/external-import/feedly/tests/test-requirements.txt
+++ b/external-import/feedly/tests/test-requirements.txt
@@ -1,0 +1,2 @@
+-r ../src/requirements.txt
+pytest==8.4.2

--- a/external-import/feedly/tests/tests_configs/test_settings.py
+++ b/external-import/feedly/tests/tests_configs/test_settings.py
@@ -1,0 +1,141 @@
+import pytest
+from models import ConfigLoader
+from pydantic import ValidationError
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
+
+
+class FakeConfigLoader(ConfigLoader):
+    """
+    Subclass of `ConfigLoader` for testing purpose.
+    Overrides `settings_customise_sources` to only use init_settings,
+    avoiding file/env loading.
+    """
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource]:
+        return (init_settings,)
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "feedly",
+                    "log_level": "error",
+                },
+                "feedly": {
+                    "stream_ids": "stream/123,stream/456",
+                    "api_key": "test-api-key",
+                    "interval": 60,
+                    "days_to_back_fill": 7,
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {},
+                "feedly": {
+                    "stream_ids": "stream/123",
+                    "api_key": "test-api-key",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that `ConfigLoader` accepts valid input.
+    For the test purpose, `settings_customise_sources` is overridden to only use
+    init_settings (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConfigLoader` input
+    """
+    settings = FakeConfigLoader(**settings_dict)
+    assert settings.opencti is not None
+    assert settings.connector is not None
+    assert settings.feedly is not None
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {},
+                "feedly": {
+                    "api_key": "test-api-key",
+                },
+            },
+            "stream_ids",
+            id="missing_mandatory_stream_ids",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {},
+                "feedly": {
+                    "stream_ids": "stream/123",
+                },
+            },
+            "api_key",
+            id="missing_mandatory_api_key",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:PORT",
+                    "token": "test-token",
+                },
+                "connector": {},
+                "feedly": {
+                    "stream_ids": "stream/123",
+                    "api_key": "test-api-key",
+                },
+            },
+            "url",
+            id="invalid_opencti_url",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that `ConfigLoader` raises on invalid input.
+    For the test purpose, `settings_customise_sources` is overridden to only use
+    init_settings (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConfigLoader` input
+    :param field_name: The field name expected in the validation error
+    """
+    with pytest.raises(
+        ValidationError,
+        match=rf"(?s)1 validation error for FakeConfigLoader.*\.{field_name}.*",
+    ):
+        FakeConfigLoader(**settings_dict)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Make FEEDLY_STREAM_IDS setting mandatory

### Related issues

*  Close #5387

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
