### PR TITLE
[ci]: Use uv to build config_schemas 

### DIFF
--- a/shared/tools/composer/generate_connectors_config_schemas/generate_connector_config_json_schema.sh
+++ b/shared/tools/composer/generate_connectors_config_schemas/generate_connector_config_json_schema.sh
@@ -85,7 +85,7 @@ activate_venv() {
     # Method to activate isolate venv
 
     # Create isolated virtual environment in connector path
-    python -m venv "$1/$VENV_NAME"
+    uv venv "$1/$VENV_NAME"
 
     # Activate virtual environment according to OS
     if [ -f "$1/$VENV_NAME/bin/activate" ]; then
@@ -101,15 +101,15 @@ activate_venv() {
     requirements_file=$(find_requirements_txt .)
     if [ -n "$requirements_file" ]; then
       # -qq: Hides both informational and warning messages, showing only errors.
-      python -m pip install -qq -r "$requirements_file"
+      uv pip install -qq -r "$requirements_file"
     else
       # If no requirements.txt, try to install the connector as a package (assuming pyproject.toml exists)
-      python -m pip install .
+      uv pip install .
     fi
 
     # Ensure connectors-sdk is available for script generation
     echo "🔄 Installing connectors-sdk for schema generation..."
-    python -m pip install "connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk"
+    uv pip install "connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk"
 
     # Return to original working directory
     popd
@@ -130,6 +130,14 @@ deactivate_venv() {
     deactivate
     rm -rf "$1"
 }
+
+# Check if 'uv' command is installed, install if missing
+if ! command -v uv &> /dev/null; then
+  echo "🔄 'uv' not found. Installing..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+else
+  echo "✅ 'uv' is already installed."
+fi
 
 # Main script
 echo -e "\033[36mGenerating config JSON schemas for a single connector...\033[0m"
@@ -270,7 +278,7 @@ echo -e "\033[32mFound pydantic-settings and/or connectors-sdk in dependencies. 
     echo -e "\033[36m> Generating configurations table...\033[0m"
     
     # Generate configurations table in __metadata/CONNECTOR_CONFIG_DOC.md
-    python -m pip install -q --disable-pip-version-check jsonschema_markdown
+    uv pip install -q jsonschema_markdown
     
     generator_config_doc_path=$(find . -name "generate_connector_config_doc.py.sample")
     if [ -n "$generator_config_doc_path" ]; then

--- a/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.sh
+++ b/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.sh
@@ -39,7 +39,7 @@ activate_venv() {
     # Method to activate isolate venv
 
     # Create isolated virtual environment in connector path
-    python -m venv "$1/$VENV_NAME"
+    uv venv "$1/$VENV_NAME"
 
     # Activate virtual environment according to OS
     if [ -f "$1/$VENV_NAME/bin/activate" ]; then
@@ -55,15 +55,15 @@ activate_venv() {
     requirements_file=$(find_requirements_txt .)
     if [ -n "$requirements_file" ]; then
       # -qq: Hides both informational and warning messages, showing only errors.
-      python -m pip install -qq -r "$requirements_file"
+      uv pip install -qq -r "$requirements_file"
     else
       # If no requirements.txt, try to install the connector as a package (assuming pyproject.toml exists)
-      python -m pip install .
+      uv pip install .
     fi
 
     # Ensure connectors-sdk is available for script generation
     echo "🔄 Installing connectors-sdk for schema generation..."
-    python -m pip install "connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk"
+    uv pip install "connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk"
 
     # Return to original working directory
     popd
@@ -84,6 +84,14 @@ deactivate_venv() {
     deactivate
     rm -rf "$1"
 }
+
+# Check if 'uv' command is installed, install if missing
+if ! command -v uv &> /dev/null; then
+  echo "🔄 'uv' not found. Installing..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+else
+  echo "✅ 'uv' is already installed."
+fi
 
 # Find all parents directory of connector with __metadata__ directory
 connector_directories_path=$(find . -type d -name "$CONNECTOR_METADATA_DIRECTORY" | sed 's:/*'"$CONNECTOR_METADATA_DIRECTORY"'$::' | sort -u)
@@ -133,7 +141,7 @@ do
         rm "$connector_directory_path/generate_connector_config_json_schema_tmp.py"
 
         # Generate configurations table in __metadata/CONNECTOR_CONFIG_DOC.md
-        python -m pip install -q --disable-pip-version-check jsonschema_markdown
+        uv pip install -q jsonschema_markdown
         generator_config_doc_path=$(find . -name "generate_connector_config_doc.py.sample")
         cp "$generator_config_doc_path" "$connector_directory_path/generate_connector_config_doc_tmp.py"
         python "$connector_directory_path/generate_connector_config_doc_tmp.py"


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* This will reduce the time to generate all config schemas as most of the execution time is spent in gettings the requirements, and `uv pip` is way faster to do this. 
Also `uv` is part of CircleCI base img (https://github.com/CircleCI-Public/cimg-python/pull/257)
*

### Related issues

* #5947 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
