### PR TITLE
[cve] Add optional Software/CPE import (#1604, #1949, #1449) & fix duplicate vulnerabilities in _filter_cvss (#5964)

### DIFF
--- a/external-import/cve/README.md
+++ b/external-import/cve/README.md
@@ -29,7 +29,7 @@ The CVE connector imports Common Vulnerabilities and Exposures (CVE) data from t
 
 The National Vulnerability Database (NVD) is the U.S. government repository of standards-based vulnerability management data. This connector retrieves CVE (Common Vulnerabilities and Exposures) data from the NVD API and imports it into OpenCTI as Vulnerability entities.
 
-The connector supports both incremental updates (maintaining data since last run) and historical import (pulling all CVEs from a specified year).
+The connector supports both incremental updates (maintaining data since last run) and historical import (pulling all CVEs from a specified year). It can also optionally resolve CPEs (Common Platform Enumerations) associated with each CVE via the [NVD CPE Match API](https://nvd.nist.gov/developers/products) and import them as Software entities linked to Vulnerabilities.
 
 ## Installation
 
@@ -69,6 +69,7 @@ There are a number of configuration options, which are set either in `docker-com
 | Maintain Data      | cve.maintain_data    | `CVE_MAINTAIN_DATA`         | true                                         | No        | Import CVEs from last run to current time (incremental updates).            |
 | Pull History       | cve.pull_history     | `CVE_PULL_HISTORY`          | false                                        | No        | Import all CVEs from `history_start_year`. Requires `history_start_year`.   |
 | History Start Year | cve.history_start_year | `CVE_HISTORY_START_YEAR`  | 2019                                         | No        | Required if `pull_history=true`. Minimum 2019 (CVSS v3.1 release).          |
+| Import Software    | cve.import_software    | `CVE_IMPORT_SOFTWARE`     | false                                        | No        | If `true`, resolve CPEs for each CVE via the NVD CPE Match API and import them as Software objects with `has` relationships to Vulnerabilities. **Warning:** this can generate a large volume of data and additional API calls. |
 
 ## Deployment
 
@@ -99,6 +100,7 @@ Configure the connector in `docker-compose.yml`:
       # - CVE_MAINTAIN_DATA=true
       # - CVE_PULL_HISTORY=false
       # - CVE_HISTORY_START_YEAR=2019
+      # - CVE_IMPORT_SOFTWARE=false  # Enable to import Software (CPE) objects
     restart: always
 ```
 
@@ -134,7 +136,7 @@ Find the connector and click the refresh button to reset the state and trigger a
 
 ## Behavior
 
-The connector fetches CVE data from the NVD API and converts it to STIX Vulnerability objects.
+The connector fetches CVE data from the NVD API and converts it to STIX Vulnerability objects. When `import_software` is enabled, it also calls the [NVD CPE Match API](https://nvd.nist.gov/developers/products) to resolve CPEs associated with each CVE and creates STIX Software objects with `has` relationships to the corresponding Vulnerability.
 
 ### Data Flow
 
@@ -143,16 +145,22 @@ graph LR
     subgraph NVD API
         direction TB
         CVE[CVE Data]
+        CPEMatch[CPE Match API]
     end
 
     subgraph OpenCTI
         direction LR
         Vulnerability[Vulnerability]
+        Software[Software]
         ExternalRef[External Reference]
+        HasRel["has (Relationship)"]
     end
 
     CVE --> Vulnerability
     CVE --> ExternalRef
+    CPEMatch -->|import_software=true| Software
+    Software --> HasRel
+    HasRel --> Vulnerability
 ```
 
 ### Entity Mapping
@@ -196,6 +204,23 @@ graph LR
 | CWE IDs              | Labels                  | Weakness classifications                         |
 | References           | External References     | Links to advisories and patches                  |
 
+#### Software Entity Mapping (when `import_software=true`)
+
+When the `import_software` option is enabled, the connector resolves CPEs (Common Platform Enumerations) for each CVE using the [NVD CPE Match API](https://nvd.nist.gov/developers/products) and creates STIX Software objects:
+
+| CPE Data             | OpenCTI Entity/Property | Description                                      |
+|----------------------|-------------------------|--------------------------------------------------|
+| CPE Name             | Software.cpe            | Full CPE 2.3 URI (e.g., `cpe:2.3:a:nodejs:node.js:16.0.0:*:*:*:*:*:*:*`) |
+| Vendor               | Software.vendor         | Vendor name extracted from CPE URI               |
+| Vendor + Product (+ Version) | Software.name  | Human-readable software name                     |
+| Version              | Software.version        | Software version (omitted if wildcard `*`)       |
+
+#### Relationship Mapping (when `import_software=true`)
+
+| Source Entity | Relationship Type | Target Entity   | Description                                |
+|---------------|-------------------|-----------------|--------------------------------------------|
+| Software      | `has`             | Vulnerability   | Indicates the software is affected by the vulnerability |
+
 ### Operating Modes
 
 1. **Incremental Updates** (`maintain_data=true`):
@@ -208,12 +233,20 @@ graph LR
    - Useful for initial population
    - Requires `history_start_year` (minimum 2019)
 
+3. **Software Import** (`import_software=true`):
+   - Resolves CPEs for each CVE via the NVD CPE Match API
+   - Creates Software entities with vendor, product, version, and CPE URI
+   - Links each Software to its Vulnerability with a `has` relationship
+   - Can be combined with any operating mode (incremental or historical)
+   - **Warning:** This generates a significant volume of additional data and API calls (one extra API call per CVE). Consider the impact on API rate limits and OpenCTI storage.
+
 ### Processing Details
 
 - **CVSS Support**: Connector supports CVSS v2, v3.1, and v4.0
 - **Rate Limiting**: NVD API has rate limits; connector handles pagination
 - **Date Range**: Maximum 120-day range per API query
 - **API Key Required**: Unauthenticated requests are heavily rate-limited
+- **CPE Match API**: When `import_software=true`, an additional API call per CVE is made to the [NVD CPE Match API](https://nvd.nist.gov/developers/products). The same API key and rate limiting (6-second sleep between requests) apply.
 
 ## Debugging
 

--- a/external-import/cve/src/config.yml.sample
+++ b/external-import/cve/src/config.yml.sample
@@ -14,4 +14,5 @@ cve:
 #  maintain_data: True # Optional, retrieve only updated data
 #  pull_history: False # Optional, If True, history_start_year is required
 #  history_start_year: 2019 # Required if pull_history is True, min 2019 (see documentation CVE and CVSS base score V3.1)
+#  import_software: False # Optional, if True, resolve CPEs and import as Software objects (generates large volume of data)
 

--- a/external-import/cve/src/models/configs/cve_configs.py
+++ b/external-import/cve/src/models/configs/cve_configs.py
@@ -37,3 +37,7 @@ class _ConfigLoaderCVE(ConfigBaseSettings):
         default=2019,
         description="Year in number. Required when pull_history is set to `True`.  Minimum 2019 as CVSS V3.1 was released in June 2019, thus most CVE published before 2019 do not include the cvssMetricV31 object.",
     )
+    import_software: bool = Field(
+        default=False,
+        description="If set to `True`, resolve CPEs associated with each CVE via the NVD CPE Match API and import them as Software objects with 'has' relationships to vulnerabilities. Warning: this can generate a large volume of data.",
+    )

--- a/external-import/cve/src/services/client/__init__.py
+++ b/external-import/cve/src/services/client/__init__.py
@@ -1,4 +1,5 @@
 from src.services.client.api import CVEClient
+from src.services.client.cpe_match import CPEMatchClient
 from src.services.client.vulnerability import CVEVulnerability
 
-__all__ = ["CVEClient", "CVEVulnerability"]
+__all__ = ["CVEClient", "CPEMatchClient", "CVEVulnerability"]

--- a/external-import/cve/src/services/client/cpe_match.py
+++ b/external-import/cve/src/services/client/cpe_match.py
@@ -25,17 +25,13 @@ class CPEMatchClient(CVEClient):
         cpe_names: set[str] = set()
         params = {"cveId": cve_id}
 
-        info_msg = (
-            f"[CPE MATCH API] Fetching CPE matches for {cve_id}"
-        )
+        info_msg = f"[CPE MATCH API] Fetching CPE matches for {cve_id}"
         self.helper.connector_logger.info(info_msg)
 
         try:
             first_response = self._request_data(self, CPE_MATCH_BASE_URL, params)
             if first_response is None:
-                warn_msg = (
-                    f"[CPE MATCH API] No response for {cve_id}, skipping CPE resolution."
-                )
+                warn_msg = f"[CPE MATCH API] No response for {cve_id}, skipping CPE resolution."
                 self.helper.connector_logger.warning(warn_msg)
                 return []
 
@@ -98,7 +94,3 @@ class CPEMatchClient(CVEClient):
             else:
                 for match in match_criteria.get("matches", []):
                     cpe_names.add(match.get("cpeName"))
-
-
-
-

--- a/external-import/cve/src/services/client/cpe_match.py
+++ b/external-import/cve/src/services/client/cpe_match.py
@@ -1,0 +1,104 @@
+from src.services.client.api import CVEClient
+
+CPE_MATCH_BASE_URL = "https://services.nvd.nist.gov/rest/json/cpematch/2.0"
+
+
+class CPEMatchClient(CVEClient):
+    """Client for the NVD CPE Match API.
+
+    Resolves CPE names associated with a given CVE ID.
+    API documentation: https://nvd.nist.gov/developers/products
+    """
+
+    def get_cpes_for_cve(self, cve_id: str) -> list[str]:
+        """Retrieve all unique CPE names associated with a CVE.
+
+        Calls the NVD CPE Match API with the given CVE ID, handles pagination,
+        and returns a deduplicated list of CPE Name strings.
+
+        Args:
+            cve_id: The CVE identifier (e.g. "CVE-2022-32223").
+
+        Returns:
+            A deduplicated list of CPE Name strings (format cpe:2.3:...).
+        """
+        cpe_names: set[str] = set()
+        params = {"cveId": cve_id}
+
+        info_msg = (
+            f"[CPE MATCH API] Fetching CPE matches for {cve_id}"
+        )
+        self.helper.connector_logger.info(info_msg)
+
+        try:
+            first_response = self._request_data(self, CPE_MATCH_BASE_URL, params)
+            if first_response is None:
+                warn_msg = (
+                    f"[CPE MATCH API] No response for {cve_id}, skipping CPE resolution."
+                )
+                self.helper.connector_logger.warning(warn_msg)
+                return []
+
+            data = first_response.json()
+            self._extract_cpe_names(data, cpe_names)
+
+            # Handle pagination
+            total_results = data.get("totalResults", 0)
+            results_per_page = data.get("resultsPerPage", 0)
+            start_index = results_per_page
+
+            while start_index < total_results:
+                paginated_params = {
+                    **params,
+                    "startIndex": start_index,
+                    "resultsPerPage": results_per_page,
+                }
+                response = self._request_data(
+                    self, CPE_MATCH_BASE_URL, paginated_params
+                )
+                if response is None:
+                    break
+                page_data = response.json()
+                self._extract_cpe_names(page_data, cpe_names)
+                results_per_page = page_data.get("resultsPerPage", 0)
+                start_index += results_per_page
+
+            info_msg = (
+                f"[CPE MATCH API] Found {len(cpe_names)} unique CPEs for {cve_id}"
+            )
+            self.helper.connector_logger.info(info_msg)
+
+        except Exception as err:
+            warn_msg = (
+                f"[CPE MATCH API] Error fetching CPEs for {cve_id}: {str(err)}. "
+                f"Continuing without CPE data."
+            )
+            self.helper.connector_logger.warning(warn_msg)
+            return []
+
+        return list(cpe_names)
+
+    @staticmethod
+    def _extract_cpe_names(data: dict, cpe_names: set[str]) -> None:
+        """Extract CPE names from a CPE Match API response.
+
+        The response contains a list of matchStrings, each containing a match
+        criteria pattern and a list of concrete CPE matches with cpeName fields.
+        We only extract the concrete cpeName values from matches, not the
+        criteria pattern itself (which may contain wildcards or version ranges).
+
+        Args:
+            data: The JSON response from the CPE Match API.
+            cpe_names: A set to collect unique CPE name strings into.
+        """
+        for match_string in data.get("matchStrings", []):
+            match_criteria = match_string.get("matchString", {})
+            if "matches" not in match_criteria or len(match_criteria["matches"]) == 0:
+                cpe_names.add(match_criteria.get("criteria"))
+            else:
+                for match in match_criteria.get("matches", []):
+                    cpe_names.add(match.get("cpeName"))
+
+
+
+

--- a/external-import/cve/src/services/client/vulnerability.py
+++ b/external-import/cve/src/services/client/vulnerability.py
@@ -71,17 +71,18 @@ class CVEVulnerability(CVEClient):
 
     def _filter_cvss(self, cve_vulnerabilities) -> list:
         cve_vulnerabilities_filtered = []
+        supported_cvss_keys = {"cvssMetricV31", "cvssMetricV40", "cvssMetricV2"}
         for cve_vulnerability in cve_vulnerabilities:
             metric_exist = cve_vulnerability["cve"]["metrics"]
             if metric_exist:
-                for key, value in metric_exist.items():
-                    # Filter on CVSS 2, 3.1, and 4.0. Don't include 3.0
-                    if (
-                        key == "cvssMetricV31"
-                        or key == "cvssMetricV40"
-                        or key == "cvssMetricV2"
-                    ):
-                        cve_vulnerabilities_filtered.append(cve_vulnerability)
+                # Check if at least one supported CVSS metric exists.
+                # A CVE can have multiple CVSS types (V2 + V3.1 + V4.0),
+                # but should only be added once.
+                has_supported_cvss = any(
+                    key in supported_cvss_keys for key in metric_exist
+                )
+                if has_supported_cvss:
+                    cve_vulnerabilities_filtered.append(cve_vulnerability)
 
         info_msg = (
             f"[API] Filter for only CVSS 2, 3.1, or 4.0 CVEs. "

--- a/external-import/cve/src/services/converter/vulnerability_to_stix2.py
+++ b/external-import/cve/src/services/converter/vulnerability_to_stix2.py
@@ -9,15 +9,21 @@ from pycti import (  # type: ignore
     Vulnerability,
 )
 from src import ConfigLoader
-from src.services.client import CVEVulnerability  # type: ignore
-from src.services.utils import APP_VERSION  # type: ignore
+from src.services.client import CPEMatchClient, CVEVulnerability  # type: ignore
+from src.services.utils import APP_VERSION, parse_cpe_uri  # type: ignore
 
 
 class CVEConverter:
     def __init__(self, helper: OpenCTIConnectorHelper, config: ConfigLoader):
         self.config = config
         self.helper = helper
+        self.import_software = self.config.cve.import_software
         self.client_api = CVEVulnerability(
+            api_key=self.config.cve.api_key.get_secret_value(),
+            helper=self.helper,
+            header=f"OpenCTI-cve/{APP_VERSION}",
+        )
+        self.cpe_match_client = CPEMatchClient(
             api_key=self.config.cve.api_key.get_secret_value(),
             helper=self.helper,
             header=f"OpenCTI-cve/{APP_VERSION}",
@@ -40,8 +46,8 @@ class CVEConverter:
 
                 # Retrieve the author object for the info message
                 info_msg = (
-                    f"[CONVERTER] Sending bundle to server with {len(vulnerabilities_bundle)} objects, "
-                    f"concerning {len(vulnerabilities_objects) - 1} vulnerabilities"
+                    f"[CONVERTER] Sending bundle to server with "
+                    f"{len(vulnerabilities_bundle)} objects"
                 )
                 self.helper.connector_logger.info(info_msg)
 
@@ -52,18 +58,27 @@ class CVEConverter:
 
     def vulnerabilities_to_stix2(self, cve_params: dict) -> Generator[list, None, None]:
         """
-        Retrieve all CVEs from NVD to convert into STIX2 format
+        Retrieve all CVEs from NVD to convert into STIX2 format.
+        When import_software is enabled, also creates Software objects and
+        'has' relationships for associated CPEs.
         :param cve_params: Dict of params
         :return: Generator of lists of data converted into STIX2
         """
         vulnerabilities_generator = self.client_api.get_vulnerabilities(cve_params)
 
         for vulnerabilities in vulnerabilities_generator:
-            vulnerabilities_stix2 = [
-                self._vulnerability_to_stix2(vulnerability)
-                for vulnerability in vulnerabilities
-            ]
-            yield vulnerabilities_stix2
+            stix_objects = []
+            for vulnerability in vulnerabilities:
+                vuln_stix = self._vulnerability_to_stix2(vulnerability)
+                stix_objects.append(vuln_stix)
+
+                if self.import_software:
+                    software_and_rels = self._resolve_cpes_for_vulnerability(
+                        vulnerability, vuln_stix
+                    )
+                    stix_objects.extend(software_and_rels)
+
+            yield stix_objects
 
     def _vulnerability_to_stix2(self, vulnerability) -> stix2.Vulnerability:
         # Getting different fields
@@ -209,6 +224,84 @@ class CVEConverter:
         )
 
         return vulnerability_to_stix2
+
+    def _resolve_cpes_for_vulnerability(
+        self, vulnerability: dict, vuln_stix: stix2.Vulnerability
+    ) -> list:
+        """
+        Resolve CPEs for a given vulnerability and create Software objects
+        with 'has' relationships.
+        :param vulnerability: Raw vulnerability dict from NVD API
+        :param vuln_stix: STIX2 Vulnerability object
+        :return: List of STIX2 Software objects and Relationship objects
+        """
+        cve_id = vulnerability["cve"]["id"]
+        stix_objects = []
+        seen_cpes = set()
+
+        cpe_names = self.cpe_match_client.get_cpes_for_cve(cve_id)
+
+        for cpe_name in cpe_names:
+            if cpe_name in seen_cpes:
+                continue
+            seen_cpes.add(cpe_name)
+
+            try:
+                software = self._create_software(cpe_name)
+                relationship = self._create_relationship(
+                    from_id=software.id,
+                    to_id=vuln_stix.id,
+                    relation="has",
+                )
+                stix_objects.append(software)
+                stix_objects.append(relationship)
+            except (ValueError, NotImplementedError) as err:
+                warn_msg = (
+                    f"[CONVERTER] Skipping CPE '{cpe_name}' for {cve_id}: {str(err)}"
+                )
+                self.helper.connector_logger.warning(warn_msg)
+                continue
+
+        if stix_objects:
+            info_msg = (
+                f"[CONVERTER] Created {len(seen_cpes)} Software objects "
+                f"for {cve_id}"
+            )
+            self.helper.connector_logger.info(info_msg)
+
+        return stix_objects
+
+    def _create_software(self, cpe_name: str) -> stix2.Software:
+        """
+        Create a STIX2 Software object from a CPE name string.
+        The stix2 library generates a deterministic ID for Software SCOs
+        based on contributing properties (name, cpe, vendor, version).
+        :param cpe_name: CPE name string (e.g. "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*")
+        :return: STIX2 Software object
+        """
+        cpe_dict = parse_cpe_uri(cpe_name)
+        vendor = cpe_dict["vendor"]
+        product = cpe_dict["product"]
+        version = cpe_dict["version"]
+
+        software_name = f"{vendor} {product}"
+        if version and version != "*":
+            software_name = f"{vendor} {product} {version}"
+
+        software_kwargs = {
+            "name": software_name,
+            "cpe": cpe_name,
+            "vendor": vendor,
+            "custom_properties": {
+                "x_opencti_created_by_ref": self.author.id,
+                "x_opencti_product": product
+            },
+        }
+
+        if version and version != "*":
+            software_kwargs["version"] = version
+
+        return stix2.Software(**software_kwargs)
 
     def _create_relationship(self, from_id: str, to_id: str, relation):
         """

--- a/external-import/cve/src/services/converter/vulnerability_to_stix2.py
+++ b/external-import/cve/src/services/converter/vulnerability_to_stix2.py
@@ -294,7 +294,7 @@ class CVEConverter:
             "vendor": vendor,
             "custom_properties": {
                 "x_opencti_created_by_ref": self.author.id,
-                "x_opencti_product": product
+                "x_opencti_product": product,
             },
         }
 

--- a/external-import/cve/src/services/utils/__init__.py
+++ b/external-import/cve/src/services/utils/__init__.py
@@ -1,5 +1,6 @@
 from src.services.utils.common import convert_hours_to_seconds
 from src.services.utils.constants import MAX_AUTHORIZED  # noqa: F401
+from src.services.utils.cpe_parser import parse_cpe_uri  # noqa: F401
 from src.services.utils.version import __version__ as APP_VERSION  # noqa: F401
 
-__all__ = ["MAX_AUTHORIZED", "convert_hours_to_seconds", "APP_VERSION"]
+__all__ = ["MAX_AUTHORIZED", "convert_hours_to_seconds", "APP_VERSION", "parse_cpe_uri"]

--- a/external-import/cve/src/services/utils/cpe_parser.py
+++ b/external-import/cve/src/services/utils/cpe_parser.py
@@ -1,0 +1,43 @@
+import re
+
+
+def parse_cpe_uri(cpe_str: str) -> dict[str, str]:
+    """Parse a CPE URI (format 1 or 2.3) and extract vendor, product, and version.
+
+    Args:
+        cpe_str: The CPE URI string (e.g. "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*")
+
+    Returns:
+        A dict with keys: part, vendor, product, version.
+
+    Raises:
+        ValueError: If the CPE URI is missing mandatory information.
+        NotImplementedError: If the CPE URI format is unknown.
+    """
+    supported_patterns = {
+        "cpe:/": (
+            r"^cpe:/(?P<part>[a-z]):"
+            r"(?P<vendor>[a-zA-Z0-9_\-]+):"
+            r"(?P<product>[a-zA-Z0-9_\-]+):"
+            r"(?P<version>[a-zA-Z0-9_\-]+)"
+        ),
+        "cpe:2.3": (
+            r"^cpe:2\.3:(?P<part>[a-z]+):"
+            r"(?P<vendor>[^:]+):"
+            r"(?P<product>[^:]+):"
+            r"(?P<version>[^:]+)"
+        ),
+    }
+    for key, supported_pattern in supported_patterns.items():
+        if cpe_str.startswith(key):
+            match = re.match(pattern=supported_pattern, string=cpe_str)
+            if match is not None:
+                return {
+                    "part": match.group("part"),
+                    "vendor": match.group("vendor"),
+                    "product": match.group("product"),
+                    "version": match.group("version"),
+                }
+            raise ValueError(f"CPE URI is missing mandatory information: {cpe_str}")
+    raise NotImplementedError(f"Unknown CPE URI format: {cpe_str}")
+

--- a/external-import/cve/src/services/utils/cpe_parser.py
+++ b/external-import/cve/src/services/utils/cpe_parser.py
@@ -40,4 +40,3 @@ def parse_cpe_uri(cpe_str: str) -> dict[str, str]:
                 }
             raise ValueError(f"CPE URI is missing mandatory information: {cpe_str}")
     raise NotImplementedError(f"Unknown CPE URI format: {cpe_str}")
-


### PR DESCRIPTION
### Proposed changes

This PR introduces the ability to optionally resolve and import CPE-associated Software entities for each CVE, and fixes a bug that caused vulnerabilities to appear multiple times in each processing batch.

**🐛 Bug Fix: Duplicate vulnerabilities in _filter_cvss**
Problem: The _filter_cvss method in vulnerability.py iterated over every key in the CVE metrics dictionary and appended the vulnerability to the filtered list once per matching CVSS key. A CVE with both cvssMetricV2 and cvssMetricV31 was included twice; one with all three supported metrics (cvssMetricV2, cvssMetricV31, cvssMetricV40) was included three times.

Fix: Replaced the inner loop with a set-based any() check so that each vulnerability is appended exactly once, regardless of how many CVSS metric types it contains.

Impact: Eliminates duplicated STIX Vulnerability objects in bundles, corrects inflated log counts, and prevents redundant processing downstream.


**✨ New Feature: Optional Software (CPE) import**
Adds a new configuration option import_software (env: CVE_IMPORT_SOFTWARE, default: false) that, when enabled, resolves CPEs associated with each CVE and imports them as STIX Software entities linked via has relationships to the corresponding Vulnerability.

**How it works**
For each CVE processed, the connector calls the [NVD CPE Match API](https://nvd.nist.gov/developers/products) (/cpematch/2.0?cveId={CVE_ID}) to retrieve associated CPE names.
Each CPE is parsed and converted into a stix2.Software object with deterministic ID (based on name, cpe, vendor, version).
A has relationship is created between the Software (source) and the Vulnerability (target), with a deterministic ID via StixCoreRelationship.generate_id.
Software objects and relationships are included in the same STIX bundle as the vulnerabilities.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/1604
* https://github.com/OpenCTI-Platform/connectors/issues/1449
* https://github.com/OpenCTI-Platform/connectors/issues/1949
* https://github.com/OpenCTI-Platform/connectors/issues/5964
* https://github.com/OpenCTI-Platform/connectors/issues/3602 
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
