### PR TITLE
[connectors-sdk] Fix `BaseConnectorSettings.to_helper_config` to work with deprecated fields

### DIFF
--- a/connectors-sdk/connectors_sdk/settings/base_settings.py
+++ b/connectors-sdk/connectors_sdk/settings/base_settings.py
@@ -407,7 +407,14 @@ class BaseConnectorSettings(BaseConfigModel, ABC):
 
     def to_helper_config(self) -> dict[str, Any]:
         """Convert model into a valid dict for `pycti.OpenCTIConnectorHelper`."""
-        return self.model_dump(mode="json", context={"mode": "pycti"})
+        return self.model_dump(
+            mode="json",
+            context={"mode": "pycti"},
+            # Deprecated fields can be set to `None` despite their type (due to `SkipValidation` annotation).
+            # To avoid `PydanticSerializationError`, we exclude all fields set to `None` during serialization.
+            # OpenCTIConnectorHelper handles missing fields with default values or internal logic.
+            exclude_none=True,
+        )
 
 
 class BaseExternalImportConnectorConfig(_BaseConnectorConfig):


### PR DESCRIPTION
### Proposed changes

* Exclude fields set to `None` (deprecated fields can be set to `None` despite their type due to `SkipValidation` annotation)

### Related issues

* close #5878 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (~~either on github or on notion~~ code comment)
- [ ] ~~Where necessary I refactored code to improve the overall quality~~

### Further comments

⚠️ Currently blocking the migration of Proofpoint TAP (#5214)
