### PR TITLE
[Cofense ThreatHQ] Fix test failure: add missing 'jwks' key to connector register mock

### DIFF
--- a/external-import/cofense-threathq/tests/test_connector.py
+++ b/external-import/cofense-threathq/tests/test_connector.py
@@ -41,6 +41,7 @@ from src.connector.services.config_loader import CofenseThreatHQConfig
                 "pass": "changeme",
             }
         },
+        "jwks": {},
     },
 )
 def test_should_promote_observables_to_indicators(_, __):


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* In `external-import/cofense-threathq/tests/test_connector.py`, add "jwks": {} to the OpenCTIApiConnector.register mock return_value dict.

### Related issues

* Closes #5845 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Steps to reproduce bug:

- Remove `"jwks": {}`
- Install pycti dependency from master branch 
- Run pytest in the connector concerned

The `test_should_promote_observables_to_indicators` test fails with `KeyError: 'jwks'`  because the mock return value for `OpenCTIApiConnector.register` is missing the jwks key that recent versions of pycti now expect during connector initialization.

Specifically, OpenCTIConnectorHelper.__init__ now reads:
`pythonself.connector_config["connector_jwks"] = connector_configuration["jwks"]`

The fix adds "jwks": {} to the mocked register return value in the test.