### PR TITLE
[Accenture ACTI] fix: pin html-to-markdown to ~=2.0

### DIFF
--- a/external-import/accenture-acti/src/requirements.txt
+++ b/external-import/accenture-acti/src/requirements.txt
@@ -2,7 +2,7 @@ pycti==7.260401.0
 pyyaml~=6.0.2
 requests~=2.33.0
 validators==0.35.0
-html-to-markdown
+html-to-markdown~=2.0
 pycognito
 isodate
 boto3


### PR DESCRIPTION
### Proposed changes

* Pin `html-to-markdown` dependency to `~=2.0` in `requirements.txt` to prevent the unpinned dependency from pulling in v3.x, which introduces breaking API changes (`convert_to_markdown` renamed to `convert`)

### Related issues

* Closes #6168

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Instead of upgrading to v3.0 (which renames `convert_to_markdown` → `convert`), we pin to `~=2.0` so the existing code continues to work without modification.