### PR TITLE
[CI] Fix Docker: client version 1.41 too old when running multi-arch build

### DIFF
--- a/.circleci/templates/dynamic.yml.j2
+++ b/.circleci/templates/dynamic.yml.j2
@@ -5,10 +5,11 @@ jobs:
 {% for sub_dir in sub_dirs %}
   build_{{top_dir}}_{{sub_dir}}:
     docker:
-      - image: cimg/base:stable-20.04
+      - image: cimg/base:current-24.04
     steps:
       - checkout
       - setup_remote_docker
+          version: default
       - run:
           name: Build {{top_dir}}/{{sub_dir}}
           command: |


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Upgrade CircleCI base image from cimg/base:stable-20.04 to cimg/base:current-24.04 (Ubuntu 24.04)

This bumps the Docker client from 20.10.x (API 1.41) to 24+ (API 1.44+), fixing the multi-arch build failure

### Related issues

* Closes #5897 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

The CircleCI remote Docker daemon was recently upgraded to 29.0.0 (API 1.52), which raised the minimum supported client API version to 1.44. The previously used cimg/base:stable-20.04 image ships with Docker client 20.10.x (API 1.41), which is now below that threshold, causing all multi-arch builds to fail at the binfmt step.

The fix is a one-line change to the base image tag. Note that cimg/base:stable-24.04 does not exist, the correct tag is current-24.04, as confirmed by local reproduction:

```sh
# Old — fails ❌
docker run --rm cimg/base:stable-20.04 docker version  # API 1.41

# New — works ✅
docker run --rm cimg/base:current-24.04 docker version  # API 1.44+
```