### PR TITLE
[connectors] CI - build ARM images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,8 @@ executors:
         type: string
         default: "rolling"
         description: Image tags
-#      platforms:
-#        type: string
-#        default: "linux/amd64,linux/arm64"
-#        description: Image platforms
     environment:
       BUILD_TAGS: <<parameters.tags>>
-#      BUILDX_PLATFORMS: <<parameters.platforms>>
     docker:
       - image: cimg/python:3.11
   ci_notifications:
@@ -259,7 +254,7 @@ workflows:
           filters:
             branches:
               only:
-                - oob/issue/4506-arm-images
+                - master
       - notify:
           name: "send_notifications_release"
           notification_executor:


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- Enable multi-architecture Docker builds (linux/amd64 and linux/arm64) for all connectors,
 allowing native support on Apple Silicon and ARM-based servers without emulation.         
- Enable Docker layer caching on setup_remote_docker to speed up CI builds


### Related issues

* Closes https://github.com/OpenCTI-Platform/connectors/issues/4506
* Closes https://github.com/OpenCTI-Platform/connectors/issues/450

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

  - The FIPS variant builds are intentionally left as amd64-only.

