### PR TITLE
[Crowdstrike] connector add capacity to drop indicators if their creation date is too old

### DIFF
--- a/external-import/crowdstrike/README.md
+++ b/external-import/crowdstrike/README.md
@@ -104,6 +104,11 @@ There are a number of configuration options, which are set either in `docker-com
 | High Score                  | crowdstrike.indicator_high_score        | `CROWDSTRIKE_INDICATOR_HIGH_SCORE`           | 80                                                   | No        | Score for high confidence indicators.                                            |
 | High Score Labels           | crowdstrike.indicator_high_score_labels | `CROWDSTRIKE_INDICATOR_HIGH_SCORE_LABELS`    | MaliciousConfidence/High                             | No        | Labels that trigger high score.                                                  |
 | Unwanted Labels             | crowdstrike.indicator_unwanted_labels   | `CROWDSTRIKE_INDICATOR_UNWANTED_LABELS`      |                                                      | No        | Filter out indicators with these labels.                                         |
+| Indicator IP Max Age          | crowdstrike.indicator_ip_max_age          | `CROWDSTRIKE_INDICATOR_IP_MAX_AGE`          |                                                   | No        | ISO8601 Duration format. Covers both IPv4 and IPv6. (e.g., `P90D`)                                                                                                                                 |
+| Indicator Domain Max Age      | crowdstrike.indicator_domain_max_age      | `CROWDSTRIKE_INDICATOR_DOMAIN_MAX_AGE`      |                                                   | No        | ISO8601 Duration format. (e.g., `P365D`)                                                                                                                                                           |
+| Indicator URL Max Age         | crowdstrike.indicator_url_max_age         | `CROWDSTRIKE_INDICATOR_URL_MAX_AGE`         |                                                   | No        | ISO8601 Duration format. (e.g., `P60D`)                                                                                                                                                            |
+| Indicator Hash Max Age        | crowdstrike.indicator_hash_max_age        | `CROWDSTRIKE_INDICATOR_HASH_MAX_AGE`        |                                                   | No        | ISO8601 Duration format. Covers MD5, SHA1, and SHA256. (e.g., `P730D`)                                                                                                                             |
+| Indicator Default Max Age     | crowdstrike.indicator_default_max_age     | `CROWDSTRIKE_INDICATOR_DEFAULT_MAX_AGE`     |                                                   | No        | ISO8601 Duration format. Default threshold for any other type. (e.g., `P30D`)                                                                                                                      |
 | No File Trigger Import      | crowdstrike.no_file_trigger_import      | `CROWDSTRIKE_NO_FILE_TRIGGER_IMPORT`         | true                                                 | No        | Import indicator updates without file triggers.                                  |
 
 **Note**: It is not recommended to use the default value `0` for configuration parameters `report_start_timestamp`, `indicator_start_timestamp`, and `malware_start_timestamp` because of the large data volumes.
@@ -146,6 +151,11 @@ Configure the connector in `docker-compose.yml`:
       - CROWDSTRIKE_REPORT_INCLUDE_TYPES=notice,tipper,intelligence report,periodic report
       - CROWDSTRIKE_REPORT_TYPE=threat-report
       - CROWDSTRIKE_INDICATOR_EXCLUDE_TYPES=hash_ion,hash_md5,hash_sha1,password,username
+      - CROWDSTRIKE_INDICATOR_IP_MAX_AGE=P90D
+      - CROWDSTRIKE_INDICATOR_DOMAIN_MAX_AGE=P365D
+      - CROWDSTRIKE_INDICATOR_URL_MAX_AGE=P60D
+      - CROWDSTRIKE_INDICATOR_HASH_MAX_AGE=P730D
+      - CROWDSTRIKE_INDICATOR_DEFAULT_MAX_AGE=P30D
       - CROWDSTRIKE_DEFAULT_X_OPENCTI_SCORE=50
     restart: always
 ```

