### PR TITLE
[all] chore: Do not check PR title if author is renovate

### DIFF
--- a/.github/workflows/pr-check-conventions.yml
+++ b/.github/workflows/pr-check-conventions.yml
@@ -57,6 +57,7 @@ jobs:
           fi
   check-pr-title-convention:
     name: Check that PR title follows convention
+    if: ${{ github.event.pull_request.user.login != 'renovate[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     "filigran team"
   ],
   "prConcurrentLimit": 2,
+  "commitMessagePrefix": "[tool] chore(deps):",
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
### Proposed changes

* Skip PR title convention check for Renovate bot PRs — Renovate generates commit messages in its own format (e.g. `Update dependency X to vY`) which doesn't conform to the project's conventional commit convention, causing false CI failures.
* Add `commitMessagePrefix` to `renovate.json` so Renovate-generated commits use the `[tool] chore(deps):` prefix, aligning with project conventions where applicable.

### Related issues

* Close #6077

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Renovate bot PRs were failing the `check-pr-title-convention` job because the bot doesn't produce conventional commit-style PR titles. Rather than adjusting the Renovate config to match (which would be fragile), the CI job now skips the check entirely when the PR author is `renovate[bot]`. The `commitMessagePrefix` addition is a best-effort alignment for the commit messages themselves.