### PR TITLE
feat: add Checkfirst import connector

### DIFF
--- a/external-import/checkfirst-import-connector/README.md
+++ b/external-import/checkfirst-import-connector/README.md
@@ -1,15 +1,56 @@
 # OpenCTI Connector: Checkfirst Import
 
-Ingest Checkfirst articles from the Checkfirst API into OpenCTI as STIX 2.1 bundles.
+Ingest Checkfirst articles from the Checkfirst API into OpenCTI as STIX 2.1 bundles, tracking the Portal-Kombat / Pravda Network Russian influence operation.
 
 This is an `EXTERNAL_IMPORT` connector that:
 
+- On first run, sends a one-off bundle of known Pravda network infrastructure (36 `pravda-XX.com` domains, 60+ `news-pravda.com` subdomains, shared hosting IP `178.21.15.85`) attributed to the Portal-Kombat intrusion set per SGDSN/VIGINUM reports (Feb + Apr 2024)
 - Fetches articles from a paginated REST API (`Api-Key` header auth)
-- Maps each article to OpenCTI STIX objects: `Channel`, `Media-Content`, `URL`, and relationships
-- Channels sourced from `https://t.me/` are typed as `Telegram`; all others as `website`
-- Sends bundles via `helper.send_stix2_bundle`
+- Maps each article to STIX 2.1 objects and sends them in batches
 - Persists page-based progress in OpenCTI connector state so reruns resume where they left off
 - Records a `last_run` unix timestamp in state for operational visibility
+
+## STIX object model
+
+### First-run infrastructure bundle
+
+Sent once when `start_page == 1` (first ever run, or `CHECKFIRST_FORCE_REPROCESS=true`):
+
+```
+IntrusionSet (Portal-Kombat)
+  ← attributed-to ← Campaign 2023
+
+Campaign 2023
+  → uses → Infrastructure (pravda-XX.com)   [per domain, start_time = first_observed]
+    → consists-of → DomainName (pravda-XX.com)
+    → consists-of → IPv4Address (178.21.15.85, stop_time = 2024-12-31)
+  DomainName (news-pravda.com subdomain)
+    → related-to → Infrastructure (pravda-XX.com)
+```
+
+### Per-article ingestion
+
+For each article row fetched from the API:
+
+```
+Campaign YYYY (per-year, first_seen = YYYY-01-01, special-cased 2023-09-01)
+  ← attributed-to ← IntrusionSet (Portal-Kombat)
+  → uses → Infrastructure (article domain)
+    → consists-of → DomainName (article domain)
+  → uses → Channel/website (article domain)   [start_time = publication date]
+    → related-to → Infrastructure (article domain)
+    → publishes → Media-Content (article)
+    → related-to → Channel/source (Telegram or website origin)
+  DomainName (article domain)
+    → related-to → Channel/website (article domain)
+  Media-Content (article)
+    → related-to → Channel/source
+    → related-to → URL (alternate URLs, if any)
+  Channel/website (article domain)
+    → related-to → DomainName (pravda-XX.com parent, if subdomain of news-pravda.com)
+```
+
+All STIX IDs are deterministic — reruns produce no duplicates.
 
 ## Requirements
 
@@ -42,7 +83,7 @@ All settings can be provided as environment variables or via `config.yml` (see `
 | `CHECKFIRST_API_ENDPOINT` | Endpoint path | `/v1/articles` |
 | `CHECKFIRST_SINCE` | Only ingest articles published on or after this date. Accepts ISO 8601 absolute dates (`2024-01-01T00:00:00Z`) or durations relative to now (`P365D`, `P1Y`, `P6M`, `P4W`) | `P365D` |
 | `CHECKFIRST_TLP_LEVEL` | TLP marking applied to all created objects (`clear`, `green`, `amber`, `amber+strict`, `red`) | `clear` |
-| `CHECKFIRST_FORCE_REPROCESS` | Ignore saved state and restart from page 1 | `false` |
+| `CHECKFIRST_FORCE_REPROCESS` | Ignore saved state and restart from page 1 (also re-sends the infrastructure bundle) | `false` |
 | `CHECKFIRST_MAX_ROW_BYTES` | Skip API rows exceeding this approximate byte size | unset |
 
 See `.env.sample` for a ready-to-use local template.
@@ -83,15 +124,23 @@ See `.env.sample` for a ready-to-use local template.
 
 - **Data > Connectors** — confirm the connector registers and shows as active
 - **Data > Ingestion** — confirm a new work item is created and completes
-- Search for ingested objects:
-  - `Media-Content` entities with `publication_date`
+- After first run, search for:
+  - 36 `Domain-Name` observables for `pravda-XX.com` domains
+  - 36 `Infrastructure` objects wrapping those domains
+  - 1 `IPv4-Addr` observable `178.21.15.85`
+  - 60+ `Domain-Name` observables for `news-pravda.com` subdomains
+  - `Campaign` objects per year (`Portal-Kombat 2023`, `Portal-Kombat 2024`, …)
+  - `IntrusionSet` — Portal-Kombat
+- Per article:
+  - `Media-Content` with `publication_date`
   - `Channel` entities (type `Telegram` or `website`)
-  - `URL` observables
-  - Relationships: `publishes`, `related-to`, `attributed-to`
+  - `Infrastructure` wrapping the publishing domain
+  - Relationships: `uses`, `consists-of`, `publishes`, `related-to`
 
 ## Notes
 
 - STIX IDs are deterministic — reruns do not create duplicate entities.
+- The infrastructure bundle is sent only when `start_page == 1`. Set `CHECKFIRST_FORCE_REPROCESS=true` to resend it.
 - The connector saves the last successfully processed API page in OpenCTI state; on restart it resumes from the next page.
 - The `since` filter is resolved to an absolute UTC datetime at connector startup; duration strings like `P365D` are supported for convenience.
-- API requests use a 300-second timeout per page. The CheckFirst infrastructure can be slow to respond on large result pages, so a generous timeout is used to avoid spurious network errors.
+- API requests use a 300-second timeout per page. The Checkfirst infrastructure can be slow to respond on large result pages.

--- a/external-import/checkfirst-import-connector/src/checkfirst_dataset/main_logic.py
+++ b/external-import/checkfirst-import-connector/src/checkfirst_dataset/main_logic.py
@@ -1,4 +1,12 @@
+"""Orchestration logic for a single Checkfirst ingestion pass.
+
+Coordinates API pagination, STIX object creation, bundle assembly, and
+state persistence. On the first run it also sends a one-off infrastructure
+bundle covering all known Pravda network domains and their shared hosting IP.
+"""
+
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 from checkfirst_dataset.alternates import parse_alternates
 from checkfirst_dataset.api_reader import iter_api_rows
@@ -6,7 +14,9 @@ from checkfirst_dataset.dates import DateParseError, parse_publication_date
 from checkfirst_dataset.reporting import RunReport, SkipReason
 from checkfirst_dataset.state import load_state_from_helper, save_state_to_helper
 from connector.converter_to_stix import ConverterToStix
+from connector.pravda_network import SUBDOMAIN_TO_DOMAIN
 from connector.settings import ConnectorSettings
+from pycti import OpenCTIConnectorHelper
 
 BUNDLE_SIZE = 1000
 
@@ -15,16 +25,116 @@ class BundleSendError(Exception):
     pass
 
 
-def _send_bundle(
-    helper, converter: ConverterToStix, objects: list, work_id: str
+def _send_infrastructure_bundle(
+    helper: OpenCTIConnectorHelper, converter: ConverterToStix, work_id: str
 ) -> None:
-    """Assemble and send a STIX bundle via the helper."""
-    stix_objects = list(objects) + [
+    """Send a one-off bundle of known Pravda network infrastructure objects.
+
+    Called only when starting from page 1 (first run or force_reprocess).
+    Relationships per domain:
+      - Campaign 2023 → attributed-to → IntrusionSet
+      - Campaign 2023 → uses [first_observed] → Infrastructure
+      - Infrastructure → consists-of → DomainName
+      - Infrastructure → consists-of → IPv4Address (with stop_time)
+      - Subdomain [first_observed] → related-to → Infrastructure
+    """
+    from connector.pravda_network import PRAVDA_DOMAINS, PRAVDA_IP
+
+    objects: list = [
+        converter.infrastructure_campaign,
+        converter.infrastructure_campaign_attributed_to_ims,
+    ]
+
+    ip_obj = converter.create_ipv4_address(
+        value=PRAVDA_IP["IP"],
+        first_seen=PRAVDA_IP["first_seen"],
+        last_seen=PRAVDA_IP["last_seen"],
+    )
+    objects.append(ip_obj)
+
+    for entry in PRAVDA_DOMAINS:
+        first_observed = entry["first_observed"]
+
+        infra_obj = converter.create_infrastructure(
+            name=entry["domain"],
+            first_seen=first_observed,
+        )
+        objects.append(infra_obj)
+
+        domain_obj = converter.create_domain_name(
+            value=entry["domain"],
+            first_seen=first_observed,
+        )
+        objects.append(domain_obj)
+
+        # Campaign → uses → Infrastructure
+        objects.append(
+            converter.create_relationship(
+                source_id=converter.infrastructure_campaign.id,
+                relationship_type="uses",
+                target_id=infra_obj.id,
+                start_time=first_observed,
+            )
+        )
+
+        # Infrastructure → consists-of → DomainName
+        objects.append(
+            converter.create_relationship(
+                source_id=infra_obj.id,
+                relationship_type="consists-of",
+                target_id=domain_obj.id,
+                start_time=first_observed,
+            )
+        )
+
+        # Infrastructure → consists-of → IPv4Address (with temporal bounds)
+        objects.append(
+            converter.create_relationship(
+                source_id=infra_obj.id,
+                relationship_type="consists-of",
+                target_id=ip_obj.id,
+                start_time=first_observed,
+                stop_time=PRAVDA_IP["last_seen"],
+            )
+        )
+
+        # Subdomains → related-to → Infrastructure
+        for subdomain in entry.get("subdomains", []):
+            sub_obj = converter.create_domain_name(
+                value=subdomain,
+                first_seen=first_observed,
+            )
+            objects.append(sub_obj)
+            objects.append(
+                converter.create_relationship(
+                    source_id=sub_obj.id,
+                    relationship_type="related-to",
+                    target_id=infra_obj.id,
+                    start_time=first_observed,
+                )
+            )
+
+    _send_bundle(helper, converter, objects, work_id)
+
+
+def _send_bundle(
+    helper: OpenCTIConnectorHelper,
+    converter: ConverterToStix,
+    objects: list,
+    work_id: str,
+) -> None:
+    """Assemble and send a STIX bundle via the helper, deduplicating by ID."""
+    seen_ids: set[str] = set()
+    unique: list = []
+    for obj in objects:
+        if obj.id not in seen_ids:
+            seen_ids.add(obj.id)
+            unique.append(obj)
+
+    stix_objects = unique + [
         converter.tlp_marking,
         converter.author,
         converter.intrusion_set,
-        converter.campaign,
-        converter.campaign_attributed_to_ims,
     ]
     bundle = helper.stix2_create_bundle(stix_objects)
     helper.send_stix2_bundle(
@@ -34,10 +144,11 @@ def _send_bundle(
     )
 
 
-def run_once(helper, settings: ConnectorSettings) -> None:
+def run_once(helper: OpenCTIConnectorHelper, settings: ConnectorSettings) -> None:
     """Run a single ingestion pass.
 
-    - Fetches data from the API endpoint.
+    - On first run (page 1): sends the Pravda network infrastructure bundle.
+    - Fetches article data from the API endpoint.
     - Builds STIX objects and sends them in bundles of BUNDLE_SIZE rows.
     - Updates state after each successfully sent bundle.
     """
@@ -78,6 +189,12 @@ def run_once(helper, settings: ConnectorSettings) -> None:
         run_name = f"{helper.connect_name} - {now.isoformat()}"
         work_id = helper.api.work.initiate_work(helper.connect_id, run_name)
 
+        if start_page == 1:
+            helper.connector_logger.info(
+                "Sending Pravda network infrastructure bundle (first run)"
+            )
+            _send_infrastructure_bundle(helper, converter, work_id)
+
         bundle_objects: list[object] = []
         rows_in_bundle = 0
         rows_yielded = 0
@@ -102,61 +219,145 @@ def run_once(helper, settings: ConnectorSettings) -> None:
 
             try:
                 published_dt = parse_publication_date(row.publication_date)
+                year = published_dt.year
 
-                channel = converter.create_channel(
+                # --- Per-year campaign (deterministic, cached) ---
+                year_campaign, year_campaign_attributed = (
+                    converter.get_campaign_for_year(year)
+                )
+
+                # --- Domain observable (extracted from article URL) ---
+                article_domain = urlparse(row.url).netloc
+                domain_obj = converter.create_domain_name(value=article_domain)
+
+                # --- Infrastructure wrapping the publishing domain ---
+                infra_obj = converter.create_infrastructure(
+                    name=article_domain,
+                    first_seen=published_dt,
+                )
+
+                # --- Channel as website (the publishing domain/subdomain) ---
+                channel_website = converter.create_channel(
+                    name=article_domain,
+                    source_url=row.url,
+                )
+
+                # --- Source as Channel (Telegram or website origin) ---
+                source_channel = converter.create_channel(
                     name=row.source_title,
                     source_url=row.source_url,
                 )
-                media_content = converter.create_media_content(
+
+                # --- Content (article) ---
+                content = converter.create_media_content(
                     title=row.og_title,
                     description=row.og_description,
                     url=row.url,
                     publication_date=published_dt,
                 )
-                source_url_obj = converter.create_url(value=row.source_url)
 
-                publishes = converter.create_relationship(
-                    source_id=channel.id,
-                    relationship_type="publishes",
-                    target_id=media_content.id,
+                # --- Relationships ---
+                # Campaign → uses → Infrastructure
+                campaign_uses_infra = converter.create_relationship(
+                    source_id=year_campaign.id,
+                    relationship_type="uses",
+                    target_id=infra_obj.id,
+                )
+                # Campaign → uses → Channel as website
+                campaign_uses_channel = converter.create_relationship(
+                    source_id=year_campaign.id,
+                    relationship_type="uses",
+                    target_id=channel_website.id,
                     start_time=published_dt,
                 )
-                related_to_source = converter.create_relationship(
-                    source_id=channel.id,
+                # Infrastructure → consists-of → DomainName
+                infra_consists_of_domain = converter.create_relationship(
+                    source_id=infra_obj.id,
+                    relationship_type="consists-of",
+                    target_id=domain_obj.id,
+                )
+                # Channel as website → related-to → Infrastructure
+                channel_related_to_infra = converter.create_relationship(
+                    source_id=channel_website.id,
                     relationship_type="related-to",
-                    target_id=source_url_obj.id,
+                    target_id=infra_obj.id,
+                    start_time=published_dt,
                 )
-                ims_uses_channel = converter.create_relationship(
-                    source_id=converter.intrusion_set.id,
-                    relationship_type="uses",
-                    target_id=channel.id,
+                # DomainName → related-to → Channel as website
+                domain_related_to_channel = converter.create_relationship(
+                    source_id=domain_obj.id,
+                    relationship_type="related-to",
+                    target_id=channel_website.id,
+                    start_time=published_dt,
                 )
-                campaign_uses_channel = converter.create_relationship(
-                    source_id=converter.campaign.id,
-                    relationship_type="uses",
-                    target_id=channel.id,
+                # Channel as website → publishes → Content
+                publishes = converter.create_relationship(
+                    source_id=channel_website.id,
+                    relationship_type="publishes",
+                    target_id=content.id,
+                    start_time=published_dt,
                 )
-
+                # Channel as website → related-to → Source as Channel
+                channel_uses_source = converter.create_relationship(
+                    source_id=channel_website.id,
+                    relationship_type="related-to",
+                    target_id=source_channel.id,
+                    start_time=published_dt,
+                )
+                # Content → related-to → Source as Channel
+                content_related_to_source = converter.create_relationship(
+                    source_id=content.id,
+                    relationship_type="related-to",
+                    target_id=source_channel.id,
+                    start_time=published_dt,
+                )
                 bundle_objects.extend(
                     [
-                        channel,
-                        media_content,
-                        source_url_obj,
-                        publishes,
-                        related_to_source,
-                        ims_uses_channel,
+                        year_campaign,
+                        year_campaign_attributed,
+                        domain_obj,
+                        infra_obj,
+                        channel_website,
+                        source_channel,
+                        content,
+                        campaign_uses_infra,
                         campaign_uses_channel,
+                        infra_consists_of_domain,
+                        channel_related_to_infra,
+                        domain_related_to_channel,
+                        publishes,
+                        channel_uses_source,
+                        content_related_to_source,
                     ]
                 )
 
+                # If the article domain is a known news-pravda.com subdomain,
+                # link the Channel as website to its parent pravda-XX.com domain.
+                parent_domain_str = SUBDOMAIN_TO_DOMAIN.get(article_domain)
+                if parent_domain_str:
+                    parent_domain_obj = converter.create_domain_name(
+                        value=parent_domain_str
+                    )
+                    bundle_objects.append(parent_domain_obj)
+                    bundle_objects.append(
+                        converter.create_relationship(
+                            source_id=channel_website.id,
+                            relationship_type="related-to",
+                            target_id=parent_domain_obj.id,
+                            start_time=published_dt,
+                        )
+                    )
+
+                # Content → related-to → alternate URLs
                 for alt in parse_alternates(row.alternates):
                     alt_url = converter.create_url(value=alt)
-                    rel = converter.create_relationship(
-                        source_id=media_content.id,
+                    alt_rel = converter.create_relationship(
+                        source_id=content.id,
                         relationship_type="related-to",
                         target_id=alt_url.id,
+                        start_time=published_dt,
                     )
-                    bundle_objects.extend([alt_url, rel])
+                    bundle_objects.extend([alt_url, alt_rel])
 
             except DateParseError as exc:
                 report.skip(SkipReason.ROW_INVALID_PUBLICATION_DATE)
@@ -167,7 +368,7 @@ def run_once(helper, settings: ConnectorSettings) -> None:
                 continue
             except Exception as exc:  # noqa: BLE001
                 report.skip(SkipReason.ROW_MAPPING_ERROR)
-                helper.connector_logger.error(
+                helper.connector_logger.warning(
                     "Skip row (mapping error)",
                     {"row": row.row_number, "error": str(exc)},
                 )

--- a/external-import/checkfirst-import-connector/src/checkfirst_dataset/types.py
+++ b/external-import/checkfirst-import-connector/src/checkfirst_dataset/types.py
@@ -1,3 +1,5 @@
+"""Protocol definitions for duck-typed interfaces used by API helpers."""
+
 from typing import Protocol
 
 

--- a/external-import/checkfirst-import-connector/src/connector/connector.py
+++ b/external-import/checkfirst-import-connector/src/connector/connector.py
@@ -1,3 +1,5 @@
+"""Entry point class for the Checkfirst external-import connector."""
+
 import sys
 
 from checkfirst_dataset.main_logic import run_once
@@ -10,7 +12,7 @@ class CheckfirstImportConnector:
 
     This follows the standard external-import connector template:
     - `process_message()` does one ingestion pass
-    - `run()` schedules runs via `OpenCTIConnectorHelper.schedule_process()`
+    - `run()` schedules runs via `OpenCTIConnectorHelper.schedule_iso()`
 
     The actual API ingestion + STIX mapping is implemented under
     `checkfirst_dataset/` and reused here.
@@ -35,7 +37,7 @@ class CheckfirstImportConnector:
 
     def run(self) -> None:
         """Start the connector using the standard scheduler."""
-        self.helper.schedule_process(
+        self.helper.schedule_iso(
             message_callback=self.process_message,
-            duration_period=self.config.connector.duration_period.total_seconds(),
+            duration_period=self.config.connector.duration_period,
         )

--- a/external-import/checkfirst-import-connector/src/connector/converter_to_stix.py
+++ b/external-import/checkfirst-import-connector/src/connector/converter_to_stix.py
@@ -15,6 +15,7 @@ from pycti import (
     Channel,
     CustomObjectChannel,
     CustomObservableMediaContent,
+    Infrastructure,
     IntrusionSet,
     OpenCTIConnectorHelper,
     StixCoreRelationship,
@@ -47,12 +48,14 @@ class ConverterToStix:
         self.tlp_marking_id = self.tlp_marking.id
 
         self.intrusion_set = self._create_intrusion_set()
-        self.campaign = self._create_campaign()
-        self.campaign_attributed_to_ims = self.create_relationship(
-            source_id=self.campaign.id,
+        self.infrastructure_campaign = self._create_campaign(year=2023)
+        self.infrastructure_campaign_attributed_to_ims = self.create_relationship(
+            source_id=self.infrastructure_campaign.id,
             relationship_type="attributed-to",
             target_id=self.intrusion_set.id,
         )
+
+        self._campaign_cache: dict[int, tuple[stix2.Campaign, stix2.Relationship]] = {}
 
     def _create_intrusion_set(self) -> stix2.IntrusionSet:
         return stix2.IntrusionSet(
@@ -63,6 +66,7 @@ class ConverterToStix:
                 "influence operations through a network of 190+ websites"
             ),
             aliases=["Portal-Kombat", "Pravda Network IMS"],
+            first_seen="2023-06-24T00:00:00Z",
             goals=[
                 "Undermine Western unity",
                 "Promote Russian narratives",
@@ -75,18 +79,20 @@ class ConverterToStix:
             allow_custom=True,
         )
 
-    def _create_campaign(self) -> stix2.Campaign:
+    def _create_campaign(self, year: int) -> stix2.Campaign:
+        name = f"Pravda Network Campaigns {year}"
+        first_seen = (
+            "2023-09-01T00:00:00Z" if year == 2023 else f"{year}-01-01T00:00:00Z"
+        )
         return stix2.Campaign(
-            id=Campaign.generate_id(
-                name="Pravda Network Campaigns",
-            ),
-            name="Pravda Network Campaigns",
+            id=Campaign.generate_id(name=name),
+            name=name,
             description=(
                 "Coordinated FIMI campaign spreading pro-Russian narratives "
                 "across multiple countries and languages"
             ),
-            aliases=["Portal-Kombat Campaign", "Pravda"],
-            first_seen="2023-09-01T00:00:00Z",
+            aliases=[f"Portal-Kombat Campaign {year}", f"Pravda {year}"],
+            first_seen=first_seen,
             objective=(
                 "Manipulate public opinion, undermine trust in Western "
                 "institutions, justify Russian actions"
@@ -95,6 +101,20 @@ class ConverterToStix:
             object_marking_refs=[self.tlp_marking_id],
             allow_custom=True,
         )
+
+    def get_campaign_for_year(
+        self, year: int
+    ) -> tuple[stix2.Campaign, stix2.Relationship]:
+        """Return (Campaign, attributed-to Relationship) for the given year, cached."""
+        if year not in self._campaign_cache:
+            campaign = self._create_campaign(year=year)
+            attributed_to = self.create_relationship(
+                source_id=campaign.id,
+                relationship_type="attributed-to",
+                target_id=self.intrusion_set.id,
+            )
+            self._campaign_cache[year] = (campaign, attributed_to)
+        return self._campaign_cache[year]
 
     def create_channel(
         self, *, name: str, source_url: str | None = None
@@ -109,7 +129,7 @@ class ConverterToStix:
         channel = CustomObjectChannel(
             id=Channel.generate_id(name=name),
             name=name,
-            channel_types=["Telegram"] if is_telegram else ["website"],
+            channel_types=["channel"] if is_telegram else ["website"],
             created_by_ref=self.author_id,
             object_marking_refs=[self.tlp_marking_id],
             external_references=external_refs,
@@ -137,6 +157,53 @@ class ConverterToStix:
         )
         return media
 
+    def create_domain_name(
+        self, *, value: str, first_seen: str | None = None
+    ) -> stix2.DomainName:
+        custom: dict = {"x_opencti_created_by_ref": self.author_id}
+        if first_seen:
+            custom["x_opencti_first_seen_at"] = first_seen
+        return stix2.DomainName(
+            value=value,
+            object_marking_refs=[self.tlp_marking_id],
+            custom_properties=custom,
+        )
+
+    def create_ipv4_address(
+        self,
+        *,
+        value: str,
+        first_seen: str | None = None,
+        last_seen: str | None = None,
+    ) -> stix2.IPv4Address:
+        custom: dict = {"x_opencti_created_by_ref": self.author_id}
+        if first_seen:
+            custom["x_opencti_first_seen_at"] = first_seen
+        if last_seen:
+            custom["x_opencti_last_seen_at"] = last_seen
+        return stix2.IPv4Address(
+            value=value,
+            object_marking_refs=[self.tlp_marking_id],
+            custom_properties=custom,
+        )
+
+    def create_infrastructure(
+        self, *, name: str, first_seen: datetime | str | None = None
+    ) -> stix2.Infrastructure:
+        custom: dict = {"x_opencti_created_by_ref": self.author_id}
+        if first_seen:
+            custom["x_opencti_first_seen_at"] = first_seen
+        return stix2.Infrastructure(
+            id=Infrastructure.generate_id(name=name),
+            name=name,
+            infrastructure_types=["hosting-infrastructure"],
+            first_seen=first_seen,
+            created_by_ref=self.author_id,
+            object_marking_refs=[self.tlp_marking_id],
+            custom_properties=custom,
+            allow_custom=True,
+        )
+
     def create_url(self, *, value: str) -> stix2.URL:
         return stix2.URL(
             value=value,
@@ -153,6 +220,7 @@ class ConverterToStix:
         relationship_type: str,
         target_id: str,
         start_time: datetime | None = None,
+        stop_time: datetime | None = None,
     ) -> stix2.Relationship:
         rel = stix2.Relationship(
             id=StixCoreRelationship.generate_id(
@@ -167,5 +235,6 @@ class ConverterToStix:
             object_marking_refs=[self.tlp_marking_id],
             allow_custom=True,
             start_time=start_time,
+            stop_time=stop_time,
         )
         return rel

--- a/external-import/checkfirst-import-connector/src/connector/pravda_network.py
+++ b/external-import/checkfirst-import-connector/src/connector/pravda_network.py
@@ -1,0 +1,224 @@
+"""Static Pravda network infrastructure data.
+
+All 36 domains share the same hosting IP (AS49352, Russia).
+"""
+
+PRAVDA_IP = {
+    "IP": "178.21.15.85",
+    "first_seen": "2023-09-01T00:00:00Z",
+    "last_seen": "2024-12-31T00:00:00Z",
+}
+
+PRAVDA_DOMAINS = [
+    {
+        "domain": "pravda-de.com",
+        "first_observed": "2023-06-24T00:00:00Z",
+        "subdomains": [
+            "deutsch.news-pravda.com",
+            "germany.news-pravda.com",
+            "austria.news-pravda.com",
+            "switzerland.news-pravda.com",
+        ],
+    },
+    {
+        "domain": "pravda-en.com",
+        "first_observed": "2023-06-24T00:00:00Z",
+        "subdomains": [
+            "news-pravda.com",
+            "uk.news-pravda.com",
+            "usa.news-pravda.com",
+        ],
+    },
+    {
+        "domain": "pravda-es.com",
+        "first_observed": "2023-06-24T00:00:00Z",
+        "subdomains": [
+            "spanish.news-pravda.com",
+            "spain.news-pravda.com",
+        ],
+    },
+    {
+        "domain": "pravda-fr.com",
+        "first_observed": "2023-08-01T00:00:00Z",
+        "subdomains": [
+            "francais.news-pravda.com",
+            "france.news-pravda.com",
+        ],
+    },
+    {
+        "domain": "pravda-pl.com",
+        "first_observed": "2023-06-24T00:00:00Z",
+        "subdomains": ["poland.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-nl.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": [
+            "dutch.news-pravda.com",
+            "netherlands.news-pravda.com",
+            "belgium.news-pravda.com",
+        ],
+    },
+    {
+        "domain": "pravda-dk.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["denmark.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-se.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["sweden.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-fi.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["finland.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-ee.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["estonia.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-lt.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["lt.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-lv.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["latvia.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-cz.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["czechia.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-sk.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["slovakia.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-si.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["slovenia.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-hr.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["croatia.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-hu.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["hungary.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-ro.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["romania.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-bg.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["bulgaria.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-gr.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["greece.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-cy.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["cyprus.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-it.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["italy.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-ie.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["ireland.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-pt.com",
+        "first_observed": "2024-03-20T00:00:00Z",
+        "subdomains": ["portuguese.news-pravda.com", "portugal.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-al.com",
+        "first_observed": "2024-03-26T00:00:00Z",
+        "subdomains": ["albania.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-ba.com",
+        "first_observed": "2024-03-26T00:00:00Z",
+        "subdomains": ["bosnia-herzegovina.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-mk.com",
+        "first_observed": "2024-03-26T00:00:00Z",
+        "subdomains": ["north-macedonia.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-md.com",
+        "first_observed": "2024-03-26T00:00:00Z",
+        "subdomains": ["md.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-rs.com",
+        "first_observed": "2024-03-26T00:00:00Z",
+        "subdomains": ["serbia.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-no.com",
+        "first_observed": "2024-03-26T00:00:00Z",
+        "subdomains": ["norway.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-cf.com",
+        "first_observed": "2024-03-26T00:00:00Z",
+        "subdomains": ["rca.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-bf.com",
+        "first_observed": "2024-03-26T00:00:00Z",
+        "subdomains": ["burkina-faso.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-ne.com",
+        "first_observed": "2024-03-26T00:00:00Z",
+        "subdomains": ["niger.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-jp.com",
+        "first_observed": "2024-03-26T00:00:00Z",
+        "subdomains": ["japan.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-tw.com",
+        "first_observed": "2024-03-26T00:00:00Z",
+        "subdomains": ["taiwan.news-pravda.com"],
+    },
+    {
+        "domain": "pravda-ko.com",
+        "first_observed": "2024-03-26T00:00:00Z",
+        "subdomains": [
+            "korea.news-pravda.com",
+            "south-korea.news-pravda.com",
+            "dprk.news-pravda.com",
+        ],
+    },
+]
+
+# Reverse lookup: news-pravda.com subdomain → parent pravda-XX.com domain
+SUBDOMAIN_TO_DOMAIN: dict[str, str] = {
+    sub: entry["domain"] for entry in PRAVDA_DOMAINS for sub in entry["subdomains"]
+}
+
+# Set of all known pravda-XX.com domain values
+PRAVDA_DOMAIN_VALUES: set[str] = {entry["domain"] for entry in PRAVDA_DOMAINS}

--- a/external-import/checkfirst-import-connector/src/connector/settings.py
+++ b/external-import/checkfirst-import-connector/src/connector/settings.py
@@ -1,3 +1,5 @@
+"""Pydantic settings models for the Checkfirst connector."""
+
 import re
 from datetime import datetime, timedelta, timezone
 from typing import Literal
@@ -37,6 +39,7 @@ class CheckfirstConfig(BaseConfigModel):
     @field_validator("api_url")
     @classmethod
     def _strip_trailing_slash(cls, v: str) -> str:
+        """Strip trailing slashes from the API URL."""
         return v.rstrip("/")
 
     api_key: str = Field(

--- a/external-import/checkfirst-import-connector/src/main.py
+++ b/external-import/checkfirst-import-connector/src/main.py
@@ -1,3 +1,5 @@
+"""Connector entry point: initialises settings, helper, and starts the run loop."""
+
 import traceback
 
 from connector.connector import CheckfirstImportConnector


### PR DESCRIPTION
## Summary

- Add new `external-import/checkfirst-import-connector` to ingest Checkfirst articles as STIX 2.1 bundles, tracking the Portal-Kombat / Pravda Network Russian influence operation
- On first run, sends a one-off infrastructure bundle of known Pravda network domains (36 `pravda-XX.com`, 60+ `news-pravda.com` subdomains, shared hosting IP `178.21.15.85`) attributed to the Portal-Kombat intrusion set per SGDSN/VIGINUM reports
- Per-article ingestion maps to `Infrastructure`, `Campaign`, `IntrusionSet`, `Channel`, `Media-Content`, `DomainName`, `URL` and relationships
- All STIX IDs are deterministic — reruns produce no duplicates
- Uses `schedule_iso()` for standard external-import scheduling

## Changes

- `pravda_network.py` — Pravda domain/IP reference data and subdomain mappings
- `main_logic.py` — orchestration: infrastructure bundle on first run, paginated article ingestion
- `converter_to_stix.py` — STIX object builders (Infrastructure, IPv4, Campaign, IntrusionSet, Channel, Media-Content, relationships)
- `connector.py` — connector entrypoint with `schedule_iso()` scheduling
- `settings.py` / `types.py` — configuration and type definitions
- `README.md` — full documentation with STIX object model diagrams