--- a/external-import/crowdstrike/docker-compose.yml
+++ b/external-import/crowdstrike/docker-compose.yml
@@ -29,6 +29,11 @@ services:
       - CROWDSTRIKE_VULNERABILITY_IMPORT_AFFECTED_PRODUCTS=false
       - CROWDSTRIKE_INDICATOR_START_TIMESTAMP= # Unix timestamp. Leave empty for default (30 days ago). BEWARE! 0 means ALL indicators!
       - CROWDSTRIKE_INDICATOR_EXCLUDE_TYPES=hash_ion,hash_md5,hash_sha1,password,username
+      - CROWDSTRIKE_INDICATOR_IP_MAX_AGE=P90D # ISO8601 Duration format. Covers both IPv4 and IPv6.
+      - CROWDSTRIKE_INDICATOR_DOMAIN_MAX_AGE=P365D # ISO8601 Duration format.
+      - CROWDSTRIKE_INDICATOR_URL_MAX_AGE=P60D # ISO8601 Duration format.
+      - CROWDSTRIKE_INDICATOR_HASH_MAX_AGE=P730D # ISO8601 Duration format. Covers MD5, SHA1, and SHA256.
+      - CROWDSTRIKE_INDICATOR_DEFAULT_MAX_AGE=P30D # ISO8601 Duration format. Default threshold for any other type.
       - CROWDSTRIKE_DEFAULT_X_OPENCTI_SCORE=50
       - CROWDSTRIKE_INDICATOR_LOW_SCORE=40
       - CROWDSTRIKE_INDICATOR_LOW_SCORE_LABELS=MaliciousConfidence/Low

--- a/external-import/crowdstrike/src/config.yml.sample
+++ b/external-import/crowdstrike/src/config.yml.sample
@@ -31,6 +31,11 @@ crowdstrike:
   report_guess_relations: false # Automatically guess and create relationships between entities in reports
   indicator_start_timestamp:   # Unix timestamp. Leave empty for default (30 days ago). BEWARE! 0 means ALL indicators!
   indicator_exclude_types: 'hash_ion,hash_md5,hash_sha1,password,username'
+  indicator_ip_max_age: 'P90D' # ISO8601 Duration format. Covers both IPv4 and IPv6.
+  indicator_domain_max_age: 'P365D' # ISO8601 Duration format.
+  indicator_url_max_age: 'P60D' # ISO8601 Duration format.
+  indicator_hash_max_age: 'P730D' # ISO8601 Duration format. Covers MD5, SHA1, and SHA256.
+  indicator_default_max_age: 'P30D' # ISO8601 Duration format. Default threshold for any other type.
   default_x_opencti_score: 50
   indicator_low_score: 40
   indicator_low_score_labels: 'MaliciousConfidence/Low'

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/connector.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/connector.py
@@ -104,6 +104,13 @@ class CrowdStrike:
             self.config.crowdstrike.indicator_high_score_labels
         )
         indicator_unwanted_labels = self.config.crowdstrike.indicator_unwanted_labels
+        indicator_max_age_by_type = {
+            "ip": self.config.crowdstrike.indicator_ip_max_age,
+            "domain": self.config.crowdstrike.indicator_domain_max_age,
+            "url": self.config.crowdstrike.indicator_url_max_age,
+            "hash": self.config.crowdstrike.indicator_hash_max_age,
+            "default": self.config.crowdstrike.indicator_default_max_age,
+        }
 
         no_file_trigger_import = self.config.crowdstrike.no_file_trigger_import
 
@@ -205,6 +212,7 @@ class CrowdStrike:
                 indicator_high_score=indicator_high_score,
                 indicator_high_score_labels=set(indicator_high_score_labels),
                 indicator_unwanted_labels=set(indicator_unwanted_labels),
+                indicator_max_age_by_type=indicator_max_age_by_type,
                 no_file_trigger_import=no_file_trigger_import,
                 scopes=set(scopes),
                 attack_lookup=self.attack_lookup,

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
@@ -1,6 +1,6 @@
 """OpenCTI CrowdStrike indicator importer module."""
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Set
 
 from crowdstrike_feeds_connector.related_actors.importer import RelatedActorImporter
