### PR TITLE
[crowdstrike] do not import reports if not in scope

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/core.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/core.py
@@ -271,6 +271,7 @@ class CrowdStrike:
                 report_status,
                 report_type,
                 no_file_trigger_import,
+                scopes=scopes_list,
             )
 
             importers.append(snort_master_importer)

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/rule/snort_suricata_master_importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/rule/snort_suricata_master_importer.py
@@ -51,6 +51,7 @@ class SnortMasterImporter(BaseImporter):
         report_status: int,
         report_type: str,
         no_file_trigger_import: bool,
+        scopes: list[str],
     ) -> None:
         """Initialize CrowdStrike Snort master importer."""
         super().__init__(helper, author, tlp_marking)
@@ -59,6 +60,7 @@ class SnortMasterImporter(BaseImporter):
         self.report_status = report_status
         self.report_type = report_type
         self.no_file_trigger_import = no_file_trigger_import
+        self.include_reports = "report" in scopes
 
         self.report_fetcher = ReportFetcher(helper, self.no_file_trigger_import)
 
@@ -266,7 +268,9 @@ class SnortMasterImporter(BaseImporter):
         failed_count = 0
 
         for snort_rule in snort_rules:
-            fetched_reports = self._get_reports_by_code(snort_rule.reports)
+            fetched_reports: List[FetchedReport] = []
+            if self.include_reports:
+                fetched_reports = self._get_reports_by_code(snort_rule.reports)
 
             snort_rule_bundle = self._create_snort_rule_bundle(
                 snort_rule, fetched_reports

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/rule/yara_master_importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/rule/yara_master_importer.py
@@ -64,6 +64,7 @@ class YaraMasterImporter(BaseImporter):
         self.report_type = report_type
         self.no_file_trigger_import = no_file_trigger_import
         self.scopes = scopes
+        self.include_reports = "report" in scopes
 
         self.report_fetcher = ReportFetcher(helper, self.no_file_trigger_import)
 
@@ -271,7 +272,9 @@ class YaraMasterImporter(BaseImporter):
         failed_count = 0
 
         for yara_rule in yara_rules:
-            fetched_reports = self._get_reports_by_code(yara_rule.reports)
+            fetched_reports: list[FetchedReport] = []
+            if self.include_reports:
+                fetched_reports = self._get_reports_by_code(yara_rule.reports)
 
             yara_rule_bundle = self._create_yara_rule_bundle(yara_rule, fetched_reports)
             if yara_rule_bundle is None:

--- a/external-import/crowdstrike/tests/rule_report_scope/test_rule_report_scope.py
+++ b/external-import/crowdstrike/tests/rule_report_scope/test_rule_report_scope.py
@@ -1,0 +1,177 @@
+"""Tests to ensure rule importers respect report scope configuration."""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+from crowdstrike_feeds_connector.rule.snort_suricata_master_importer import (
+    SnortMasterImporter,
+)
+from crowdstrike_feeds_connector.rule.yara_master_importer import YaraMasterImporter
+from crowdstrike_feeds_services.utils.snort_parser import SnortRule
+from crowdstrike_feeds_services.utils.yara_parser import YaraRule
+
+
+@pytest.fixture
+def patched_yara_dependencies() -> None:
+    with (
+        patch("crowdstrike_feeds_connector.rule.yara_master_importer.RulesAPI"),
+        patch("crowdstrike_feeds_connector.rule.yara_master_importer.ActorsAPI"),
+        patch("crowdstrike_feeds_connector.rule.yara_master_importer.ReportFetcher"),
+    ):
+        yield
+
+
+@pytest.fixture
+def patched_snort_dependencies() -> None:
+    with (
+        patch(
+            "crowdstrike_feeds_connector.rule.snort_suricata_master_importer.RulesAPI"
+        ),
+        patch(
+            "crowdstrike_feeds_connector.rule.snort_suricata_master_importer.ReportFetcher"
+        ),
+    ):
+        yield
+
+
+def _build_helper() -> MagicMock:
+    helper = MagicMock()
+    helper.log_info = MagicMock()
+    helper.log_error = MagicMock()
+    helper.log_debug = MagicMock()
+    helper.log_warning = MagicMock()
+    helper.connect_confidence_level = 80
+    return helper
+
+
+def _build_yara_rule() -> YaraRule:
+    return YaraRule(
+        name="rule_yara_1",
+        description="desc",
+        last_modified=date(2026, 1, 1),
+        reports=["CS-TEST-1234"],
+        actors=[],
+        malware_families=[],
+        rule='rule rule_yara_1 { meta: description = "desc" condition: true }',
+    )
+
+
+def _build_snort_rule() -> SnortRule:
+    return SnortRule(
+        name="rule_snort_1",
+        description="desc",
+        last_modified=date(2026, 1, 1),
+        reports=["CS-TEST-1234"],
+        rule='alert ip any any -> any any (msg: "desc [CS-TEST-1234]"; rev:20260101;)',
+    )
+
+
+def test_yara_master_skips_report_fetch_when_report_scope_absent(
+    patched_yara_dependencies: None,
+) -> None:
+    """YARA importer does not fetch report entities if report scope is not enabled."""
+    del patched_yara_dependencies
+
+    importer = YaraMasterImporter(
+        helper=_build_helper(),
+        author=MagicMock(),
+        tlp_marking=MagicMock(),
+        report_status=0,
+        report_type="threat-report",
+        no_file_trigger_import=True,
+        scopes=["yara_master"],
+    )
+
+    rule = _build_yara_rule()
+    importer._get_reports_by_code = MagicMock(return_value=["unexpected"])
+    importer._create_yara_rule_bundle = MagicMock(return_value=MagicMock())
+    importer._send_bundle = MagicMock()
+
+    importer._process_yara_rule_group(("group", [rule]))
+
+    importer._get_reports_by_code.assert_not_called()
+    importer._create_yara_rule_bundle.assert_called_once_with(rule, [])
+
+
+def test_yara_master_fetches_reports_when_report_scope_present(
+    patched_yara_dependencies: None,
+) -> None:
+    """YARA importer fetches linked reports when report scope is enabled."""
+    del patched_yara_dependencies
+
+    importer = YaraMasterImporter(
+        helper=_build_helper(),
+        author=MagicMock(),
+        tlp_marking=MagicMock(),
+        report_status=0,
+        report_type="threat-report",
+        no_file_trigger_import=True,
+        scopes=["yara_master", "report"],
+    )
+
+    rule = _build_yara_rule()
+    fetched_reports = [MagicMock()]
+    importer._get_reports_by_code = MagicMock(return_value=fetched_reports)
+    importer._create_yara_rule_bundle = MagicMock(return_value=MagicMock())
+    importer._send_bundle = MagicMock()
+
+    importer._process_yara_rule_group(("group", [rule]))
+
+    importer._get_reports_by_code.assert_called_once_with(rule.reports)
+    importer._create_yara_rule_bundle.assert_called_once_with(rule, fetched_reports)
+
+
+def test_snort_master_skips_report_fetch_when_report_scope_absent(
+    patched_snort_dependencies: None,
+) -> None:
+    """Snort importer does not fetch report entities if report scope is not enabled."""
+    del patched_snort_dependencies
+
+    importer = SnortMasterImporter(
+        helper=_build_helper(),
+        author=MagicMock(),
+        tlp_marking=MagicMock(),
+        report_status=0,
+        report_type="threat-report",
+        no_file_trigger_import=True,
+        scopes=["snort_suricata_master"],
+    )
+
+    rule = _build_snort_rule()
+    importer._get_reports_by_code = MagicMock(return_value=["unexpected"])
+    importer._create_snort_rule_bundle = MagicMock(return_value=MagicMock())
+    importer._send_bundle = MagicMock()
+
+    importer._process_snort_rule_group(("group", [rule]))
+
+    importer._get_reports_by_code.assert_not_called()
+    importer._create_snort_rule_bundle.assert_called_once_with(rule, [])
+
+
+def test_snort_master_fetches_reports_when_report_scope_present(
+    patched_snort_dependencies: None,
+) -> None:
+    """Snort importer fetches linked reports when report scope is enabled."""
+    del patched_snort_dependencies
+
+    importer = SnortMasterImporter(
+        helper=_build_helper(),
+        author=MagicMock(),
+        tlp_marking=MagicMock(),
+        report_status=0,
+        report_type="threat-report",
+        no_file_trigger_import=True,
+        scopes=["snort_suricata_master", "report"],
+    )
+
+    rule = _build_snort_rule()
+    fetched_reports = [MagicMock()]
+    importer._get_reports_by_code = MagicMock(return_value=fetched_reports)
+    importer._create_snort_rule_bundle = MagicMock(return_value=MagicMock())
+    importer._send_bundle = MagicMock()
+
+    importer._process_snort_rule_group(("group", [rule]))
+
+    importer._get_reports_by_code.assert_called_once_with(rule.reports)
+    importer._create_snort_rule_bundle.assert_called_once_with(rule, fetched_reports)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Do not fetch report in yara or snort when report not in scope
* Add tests for this use case

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/5814

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
