### PR TITLE
[mwdb] Set indicator_types and x_opencti_main_observable_type on STIX Indicators

### DIFF
--- a/external-import/mwdb/src/mwdb.py
+++ b/external-import/mwdb/src/mwdb.py
@@ -203,22 +203,26 @@ class MWDB:
             pattern = "[ipv4-addr:value = '" + value + "']"
             relation_description = "Malware communicates with C2"
             tags = ["C2"]
+            observable_type = "IPv4-Addr"
         elif configtype == "c2-url-ref":
             description = "C2 URL containing a list of possible references"
             pattern = "[url:value = '" + value + "']"
             relation_description = "Malware communicates with this url"
             tags = ["C2 LIST"]
+            observable_type = "Url"
         else:
             description = "C2 - URL" + value
             pattern = "[url:value = '" + value + "']"
             relation_description = "Malware communicates with C2"
             tags = ["C2"]
+            observable_type = "Url"
 
         if str(self.create_indicators).capitalize() == "True":
             indicatorc2 = stix2.Indicator(
                 id=Indicator.generate_id(pattern),
                 name=value,
                 description=description,
+                indicator_types=["malicious-activity"],
                 pattern_type="stix",
                 pattern=pattern,
                 valid_from=parser.parse(virus["malware"]["upload_time"]),
@@ -230,6 +234,7 @@ class MWDB:
                 modified=parser.parse(virus["malware"]["upload_time"]),
                 custom_properties={
                     "x_opencti_score": self.score,
+                    "x_opencti_main_observable_type": observable_type,
                 },
             )
             objects.append(indicatorc2)
@@ -487,6 +492,7 @@ class MWDB:
                     id=Indicator.generate_id(pattern),
                     name=str(malware.file_name).replace("-" + malware.sha256, ""),
                     description=description,
+                    indicator_types=["malicious-activity"],
                     pattern_type="stix",
                     pattern=pattern,
                     valid_from=malware.upload_time,
@@ -498,6 +504,7 @@ class MWDB:
                     modified=malware.upload_time,
                     custom_properties={
                         "x_opencti_score": self.score,
+                        "x_opencti_main_observable_type": "StixFile",
                     },
                 )
 


### PR DESCRIPTION
### Proposed changes

* Set `indicator_types=["malicious-activity"]` on all STIX Indicators created by the MWDB connector (both file hash and C2 indicators)
* Set `x_opencti_main_observable_type` on all STIX Indicators, mapped correctly per indicator type:
  - File hash indicators → `"StixFile"` (pattern: `[file:hashes.'SHA-256' = '...']`)
  - C2 IP indicators → `"IPv4-Addr"` (pattern: `[ipv4-addr:value = '...']`)
  - C2 URL indicators → `"Url"` (pattern: `[url:value = '...']`)
* Without these properties, indicators imported from MWDB appear with blank type fields in OpenCTI

### Related issues

* N/A

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

All samples in MWDB (CERT Polska malware repository) are confirmed malware, making `malicious-activity` the correct indicator type. The `x_opencti_main_observable_type` is now set dynamically based on the STIX pattern type rather than hardcoded, ensuring correct mapping for file hashes, C2 IPs, and C2 URLs.

Only 7 lines added in `external-import/mwdb/src/mwdb.py` across 2 functions (`process_c2` and `process_virus`).