### PR TITLE
Switch LTS tag format from 7.260309.0-ltsx to 7.260309.0-lts.x (#5948)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ workflows:
             - test
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts[0-9]*)?/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
             branches:
               ignore: /.*/
       - build:


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Update tag regex to trigger Circle CI release build to replace format 7.260309.0-ltsx with 7.260309.0-lts.x

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/5948