@@ -43,6 +43,7 @@ class IndicatorImporterConfig(NamedTuple):
     indicator_high_score: int
     indicator_high_score_labels: Set[str]
     indicator_unwanted_labels: Set[str]
+    indicator_max_age_by_type: Dict[str, Optional[timedelta]]
     no_file_trigger_import: bool
     scopes: set[str]
     attack_lookup: Optional[AttackTechniqueLookup]
@@ -84,6 +85,7 @@ class IndicatorImporter(BaseImporter):
         self.indicator_high_score = config.indicator_high_score
         self.indicator_high_score_labels = config.indicator_high_score_labels
         self.indicator_unwanted_labels = config.indicator_unwanted_labels
+        self.indicator_max_age_by_type = config.indicator_max_age_by_type
         self.next_page: Optional[str] = None
         self.no_file_trigger_import = config.no_file_trigger_import
         self.scopes = config.scopes
@@ -219,6 +221,9 @@ class IndicatorImporter(BaseImporter):
     def _process_indicator(self, indicator: dict) -> bool:
         self._info("Processing indicator {0}...", indicator["id"])
 
+        if self._is_indicator_too_old(indicator):
+            return True
+
         indicator_bundle = self._create_indicator_bundle(indicator)
         if indicator_bundle is None:
             self._warning("Discarding indicator {0} bundle", indicator["id"])
@@ -230,6 +235,45 @@ class IndicatorImporter(BaseImporter):
         self._send_bundle(indicator_bundle)
 
         return True
+
+    def _is_indicator_too_old(self, indicator: dict) -> bool:
+        indicator_type = indicator.get("type", "")
+        published_date_timestamp = indicator.get("published_date")
+
+        if published_date_timestamp is None:
+            return False
+
+        published_date = timestamp_to_datetime(published_date_timestamp)
+        now = datetime.now(timezone.utc)
+
+        threshold_key = "default"
+        if indicator_type in ["ip_address", "ip_address_block"]:
+            threshold_key = "ip"
+        elif indicator_type == "domain":
+            threshold_key = "domain"
+        elif indicator_type == "url":
+            threshold_key = "url"
+        elif indicator_type in ["hash_md5", "hash_sha1", "hash_sha256"]:
+            threshold_key = "hash"
+
+        threshold = self.indicator_max_age_by_type.get(threshold_key)
+
+        # Fallback to default if type-specific threshold is not defined
+        if threshold is None and threshold_key != "default":
+            threshold = self.indicator_max_age_by_type.get("default")
+
+        if threshold is not None:
+            if published_date < (now - threshold):
+                self._info(
+                    "Indicator {0} (type: {1}, published: {2}) is older than the threshold ({3}), skipping...",
+                    indicator["id"],
+                    indicator_type,
+                    published_date,
+                    threshold,
+                )
+                return True
+
+        return False
 
     def _get_reports_by_code(self, codes: List[str]) -> List[FetchedReport]:
         return self.report_fetcher.get_by_codes(codes)

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/settings.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/settings.py
@@ -179,6 +179,35 @@ class CrowdstrikeConfig(BaseConfigModel):
         ],
         description="Comma-separated list of indicator types to exclude from import.",
     )
