### PR TITLE
[intel471] Fix proxy URL handling in V2 connector

### DIFF
--- a/external-import/intel471_v2/src/intel471/backend.py
+++ b/external-import/intel471_v2/src/intel471/backend.py
@@ -45,8 +45,9 @@ def get_client(
 ) -> ClientWrapper:
     config_kwargs = {"username": api_username, "password": api_key}
     if proxy_url:
-        config_kwargs["proxy"] = proxy_url
-        if proxy_auth := parse_url(proxy_url).auth:
+        proxy_url_str = str(proxy_url)
+        config_kwargs["proxy"] = proxy_url_str
+        if proxy_auth := parse_url(proxy_url_str).auth:
             config_kwargs["proxy_headers"] = make_headers(proxy_basic_auth=proxy_auth)
 
     if backend_name == BackendName.TITAN:

--- a/external-import/intel471_v2/tests/tests_connector/test_backend.py
+++ b/external-import/intel471_v2/tests/tests_connector/test_backend.py
@@ -1,0 +1,89 @@
+from unittest.mock import patch
+import base64
+
+import pytest
+from pydantic import HttpUrl
+
+from intel471.backend import BackendName, get_client
+
+BACKENDS = [
+    pytest.param(BackendName.TITAN, "intel471.backend.titan_client", id="titan"),
+    pytest.param(BackendName.VERITY471, "intel471.backend.verity471", id="verity471"),
+]
+
+
+@pytest.mark.parametrize("backend_name, patch_target", BACKENDS)
+@pytest.mark.parametrize(
+    "proxy_url",
+    [
+        pytest.param("http://proxy.example.com:3128", id="string"),
+        pytest.param(HttpUrl("http://proxy.example.com:3128"), id="httpurl"),
+    ],
+)
+def test_get_client_proxy_without_auth_is_set(proxy_url, backend_name, patch_target):
+    """
+    Test that get_client correctly handles both string and Pydantic HttpUrl proxy values.
+    A TypeError was raised when an HttpUrl was passed directly to urllib3's parse_url(), which
+    expects a plain string. The fix converts proxy_url to str() before use.
+    """
+    with patch(patch_target) as mock_client:
+        get_client(
+            backend_name=backend_name,
+            api_username="test-user",
+            api_key="test-key",
+            proxy_url=proxy_url,
+        )
+
+        call_kwargs = mock_client.Configuration.call_args.kwargs
+        assert isinstance(call_kwargs["proxy"], str)
+        assert call_kwargs["proxy"].startswith("http://proxy.example.com:3128")
+        assert "proxy_headers" not in call_kwargs
+
+
+@pytest.mark.parametrize("backend_name, patch_target", BACKENDS)
+@pytest.mark.parametrize(
+    "proxy_url",
+    [
+        pytest.param("http://user:pass@proxy.example.com:3128", id="string"),
+        pytest.param(HttpUrl("http://user:pass@proxy.example.com:3128"), id="httpurl"),
+    ],
+)
+def test_get_client_proxy_auth_headers_are_set(proxy_url, backend_name, patch_target):
+    """
+    Test that get_client extracts proxy auth credentials and sets proxy_headers for both
+    string and HttpUrl proxy values that contain user:password credentials.
+    """
+    with patch(patch_target) as mock_client:
+        get_client(
+            backend_name=backend_name,
+            api_username="test-user",
+            api_key="test-key",
+            proxy_url=proxy_url,
+        )
+
+        call_kwargs = mock_client.Configuration.call_args.kwargs
+        assert isinstance(call_kwargs["proxy"], str)
+        assert call_kwargs["proxy"].startswith(
+            "http://user:pass@proxy.example.com:3128"
+        )
+        expected_auth = base64.b64encode(b"user:pass").decode()
+        assert call_kwargs["proxy_headers"] == {
+            "proxy-authorization": f"Basic {expected_auth}"
+        }
+
+
+@pytest.mark.parametrize("backend_name, patch_target", BACKENDS)
+def test_get_client_without_proxy(backend_name, patch_target):
+    """
+    Test that get_client omits proxy-related config when no proxy_url is provided.
+    """
+    with patch(patch_target) as mock_client:
+        get_client(
+            backend_name=backend_name,
+            api_username="test-user",
+            api_key="test-key",
+        )
+
+        call_kwargs = mock_client.Configuration.call_args.kwargs
+        assert "proxy" not in call_kwargs
+        assert "proxy_headers" not in call_kwargs

--- a/external-import/intel471_v2/tests/tests_connector/test_backend.py
+++ b/external-import/intel471_v2/tests/tests_connector/test_backend.py
@@ -1,10 +1,9 @@
-from unittest.mock import patch
 import base64
+from unittest.mock import patch
 
 import pytest
-from pydantic import HttpUrl
-
 from intel471.backend import BackendName, get_client
+from pydantic import HttpUrl
 
 BACKENDS = [
     pytest.param(BackendName.TITAN, "intel471.backend.titan_client", id="titan"),


### PR DESCRIPTION
### Proposed changes

`Intel471Connector` passes `self.config.intel471.proxy` (declared as `HttpUrl | None` in `intel471/settings.py`) straight into `backend.get_client(..., proxy_url=...)`. The previous shape handed that value directly to `urllib3.util.parse_url`, which raises `TypeError` on a Pydantic `HttpUrl` (`parse_url` expects a plain `str`) — every proxy-configured deployment crashed on startup (Issue #6141).

The fix casts `proxy_url` to `str` once, then both feeds the string to the `Configuration(proxy=...)` kwarg and parses the basic-auth out of it with `parse_url`. New tests cover the proxy-handling path end-to-end for both `str` and Pydantic-`HttpUrl` inputs, with and without `user:pass@…` basic-auth, across both `titan` and `verity471` backends — the case that triggered #6141 is now a regression test.

### Related issues

Closes #6141

### Follow-up (non-blocking)

Copilot reviewer suggested widening the `get_client` signature from `Union[str, None]` to `Union[str, HttpUrl, None]` so the static type matches what the only real caller actually passes. The runtime cast already handles both shapes correctly, and `maintainer_can_modify: false` on this PR prevents pushing the one-line annotation tweak from the maintainer side — left as a follow-up cleanup so this clean bug-fix can land.

### Checklist

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key
- [x] I tested the code for its functionality using different use cases
- [~] I added/updated the relevant documentation
- [x] Where necessary I refactored code to improve the overall quality
