### PR TITLE
[CI] Fix get_tags crash when "latest" tag is not in the list

### DIFF
--- a/.circleci/scripts/generate_ci.py
+++ b/.circleci/scripts/generate_ci.py
@@ -82,19 +82,17 @@ def get_pycti() -> dict:
 def get_tags() -> list[str]:
     data = []
     tags = os.getenv("BUILD_TAGS")
-    latest_semver = os.getenv("LATEST_SEMANTIC_VERSION")
-    print("LATEST_SEMANTIC_VERSION", latest_semver)
+    circle_tag = os.getenv("CIRCLE_TAG")
+    latest_version = os.getenv("LATEST_SEMANTIC_VERSION")
+    print("LATEST_SEMANTIC_VERSION", latest_version)
 
     if tags:
         data.extend(tags.split(","))
 
-    circle_tag = os.getenv("CIRCLE_TAG")
     if circle_tag:
         data.append(circle_tag)
 
-    latest_version = os.getenv("LATEST_SEMANTIC_VERSION")
-
-    if latest_version != circle_tag:
+    if latest_version != circle_tag and "latest" in data:
         data.remove("latest")
 
     print("TAGS_LIST", data)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix `ValueError` crash in `get_tags()` when `"latest"` is not in the tag list by adding a membership check before calling `data.remove("latest")`
* Consolidate duplicate `os.getenv("LATEST_SEMANTIC_VERSION")` reads into a single call


### Related issues

* Closes #5882 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
