### PR TITLE
[Zscaler] Fix call fails after Zscaler session expiration

### DIFF
--- a/stream/zscaler/src/stream_connector/connector.py
+++ b/stream/zscaler/src/stream_connector/connector.py
@@ -47,7 +47,7 @@ class ZscalerConnector:
             self.opencti_url, self.opencti_token, ssl_verify=self.ssl_verify
         )
 
-        self.zscaler_base_url="https://zsapi.zscalertwo.net/api/v1"
+        self.zscaler_base_url = "https://zsapi.zscalertwo.net/api/v1"
         self.session = requests.Session()
 
         self.rate_limit = 400  # Limit to 400 requests per hour
@@ -98,7 +98,6 @@ class ZscalerConnector:
                 f"Failed to authenticate with Zscaler: {status_code} - {text}"
             )
 
-
     def handle_rate_limit(self, request_func, *args, **kwargs):
         """Handle rate limits for the Zscaler API by applying a delay if the limit is reached."""
 
@@ -117,11 +116,13 @@ class ZscalerConnector:
                 time.sleep(int(retry_after))
 
             if response and response.status_code == 401:
-                msg = f"Request failed with status 401 : SESSION_NOT_VALID. Re-authentication has started..."
+                msg = "Request failed with status 401 : SESSION_NOT_VALID. Re-authentication has started..."
                 self.helper.connector_logger.warning(msg)
                 self.authenticate_with_zscaler()
                 if not self.session.cookies.get("JSESSIONID"):
-                    self.helper.connector_logger.error("Re-authentication failed, aborting retry.")
+                    self.helper.connector_logger.error(
+                        "Re-authentication failed, aborting retry."
+                    )
                     return None
                 continue
             else:
@@ -151,9 +152,7 @@ class ZscalerConnector:
         lookup_url = f"{self.zscaler_base_url}/urlLookup"
         payload = json.dumps([domain])
 
-        response = self.handle_rate_limit(
-            self.session.post, lookup_url, data=payload
-        )
+        response = self.handle_rate_limit(self.session.post, lookup_url, data=payload)
 
         msg = f"=== Checking domain {domain} ==="
         self.helper.connector_logger.debug(msg)
@@ -229,9 +228,7 @@ class ZscalerConnector:
             "urls": [domain],
         }
 
-        response = self.handle_rate_limit(
-            self.session.put, base_url, json=payload
-        )
+        response = self.handle_rate_limit(self.session.put, base_url, json=payload)
 
         if response and response.status_code == 200:
             msg = f"Successfully sent {event_type} for {domain}."

--- a/stream/zscaler/src/stream_connector/connector.py
+++ b/stream/zscaler/src/stream_connector/connector.py
@@ -114,6 +114,7 @@ class ZscalerConnector:
                 msg = f"Rate limit exceeded. Retrying in {retry_after} seconds..."
                 self.helper.connector_logger.warning(msg)
                 time.sleep(int(retry_after))
+                continue
 
             if response and response.status_code == 401:
                 msg = "Request failed with status 401 : SESSION_NOT_VALID. Re-authentication has started..."

--- a/stream/zscaler/src/stream_connector/connector.py
+++ b/stream/zscaler/src/stream_connector/connector.py
@@ -47,9 +47,8 @@ class ZscalerConnector:
             self.opencti_url, self.opencti_token, ssl_verify=self.ssl_verify
         )
 
-        self.zscaler_token = None
-        self.zscaler_token_expiry = None
-        self.session_cookie = None  # To store the JSESSIONID
+        self.zscaler_base_url="https://zsapi.zscalertwo.net/api/v1"
+        self.session = requests.Session()
 
         self.rate_limit = 400  # Limit to 400 requests per hour
         self.retry_delay = 65  # Retry delay in seconds
@@ -58,7 +57,7 @@ class ZscalerConnector:
         """Authenticate with Zscaler and obtain a session token."""
         self.helper.connector_logger.info("Authenticating with Zscaler...")
 
