### PR TITLE
[ransomwareLive] Fix "source_code" link in manifest

### DIFF
--- a/external-import/ransomwarelive/__metadata__/connector_manifest.json
+++ b/external-import/ransomwarelive/__metadata__/connector_manifest.json
@@ -13,7 +13,7 @@
   "max_confidence_level": 50,
   "support_version": ">= 6.7.5",
   "subscription_link": "https://www.ransomware.live",
-  "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/oob/connector_manager/external-import/ransomwarelive",
+  "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/ransomwarelive",
   "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-ransomwarelive",


### PR DESCRIPTION
### Proposed changes

* Update and fix manifest "source_code" value

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/6017

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
