### PR TITLE
[google-ti-feeds] Allow optional configs

### DIFF
--- a/external-import/google-ti-feeds/connector/src/octi/configs/connector_config.py
+++ b/external-import/google-ti-feeds/connector/src/octi/configs/connector_config.py
@@ -12,7 +12,7 @@ class ConnectorConfig(BaseConfig):
     """Configuration for the connector."""
 
     yaml_section: ClassVar[str] = "connector"
-    model_config = SettingsConfigDict(env_prefix="connector_")
+    model_config = SettingsConfigDict(env_prefix="connector_", extra="allow")
 
     id: str = Field(
         ...,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Allow extra keys in pydantic config

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/5978

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
