### PR TITLE
[CI] Do not push latest docker tag if the release is not the most recent one

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,6 @@ jobs:
           name: Execute Python Script
           command: |
             export LATEST_SEMANTIC_VERSION=$(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
-            export CIRCLE_TAG="7.260227.0"
             python .circleci/scripts/generate_ci.py
       - continuation/continue:
           configuration_path: dynamic.yml
@@ -191,105 +190,95 @@ jobs:
 workflows:
   connectors:
     jobs:
+      - ensure_formatting:
+          filters:
+            tags:
+              only: /.*/
+      - base_linter:
+          filters:
+            tags:
+              only: /.*/
+      - linter:
+          filters:
+            tags:
+              only: /.*/
+      - test:
+          filters:
+            tags:
+              only: /.*/
+      - build_manifest:
+          requires:
+            - ensure_formatting
+            - base_linter
+            - linter
+            - test
       - build:
-          name: "build_correct_version"
+          name: "build_release"
           ci_executor:
             name: ci_environment
             tags: "latest"
+          requires:
+            - ensure_formatting
+            - base_linter
+            - linter
+            - test
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*/
             branches:
-              only: "circleci/tags-version"
-#      - ensure_formatting:
-#          filters:
-#            tags:
-#              only: /.*/
-#      - base_linter:
-#          filters:
-#            tags:
-#              only: /.*/
-#      - linter:
-#          filters:
-#            tags:
-#              only: /.*/
-#      - test:
-#          filters:
-#            tags:
-#              only: /.*/
-#      - build_manifest:
-#          requires:
-#            - ensure_formatting
-#            - base_linter
-#            - linter
-#            - test
-#      - build:
-#          name: "build_release"
-#          ci_executor:
-#            name: ci_environment
-#            tags: "latest"
-#          requires:
-#            - ensure_formatting
-#            - base_linter
-#            - linter
-#            - test
-#          filters:
-#            tags:
-#              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*/
-#            branches:
-#              ignore: /.*/
-#      - build:
-#          name: "build_prerelease"
-#          ci_executor:
-#            name: ci_environment
-#            tags: "prerelease"
-#          requires:
-#            - ensure_formatting
-#            - base_linter
-#            - linter
-#            - test
-#          filters:
-#            branches:
-#              only:
-#                - /release\/.*/
-#      - build:
-#          name: "build_rolling"
-#          ci_executor:
-#            name: ci_environment
-#            tags: "rolling"
-#          requires:
-#            - ensure_formatting
-#            - base_linter
-#            - linter
-#            - test
-#          filters:
-#            branches:
-#              only:
-#                - master
-#      - notify:
-#          name: "send_notifications_release"
-#          notification_executor:
-#            name: ci_notifications
-#          requires:
-#            - build_release
-#          filters:
-#            tags:
-#              only: /.*/
-#      - notify:
-#          name: "send_notifications_rolling"
-#          notification_executor:
-#            name: ci_notifications
-#          requires:
-#            - build_rolling
-#          filters:
-#            tags:
-#              only: /.*/
-#      - notify:
-#          name: "send_notifications_prerelease"
-#          notification_executor:
-#            name: ci_notifications
-#          requires:
-#            - build_prerelease
-#          filters:
-#            tags:
-#              only: /.*/
+              ignore: /.*/
+      - build:
+          name: "build_prerelease"
+          ci_executor:
+            name: ci_environment
+            tags: "prerelease"
+          requires:
+            - ensure_formatting
+            - base_linter
+            - linter
+            - test
+          filters:
+            branches:
+              only:
+                - /release\/.*/
+      - build:
+          name: "build_rolling"
+          ci_executor:
+            name: ci_environment
+            tags: "rolling"
+          requires:
+            - ensure_formatting
+            - base_linter
+            - linter
+            - test
+          filters:
+            branches:
+              only:
+                - master
+      - notify:
+          name: "send_notifications_release"
+          notification_executor:
+            name: ci_notifications
+          requires:
+            - build_release
+          filters:
+            tags:
+              only: /.*/
+      - notify:
+          name: "send_notifications_rolling"
+          notification_executor:
+            name: ci_notifications
+          requires:
+            - build_rolling
+          filters:
+            tags:
+              only: /.*/
+      - notify:
+          name: "send_notifications_prerelease"
+          notification_executor:
+            name: ci_notifications
+          requires:
+            - build_prerelease
+          filters:
+            tags:
+              only: /.*/

--- a/.circleci/scripts/generate_ci.py
+++ b/.circleci/scripts/generate_ci.py
@@ -82,22 +82,15 @@ def get_pycti() -> dict:
 def get_tags() -> list[str]:
     data = []
     tags = os.getenv("BUILD_TAGS")
-
-    # TODO REMOVE
     latest_semver = os.getenv("LATEST_SEMANTIC_VERSION")
     print("LATEST_SEMANTIC_VERSION", latest_semver)
 
-    # TODO REMOVE
-    print("TAGS_BEFORE", tags)
     if tags:
         data.extend(tags.split(","))
 
     circle_tag = os.getenv("CIRCLE_TAG")
     if circle_tag:
         data.append(circle_tag)
-
-    # TODO REMOVE
-    print("DATA_BEFORE_FINAL_LIST", data)
 
     latest_version = os.getenv("LATEST_SEMANTIC_VERSION")
 
@@ -121,17 +114,15 @@ def write_config(template):
 
 
 def main():
-    tags = get_tags()
-    print("TAGS", tags)
-    # template = get_template()
-    # config = template.render(
-    #     dirs=get_dirs(),
-    #     param=get_parameters(),
-    #     pycti=get_pycti(),
-    #     tags=get_tags(),
-    #     repo=REPOSITORY,
-    # )
-    # write_config(config)
+    template = get_template()
+    config = template.render(
+        dirs=get_dirs(),
+        param=get_parameters(),
+        pycti=get_pycti(),
+        tags=get_tags(),
+        repo=REPOSITORY,
+    )
+    write_config(config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Do not push latest docker tag if the release is not the most recent one : add condition to remove "latest" when the release is note the recent one

### Related issues

* Closes https://github.com/OpenCTI-Platform/connectors/issues/5879

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Tests on CI

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

When latest version is pushed, we want to keep "latest"
<img width="802" height="194" alt="image" src="https://github.com/user-attachments/assets/d48f390b-3896-414f-b38f-c43f202f0139" />

When it is not the recent release, we don't want to have the "latest: tag

<img width="844" height="288" alt="image" src="https://github.com/user-attachments/assets/3e97cd8b-3e98-491e-9afd-9fed6bddb3d0" />
