### PR TITLE
[cisa-kev]: Add KEV flag only mode option (Fixes #6113)

### DIFF
--- a/external-import/cisa-known-exploited-vulnerabilities/.env.sample
+++ b/external-import/cisa-known-exploited-vulnerabilities/.env.sample
@@ -1,3 +1,6 @@
 # OpenCTI configuration
 OPENCTI_URL=http://localhost:PORT
 OPENCTI_TOKEN=ChangeMe
+
+# CISA KEV connector specific
+#CISA_KEV_FLAG_ONLY=false

--- a/external-import/cisa-known-exploited-vulnerabilities/README.md
+++ b/external-import/cisa-known-exploited-vulnerabilities/README.md
@@ -22,6 +22,7 @@ The CISA KEV connector imports the Known Exploited Vulnerabilities Catalog from 
     - [Manual Deployment](#manual-deployment)
   - [Usage](#usage)
   - [Behavior](#behavior)
+    - [KEV Flag Only Mode](#kev-flag-only-mode)
   - [Debugging](#debugging)
   - [Additional information](#additional-information)
 
@@ -65,6 +66,7 @@ There are a number of configuration options, which are set either in `docker-com
 |-------------------------|----------------------------|---------------------------------|-------------------------------------------------------------------------------|-----------|------------------------------------------------------------------------|
 | Catalog URL             | cisa.catalog_url           | `CISA_CATALOG_URL`              | https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json | No   | URL of the CISA KEV catalog JSON feed.                                 |
 | Create Infrastructures  | cisa.create_infrastructures| `CISA_CREATE_INFRASTRUCTURES`   | true                                                                          | No        | Create Infrastructure entities for affected products.                  |
+| KEV Flag Only           | cisa.kev_flag_only         | `CISA_KEV_FLAG_ONLY`            | false                                                                         | No        | When enabled, the connector only sets the `x_opencti_cisa_kev` flag on Vulnerability objects without modifying any other attribute (description, dates, markings) and without creating additional entities or relationships. See [KEV Flag Only Mode](#kev-flag-only-mode). |
 | TLP                     | cisa.tlp                   | `CISA_TLP`                      | TLP:CLEAR                                                                     | No        | TLP marking for imported data (`TLP:CLEAR`, `TLP:GREEN`, `TLP:AMBER`, `TLP:AMBER+STRICT`, `TLP:RED`). |
 | Interval (deprecated)   | cisa.interval              | `CISA_INTERVAL`                 | 7                                                                             | No        | **[DEPRECATED]** Interval in days between runs. Use `CONNECTOR_DURATION_PERIOD` instead. |
 
@@ -93,6 +95,7 @@ Configure the connector in `docker-compose.yml`:
       - CONNECTOR_DURATION_PERIOD=P1D
       - CISA_CATALOG_URL=https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
       - CISA_CREATE_INFRASTRUCTURES=true
+      - CISA_KEV_FLAG_ONLY=false
       - CISA_TLP=TLP:CLEAR
     restart: always
 ```
@@ -183,8 +186,26 @@ graph LR
 
 1. **Catalog Version Check**: Only processes if catalog `dateReleased` has changed since last run
 2. **Custom Property**: All vulnerabilities marked with `x_opencti_cisa_kev: true` for easy filtering
-3. **Vendor Tracking**: Creates Identity entities for each unique vendor
-4. **Optional Infrastructure**: Can optionally create Infrastructure entities for affected products
+3. **Vendor Tracking**: Creates Identity entities for each unique vendor (disabled in KEV Flag Only mode)
+4. **Optional Infrastructure**: Can optionally create Infrastructure entities for affected products (disabled in KEV Flag Only mode)
+
+### KEV Flag Only Mode
+
+When `CISA_KEV_FLAG_ONLY` is set to `true`, the connector operates in a minimal mode where it **only** sets the `x_opencti_cisa_kev: true` custom property on Vulnerability objects. In this mode:
+
+- **No attribute is modified** on the Vulnerability besides `x_opencti_cisa_kev` (no description, creation date, or TLP marking is set)
+- **No additional entities** are created (no CISA Identity, vendor Identity, Software, or Infrastructure)
+- **No relationships** are created
+
+This is useful when you already have Vulnerability data from other sources (e.g., a CVE connector) and you only want to tag which ones appear in the CISA KEV catalog, without overwriting any existing attributes.
+
+**Example configuration:**
+
+```yaml
+- CISA_KEV_FLAG_ONLY=true
+```
+
+> **Note:** When `CISA_KEV_FLAG_ONLY` is enabled, the `CISA_CREATE_INFRASTRUCTURES` and `CISA_TLP` options have no effect.
 
 ### Filtering KEV Vulnerabilities
 

--- a/external-import/cisa-known-exploited-vulnerabilities/__metadata__/connector_config_schema.json
+++ b/external-import/cisa-known-exploited-vulnerabilities/__metadata__/connector_config_schema.json
@@ -62,6 +62,11 @@
       "description": "Allows you to create or not create an infrastructure in OpenCTI.",
       "type": "boolean"
     },
+    "CISA_KEV_FLAG_ONLY": {
+      "default": false,
+      "description": "When enabled, the connector only sets the x_opencti_cisa_kev flag on Vulnerability objects without creating additional entities (vendors, software, infrastructures) or relationships.",
+      "type": "boolean"
+    },
     "CISA_TLP": {
       "default": "TLP:CLEAR",
       "description": "Traffic Light Protocol (TLP) level to apply on objects imported into OpenCTI. Possible values: TLP:CLEAR, TLP:GREEN, TLP:AMBER, TLP:AMBER+STRICT, TLP:RED.",

--- a/external-import/cisa-known-exploited-vulnerabilities/src/main.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/main.py
@@ -30,6 +30,7 @@ class Cisa:
         # Extra config
         self.cisa_catalog_url = self.config.cisa.catalog_url
         self.cisa_create_infrastructures = self.config.cisa.create_infrastructures
+        self.cisa_kev_flag_only = self.config.cisa.kev_flag_only
         self.tlp = self.config.cisa.tlp
         self.cisa_interval = self.config.cisa.interval
 
@@ -111,8 +112,24 @@ class Cisa:
     def build_bundle(self, data):
         self.helper.log_info("Building CISA Bundle")
         vuln = data
-        stix_objects = [self.created_by_stix]
         vuln_cve = vuln["cveID"]
+
+        # In kev_flag_only mode, only emit a minimal Vulnerability carrying
+        # the x_opencti_cisa_kev flag — no description, dates, markings,
+        # vendors, software, infrastructures or relationships are touched.
+        if self.cisa_kev_flag_only:
+            stix_vuln = stix2.Vulnerability(
+                id=Vulnerability.generate_id(vuln_cve),
+                name=vuln_cve,
+                custom_properties={
+                    "x_opencti_cisa_kev": True,
+                },
+            )
+            bundle = self.helper.stix2_create_bundle([stix_vuln])
+            self.helper.log_info("CISA Bundle Complete (KEV flag only mode)")
+            return bundle
+
+        stix_objects = [self.created_by_stix]
         vendor_name = vuln["vendorProject"]
         product = vuln["product"]
         description = vuln["shortDescription"]
@@ -134,6 +151,7 @@ class Cisa:
             },
         )
         stix_objects.append(stix_vuln)
+
         vuln_id = stix_vuln["id"]
 
         # Software vendor

--- a/external-import/cisa-known-exploited-vulnerabilities/src/models/configs/cisakev_configs.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/models/configs/cisakev_configs.py
@@ -31,6 +31,10 @@ class _ConfigLoaderCISAKEV(ConfigBaseSettings):
         default=True,
         description="Allows you to create or not create an infrastructure in OpenCTI.",
     )
+    kev_flag_only: bool = Field(
+        default=False,
+        description="When enabled, the connector only sets the x_opencti_cisa_kev flag on Vulnerability objects without creating additional entities (vendors, software, infrastructures) or relationships.",
+    )
     tlp: TLPToLower = Field(
         default="TLP:CLEAR",
         description="Traffic Light Protocol (TLP) level to apply on objects imported into OpenCTI. Possible values: TLP:CLEAR, TLP:GREEN, TLP:AMBER, TLP:AMBER+STRICT, TLP:RED.",


### PR DESCRIPTION
### Proposed changes

Add a new `CISA_KEV_FLAG_ONLY` configuration option that, when enabled, makes the connector only set the `x_opencti_cisa_kev` flag on Vulnerability objects without modifying other attributes (description, dates, markings) or creating additional entities and relationships.

This is useful when vulnerability data is already managed by another source (e.g. CVE connector) and only the KEV tagging is needed

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/6113

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