-        url = "https://zsapi.zscalertwo.net/api/v1/authenticatedSession"
+        url = f"{self.zscaler_base_url}/authenticatedSession"
         timestamp = str(int(time.time() * 1000))
         obfuscated_api_key = obfuscate_api_key(self.api_key, timestamp)
 
@@ -71,7 +70,7 @@ class ZscalerConnector:
         headers = {"Content-Type": "application/json"}
 
         response = self.handle_rate_limit(
-            requests.post, url, json=payload, headers=headers
+            self.session.post, url, json=payload, headers=headers
         )
 
         safe_payload = sanitize_payload(payload)
@@ -79,30 +78,18 @@ class ZscalerConnector:
             f"Payload sent (sanitized): {json.dumps(safe_payload, indent=4)}"
         )
 
-        if response:
+        if response and response.status_code == 200:
             self.helper.connector_logger.debug(
                 f"Raw response from Zscaler: {response.text}"
             )
-
-        if response and response.status_code == 200:
             # retrieve the JSESSIONID cookie
-            self.session_cookie = response.cookies.get("JSESSIONID")
-
-            # if not found → try an authToken in the JSON (depending on the Zscaler tenant)
-            if not self.session_cookie:
-                try:
-                    data = response.json()
-                    self.session_cookie = data.get("authToken")
-                except Exception:
-                    self.session_cookie = None
-
-            if self.session_cookie:
+            if self.session.cookies.get("JSESSIONID"):
                 self.helper.connector_logger.info(
-                    f"Authenticated successfully with Zscaler. Token: {self.session_cookie[:10]}..."
+                    "Authenticated successfully with Zscaler."
                 )
             else:
                 self.helper.connector_logger.error(
-                    "Authentication succeeded but no session token found in the response."
+                    "Authentication succeeded but no JSESSIONID cookie found in the response."
                 )
         else:
             status_code = response.status_code if response else "No response"
@@ -110,7 +97,7 @@ class ZscalerConnector:
             self.helper.connector_logger.error(
                 f"Failed to authenticate with Zscaler: {status_code} - {text}"
             )
-            self.session_cookie = None
+
 
     def handle_rate_limit(self, request_func, *args, **kwargs):
         """Handle rate limits for the Zscaler API by applying a delay if the limit is reached."""
@@ -122,11 +109,21 @@ class ZscalerConnector:
             response = request_func(*args, **kwargs)
             if response and response.status_code == 200:
                 return response
+
             if response and response.status_code == 429:
                 retry_after = response.headers.get("Retry-After", retry_delay)
                 msg = f"Rate limit exceeded. Retrying in {retry_after} seconds..."
                 self.helper.connector_logger.warning(msg)
                 time.sleep(int(retry_after))
+
+            if response and response.status_code == 401:
+                msg = f"Request failed with status 401 : SESSION_NOT_VALID. Re-authentication has started..."
+                self.helper.connector_logger.warning(msg)
+                self.authenticate_with_zscaler()
+                if not self.session.cookies.get("JSESSIONID"):
+                    self.helper.connector_logger.error("Re-authentication failed, aborting retry.")
+                    return None
+                continue
             else:
                 msg = f"Request failed with status {response.status_code}: {response.text}"
                 self.helper.connector_logger.error(msg)
@@ -134,16 +131,6 @@ class ZscalerConnector:
 
         self.helper.connector_logger.error("Max retries reached. Request failed.")
         return None
-
-    def get_zscaler_session_cookie(self):
-        """Retrieve or renew the Zscaler session by getting the JSESSIONID cookie."""
-
-        if self.session_cookie is None:
-            self.helper.connector_logger.warning(
-                "Zscaler session expired or missing. Re-authenticating..."
-            )
-            self.authenticate_with_zscaler()
-        return self.session_cookie
 
     def extract_domain(self, pattern):
         """Extract domain from the STIX pattern if it follows the format [domain-name:value = 'example.com']"""
@@ -160,18 +147,12 @@ class ZscalerConnector:
 
     def get_domain_classification_in_zscaler(self, domain):
         """Retrieve the classification of a domain in Zscaler via the urlLookup API."""
