### PR TITLE
[Feedly] add validation for stream_ids config field

### DIFF
--- a/external-import/feedly/src/models/configs/feedly_configs.py
+++ b/external-import/feedly/src/models/configs/feedly_configs.py
@@ -1,6 +1,6 @@
 from connectors_sdk import ListFromString
 from models.configs import ConfigBaseSettings
-from pydantic import Field, PositiveInt, SecretStr
+from pydantic import Field, PositiveInt, SecretStr, field_validator
 
 
 class _ConfigLoaderFeedly(ConfigBaseSettings):
@@ -19,6 +19,7 @@ class _ConfigLoaderFeedly(ConfigBaseSettings):
             "Comma separated list of Feedly stream IDs to monitor. "
             "Each stream ID represents a specific feed or collection to import from Feedly."
         ),
+        json_schema_extra={"default": []},
     )
     days_to_back_fill: PositiveInt = Field(
         default=7,
@@ -40,3 +41,12 @@ class _ConfigLoaderFeedly(ConfigBaseSettings):
             "If false, all relationship objects will be filtered out before sending to OpenCTI."
         ),
     )
+
+    @field_validator("stream_ids", mode="after")
+    @classmethod
+    def streams_ids_must_be_filled(cls, v):
+        if v == []:
+            raise ValueError(
+                "At least one stream ID must be provided in the stream_ids setting."
+            )
+        return v


### PR DESCRIPTION


### Proposed changes

* Add a field validator to ensure at least one Feedly stream ID is provided. Also add json_schema_extra to reflect the default empty list in the JSON schema but keeping this field as required.

### Related issues

* Fixes #5888 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
