### PR TITLE
[ESET enrichment] Add TLP for enriched report data

### DIFF
--- a/internal-enrichment/eset-enrichment/src/eset/connector.py
+++ b/internal-enrichment/eset-enrichment/src/eset/connector.py
@@ -1,12 +1,47 @@
 import base64
 import re
 import urllib.parse
+from typing import Dict, List, Mapping, Optional
 from urllib.parse import urlparse
 
 import requests
-from pycti import OpenCTIConnectorHelper, get_config_variable
+import stix2
+from pycti import MarkingDefinition, OpenCTIConnectorHelper, get_config_variable
 
 from .config_variables import ConfigConnector
+
+ALLOWED_TLPS = {
+    "tlp:clear",
+    "tlp:white",
+    "tlp:green",
+    "tlp:amber",
+    "tlp:amber+strict",
+    "tlp:red",
+}
+
+
+def create_tlp_marking(tlp_value: str) -> stix2.MarkingDefinition:
+    tlp_value_lower = tlp_value.lower()
+
+    if tlp_value_lower == "tlp:clear" or tlp_value_lower == "tlp:white":
+        return stix2.TLP_WHITE
+    if tlp_value_lower == "tlp:green":
+        return stix2.TLP_GREEN
+    if tlp_value_lower == "tlp:amber":
+        return stix2.TLP_AMBER
+    if tlp_value_lower == "tlp:amber+strict":
+        return stix2.MarkingDefinition(
+            id=MarkingDefinition.generate_id("TLP", "TLP:AMBER+STRICT"),
+            definition_type="statement",
+            definition={"statement": "custom"},
+            allow_custom=True,
+            x_opencti_definition_type="TLP",
+            x_opencti_definition="TLP:AMBER+STRICT",
+        )
+    if tlp_value_lower == "tlp:red":
+        return stix2.TLP_RED
+
+    raise ValueError(f"unknown TLP value {tlp_value}")
 
 
 class EsetConnector:
@@ -100,9 +135,18 @@ class EsetConnector:
 
         return None
 
+    def _get_tlp_from_labels(self, labels: List[Dict]) -> Optional[str]:
+        """Returns valid TLP value from object labels."""
+        if labels:
+            for label in labels:
+                if label["value"].lower() in ALLOWED_TLPS:
+                    return label["value"]
+
+        return None
+
     def enrich_report(
         self, report_object: dict, api_url: str, report_name: str
-    ) -> None:
+    ) -> Dict:
         """Download report from ESET portal and updates report STIX object."""
         with requests.get(
             api_url,
@@ -113,17 +157,16 @@ class EsetConnector:
             response.raise_for_status()
             content = response.content
 
+        file = {
+            "name": report_name,
+            "data": base64.b64encode(content).decode("utf-8"),
+            "mime_type": "application/octet-pdf",
+        }
         files = report_object.get("x_opencti_files", [])
-
-        files.append(
-            {
-                "name": report_name,
-                "data": base64.b64encode(content).decode("utf-8"),
-                "mime_type": "application/octet-pdf",
-            }
-        )
+        files.append(file)
 
         report_object["x_opencti_files"] = files
+        return file
 
     # noinspection PyMethodMayBeStatic
     def has_attachment(self, import_files: list, attachment_name: str) -> bool:
@@ -180,7 +223,40 @@ class EsetConnector:
             {"entity_id": entity_id, "name": report_name, "url": url},
         )
 
