### PR TITLE
[reversinglabs-malware-presence ] Fix Note.generate_id() calls

### DIFF
--- a/internal-enrichment/reversinglabs-malware-presence/src/main.py
+++ b/internal-enrichment/reversinglabs-malware-presence/src/main.py
@@ -163,7 +163,6 @@ class ReversingLabsConnector(InternalEnrichmentConnector):
         return stix_indicator_with_relationship
 
     def _generate_stix_note(self, data):
-        now = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
         hash = data["rl"]["malware_presence"]["query_hash"]
         status = data["rl"]["malware_presence"]["status"]
         scanner_count = data["rl"]["malware_presence"]["scanner_count"]
@@ -183,7 +182,7 @@ class ReversingLabsConnector(InternalEnrichmentConnector):
 
         # Create Note
         stix_note = stix2.Note(
-            id=Note.generate_id(now, content),
+            id=Note.generate_id(None, content),
             abstract=abstract,
             content=content,
             created_by_ref=self.reversinglabs_identity["standard_id"],


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove usage of datetime.now() or format_date() (causes note duplication)
*

### Related issues

* Closes #5890
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
