### PR TITLE
[mwdb] Fix silent C2 data loss when config entries are dicts

### DIFF
--- a/external-import/mwdb/src/mwdb.py
+++ b/external-import/mwdb/src/mwdb.py
@@ -296,9 +296,12 @@ class MWDB:
         if "c2" in config.cfg:
             for c2 in config.cfg["c2"]:
                 try:
+                    if isinstance(c2, dict):
+                        c2 = c2.get("host", str(c2))
+                    c2 = str(c2)
                     if re.match("^https?://.*", c2):
                         c2obj.extend(self.process_c2(c2, virus, "c2-url"))
-                    if re.match(
+                    elif re.match(
                         r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d{1,5})?",
                         c2,
                     ):


### PR DESCRIPTION
### Proposed changes

- Handle C2 entries returned as dicts (e.g. `{"host": "1.2.3.4", "port": 443}`) by extracting the `host` key, with `str()` fallback
- Coerce all C2 values to `str` before regex matching to prevent `TypeError` on non-string types
- Change second regex branch from `if` to `elif` to prevent double-processing when a C2 URL contains an IP address (e.g. `http://1.2.3.4:8080` would previously match both URL and IP branches)

### Related issues

- Closes #6042

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

MWDB configs from certain malware families (e.g. some Emotet, AgentTesla variants) return C2 entries as dicts rather than plain strings. When this happens, `re.match()` receives a dict and raises `TypeError`, which is silently swallowed by the broad `except Exception` clause in `process_config`. The C2 indicator is dropped with no visible error — the connector logs a generic error but continues, so operators have no indication that C2 data is being lost.

This is a minimal 4-line fix (3 additions + 1 `if` → `elif` change) confined to `process_config` in `external-import/mwdb/src/mwdb.py`.