### PR TITLE
[tool] chore(tooling): fix add to project workflow (#5884)

### DIFF
--- a/.github/workflows/integrations-add-to-project.yml
+++ b/.github/workflows/integrations-add-to-project.yml
@@ -5,7 +5,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 


### PR DESCRIPTION
#### Proposed changes

- Use to `pull_request_target` so workflow run has access to repo variables

#### Related issues

- #5884 