### PR TITLE
[Feedly] Remove port from IPv4 Observable

### DIFF
--- a/external-import/feedly/src/feedly/opencti_connector/connector.py
+++ b/external-import/feedly/src/feedly/opencti_connector/connector.py
@@ -87,10 +87,12 @@ class FeedlyConnector:
                 continue
 
             o["value"] = match["addr"]
+            tlp_marking = o.get("object_marking_refs", [])
             nt = NetworkTraffic(
                 dst_ref=o["id"],
                 dst_port=int(match["port"]),
                 protocols=["tcp"],
+                object_marking_refs=tlp_marking,
             )
             new_objects.append(json.loads(nt.serialize()))
 

--- a/external-import/feedly/tests/test_connector.py
+++ b/external-import/feedly/tests/test_connector.py
@@ -29,6 +29,34 @@ class TestFixIpAddressesWithPorts:
         assert nt["protocols"] == ["tcp"]
         assert nt["id"].startswith("network-traffic--")
 
+    def test_tlp_marking_is_propagated_to_network_traffic(self):
+        tlp_white = "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9"
+        ip_obj = {
+            "type": "ipv4-addr",
+            "id": IPV4_ID,
+            "value": "1.2.3.4:8080",
+            "object_marking_refs": [tlp_white],
+        }
+        bundle = _make_bundle([ip_obj])
+
+        FeedlyConnector._fix_ip_addresses_with_ports(bundle)
+
+        nt = next(o for o in bundle["objects"] if o["type"] == "network-traffic")
+        assert nt["object_marking_refs"] == [tlp_white]
+
+    def test_no_marking_on_ip_means_no_marking_on_network_traffic(self):
+        ip_obj = {
+            "type": "ipv4-addr",
+            "id": IPV4_ID,
+            "value": "1.2.3.4:8080",
+        }
+        bundle = _make_bundle([ip_obj])
+
+        FeedlyConnector._fix_ip_addresses_with_ports(bundle)
+
+        nt = next(o for o in bundle["objects"] if o["type"] == "network-traffic")
+        assert "object_marking_refs" not in nt
+
     def test_plain_ipv4_without_port_is_unchanged(self):
         ip_obj = {
             "type": "ipv4-addr",


### PR DESCRIPTION
IPv4 Observable cannot contains port and is limited to the address only. If the value contains a port then it is extracted into a Network-Traffic observable.

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* IPv4 Observable cannot contains port and is limited to the address only. If the value contains a port then it is extracted into a Network-Traffic observable.

### Related issues

* Close #3950 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