-        session_cookie = self.get_zscaler_session_cookie()
 
-        headers = {
-            "Content-Type": "application/json",
-            "Cookie": f"JSESSIONID={session_cookie}",
-        }
-
-        lookup_url = "https://zsapi.zscalertwo.net/api/v1/urlLookup"
+        lookup_url = f"{self.zscaler_base_url}/urlLookup"
         payload = json.dumps([domain])
 
         response = self.handle_rate_limit(
-            requests.post, lookup_url, headers=headers, data=payload
+            self.session.post, lookup_url, data=payload
         )
 
         msg = f"=== Checking domain {domain} ==="
@@ -188,15 +169,9 @@ class ZscalerConnector:
     def get_zscaler_blocked_domains(self):
         """Retrieve the list of blocked domains in the specified Zscaler blacklist."""
 
-        session_cookie = self.get_zscaler_session_cookie()
-        headers = {
-            "Content-Type": "application/json",
-            "Cookie": f"JSESSIONID={session_cookie}",
-        }
-
         # Dynamic URL for blacklisting
-        url = f"https://zsapi.zscalertwo.net/api/v1/urlCategories/{self.zscaler_blacklist_name}"
-        response = self.handle_rate_limit(requests.get, url, headers=headers)
+        url = f"{self.zscaler_base_url}/urlCategories/{self.zscaler_blacklist_name}"
+        response = self.handle_rate_limit(self.session.get, url)
 
         if response and response.status_code == 200:
             return response.json().get("urls", [])
@@ -208,13 +183,8 @@ class ZscalerConnector:
         return []
 
     def get_current_configured_name(self):
-        session_cookie = self.get_zscaler_session_cookie()
-        headers = {
-            "Content-Type": "application/json",
-            "Cookie": f"JSESSIONID={session_cookie}",
-        }
-        url = f"https://zsapi.zscalertwo.net/api/v1/urlCategories/{self.zscaler_blacklist_name}"
-        response = self.handle_rate_limit(requests.get, url, headers=headers)
+        url = f"{self.zscaler_base_url}/urlCategories/{self.zscaler_blacklist_name}"
+        response = self.handle_rate_limit(self.session.get, url)
         if response and response.status_code == 200:
             return response.json().get("configuredName")
         return None
@@ -243,18 +213,12 @@ class ZscalerConnector:
 
     def send_to_zscaler(self, domain, event_type):
         """Send creation or deletion events to Zscaler."""
-        session_cookie = self.get_zscaler_session_cookie()
-        headers = {
-            "Content-Type": "application/json",
-            "Cookie": f"JSESSIONID={session_cookie}",
-        }
-
         real_configured_name = self.get_current_configured_name()
 
         if event_type == "create":
-            base_url = f"https://zsapi.zscalertwo.net/api/v1/urlCategories/{self.zscaler_blacklist_name}?action=ADD_TO_LIST"
+            base_url = f"{self.zscaler_base_url}/urlCategories/{self.zscaler_blacklist_name}?action=ADD_TO_LIST"
         elif event_type == "delete":
-            base_url = f"https://zsapi.zscalertwo.net/api/v1/urlCategories/{self.zscaler_blacklist_name}?action=REMOVE_FROM_LIST"
+            base_url = f"{self.zscaler_base_url}/urlCategories/{self.zscaler_blacklist_name}?action=REMOVE_FROM_LIST"
         else:
             msg = "Unsupported event type."
             self.helper.connector_logger.error(msg)
@@ -266,7 +230,7 @@ class ZscalerConnector:
         }
 
         response = self.handle_rate_limit(
-            requests.put, base_url, headers=headers, json=payload
+            self.session.put, base_url, json=payload
         )
 
         if response and response.status_code == 200:
@@ -286,18 +250,12 @@ class ZscalerConnector:
     def activate_zscaler_changes(self, max_retries=5, delay=30):
         """Activate configuration changes in Zscaler with retry/backoff handled by tenacity."""
 
