### PR TITLE
[misp] Tag IPv4 CIDR ranges as IPv4 observables instead of IPv6

### DIFF
--- a/external-import/misp/src/connector/use_cases/convert_attribute.py
+++ b/external-import/misp/src/connector/use_cases/convert_attribute.py
@@ -166,8 +166,11 @@ class AttributeConverter:
         custom_properties: dict[str, str],
     ) -> stix2.IPv4Address | stix2.IPv6Address:
         try:
+            # Handling for value being IP v4 address range
+            test_value = value.split("/")[0]
+
             # Test if valid IP v4 address
-            ipaddress.IPv4Address(value)
+            ipaddress.IPv4Address(test_value)
 
             return stix2.IPv4Address(
                 value=value,

--- a/external-import/misp/src/connector/use_cases/convert_attribute.py
+++ b/external-import/misp/src/connector/use_cases/convert_attribute.py
@@ -165,24 +165,57 @@ class AttributeConverter:
         markings: list[stix2.v21.MarkingDefinition],
         custom_properties: dict[str, str],
     ) -> stix2.IPv4Address | stix2.IPv6Address:
+        """Build a STIX 2.1 IPv4 / IPv6 observable from a MISP ``ip-src`` / ``ip-dst`` value.
+
+        Both single hosts (``1.2.3.4``, ``::1``) and CIDR ranges
+        (``192.168.0.0/24``, ``2001:db8::/32``) are accepted — the STIX 2.1
+        spec explicitly allows CIDR notation in the ``IPv4-Addr`` /
+        ``IPv6-Addr`` ``value`` field.
+
+        ``ipaddress.ip_network(value, strict=False)`` validates the **full**
+        input in a single call — including the prefix length — so:
+
+        * ``192.168.0.0/24`` correctly resolves to ``version == 4`` (the
+          previous ``ipaddress.IPv4Address(value)`` call raised on the
+          ``/`` and silently routed the value to the IPv6 fallback,
+          producing the IPv6-tagged-IPv4-range bug this PR set out to fix);
+        * ``1.2.3.4/999`` and other malformed-prefix variants raise
+          ``ValueError`` instead of slipping through a "validate only the
+          address half" guard, so the connector no longer emits an
+          ``IPv4Address`` observable with a structurally invalid
+          ``value``;
+        * ``strict=False`` lets host-bits-set CIDRs (``1.2.3.4/24`` →
+          ``1.2.3.0/24``) through without raising — MISP attributes
+          commonly carry the address-with-mask form, and the converter's
+          job is to type-tag the observable, not to canonicalise the
+          range on its behalf.
+
+        The ``ValueError`` branch keeps the connector's prior
+        "anything that does not parse as IPv4 is an IPv6 observable"
+        contract — the MISP source of truth gets to decide what is and
+        is not a valid IP; the converter only chooses the STIX type
+        tag.
+        """
         try:
-            # Handling for value being IP v4 address range
-            test_value = value.split("/")[0]
-
-            # Test if valid IP v4 address
-            ipaddress.IPv4Address(test_value)
-
-            return stix2.IPv4Address(
-                value=value,
-                object_marking_refs=markings,
-                custom_properties=custom_properties,
-            )
-        except ipaddress.AddressValueError:
+            network = ipaddress.ip_network(value, strict=False)
+        except ValueError:
             return stix2.IPv6Address(
                 value=value,
                 object_marking_refs=markings,
                 custom_properties=custom_properties,
             )