+    indicator_ip_max_age: timedelta | None = Field(
+        default=None,
+        description=(
+            "ISO8601 Duration format starting with 'P' for Period (e.g., 'P90D' for 90 days). "
+            "Covers both IPv4 and IPv6."
+        ),
+    )
+    indicator_domain_max_age: timedelta | None = Field(
+        default=None,
+        description="ISO8601 Duration format starting with 'P' for Period (e.g., 'P365D' for 365 days).",
+    )
+    indicator_url_max_age: timedelta | None = Field(
+        default=None,
+        description="ISO8601 Duration format starting with 'P' for Period (e.g., 'P60D' for 60 days).",
+    )
+    indicator_hash_max_age: timedelta | None = Field(
+        default=None,
+        description=(
+            "ISO8601 Duration format starting with 'P' for Period (e.g., 'P730D' for 730 days). "
+            "Covers MD5, SHA1, and SHA256 hashes."
+        ),
+    )
+    indicator_default_max_age: timedelta | None = Field(
+        default=None,
+        description=(
+            "ISO8601 Duration format starting with 'P' for Period (e.g., 'P30D' for 30 days). "
+            "Default threshold for any other indicator type."
+        ),
+    )
     default_x_opencti_score: PositiveInt = Field(
         default=50,
         description="Default confidence score for entities without explicit score.",

--- a/external-import/crowdstrike/tests/test_indicator_age_filtering.py
+++ b/external-import/crowdstrike/tests/test_indicator_age_filtering.py
@@ -1,0 +1,276 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+from crowdstrike_feeds_connector.indicator.importer import (
+    IndicatorImporter,
+    IndicatorImporterConfig,
+)
+
+
+def test_is_indicator_too_old():
+    mock_config = MagicMock()
+    mock_helper = MagicMock()
+
+    age_config = {
+        "ip": timedelta(days=90),
+        "domain": timedelta(days=365),
+        "url": timedelta(days=60),
+        "hash": timedelta(days=730),
+        "default": timedelta(days=30),
+    }
+
+    config = IndicatorImporterConfig(
+        config=mock_config,
+        helper=mock_helper,
+        author=MagicMock(),
+        default_latest_timestamp=0,
+        tlp_marking=MagicMock(),
+        create_observables=True,
+        create_indicators=True,
+        exclude_types=[],
+        report_status=0,
+        report_type="threat-report",
+        default_x_opencti_score=50,
+        indicator_low_score=40,
+        indicator_low_score_labels=set(),
+        indicator_medium_score=60,
+        indicator_medium_score_labels=set(),
+        indicator_high_score=80,
+        indicator_high_score_labels=set(),
+        indicator_unwanted_labels=set(),
+        indicator_max_age_by_type=age_config,
+        no_file_trigger_import=True,
+        scopes=set(["indicator"]),
+        attack_lookup=None,
+    )
+
+    importer = IndicatorImporter(config)
+
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+
+    test_cases = [
+        ("ip_address", 10, False),
+        ("ip_address", 100, True),
+        ("ip_address_block", 89, False),
+        ("ip_address_block", 91, True),
+        ("domain", 100, False),
+        ("domain", 400, True),
+        ("url", 10, False),
+        ("url", 70, True),
+        ("hash_md5", 100, False),
+        ("hash_md5", 800, True),
+        ("hash_sha1", 100, False),
+        ("hash_sha1", 800, True),
+        ("hash_sha256", 100, False),
+        ("hash_sha256", 800, True),
+        ("registry", 10, False),
+        ("registry", 40, True),
+        ("mutex_name", 10, False),
+        ("mutex_name", 40, True),
+    ]
+
+    for status_type, days_ago, expected in test_cases:
+        published_date = now_ts - (days_ago * 24 * 60 * 60)
+        indicator = {
+            "id": f"indicator-{status_type}-{days_ago}",
+            "type": status_type,
+            "published_date": published_date,
+        }
+        assert (
+            importer._is_indicator_too_old(indicator) == expected
+        ), f"Failed for {status_type} published {days_ago} days ago"
+
+
+def test_is_indicator_too_old_missing_published_date():
+    age_config = {
+        "ip": timedelta(days=90),
+        "default": timedelta(days=30),
+    }
+
+    config = IndicatorImporterConfig(
+        config=MagicMock(),
+        helper=MagicMock(),
+        author=MagicMock(),
+        default_latest_timestamp=0,
+        tlp_marking=MagicMock(),
+        create_observables=True,
+        create_indicators=True,
+        exclude_types=[],
+        report_status=0,
+        report_type="threat-report",
+        default_x_opencti_score=50,
+        indicator_low_score=40,
+        indicator_low_score_labels=set(),
+        indicator_medium_score=60,
+        indicator_medium_score_labels=set(),
+        indicator_high_score=80,
+        indicator_high_score_labels=set(),
+        indicator_unwanted_labels=set(),
+        indicator_max_age_by_type=age_config,
+        no_file_trigger_import=True,
+        scopes=set(["indicator"]),
+        attack_lookup=None,
+    )
+
+    importer = IndicatorImporter(config)
+
+    indicator = {
+        "id": "no-date-indicator",
+        "type": "ip_address",
+    }
+    assert not importer._is_indicator_too_old(indicator)
+
+
+def test_is_indicator_too_old_no_config():
+    config = IndicatorImporterConfig(
+        config=MagicMock(),
+        helper=MagicMock(),
+        author=MagicMock(),
+        default_latest_timestamp=0,
+        tlp_marking=MagicMock(),
+        create_observables=True,
+        create_indicators=True,
+        exclude_types=[],
+        report_status=0,
+        report_type="threat-report",
+        default_x_opencti_score=50,
+        indicator_low_score=40,
+        indicator_low_score_labels=set(),
+        indicator_medium_score=60,
+        indicator_medium_score_labels=set(),
+        indicator_high_score=80,
+        indicator_high_score_labels=set(),
+        indicator_unwanted_labels=set(),
+        indicator_max_age_by_type={
+            "ip": None,
+            "domain": None,
+            "url": None,
+            "hash": None,
+            "default": None,
+        },
+        no_file_trigger_import=True,
+        scopes=set(["indicator"]),
+        attack_lookup=None,
+    )
+
+    importer = IndicatorImporter(config)
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+
+    indicator = {
+        "id": "old-ip",
+        "type": "ip_address",
+        "published_date": now_ts - (1000 * 24 * 60 * 60),
+    }
+    assert not importer._is_indicator_too_old(indicator)
+
+
+def test_is_indicator_too_old_fallback_to_default():
+    age_config = {"default": timedelta(days=30)}
+
+    config = IndicatorImporterConfig(
+        config=MagicMock(),
+        helper=MagicMock(),
+        author=MagicMock(),
+        default_latest_timestamp=0,
+        tlp_marking=MagicMock(),
+        create_observables=True,
+        create_indicators=True,
+        exclude_types=[],
+        report_status=0,
+        report_type="threat-report",
+        default_x_opencti_score=50,
+        indicator_low_score=40,
+        indicator_low_score_labels=set(),
+        indicator_medium_score=60,
+        indicator_medium_score_labels=set(),
+        indicator_high_score=80,
+        indicator_high_score_labels=set(),
+        indicator_unwanted_labels=set(),
+        indicator_max_age_by_type=age_config,
+        no_file_trigger_import=True,
+        scopes=set(["indicator"]),
+        attack_lookup=None,
+    )
+
+    importer = IndicatorImporter(config)
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+
+    indicator_recent = {
+        "id": "recent-ip",
+        "type": "ip_address",
+        "published_date": now_ts - (10 * 24 * 60 * 60),
+    }
+    indicator_old = {
+        "id": "old-ip",
+        "type": "ip_address",
+        "published_date": now_ts - (40 * 24 * 60 * 60),
+    }
+
+    assert not importer._is_indicator_too_old(indicator_recent)
+    assert importer._is_indicator_too_old(indicator_old)
+
+
+def test_is_indicator_too_old_exact_boundary():
+    """Test that an indicator published exactly at the threshold is NOT filtered.
+
+    The comparison uses strict '<', so published_date == (now - threshold) is not too old.
+    Uses mocked time to avoid flakiness from clock drift between test and method.
+    """
+    fixed_now = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+    age_config = {
+        "ip": timedelta(days=90),
+        "default": timedelta(days=30),
+    }
+
+    config = IndicatorImporterConfig(
+        config=MagicMock(),
+        helper=MagicMock(),
+        author=MagicMock(),
+        default_latest_timestamp=0,
+        tlp_marking=MagicMock(),
+        create_observables=True,
+        create_indicators=True,
+        exclude_types=[],
+        report_status=0,
+        report_type="threat-report",
+        default_x_opencti_score=50,
+        indicator_low_score=40,
+        indicator_low_score_labels=set(),
+        indicator_medium_score=60,
+        indicator_medium_score_labels=set(),
+        indicator_high_score=80,
+        indicator_high_score_labels=set(),
+        indicator_unwanted_labels=set(),
+        indicator_max_age_by_type=age_config,
+        no_file_trigger_import=True,
+        scopes=set(["indicator"]),
+        attack_lookup=None,
+    )
+
+    importer = IndicatorImporter(config)
+
+    exactly_at_threshold = fixed_now - timedelta(days=90)
+    exactly_at_threshold_ts = int(exactly_at_threshold.timestamp())
+
+    one_second_past = fixed_now - timedelta(days=90, seconds=1)
+    one_second_past_ts = int(one_second_past.timestamp())
+
+    with patch(
+        "crowdstrike_feeds_connector.indicator.importer.datetime"
+    ) as mock_datetime:
+        mock_datetime.now.return_value = fixed_now
+        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+
+        indicator_at_boundary = {
+            "id": "boundary-ip",
+            "type": "ip_address",
+            "published_date": exactly_at_threshold_ts,
+        }
+        assert not importer._is_indicator_too_old(indicator_at_boundary)
+
+        indicator_past_boundary = {
+            "id": "past-boundary-ip",
+            "type": "ip_address",
+            "published_date": one_second_past_ts,
+        }
+        assert importer._is_indicator_too_old(indicator_past_boundary)

--- a/external-import/crowdstrike/tests/test_indicator_age_filtering.py
+++ b/external-import/crowdstrike/tests/test_indicator_age_filtering.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
+
 from crowdstrike_feeds_connector.indicator.importer import (
     IndicatorImporter,
     IndicatorImporterConfig,

--- a/external-import/crowdstrike/tests/test_settings.py
+++ b/external-import/crowdstrike/tests/test_settings.py
@@ -72,6 +72,11 @@ NOW_TIMESTAMP = int(datetime.now(timezone.utc).timestamp())
                     "indicator_high_score_labels": ["MaliciousConfidence/High"],
                     "indicator_unwanted_labels": [],
                     "no_file_trigger_import": True,
+                    "indicator_ip_max_age": "P90D",
+                    "indicator_domain_max_age": "P365D",
+                    "indicator_url_max_age": "P60D",
+                    "indicator_hash_max_age": "P730D",
+                    "indicator_default_max_age": "P30D",
                     "vulnerability_start_timestamp": NOW_TIMESTAMP,
                 },
             },
@@ -261,6 +266,21 @@ def test_settings_should_accept_valid_input(settings_dict):
             },
             "crowdstrike.client_id",
             id="missing_crowdstrike_client_id",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "crowdstrike": {
+                    "client_id": "test-client-id",
+                    "client_secret": "test-client-secret",
+                    "indicator_ip_max_age": "90",  # Invalid ISO 8601 duration
+                },
+            },
+            "crowdstrike.indicator_ip_max_age",
+            id="invalid_duration_format",
         ),
     ],
 )


### PR DESCRIPTION
### Proposed changes

 - Add configurable age-based filtering for CrowdStrike indicators, allowing operators to skip indicators older than a per-type threshold during import
 - Thresholds are configured using ISO 8601 duration format (e.g., P90D for 90 days) and support five categories: ip, domain, url, hash, and default (catch-all fallback)
 - Feature is entirely opt-in: all thresholds default to None (no filtering)

### Related issues

* Fixes https://github.com/OpenCTI-Platform/connectors/issues/6275

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality