### PR TITLE
[connectors-sdk] Suppress `UserWarning` emitted from `BaseSettings` during tests

### DIFF
--- a/connectors-sdk/connectors_sdk/settings/base_settings.py
+++ b/connectors-sdk/connectors_sdk/settings/base_settings.py
@@ -159,18 +159,16 @@ class _SettingsLoader(BaseSettings):
         """
         config_yml_file_path = cls._get_config_yml_file_path()
         if config_yml_file_path:
-            settings_cls.model_config["yaml_file"] = config_yml_file_path
             return (
                 env_settings,
-                YamlConfigSettingsSource(settings_cls),
+                YamlConfigSettingsSource(settings_cls, yaml_file=config_yml_file_path),
             )
 
         dot_env_file_path = cls._get_dot_env_file_path()
         if dot_env_file_path:
-            settings_cls.model_config["env_file"] = dot_env_file_path
             return (
                 env_settings,
-                DotEnvSettingsSource(settings_cls),
+                DotEnvSettingsSource(settings_cls, env_file=dot_env_file_path),
             )
 
         return (env_settings,)


### PR DESCRIPTION
### Proposed changes

* pass `yaml_file` and `env_file` as arguments

### Related issues

* close #5954 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] ~~I added/update the relevant documentation (either on github or on notion)~~
- [x] ~~Where necessary I refactored code to improve the overall quality~~

### Further comments

This PR should affect tests only (no more `UserWarning` emitted by pydantic_settings).