+
+        if network.version == 4:
+            return stix2.IPv4Address(
+                value=value,
+                object_marking_refs=markings,
+                custom_properties=custom_properties,
+            )
+        return stix2.IPv6Address(
+            value=value,
+            object_marking_refs=markings,
+            custom_properties=custom_properties,
+        )
 
     def create_intrusion_set_from_attribute(
         self,

--- a/external-import/misp/src/requirements.txt
+++ b/external-import/misp/src/requirements.txt
@@ -1,5 +1,5 @@
 datasize==1.0.0
-pycti==7.260521.0
+pycti==7.260522.0
 pympler==1.1
 urllib3==2.7.0
 pymisp~=2.5.17

--- a/external-import/misp/tests/tests_connector/test_convert_attribute.py
+++ b/external-import/misp/tests/tests_connector/test_convert_attribute.py
@@ -1,0 +1,126 @@
+"""Unit tests for ``AttributeConverter.create_stix2_ip_address``.
+
+Pins the IPv4 / IPv6 type-tagging contract added in this PR:
+
+* Single-host IPv4 (``1.2.3.4``) → ``stix2.IPv4Address`` (regression
+  guard — pre-PR behaviour also handled this correctly).
+* CIDR-form IPv4 (``192.168.0.0/24``) → ``stix2.IPv4Address`` (THE bug
+  this PR set out to fix — pre-PR these were silently routed to the
+  IPv6 fallback because ``IPv4Address(value)`` raised on the ``/``).
+* Single-host IPv6 (``::1``, ``2001:db8::1``) → ``stix2.IPv6Address``.
+* CIDR-form IPv6 (``2001:db8::/32``) → ``stix2.IPv6Address``.
+* ``1.2.3.4/24`` (host bits set) → ``stix2.IPv4Address``
+  (``strict=False`` lets MISP's address-with-mask form through).
+* Malformed-prefix (``1.2.3.4/999``) → ``stix2.IPv6Address`` fallback
+  — the previous "validate only the address half" guard would have
+  let this through as IPv4 with a structurally invalid ``value``.
+* Extra-slash (``1.2.3.4/24/extra``) → ``stix2.IPv6Address`` fallback,
+  same reasoning.
+* Plain garbage (``"garbage"``, ``""``) → ``stix2.IPv6Address``
+  fallback — preserves the connector's prior contract that
+  anything that does not parse as IPv4 is type-tagged as IPv6 (the
+  MISP source of truth gets to decide what is and is not a valid IP;
+  the converter only chooses the STIX type).
+"""
+
+import pytest
+import stix2
+from connector.use_cases.common import ConverterConfig
+from connector.use_cases.convert_attribute import AttributeConverter
+
+
+@pytest.fixture
+def attribute_converter() -> AttributeConverter:
+    return AttributeConverter(
+        config=ConverterConfig(external_reference_base_url="http://dummy")
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Single host IPv4 (regression guard for the pre-PR happy path).
+        "1.2.3.4",
+        "0.0.0.0",
+        "255.255.255.255",
+        # CIDR IPv4 — THE bug this PR sets out to fix. Pre-PR these
+        # were silently routed to the IPv6 fallback because
+        # ``IPv4Address(value)`` raised on the ``/``.
+        "192.168.0.0/24",
+        "10.0.0.0/8",
+        # Host-bits-set CIDRs (MISP's address-with-mask form).
+        # ``strict=False`` makes ``ip_network`` accept these.
+        "1.2.3.4/24",
+        "192.168.1.5/16",
+    ],
+)
+def test_ipv4_values_return_ipv4_address(attribute_converter, value):
+    result = attribute_converter.create_stix2_ip_address(
+        value=value, markings=[], custom_properties={}
+    )
+
+    assert isinstance(result, stix2.IPv4Address)
+    # ``value`` must round-trip verbatim — the connector intentionally
+    # does NOT canonicalise the CIDR (1.2.3.4/24 stays as-is instead of
+    # being rewritten to 1.2.3.0/24) because the MISP source of truth
+    # is the authority on the address-with-mask presentation.
+    assert result.value == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Single host IPv6.
+        "::1",
+        "2001:db8::1",
+        "fe80::1%eth0".split("%")[0],  # canonical form without zone id
+        # CIDR IPv6.
+        "2001:db8::/32",
+        "::/0",
+    ],
+)
+def test_ipv6_values_return_ipv6_address(attribute_converter, value):
+    result = attribute_converter.create_stix2_ip_address(
+        value=value, markings=[], custom_properties={}
+    )
+
+    assert isinstance(result, stix2.IPv6Address)
+    assert result.value == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Malformed prefix length — the pre-fix split-and-validate-half
+        # guard let these through as IPv4 with a structurally invalid
+        # ``value``. ``ip_network`` rejects them.
+        "1.2.3.4/999",
+        "1.2.3.4/-1",
+        # Extra-slash garbage.
+        "1.2.3.4/24/extra",
+        # Truly invalid input — preserves the connector's prior
+        # "everything that does not parse as IPv4 is type-tagged as
+        # IPv6" contract so the bundle still gets an observable for
+        # the operator to triage.
+        "not-an-ip",
+        "",
+        "999.999.999.999",
+    ],
+)
+def test_invalid_values_fall_back_to_ipv6(attribute_converter, value):
+    """Malformed / unparseable values fall back to the IPv6 type tag.
+
+    This is a deliberate compatibility decision — the connector's prior
+    behaviour was to type-tag anything that was not a valid IPv4 as
+    IPv6 (without re-validating that the value actually was IPv6),
+    leaving the source-of-truth call to MISP. The fix narrows the
+    "is IPv4" check (so CIDR ranges no longer trip into the fallback)
+    but keeps the fallback branch as-is so the contract for genuinely
+    invalid input is unchanged.
+    """
+    result = attribute_converter.create_stix2_ip_address(
+        value=value, markings=[], custom_properties={}
+    )
+
+    assert isinstance(result, stix2.IPv6Address)
+    assert result.value == value


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* MISP attributes of type `ip-src` / `ip-dst` whose value is an IPv4 CIDR range (`192.168.0.0/24`) were being type-tagged as `IPv6-Addr` observables in OpenCTI. Root cause: `AttributeConverter.create_stix2_ip_address` validated only the host portion via `ipaddress.IPv4Address(value)`, which raises `AddressValueError` on the `/`, silently routing the value into the IPv6 fallback branch and producing an `IPv6-Addr` entity for what is unambiguously an IPv4 range.
* Switched the guard to `ipaddress.ip_network(value, strict=False)` so the full value (including any prefix length) is validated in a single call, then route on `network.version`. `strict=False` lets MISP's host-bits-set address-with-mask form (`1.2.3.4/24`) through without raising, since the converter's job is to type-tag the observable — not to canonicalise the range on MISP's behalf. The fallback branch (`ValueError → IPv6Address`) preserves the connector's prior "anything that does not parse as IPv4 is type-tagged as IPv6" contract so genuinely invalid input still produces an observable the operator can triage. Inline docstring captures the rationale so a future refactor cannot regress either half.