-        self.enrich_report(stix_object, url, report_name)
+        file = self.enrich_report(stix_object, url, report_name)
+
+        # Add TLP marking for file data. If the report has non-default TLP, use it.
+        # Otherwise, assign TLP specified as label.
+        tlp_marking: Optional[Mapping] = None
+
+        if enrichment_entity["objectMarking"]:
+            for marking_definition in enrichment_entity["objectMarking"]:
+                if marking_definition["definition_type"] == "TLP":
+                    tlp_marking = marking_definition
+
+        tlp_value_label: Optional[str] = self._get_tlp_from_labels(
+            enrichment_entity.get("objectLabel")
+        )
+
+        if (not tlp_value_label and tlp_marking) or (
+            tlp_marking
+            and (
+                tlp_marking["definition"].lower() != "tlp:clear"
+                and tlp_marking["definition"].lower() != "tlp:white"
+            )
+        ):
+            file["object_marking_refs"] = tlp_marking["standard_id"]
+        elif tlp_value_label:
+            tlp_marking = create_tlp_marking(tlp_value_label)
+
+            self.helper.log_debug(
+                "Adding TLP marking found as label",
+                {"entity_id": entity_id, "tlp": tlp_value_label},
+            )
+
+            stix_objects.append(tlp_marking)
+            file["object_marking_refs"] = tlp_marking["id"]
+
         stix_objects_bundle = self.helper.stix2_create_bundle(stix_objects)
 
         self.helper.log_debug(

--- a/internal-enrichment/eset-enrichment/tests/test_eset_connector.py
+++ b/internal-enrichment/eset-enrichment/tests/test_eset_connector.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import urllib.parse
 from unittest import mock
@@ -10,6 +11,15 @@ def find_call(calls, call_args: tuple):
     for call in calls:
         if call.args == call_args:
             return call
+
+
+@contextlib.contextmanager
+def patch_download(content):
+    with mock.patch("requests.get") as mock_get:
+        mock_response = mock.MagicMock(content=content, raise_for_status=mock.Mock())
+        mock_response.__enter__.return_value = mock_response
+        mock_get.return_value = mock_response
+        yield mock_get
 
 
 @pytest.mark.usefixtures("setup_config")
@@ -98,13 +108,7 @@ class TestEsetConnector(object):
         self.connector.helper.send_stix2_bundle.reset_mock()
 
         with mock.patch.object(self.connector, "host", api_host):
-            with mock.patch("requests.get") as mock_get:
-                mock_response = mock.MagicMock(
-                    content=report_payload, raise_for_status=mock.Mock()
-                )
-                mock_response.__enter__.return_value = mock_response
-                mock_get.return_value = mock_response
-
+            with patch_download(report_payload) as mock_get:
                 self.connector.process_message(enrichment_data)
 
                 mock_get.assert_called_once()
@@ -126,6 +130,109 @@ class TestEsetConnector(object):
                                 "name": "AS-2024-0005 Report.pdf",
                                 "data": "VEhJUyBJUyBNT0NLIFJFUE9SVA==",
                                 "mime_type": "application/octet-pdf",
+                                "object_marking_refs": "marking-definition--826578e1-40ad-459f-bc73-ede076f81f37",
+                            }
+                        ]
+                        break
+                else:
+                    assert False, "Report not found in sent bundle"
+                self.connector.helper.send_stix2_bundle.reset_mock()
+
+    @pytest.mark.parametrize("api_host", ["https://eti.eset.com/"])
+    @pytest.mark.usefixtures("enrichment_data")
+    @pytest.mark.usefixtures("report_payload")
+    def test_enrich_entity_with_default_tlp(
+        self, api_host, enrichment_data, report_payload
+    ):
+        self.connector.helper.send_stix2_bundle.reset_mock()
+
+        enrichment_data["enrichment_entity"]["objectMarking"] = [
+            {
+                "id": "aa707c73-6fe6-487e-9e99-99d30ecd6614",
+                "standard_id": "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9",
+                "entity_type": "Marking-Definition",
+                "definition_type": "TLP",
+                "definition": "TLP:CLEAR",
+                "created": "2026-03-12T11:39:41.424Z",
+                "modified": "2026-03-12T11:54:57.183Z",
+                "x_opencti_order": 1,
+                "x_opencti_color": "#ffffff",
+                "createdById": None,
+            }
+        ]
+
+        with mock.patch.object(self.connector, "host", api_host):
+            with patch_download(report_payload):
+                self.connector.process_message(enrichment_data)
+
+                for o in json.loads(
+                    self.connector.helper.send_stix2_bundle.call_args.args[0]
+                )["objects"]:
+                    if o["type"] == "report":
+                        assert o["x_opencti_files"] == [
+                            {
+                                "name": "AS-2024-0005 Report.pdf",
+                                "data": "VEhJUyBJUyBNT0NLIFJFUE9SVA==",
+                                "mime_type": "application/octet-pdf",
+                                "object_marking_refs": "marking-definition--826578e1-40ad-459f-bc73-ede076f81f37",
+                            }
+                        ]
+                        break
+                else:
+                    assert False, "Report not found in sent bundle"
+                self.connector.helper.send_stix2_bundle.reset_mock()
+
+    @pytest.mark.parametrize("api_host", ["https://eti.eset.com/"])
+    @pytest.mark.usefixtures("enrichment_data")
+    @pytest.mark.usefixtures("report_payload")
+    def test_enrich_entity_with_default_tlp_and_missing_label_tlp(
+        self, api_host, enrichment_data, report_payload
+    ):
+        self.connector.helper.send_stix2_bundle.reset_mock()
+
+        enrichment_data["enrichment_entity"]["objectMarking"] = [
+            {
+                "id": "aa707c73-6fe6-487e-9e99-99d30ecd6614",
+                "standard_id": "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9",
+                "entity_type": "Marking-Definition",
+                "definition_type": "TLP",
+                "definition": "TLP:CLEAR",
+                "created": "2026-03-12T11:39:41.424Z",
+                "modified": "2026-03-12T11:54:57.183Z",
+                "x_opencti_order": 1,
+                "x_opencti_color": "#ffffff",
+                "createdById": None,
+            }
+        ]
+        enrichment_data["enrichment_entity"]["objectLabel"] = [
+            {
+                "id": "e2528867-8a15-423e-909c-744eb1007c61",
+                "value": "activity summary",
+                "color": "#95b717",
+                "createdById": None,
+            },
+            {
+                "id": "4aa66244-3479-4821-8ed7-38d5aa7b65c5",
+                "value": "eset",
+                "color": "#dda52f",
+                "createdById": None,
+            },
+        ]
+
+        with mock.patch.object(self.connector, "host", api_host):
+            with patch_download(report_payload):
+                self.connector.process_message(enrichment_data)
+
+                for o in json.loads(
+                    self.connector.helper.send_stix2_bundle.call_args.args[0]
+                )["objects"]:
+                    if o["type"] == "report":
+                        assert o["x_opencti_files"] == [
+                            {
+                                "name": "AS-2024-0005 Report.pdf",
+                                "data": "VEhJUyBJUyBNT0NLIFJFUE9SVA==",
+                                "mime_type": "application/octet-pdf",
+                                "object_marking_refs": "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9",
                             }
                         ]
                         break


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

ESET enrichment connector adds TLP marking for downloaded data based on:
* Report TLP
* or TLP value found amongst Report object labels

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->