-        session_cookie = self.get_zscaler_session_cookie()
-        headers = {
-            "Content-Type": "application/json",
-            "Cookie": f"JSESSIONID={session_cookie}",
-        }
-
-        status_url = "https://zsapi.zscalertwo.net/api/v1/status"
-        activate_url = "https://zsapi.zscalertwo.net/api/v1/status/activate"
+        status_url = f"{self.zscaler_base_url}/status"
+        activate_url = f"{self.zscaler_base_url}/status/activate"
 
         for attempt in range(1, max_retries + 1):
             # Check if already ACTIVE/PENDING/INPROGRESS
-            status_resp = requests.get(status_url, headers=headers)
+            status_resp = self.session.get(status_url)
             if status_resp and status_resp.status_code == 200:
                 status = status_resp.json().get("status")
                 if status in ("ACTIVE", "PENDING", "INPROGRESS"):
@@ -307,7 +265,7 @@ class ZscalerConnector:
                     return True
 
             # Try activation
-            resp = requests.post(activate_url, headers=headers)
+            resp = self.session.post(activate_url)
             if resp and resp.status_code == 200:
                 self.helper.connector_logger.info("Zscaler configuration activated.")
                 return True

--- a/stream/zscaler/tests/conftest.py
+++ b/stream/zscaler/tests/conftest.py
@@ -1,0 +1,72 @@
+import pytest
+from unittest.mock import Mock
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+from stream_connector import ZscalerConnector
+from stream_connector.utils import obfuscate_api_key
+from pycti import OpenCTIConnectorHelper
+
+@pytest.fixture(autouse=True)
+def mock_obfuscate(monkeypatch):
+    """Mock obfuscate_api_key to return a dummy string."""
+    monkeypatch.setattr("stream_connector.utils.obfuscate_api_key", lambda api_key, timestamp: "dummy-obfuscated")
+
+@pytest.fixture
+def connector(helper_mock, mock_config, mock_session, mock_opencti_client):
+    """Provide a ZscalerConnector instance with mocked config, session and OpenCTI client"""
+    from stream_connector import connector
+
+    zscaler_connector = connector.ZscalerConnector(
+        config_path=None,
+        helper=helper_mock,
+        opencti_url=mock_config.opencti.url,
+        opencti_token=mock_config.opencti.token,
+        ssl_verify=mock_config.ssl_verify,
+        zscaler_username=mock_config.zscaler.username,
+        zscaler_password=mock_config.zscaler.password,
+        zscaler_api_key=mock_config.zscaler.api_key,
+        zscaler_blacklist_name=mock_config.zscaler.blacklist_name,
+    )
+    zscaler_connector.session = mock_session
+    return zscaler_connector
+
+@pytest.fixture
+def mock_config():
+    """Simulate configuration values for ZscalerConnector"""
+    mock = Mock()
+    mock.opencti.url = "https://opencti.example.com"
+    mock.opencti.token = "dummy-token"
+    mock.ssl_verify = False
+    mock.zscaler.username = "user"
+    mock.zscaler.password = "pass"
+    mock.zscaler.api_key = "api-key"
+    mock.zscaler.blacklist_name = "blacklist"
+    return mock
+
+@pytest.fixture
+def mock_opencti_client(monkeypatch):
+    mock_client = Mock()
+    mock_client.health_check.return_value = True
+
+    from stream_connector import connector
+    monkeypatch.setattr(connector, "OpenCTIApiClient", lambda *args, **kwargs: mock_client)
+
+    return mock_client
+
+@pytest.fixture
+def helper_mock():
+    """Mock OpenCTIConnectorHelper with logger and listen_stream"""
+    helper = Mock(spec=OpenCTIConnectorHelper)
+    helper.connector_logger = Mock()
+    helper.listen_stream = Mock()
+    return helper
+
+@pytest.fixture
+def mock_session(monkeypatch):
+    """Patch requests.Session to avoid real HTTP calls"""
+    from stream_connector import connector
+    mock_sess = Mock()
+    monkeypatch.setattr(connector.requests, "Session", lambda: mock_sess)
+    return mock_sess