### Test coverage

Added `external-import/misp/tests/tests_connector/test_convert_attribute.py` — a parametrised suite that pins every shape of the type-tagging contract:

* Single-host IPv4 (`1.2.3.4`, `0.0.0.0`, `255.255.255.255`) → `stix2.IPv4Address` (regression guard for the pre-PR happy path).
* CIDR IPv4 (`192.168.0.0/24`, `10.0.0.0/8`) → `stix2.IPv4Address` (THE bug this PR sets out to fix).
* Host-bits-set CIDRs (`1.2.3.4/24`, `192.168.1.5/16`) → `stix2.IPv4Address` via `strict=False`.
* Single-host IPv6 (`::1`, `2001:db8::1`, `fe80::1`) → `stix2.IPv6Address`.
* CIDR IPv6 (`2001:db8::/32`, `::/0`) → `stix2.IPv6Address`.
* Malformed-prefix (`1.2.3.4/999`, `1.2.3.4/-1`), extra-slash (`1.2.3.4/24/extra`), and plain garbage (`not-an-ip`, `""`, `999.999.999.999`) → `stix2.IPv6Address` fallback (preserves the prior contract).
* Every assertion also verifies that `value` round-trips verbatim (the connector intentionally does NOT canonicalise `1.2.3.4/24` to `1.2.3.0/24` because the MISP source-of-truth is the authority on the address-with-mask presentation).

### Maintainer pass on top of the contributor's draft

* Replaced the contributor's `value.split("/")[0]` "validate only the address half" guard with `ipaddress.ip_network(value, strict=False)` so the full value is validated in a single call. The split-and-validate-half shape would have let `1.2.3.4/999` through as IPv4 with a structurally invalid `value` — addressed by the new guard and pinned by a dedicated test case (Copilot review thread on `convert_attribute.py:200` flagged this exact regression risk; the fix lands on commit `42d806e3e` and the test case `test_invalid_values_fall_back_to_ipv6[1.2.3.4/999]` locks it in).
* Bumped `pycti==7.260521.0` → `7.260522.0` in `external-import/misp/src/requirements.txt` to match the `connectors-sdk @ master` pin that shipped on `0a0e19ff6` (`[all] Release 7.260522.0`). The previous mismatch produced an unsatisfiable-resolver error on the `Test external-import/misp` and `Test tests/test-requirements.txt` jobs; the bump is verified on a throwaway branch where Build Manifest + Lint & Format resolve cleanly. Commit `b6b030f44`.

### Related issues

Closes #6508 — `[misp] IPv4 CIDR ranges (e.g. 192.168.0.0/24) are mis-tagged as IPv6 observables`.

### Local validation

* `black --check`, `isort --profile black --check-only`, `flake8 --select=F`, `flake8 --ignore=E,W` clean across the touched files.
* `pytest external-import/misp/tests/tests_connector/test_convert_attribute.py` passes the new 18 parametrised cases locally.
* Build Manifest workflow re-verified on a throwaway branch off `b6b030f44` — succeeds with the bumped `pycti==7.260522.0` pin.

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
