### PR TITLE
[microsoft-sentinel-incidents] Skip ip when no address

### DIFF
--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/connector.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/connector.py
@@ -185,7 +185,10 @@ class MicrosoftSentinelIncidentsConnector:
                             )
                             stix_objects.append(stix_relationship_account)
                     case "ip":
-                        version = detect_ip_version(entity.get("Address"))
+                        address = entity.get("Address")
+                        if not address:
+                            continue
+                        version = detect_ip_version(address)
                         if version == "ipv4":
                             stix_ip = self.converter_to_stix.create_evidence_ipv4(
                                 entity

--- a/external-import/microsoft-sentinel-incidents/tests/tests_connector/test_extract_ip_entity.py
+++ b/external-import/microsoft-sentinel-incidents/tests/tests_connector/test_extract_ip_entity.py
@@ -1,0 +1,119 @@
+"""Regression tests for #6183: ip entity without Address field must not crash."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from microsoft_sentinel_incidents_connector.connector import (
+    MicrosoftSentinelIncidentsConnector,
+    detect_ip_version,
+)
+
+
+@pytest.fixture
+def connector():
+    conn = object.__new__(MicrosoftSentinelIncidentsConnector)
+    conn.helper = MagicMock()
+    conn.client = MagicMock()
+    conn.converter_to_stix = MagicMock()
+    conn.config = MagicMock()
+    return conn
+
+
+def _make_alert(entities):
+    return {
+        "Entities": json.dumps(entities),
+        "Techniques": "[]",
+        "SubTechniques": "[]",
+    }
+
+
+class TestDetectIpVersion:
+    def test_ipv4(self):
+        assert detect_ip_version("192.168.1.1") == "ipv4"
+
+    def test_ipv4_cidr(self):
+        assert detect_ip_version("10.0.0.0/8") == "ipv4"
+
+    def test_ipv6(self):
+        assert detect_ip_version("2001:db8::1") == "ipv6"
+
+
+class TestExtractIpEntityWithoutAddress:
+    """Cover lines 188-191: ip entity with missing Address is skipped."""
+
+    def test_ip_entity_without_address_is_skipped(self, connector):
+        """An ip entity with no Address field must be silently skipped (#6183)."""
+        alert = _make_alert([{"Type": "ip"}])
+        connector.client.get_alerts.return_value = [alert]
+        connector.converter_to_stix.create_incident.return_value = MagicMock(
+            id="incident--fake"
+        )
+        connector.converter_to_stix.create_custom_case_incident.return_value = (
+            MagicMock()
+        )
+
+        result = connector._extract_intelligence(0, {"AlertIds": "123"})
+
+        connector.converter_to_stix.create_evidence_ipv4.assert_not_called()
+        connector.converter_to_stix.create_evidence_ipv6.assert_not_called()
+        # Only incident + case, no IP objects
+        assert len(result) == 2
+
+    def test_ip_entity_with_none_address_is_skipped(self, connector):
+        """An ip entity with Address explicitly set to None must be skipped."""
+        alert = _make_alert([{"Type": "ip", "Address": None}])
+        connector.client.get_alerts.return_value = [alert]
+        connector.converter_to_stix.create_incident.return_value = MagicMock(
+            id="incident--fake"
+        )
+        connector.converter_to_stix.create_custom_case_incident.return_value = (
+            MagicMock()
+        )
+
+        connector._extract_intelligence(0, {"AlertIds": "123"})
+
+        connector.converter_to_stix.create_evidence_ipv4.assert_not_called()
+        connector.converter_to_stix.create_evidence_ipv6.assert_not_called()
+
+    def test_ip_entity_with_valid_ipv4_address(self, connector):
+        """An ip entity with a valid IPv4 address must call create_evidence_ipv4."""
+        alert = _make_alert([{"Type": "ip", "Address": "10.0.0.1"}])
+        connector.client.get_alerts.return_value = [alert]
+        connector.converter_to_stix.create_incident.return_value = MagicMock(
+            id="incident--fake"
+        )
+        connector.converter_to_stix.create_evidence_ipv4.return_value = MagicMock(
+            id="ipv4-addr--fake"
+        )
+        connector.converter_to_stix.create_custom_case_incident.return_value = (
+            MagicMock()
+        )
+
+        connector._extract_intelligence(0, {"AlertIds": "123"})
+
+        connector.converter_to_stix.create_evidence_ipv4.assert_called_once_with(
+            {"Type": "ip", "Address": "10.0.0.1"}
+        )
+        connector.converter_to_stix.create_evidence_ipv6.assert_not_called()
+
+    def test_ip_entity_with_valid_ipv6_address(self, connector):
+        """An ip entity with an IPv6 address must call create_evidence_ipv6."""
+        alert = _make_alert([{"Type": "ip", "Address": "2001:db8::1"}])
+        connector.client.get_alerts.return_value = [alert]
+        connector.converter_to_stix.create_incident.return_value = MagicMock(
+            id="incident--fake"
+        )
+        connector.converter_to_stix.create_evidence_ipv6.return_value = MagicMock(
+            id="ipv6-addr--fake"
+        )
+        connector.converter_to_stix.create_custom_case_incident.return_value = (
+            MagicMock()
+        )
+
+        connector._extract_intelligence(0, {"AlertIds": "123"})
+
+        connector.converter_to_stix.create_evidence_ipv6.assert_called_once_with(
+            {"Type": "ip", "Address": "2001:db8::1"}
+        )
+        connector.converter_to_stix.create_evidence_ipv4.assert_not_called()


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Skip ip when no address

### Related issues

*  Closes: #6183 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