--- a/stream/zscaler/tests/conftest.py
+++ b/stream/zscaler/tests/conftest.py
@@ -23,7 +23,6 @@ def mock_obfuscate(monkeypatch):
 def connector(helper_mock, mock_config, mock_session, mock_opencti_client):
     """Provide a ZscalerConnector instance with mocked config, session and OpenCTI client"""
 
-
     zscaler_connector = zscaler.ZscalerConnector(
         config_path=None,
         helper=helper_mock,

--- a/stream/zscaler/tests/conftest.py
+++ b/stream/zscaler/tests/conftest.py
@@ -1,24 +1,30 @@
-import pytest
-from unittest.mock import Mock
-import sys
 import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
 
-from stream_connector import ZscalerConnector
-from stream_connector.utils import obfuscate_api_key
 from pycti import OpenCTIConnectorHelper
+from stream_connector import connector as zscaler
+
 
 @pytest.fixture(autouse=True)
 def mock_obfuscate(monkeypatch):
     """Mock obfuscate_api_key to return a dummy string."""
-    monkeypatch.setattr("stream_connector.utils.obfuscate_api_key", lambda api_key, timestamp: "dummy-obfuscated")
+    monkeypatch.setattr(
+        "stream_connector.utils.obfuscate_api_key",
+        lambda api_key, timestamp: "dummy-obfuscated",
+    )
+
 
 @pytest.fixture
 def connector(helper_mock, mock_config, mock_session, mock_opencti_client):
     """Provide a ZscalerConnector instance with mocked config, session and OpenCTI client"""
-    from stream_connector import connector
 
-    zscaler_connector = connector.ZscalerConnector(
+
+    zscaler_connector = zscaler.ZscalerConnector(
         config_path=None,
         helper=helper_mock,
         opencti_url=mock_config.opencti.url,
@@ -31,6 +37,7 @@ def connector(helper_mock, mock_config, mock_session, mock_opencti_client):
     )
     zscaler_connector.session = mock_session
     return zscaler_connector
+
 
 @pytest.fixture
 def mock_config():
@@ -45,15 +52,18 @@ def mock_config():
     mock.zscaler.blacklist_name = "blacklist"
     return mock
 
+
 @pytest.fixture
 def mock_opencti_client(monkeypatch):
     mock_client = Mock()
     mock_client.health_check.return_value = True
 
-    from stream_connector import connector
-    monkeypatch.setattr(connector, "OpenCTIApiClient", lambda *args, **kwargs: mock_client)
+    monkeypatch.setattr(
+        zscaler, "OpenCTIApiClient", lambda *args, **kwargs: mock_client
+    )
 
     return mock_client
+
 
 @pytest.fixture
 def helper_mock():
@@ -63,10 +73,11 @@ def helper_mock():
     helper.listen_stream = Mock()
     return helper
 
+
 @pytest.fixture
 def mock_session(monkeypatch):
     """Patch requests.Session to avoid real HTTP calls"""
-    from stream_connector import connector
+
     mock_sess = Mock()
-    monkeypatch.setattr(connector.requests, "Session", lambda: mock_sess)
+    monkeypatch.setattr(zscaler.requests, "Session", lambda: mock_sess)
     return mock_sess

--- a/stream/zscaler/tests/constraints/reauthentication_fails.constraint.feature
+++ b/stream/zscaler/tests/constraints/reauthentication_fails.constraint.feature
@@ -1,0 +1,6 @@
+Feature: Re-authentication failure
+
+    Scenario: Re-authentication fails
+        Given a Zscaler connector with an expired session
+        When a request returns 401 and re-authentication fails
+        Then the connector should stop retrying and return None

--- a/stream/zscaler/tests/constraints/test_reauthentication_fails.py
+++ b/stream/zscaler/tests/constraints/test_reauthentication_fails.py
@@ -1,22 +1,26 @@
-import pytest
-from pytest_bdd import scenarios, given, when, then
 from unittest.mock import Mock
 
+import pytest
+from pytest_bdd import given, scenarios, then, when
+
 scenarios("./reauthentication_fails.constraint.feature")
+
 
 @pytest.fixture(autouse=True)
 def mock_obfuscate(monkeypatch):
     monkeypatch.setattr(
         "stream_connector.connector.obfuscate_api_key",
-        lambda api_key, timestamp: "dummy-obfuscated"
+        lambda api_key, timestamp: "dummy-obfuscated",
     )
+
 
 @pytest.fixture(autouse=True)
 def mock_authenticate(monkeypatch):
     monkeypatch.setattr(
         "stream_connector.connector.ZscalerConnector.authenticate_with_zscaler",
-        lambda self: None
+        lambda self: None,
     )
+
 
 @pytest.fixture
 def expired_connector(connector, mock_session):

--- a/stream/zscaler/tests/constraints/test_reauthentication_fails.py
+++ b/stream/zscaler/tests/constraints/test_reauthentication_fails.py
@@ -1,0 +1,52 @@
+import pytest
+from pytest_bdd import scenarios, given, when, then
+from unittest.mock import Mock
+
+scenarios("./reauthentication_fails.constraint.feature")
+
+@pytest.fixture(autouse=True)
+def mock_obfuscate(monkeypatch):
+    monkeypatch.setattr(
+        "stream_connector.connector.obfuscate_api_key",
+        lambda api_key, timestamp: "dummy-obfuscated"
+    )
+
+@pytest.fixture(autouse=True)
+def mock_authenticate(monkeypatch):
+    monkeypatch.setattr(
+        "stream_connector.connector.ZscalerConnector.authenticate_with_zscaler",
+        lambda self: None
+    )
+
+@pytest.fixture
+def expired_connector(connector, mock_session):
+    connector.session = mock_session
+    connector.session.cookies = {}
+    return connector
+
+
+@given("a Zscaler connector with an expired session")
+def step_given_expired_session(expired_connector):
+    return expired_connector
+
+
+@when("a request returns 401 and re-authentication fails")
+def step_request_401(expired_connector):
+    connector = expired_connector
+
+    def fake_post(*args, **kwargs):
+        response = Mock()
+        response.status_code = 401
+        response.text = "SESSION_NOT_VALID"
+        response.cookies = {}
+        return response
+
+    connector.session.post.side_effect = fake_post
+    connector._last_response = connector.handle_rate_limit(connector.session.post)
+    return connector
+
+
+@then("the connector should stop retrying and return None")
+def step_stop_retry(expired_connector):
+    connector = expired_connector
+    assert connector._last_response is None

--- a/stream/zscaler/tests/features/test_zscaler_session.py
+++ b/stream/zscaler/tests/features/test_zscaler_session.py
@@ -1,0 +1,64 @@
+from pytest_bdd import scenarios, given, when, then
+from unittest.mock import Mock
+from requests.cookies import RequestsCookieJar
+
+scenarios("./zscaler_session.feature")
+
+@given("a valid authenticated Zscaler session")
+def valid_session(connector):
+    cookie_jar = RequestsCookieJar()
+    cookie_jar.set("JSESSIONID", "initial-session")
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.cookies = cookie_jar
+
+    connector.session.post = Mock(return_value=mock_response)
+    connector.session.cookies = cookie_jar
+
+# ----------------
+# Scenario: Request succeeds with a valid session
+@when("a request is made to Zscaler")
+def make_request(connector):
+    connector.handle_rate_limit(connector.session.post, "https://zsapi.example.com")
+
+
+@then("the request should succeed without re-authentication")
+def request_succeeds(connector):
+    jsessionid = connector.session.cookies.get("JSESSIONID")
+    assert jsessionid == "initial-session"
+# ----------------
+
+# ----------------
+# Scenario: Request auto-reconnects on expired session
+@when("the session expires and a request returns 401")
+def session_expires(connector, monkeypatch):
+
+    resp_401 = Mock()
+    resp_401.status_code = 401
+    resp_401.text = "SESSION_EXPIRED"
+    resp_401.cookies = RequestsCookieJar()
+
+    new_cookie = RequestsCookieJar()
+    new_cookie.set("JSESSIONID", "new-session")
+
+    resp_200 = Mock()
+    resp_200.status_code = 200
+    resp_200.cookies = new_cookie
+
+    def fake_authenticate(self):
+        self.session.cookies = new_cookie
+
+    monkeypatch.setattr(
+        "stream_connector.connector.ZscalerConnector.authenticate_with_zscaler",
+        fake_authenticate
+    )
+
+    connector.session.post = Mock(side_effect=[resp_401, resp_200])
+    connector._last_response = connector.handle_rate_limit(connector.session.post)
+
+@then("the connector should re-authenticate and succeed")
+def reauth_success(connector):
+    assert connector._last_response.status_code == 200
+    assert connector.session.cookies.get("JSESSIONID") == "new-session"
+# ----------------

--- a/stream/zscaler/tests/features/test_zscaler_session.py
+++ b/stream/zscaler/tests/features/test_zscaler_session.py
@@ -1,8 +1,10 @@
-from pytest_bdd import scenarios, given, when, then
 from unittest.mock import Mock
+
+from pytest_bdd import given, scenarios, then, when
 from requests.cookies import RequestsCookieJar
 
 scenarios("./zscaler_session.feature")
+
 
 @given("a valid authenticated Zscaler session")
 def valid_session(connector):
@@ -16,6 +18,7 @@ def valid_session(connector):
     connector.session.post = Mock(return_value=mock_response)
     connector.session.cookies = cookie_jar
 
+
 # ----------------
 # Scenario: Request succeeds with a valid session
 @when("a request is made to Zscaler")
@@ -27,7 +30,10 @@ def make_request(connector):
 def request_succeeds(connector):
     jsessionid = connector.session.cookies.get("JSESSIONID")
     assert jsessionid == "initial-session"
+
+
 # ----------------
+
 
 # ----------------
 # Scenario: Request auto-reconnects on expired session
@@ -51,14 +57,17 @@ def session_expires(connector, monkeypatch):
 
     monkeypatch.setattr(
         "stream_connector.connector.ZscalerConnector.authenticate_with_zscaler",
-        fake_authenticate
+        fake_authenticate,
     )
 
     connector.session.post = Mock(side_effect=[resp_401, resp_200])
     connector._last_response = connector.handle_rate_limit(connector.session.post)
 
+
 @then("the connector should re-authenticate and succeed")
 def reauth_success(connector):
     assert connector._last_response.status_code == 200
     assert connector.session.cookies.get("JSESSIONID") == "new-session"
+
+
 # ----------------

--- a/stream/zscaler/tests/features/zscaler_session.feature
+++ b/stream/zscaler/tests/features/zscaler_session.feature
@@ -1,0 +1,11 @@
+Feature: Zscaler session handling
+
+  Scenario: Request succeeds with a valid session
+    Given a valid authenticated Zscaler session
+    When a request is made to Zscaler
+    Then the request should succeed without re-authentication
+
+  Scenario: Request auto-reconnects on expired session
+    Given a valid authenticated Zscaler session
+    When the session expires and a request returns 401
+    Then the connector should re-authenticate and succeed

--- a/stream/zscaler/tests/test-requirements.txt
+++ b/stream/zscaler/tests/test-requirements.txt
@@ -1,0 +1,6 @@
+-r ../src/requirements.txt
+pytest>=7.0
+pytest-bdd>=6.0
+pytest-mock>=3.0
+
+pytest-cov>=4.0


### PR DESCRIPTION
### Proposed changes

- Explicitly detect HTTP 401 errors (SESSION_NOT_VALID)
- Automatically trigger re-authentication when session expires
- Retry the failed request after obtaining a new valid session
- Abort retry if re-authentication fails (no session token retrieved)
- Centralize Zscaler base URLs configuration
- Use requests.Session for cookie persistence and connection reuse
- Add unit tests to validate session handling and retry logic
- Fix : handle retry correctly on HTTP 429 (rate limiting)

### Related issues

* #6152

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
