### PR TITLE
[Censys enrichment] NameError: name 'EmbeddedIdentifiedStixObject' is not defined #6170

### DIFF
--- a/internal-enrichment/censys-enrichment/src/censys_enrichment/converter.py
+++ b/internal-enrichment/censys-enrichment/src/censys_enrichment/converter.py
@@ -458,7 +458,7 @@ class Converter:
         Yields:
             BaseObject: STIX objects representing certificates and their relationships
         """
-        observable = EmbeddedIdentifiedStixObject(stix_object=stix_entity)
+        observable = Reference(id=stix_entity.get("id"))
 
         yield from [
             self.author,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove EmbeddedIdentifiedStixObject

### Related issues

* closing #6170 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
