### PR TITLE
[ci] try to rebase before pushing manifest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,18 @@ jobs:
                 # Add custom flag to avoid triggering workflows
                 git commit -m "[Automation] Build and update manifest [ci build-manifest]"
                 # Push quietly to prevent showing the token in log
-                git push -q https://${GITHUB_TOKEN}@github.com/OpenCTI-Platform/connectors.git ${CIRCLE_BRANCH}   
+                if git push -q https://${GITHUB_TOKEN}@github.com/OpenCTI-Platform/connectors.git ${CIRCLE_BRANCH}; then
+                  echo "Manifest changes pushed successfully."
+                  exit 0
+                else
+                  echo "Push rejected, ${CIRCLE_BRANCH} probably moved. Trying rebase..."
+                  if ! git pull --rebase origin ${CIRCLE_BRANCH}; then
+                    echo "Rebase failed, aborting."
+                    git rebase --abort
+                    exit 1
+                  fi
+                  git push -q https://${GITHUB_TOKEN}@github.com/OpenCTI-Platform/connectors.git ${CIRCLE_BRANCH}
+                fi
               else
                 echo "Manifest not changed. Skipping commit."
                 exit 0


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Try to rebase before pushing manifest to avoid CI failure when PRs are merged in the same time.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/5947

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
