### PR TITLE
[CVE] Refactor NVD API to async aiohttp and add CPE/Software ingestion

### DIFF
--- a/external-import/cve/README.md
+++ b/external-import/cve/README.md
@@ -29,7 +29,7 @@ The CVE connector imports Common Vulnerabilities and Exposures (CVE) data from t
 
 The National Vulnerability Database (NVD) is the U.S. government repository of standards-based vulnerability management data. This connector retrieves CVE (Common Vulnerabilities and Exposures) data from the NVD API and imports it into OpenCTI as Vulnerability entities.
 
-The connector supports both incremental updates (maintaining data since last run) and historical import (pulling all CVEs from a specified year).
+The connector supports both incremental updates (maintaining data since last run) and historical import (pulling all CVEs from a specified year). It can also optionally resolve CPEs (Common Platform Enumerations) associated with each CVE via the [NVD CPE Match API](https://nvd.nist.gov/developers/products) and import them as Software entities linked to Vulnerabilities.
 
 ## Installation
 
@@ -69,6 +69,7 @@ There are a number of configuration options, which are set either in `docker-com
 | Maintain Data      | cve.maintain_data    | `CVE_MAINTAIN_DATA`         | true                                         | No        | Import CVEs from last run to current time (incremental updates).            |
 | Pull History       | cve.pull_history     | `CVE_PULL_HISTORY`          | false                                        | No        | Import all CVEs from `history_start_year`. Requires `history_start_year`.   |
 | History Start Year | cve.history_start_year | `CVE_HISTORY_START_YEAR`  | 2019                                         | No        | Required if `pull_history=true`. Minimum 2019 (CVSS v3.1 release).          |
+| Import Software    | cve.import_software    | `CVE_IMPORT_SOFTWARE`     | false                                        | No        | If `true`, resolve CPEs for each CVE via the NVD CPE Match API and import them as Software objects with `has` relationships to Vulnerabilities. **Warning:** this can generate a large volume of data and additional API calls. |
 
 ## Deployment
 
@@ -99,6 +100,7 @@ Configure the connector in `docker-compose.yml`:
       # - CVE_MAINTAIN_DATA=true
       # - CVE_PULL_HISTORY=false
       # - CVE_HISTORY_START_YEAR=2019
+      # - CVE_IMPORT_SOFTWARE=false  # Enable to import Software (CPE) objects
     restart: always
 ```
 
@@ -134,7 +136,7 @@ Find the connector and click the refresh button to reset the state and trigger a
 
 ## Behavior
 
-The connector fetches CVE data from the NVD API and converts it to STIX Vulnerability objects.
+The connector fetches CVE data from the NVD API and converts it to STIX Vulnerability objects. When `import_software` is enabled, it also calls the [NVD CPE Match API](https://nvd.nist.gov/developers/products) to resolve CPEs associated with each CVE and creates STIX Software objects with `has` relationships to the corresponding Vulnerability.
 
 ### Data Flow
 
@@ -143,16 +145,22 @@ graph LR
     subgraph NVD API
         direction TB
         CVE[CVE Data]
+        CPEMatch[CPE Match API]
     end
 
     subgraph OpenCTI
         direction LR
         Vulnerability[Vulnerability]
+        Software[Software]
         ExternalRef[External Reference]
+        HasRel["has (Relationship)"]
     end
 
     CVE --> Vulnerability
     CVE --> ExternalRef
+    CPEMatch -->|import_software=true| Software
+    Software --> HasRel
+    HasRel --> Vulnerability
 ```
 
 ### Entity Mapping
@@ -196,6 +204,23 @@ graph LR
 | CWE IDs              | Labels                  | Weakness classifications                         |
 | References           | External References     | Links to advisories and patches                  |
 
+#### Software Entity Mapping (when `import_software=true`)
+
+When the `import_software` option is enabled, the connector resolves CPEs (Common Platform Enumerations) for each CVE using the [NVD CPE Match API](https://nvd.nist.gov/developers/products) and creates STIX Software objects:
+
+| CPE Data             | OpenCTI Entity/Property | Description                                      |
+|----------------------|-------------------------|--------------------------------------------------|
+| CPE Name             | Software.cpe            | Full CPE 2.3 URI (e.g., `cpe:2.3:a:nodejs:node.js:16.0.0:*:*:*:*:*:*:*`) |
+| Vendor               | Software.vendor         | Vendor name extracted from CPE URI               |
+| Vendor + Product (+ Version) | Software.name  | Human-readable software name                     |
+| Version              | Software.version        | Software version (omitted if wildcard `*`)       |
+
+#### Relationship Mapping (when `import_software=true`)
+
+| Source Entity | Relationship Type | Target Entity   | Description                                |
+|---------------|-------------------|-----------------|--------------------------------------------|
+| Software      | `has`             | Vulnerability   | Indicates the software is affected by the vulnerability |
+
 ### Operating Modes
 
 1. **Incremental Updates** (`maintain_data=true`):
@@ -208,12 +233,20 @@ graph LR
    - Useful for initial population
    - Requires `history_start_year` (minimum 2019)
 
+3. **Software Import** (`import_software=true`):
+   - Resolves CPEs for each CVE via the NVD CPE Match API
+   - Creates Software entities with vendor, product, version, and CPE URI
+   - Links each Software to its Vulnerability with a `has` relationship
+   - Can be combined with any operating mode (incremental or historical)
+   - **Warning:** This generates a significant volume of additional data and API calls (one extra API call per CVE). Consider the impact on API rate limits and OpenCTI storage.
+
 ### Processing Details
 
 - **CVSS Support**: Connector supports CVSS v2, v3.1, and v4.0
 - **Rate Limiting**: NVD API has rate limits; connector handles pagination
 - **Date Range**: Maximum 120-day range per API query
 - **API Key Required**: Unauthenticated requests are heavily rate-limited
+- **CPE Match API**: When `import_software=true`, an additional API call per CVE is made to the [NVD CPE Match API](https://nvd.nist.gov/developers/products). The same API key and rate limiting (6-second sleep between requests) apply.
 
 ## Debugging
 

--- a/external-import/cve/README.md
+++ b/external-import/cve/README.md
@@ -31,6 +31,11 @@ The National Vulnerability Database (NVD) is the U.S. government repository of s
 
 The connector supports both incremental updates (maintaining data since last run) and historical import (pulling all CVEs from a specified year). It can also optionally resolve CPEs (Common Platform Enumerations) associated with each CVE via the [NVD CPE Match API](https://nvd.nist.gov/developers/products) and import them as Software entities linked to Vulnerabilities.
 
+> [!WARNING]
+> **`import_software` option — High data volume risk**
+>
+> Enabling the `CVE_IMPORT_SOFTWARE` option can lead to the ingestion of a **very significant volume of data** into the platform. Each CVE may resolve to dozens (or even hundreds) of CPE matches, resulting in massive amounts of Software entities and `has` relationships being created. This dramatically increases storage usage, ingestion time, and API calls to the NVD. **Enable this option only if you fully understand the impact and have sized your platform accordingly.**
+
 ## Installation
 
 ### Requirements
@@ -69,7 +74,7 @@ There are a number of configuration options, which are set either in `docker-com
 | Maintain Data      | cve.maintain_data    | `CVE_MAINTAIN_DATA`         | true                                         | No        | Import CVEs from last run to current time (incremental updates).            |
 | Pull History       | cve.pull_history     | `CVE_PULL_HISTORY`          | false                                        | No        | Import all CVEs from `history_start_year`. Requires `history_start_year`.   |
 | History Start Year | cve.history_start_year | `CVE_HISTORY_START_YEAR`  | 2019                                         | No        | Required if `pull_history=true`. Minimum 2019 (CVSS v3.1 release).          |
-| Import Software    | cve.import_software    | `CVE_IMPORT_SOFTWARE`     | false                                        | No        | If `true`, resolve CPEs for each CVE via the NVD CPE Match API and import them as Software objects with `has` relationships to Vulnerabilities. **Warning:** this can generate a large volume of data and additional API calls. |
+| Import Software    | cve.import_software    | `CVE_IMPORT_SOFTWARE`     | false                                        | No        | If `true`, resolve CPEs for each CVE via the NVD CPE Match API and import them as Software objects with `has` relationships to Vulnerabilities. **⚠️ WARNING: Enabling this option can lead to the ingestion of a VERY SIGNIFICANT volume of data into the platform. Each CVE may resolve to dozens of CPE matches, resulting in massive amounts of Software entities and relationships. Use with caution and ensure your platform is sized accordingly.** |
 
 ## Deployment
 
@@ -238,7 +243,7 @@ When the `import_software` option is enabled, the connector resolves CPEs (Commo
    - Creates Software entities with vendor, product, version, and CPE URI
    - Links each Software to its Vulnerability with a `has` relationship
    - Can be combined with any operating mode (incremental or historical)
-   - **Warning:** This generates a significant volume of additional data and API calls (one extra API call per CVE). Consider the impact on API rate limits and OpenCTI storage.
+   - **⚠️ WARNING: Enabling this option can lead to the ingestion of a VERY SIGNIFICANT volume of data into the platform.** Each CVE may resolve to dozens (or even hundreds) of CPE matches, resulting in massive amounts of Software entities and relationships. This also generates one additional NVD API call per CVE, significantly impacting rate limits and ingestion time. **Ensure your platform is sized accordingly before enabling this option.**
 
 ### Processing Details
 

--- a/external-import/cve/__metadata__/connector_config_schema.json
+++ b/external-import/cve/__metadata__/connector_config_schema.json
@@ -84,6 +84,11 @@
       "description": "Year in number. Required when pull_history is set to `True`.  Minimum 2019 as CVSS V3.1 was released in June 2019, thus most CVE published before 2019 do not include the cvssMetricV31 object.",
       "exclusiveMinimum": 0,
       "type": "integer"
+    },
+    "CVE_IMPORT_SOFTWARE": {
+      "default": false,
+      "description": "⚠️ WARNING: Enabling this option can lead to the ingestion of a VERY SIGNIFICANT volume of data into the platform. Each CVE may resolve to dozens of CPE matches, resulting in massive amounts of Software entities and relationships. Use with caution. If set to true, resolve CPEs associated with each CVE via the NVD CPE Match API and import them as Software objects with 'has' relationships to vulnerabilities.",
+      "type": "boolean"
     }
   },
   "required": [

--- a/external-import/cve/src/config.yml.sample
+++ b/external-import/cve/src/config.yml.sample
@@ -14,4 +14,5 @@ cve:
 #  maintain_data: True # Optional, retrieve only updated data
 #  pull_history: False # Optional, If True, history_start_year is required
 #  history_start_year: 2019 # Required if pull_history is True, min 2019 (see documentation CVE and CVSS base score V3.1)
+#  import_software: False # Optional, if True, resolve CPEs and import as Software objects (generates large volume of data)
 

--- a/external-import/cve/src/connector/cve_connector.py
+++ b/external-import/cve/src/connector/cve_connector.py
@@ -3,10 +3,10 @@ import sys
 import time
 from datetime import datetime, timedelta, timezone
 
-from pycti import OpenCTIConnectorHelper  # type: ignore
+from pycti import OpenCTIConnectorHelper
 from src import ConfigLoader
-from src.services import CVEConverter  # type: ignore
-from src.services.utils import (  # type: ignore
+from src.services import CVEConverter
+from src.services.utils import (
     MAX_AUTHORIZED,
     convert_hours_to_seconds,
 )
@@ -17,7 +17,6 @@ class CVEConnector:
         """
         Initialize the CVEConnector with necessary configurations
         """
-
         # Load configuration file and connection helper
         # Instantiate the connector helper from config
         self.config = ConfigLoader()
@@ -81,25 +80,19 @@ class CVEConnector:
         )
 
     async def _async_ingest(self, cve_params: dict, work_id: str) -> None:
-        """Run the two-phase async ingestion pipeline.
+        """Run the streaming async ingestion pipeline.
 
-        Phase 1: Fetch CVEs → convert to STIX2 → send bundles immediately.
-        Phase 2: Resolve CPEs in parallel → send Software bundles in batches
-                 (only when import_software is enabled).
+        CVE bundles are sent as pages arrive from the NVD API.
+        CPE resolution starts immediately and runs concurrently
+        with further CVE fetching (bounded by cpe_max_concurrency).
         """
         # Reset rate limiter state to avoid stale asyncio.Lock across runs
         self.converter._rate_limiter.reset()
         try:
             self.helper.connector_logger.info(
-                "[CONNECTOR] Phase 1: CVE ingestion (immediate bundle sends)"
+                "[CONNECTOR] Starting CVE+CPE streaming pipeline"
             )
-            cpe_work = await self.converter.send_cve_bundles(cve_params, work_id)
-
-            if cpe_work:
-                self.helper.connector_logger.info(
-                    "[CONNECTOR] Phase 2: Parallel CPE resolution"
-                )
-                await self.converter.send_cpe_bundles(cpe_work, work_id)
+            await self.converter.ingest(cve_params, work_id)
         finally:
             await self.converter.close()
 
@@ -239,9 +232,10 @@ class CVEConnector:
             if current_state is not None and "last_run" in current_state:
                 last_run = current_state["last_run"]
 
-                msg = "[CONNECTOR] Connector last run: " + datetime.fromtimestamp(
+                last_run_dt = datetime.fromtimestamp(
                     last_run, tz=timezone.utc
                 ).strftime("%Y-%m-%d %H:%M:%S")
+                msg = f"[CONNECTOR] Connector last run: {last_run_dt}"
                 self.helper.connector_logger.info(msg)
             else:
                 last_run = None
@@ -297,9 +291,8 @@ class CVEConnector:
                 new_interval = self.interval - (current_time - last_run)
                 new_interval_in_hours = round(new_interval / 60 / 60, 2)
                 self.helper.connector_logger.info(
-                    "[CONNECTOR] Connector will not run, next run in: "
-                    + str(new_interval_in_hours)
-                    + " hours"
+                    f"[CONNECTOR] Connector will not run, next run in: "
+                    f"{new_interval_in_hours} hours"
                 )
 
             time.sleep(5)
@@ -309,5 +302,5 @@ class CVEConnector:
             self.helper.connector_logger.info(msg)
             sys.exit(0)
         except Exception as e:
-            error_msg = f"[CONNECTOR] Error while processing data: {str(e)}"
+            error_msg = f"[CONNECTOR] Error while processing data: {e}"
             self.helper.connector_logger.error(error_msg, meta={"error": str(e)})

--- a/external-import/cve/src/connector/cve_connector.py
+++ b/external-import/cve/src/connector/cve_connector.py
@@ -46,8 +46,8 @@ class CVEConnector:
         :return: Work id in string
         """
         now = datetime.fromtimestamp(timestamp, tz=timezone.utc)
-        friendly_name = f"{self.helper.connect_name} run @ " + now.strftime(
-            "%Y-%m-%d %H:%M:%S"
+        friendly_name = (
+            f"{self.helper.connect_name} run @ {now.strftime('%Y-%m-%d %H:%M:%S')}"
         )
         work_id = self.helper.api.work.initiate_work(
             self.helper.connect_id, friendly_name
@@ -64,9 +64,11 @@ class CVEConnector:
         :param current_time: Time in int
         :param work_id: Work id in string
         """
+        last_run_dt = datetime.fromtimestamp(current_time, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
         msg = (
-            f"[CONNECTOR] Connector successfully run, storing last_run as "
-            f"{datetime.fromtimestamp(current_time, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}"
+            f"[CONNECTOR] Connector successfully run, storing last_run as {last_run_dt}"
         )
         self.helper.connector_logger.info(msg)
         self.helper.api.work.to_processed(work_id, msg)
@@ -74,9 +76,7 @@ class CVEConnector:
 
         interval_in_hours = round(self.interval / 60 / 60, 2)
         self.helper.connector_logger.info(
-            "[CONNECTOR] Last_run stored, next run in: "
-            + str(interval_in_hours)
-            + " hours"
+            f"[CONNECTOR] Last_run stored, next run in: {interval_in_hours} hours"
         )
 
     async def _async_ingest(self, cve_params: dict, work_id: str) -> None:
@@ -103,9 +103,7 @@ class CVEConnector:
         :param work_id: Work id in string
         """
         if self.config.cve.max_date_range > MAX_AUTHORIZED:
-            error_msg = "The max_date_range cannot exceed {} days".format(
-                MAX_AUTHORIZED
-            )
+            error_msg = f"The max_date_range cannot exceed {MAX_AUTHORIZED} days"
             raise Exception(error_msg)
 
         date_range = timedelta(days=self.config.cve.max_date_range)

--- a/external-import/cve/src/connector/cve_connector.py
+++ b/external-import/cve/src/connector/cve_connector.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 import time
 from datetime import datetime, timedelta, timezone
@@ -79,6 +80,29 @@ class CVEConnector:
             + " hours"
         )
 
+    async def _async_ingest(self, cve_params: dict, work_id: str) -> None:
+        """Run the two-phase async ingestion pipeline.
+
+        Phase 1: Fetch CVEs → convert to STIX2 → send bundles immediately.
+        Phase 2: Resolve CPEs in parallel → send Software bundles in batches
+                 (only when import_software is enabled).
+        """
+        # Reset rate limiter state to avoid stale asyncio.Lock across runs
+        self.converter._rate_limiter.reset()
+        try:
+            self.helper.connector_logger.info(
+                "[CONNECTOR] Phase 1: CVE ingestion (immediate bundle sends)"
+            )
+            cpe_work = await self.converter.send_cve_bundles(cve_params, work_id)
+
+            if cpe_work:
+                self.helper.connector_logger.info(
+                    "[CONNECTOR] Phase 2: Parallel CPE resolution"
+                )
+                await self.converter.send_cpe_bundles(cpe_work, work_id)
+        finally:
+            await self.converter.close()
+
     def _import_recent(self, now: datetime, work_id: str) -> None:
         """
         Import the most recent CVEs depending on date range chosen
@@ -96,7 +120,7 @@ class CVEConnector:
 
         cve_params = self._update_cve_params(start_date, now)
 
-        self.converter.send_bundle(cve_params, work_id)
+        asyncio.run(self._async_ingest(cve_params, work_id))
 
     def _import_history(
         self, start_date: datetime, end_date: datetime, work_id: str
@@ -142,12 +166,11 @@ class CVEConnector:
                     end_date_current_year = start_date_current_year + timedelta(
                         days=days_in_year
                     )
-                    # Update date range
                     cve_params = self._update_cve_params(
                         start_date_current_year, end_date_current_year
                     )
 
-                    self.converter.send_bundle(cve_params, work_id)
+                    asyncio.run(self._async_ingest(cve_params, work_id))
                     days_in_year = 0
 
                 """
@@ -155,23 +178,21 @@ class CVEConnector:
                 1 year % 120 days => 5 or 6 (depends if it is a leap year or not)
                 """
                 if days_in_year > 6:
-                    # Update date range
                     cve_params = self._update_cve_params(
                         start_date_current_year, end_date_current_year
                     )
 
-                    self.converter.send_bundle(cve_params, work_id)
+                    asyncio.run(self._async_ingest(cve_params, work_id))
                     start_date_current_year += timedelta(days=MAX_AUTHORIZED)
                     days_in_year -= MAX_AUTHORIZED
                 else:
                     end_date_current_year = start_date_current_year + timedelta(
                         days=days_in_year
                     )
-                    # Update date range
                     cve_params = self._update_cve_params(
                         start_date_current_year, end_date_current_year
                     )
-                    self.converter.send_bundle(cve_params, work_id)
+                    asyncio.run(self._async_ingest(cve_params, work_id))
                     days_in_year = 0
 
             info_msg = f"[CONNECTOR] Importing CVE history for year {year} finished"
@@ -190,9 +211,8 @@ class CVEConnector:
 
         last_run_ts = datetime.fromtimestamp(last_run, tz=timezone.utc)
 
-        # Update date range
         cve_params = self._update_cve_params(last_run_ts, now)
-        self.converter.send_bundle(cve_params, work_id)
+        asyncio.run(self._async_ingest(cve_params, work_id))
 
     @staticmethod
     def _update_cve_params(start_date: datetime, end_date: datetime) -> dict:

--- a/external-import/cve/src/models/configs/cve_configs.py
+++ b/external-import/cve/src/models/configs/cve_configs.py
@@ -41,3 +41,11 @@ class _ConfigLoaderCVE(ConfigBaseSettings):
         default=False,
         description="⚠️ WARNING: Enabling this option can lead to the ingestion of a VERY SIGNIFICANT volume of data into the platform. Each CVE may resolve to dozens of CPE matches, resulting in massive amounts of Software entities and relationships. Use with caution. If set to `True`, resolve CPEs associated with each CVE via the NVD CPE Match API and import them as Software objects with 'has' relationships to vulnerabilities.",
     )
+    cpe_max_concurrency: PositiveInt = Field(
+        default=10,
+        description="Maximum number of concurrent CPE resolution tasks when import_software is enabled.",
+    )
+    cpe_bundle_batch_size: PositiveInt = Field(
+        default=100,
+        description="Number of resolved CVEs whose CPE data to accumulate before sending a STIX bundle.",
+    )

--- a/external-import/cve/src/models/configs/cve_configs.py
+++ b/external-import/cve/src/models/configs/cve_configs.py
@@ -39,5 +39,5 @@ class _ConfigLoaderCVE(ConfigBaseSettings):
     )
     import_software: bool = Field(
         default=False,
-        description="If set to `True`, resolve CPEs associated with each CVE via the NVD CPE Match API and import them as Software objects with 'has' relationships to vulnerabilities. Warning: this can generate a large volume of data.",
+        description="⚠️ WARNING: Enabling this option can lead to the ingestion of a VERY SIGNIFICANT volume of data into the platform. Each CVE may resolve to dozens of CPE matches, resulting in massive amounts of Software entities and relationships. Use with caution. If set to `True`, resolve CPEs associated with each CVE via the NVD CPE Match API and import them as Software objects with 'has' relationships to vulnerabilities.",
     )

--- a/external-import/cve/src/models/configs/cve_configs.py
+++ b/external-import/cve/src/models/configs/cve_configs.py
@@ -37,3 +37,7 @@ class _ConfigLoaderCVE(ConfigBaseSettings):
         default=2019,
         description="Year in number. Required when pull_history is set to `True`.  Minimum 2019 as CVSS V3.1 was released in June 2019, thus most CVE published before 2019 do not include the cvssMetricV31 object.",
     )
+    import_software: bool = Field(
+        default=False,
+        description="If set to `True`, resolve CPEs associated with each CVE via the NVD CPE Match API and import them as Software objects with 'has' relationships to vulnerabilities. Warning: this can generate a large volume of data.",
+    )

--- a/external-import/cve/src/requirements.txt
+++ b/external-import/cve/src/requirements.txt
@@ -2,4 +2,5 @@ pycti==7.260409.0
 urllib3==2.6.3
 pydantic>=2.10, <3
 pydantic-settings==2.10.1
+aiohttp>=3.9, <4
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/cve/src/services/client/__init__.py
+++ b/external-import/cve/src/services/client/__init__.py
@@ -1,4 +1,5 @@
 from src.services.client.api import CVEClient
+from src.services.client.cpe_match import CPEMatchClient
 from src.services.client.vulnerability import CVEVulnerability
 
-__all__ = ["CVEClient", "CVEVulnerability"]
+__all__ = ["CVEClient", "CPEMatchClient", "CVEVulnerability"]

--- a/external-import/cve/src/services/client/api.py
+++ b/external-import/cve/src/services/client/api.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 
 import aiohttp
-from src.services.client.endpoints import BASE_URL  # noqa: F401
 from src.services.utils.rate_limiter import AsyncRateLimiter
 
 logger = logging.getLogger(__name__)

--- a/external-import/cve/src/services/client/api.py
+++ b/external-import/cve/src/services/client/api.py
@@ -1,91 +1,103 @@
-import time
+import asyncio
+import logging
 
-import requests
-from requests.adapters import HTTPAdapter
-from src.services.client.endpoints import BASE_URL
-from urllib3.util import Retry
+import aiohttp
+from src.services.client.endpoints import BASE_URL  # noqa: F401
+from src.services.utils.rate_limiter import AsyncRateLimiter
+
+logger = logging.getLogger(__name__)
 
 
 class CVEClient:
-    """
-    Working with CVE API
-    """
+    """Async HTTP client for the NVD API (CVE & CPE Match)."""
 
-    def __init__(self, api_key, helper, header):
-        """
-        Initialize CVE API with necessary configurations
-        :param api_key: API key in string
-        :param helper: OCTI helper
-        :param header:
-        """
-        headers = {"apiKey": api_key, "User-Agent": header}
+    def __init__(
+        self,
+        api_key: str,
+        helper,
+        header: str,
+        rate_limiter: AsyncRateLimiter,
+    ):
         self.token = api_key
         self.helper = helper
-        self.session = requests.Session()
-        self.session.headers.update(headers)
+        self._rate_limiter = rate_limiter
+        self._headers = {"apiKey": api_key, "User-Agent": header}
+        self._session: aiohttp.ClientSession | None = None
 
-    @staticmethod
-    def _request_data(self, api_url: str, params=None):
-        """
-        Internal method to handle API requests
-        :return: Response in JSON format
-        """
-        try:
-            response = self.request(api_url, params)
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            timeout = aiohttp.ClientTimeout(total=60)
+            self._session = aiohttp.ClientSession(
+                headers=self._headers,
+                timeout=timeout,
+            )
+        return self._session
 
-            info_msg = f"[API] HTTP Get Request to endpoint for path ({api_url})"
-            self.helper.connector_logger.info(info_msg)
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
 
-            response.raise_for_status()
-            return response
+    async def request(self, api_url: str, params: dict | None = None):
+        """Make a rate-limited GET request with retry logic."""
+        max_retries = 4
+        backoff_factor = 6
+        retryable_statuses = {429, 500, 502, 503, 504}
 
-        except requests.RequestException as err:
-            error_msg = f"[API] Error while fetching data from {api_url}: {str(err)}"
-            self.helper.connector_logger.error(error_msg, meta={"error": str(err)})
-            return None
+        for attempt in range(max_retries + 1):
+            await self._rate_limiter.acquire()
+            session = await self._get_session()
 
-    def request(self, api_url, params):
-        # Define the retry strategy
-        retry_strategy = Retry(
-            total=4,  # Maximum number of retries
-            backoff_factor=6,  # Exponential backoff factor (e.g., 2 means 1, 2, 4, 8 seconds, ...)
-            status_forcelist=[429, 500, 502, 503, 504],  # HTTP status codes to retry on
-        )
-        # Create an HTTP adapter with the retry strategy and mount it to session
-        adapter = HTTPAdapter(max_retries=retry_strategy)
+            try:
+                async with session.get(api_url, params=params) as response:
+                    if response.status == 200:
+                        return await response.json()
 
-        self.session.mount("http://", adapter)
-        self.session.mount("https://", adapter)
+                    if response.status == 404:
+                        error_data = dict(response.headers)
+                        if error_data.get("message") == "Invalid apiKey.":
+                            raise Exception(
+                                "[API] Invalid API Key provided. "
+                                "Please check your configuration."
+                            )
+                        raise Exception(f"[API] Error: {error_data.get('message')}")
 
-        response = self.session.get(api_url, params=params)
+                    if response.status in retryable_statuses and attempt < max_retries:
+                        wait = backoff_factor * (2**attempt)
+                        self.helper.connector_logger.warning(
+                            f"[API] Retryable status {response.status}, "
+                            f"waiting {wait}s (attempt {attempt + 1}/{max_retries})"
+                        )
+                        await asyncio.sleep(wait)
+                        continue
 
-        if response.status_code == 200:
-            # It is recommended that users "sleep" their scripts for six seconds between requests (NIST)
-            time.sleep(6)
-            return response
-        elif response.status_code == 404:
-            error_data = response.headers
-            if error_data.get("message") == "Invalid apiKey.":
-                raise Exception(
-                    "[API] Invalid API Key provided. Please check your configuration."
-                )
-            else:
-                raise Exception(f"[API] Error: {error_data.get('message')}")
+                    raise Exception(
+                        f"[API] Request to {api_url} failed with status "
+                        f"{response.status}"
+                    )
+            except aiohttp.ClientError as err:
+                if attempt < max_retries:
+                    wait = backoff_factor * (2**attempt)
+                    self.helper.connector_logger.warning(
+                        f"[API] Connection error, waiting {wait}s "
+                        f"(attempt {attempt + 1}/{max_retries}): {err}"
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                raise
+
         raise Exception(
             "[API] Attempting to retrieve data failed. Wait for connector to re-run..."
         )
 
-    def get_complete_collection(self, cve_params=None):
-        """
-        If params is None, retrieve all CVEs in National Vulnerability Database
-        :param cve_params: Params to filter what list to return
-        :return: A list of dicts of the complete collection of CVE from NVD
-        """
+    async def get_complete_collection(self, api_url: str, params: dict | None = None):
+        """Fetch a JSON collection from the given NVD API endpoint."""
         try:
-            response = self._request_data(self, BASE_URL, params=cve_params)
+            info_msg = f"[API] HTTP Get Request to endpoint for path ({api_url})"
+            self.helper.connector_logger.info(info_msg)
 
-            cve_collection = response.json()
-            return cve_collection
+            data = await self.request(api_url, params)
+            return data
 
         except Exception as err:
-            self.helper.connector_logger.error(err, meta={"error": str(err)})
+            self.helper.connector_logger.error(str(err), meta={"error": str(err)})
+            return None

--- a/external-import/cve/src/services/client/cpe_match.py
+++ b/external-import/cve/src/services/client/cpe_match.py
@@ -25,17 +25,13 @@ class CPEMatchClient(CVEClient):
         cpe_names: set[str] = set()
         params = {"cveId": cve_id}
 
-        info_msg = (
-            f"[CPE MATCH API] Fetching CPE matches for {cve_id}"
-        )
+        info_msg = f"[CPE MATCH API] Fetching CPE matches for {cve_id}"
         self.helper.connector_logger.info(info_msg)
 
         try:
             first_response = self._request_data(self, CPE_MATCH_BASE_URL, params)
             if first_response is None:
-                warn_msg = (
-                    f"[CPE MATCH API] No response for {cve_id}, skipping CPE resolution."
-                )
+                warn_msg = f"[CPE MATCH API] No response for {cve_id}, skipping CPE resolution."
                 self.helper.connector_logger.warning(warn_msg)
                 return []
 
@@ -98,7 +94,3 @@ class CPEMatchClient(CVEClient):
             else:
                 for match in match_criteria.get("matches", []):
                     cpe_names.add(match.get("cpeName"))
-
-
-
-

--- a/external-import/cve/src/services/client/cpe_match.py
+++ b/external-import/cve/src/services/client/cpe_match.py
@@ -1,0 +1,104 @@
+from src.services.client.api import CVEClient
+
+CPE_MATCH_BASE_URL = "https://services.nvd.nist.gov/rest/json/cpematch/2.0"
+
+
+class CPEMatchClient(CVEClient):
+    """Client for the NVD CPE Match API.
+
+    Resolves CPE names associated with a given CVE ID.
+    API documentation: https://nvd.nist.gov/developers/products
+    """
+
+    def get_cpes_for_cve(self, cve_id: str) -> list[str]:
+        """Retrieve all unique CPE names associated with a CVE.
+
+        Calls the NVD CPE Match API with the given CVE ID, handles pagination,
+        and returns a deduplicated list of CPE Name strings.
+
+        Args:
+            cve_id: The CVE identifier (e.g. "CVE-2022-32223").
+
+        Returns:
+            A deduplicated list of CPE Name strings (format cpe:2.3:...).
+        """
+        cpe_names: set[str] = set()
+        params = {"cveId": cve_id}
+
+        info_msg = (
+            f"[CPE MATCH API] Fetching CPE matches for {cve_id}"
+        )
+        self.helper.connector_logger.info(info_msg)
+
+        try:
+            first_response = self._request_data(self, CPE_MATCH_BASE_URL, params)
+            if first_response is None:
+                warn_msg = (
+                    f"[CPE MATCH API] No response for {cve_id}, skipping CPE resolution."
+                )
+                self.helper.connector_logger.warning(warn_msg)
+                return []
+
+            data = first_response.json()
+            self._extract_cpe_names(data, cpe_names)
+
+            # Handle pagination
+            total_results = data.get("totalResults", 0)
+            results_per_page = data.get("resultsPerPage", 0)
+            start_index = results_per_page
+
+            while start_index < total_results:
+                paginated_params = {
+                    **params,
+                    "startIndex": start_index,
+                    "resultsPerPage": results_per_page,
+                }
+                response = self._request_data(
+                    self, CPE_MATCH_BASE_URL, paginated_params
+                )
+                if response is None:
+                    break
+                page_data = response.json()
+                self._extract_cpe_names(page_data, cpe_names)
+                results_per_page = page_data.get("resultsPerPage", 0)
+                start_index += results_per_page
+
+            info_msg = (
+                f"[CPE MATCH API] Found {len(cpe_names)} unique CPEs for {cve_id}"
+            )
+            self.helper.connector_logger.info(info_msg)
+
+        except Exception as err:
+            warn_msg = (
+                f"[CPE MATCH API] Error fetching CPEs for {cve_id}: {str(err)}. "
+                f"Continuing without CPE data."
+            )
+            self.helper.connector_logger.warning(warn_msg)
+            return []
+
+        return list(cpe_names)
+
+    @staticmethod
+    def _extract_cpe_names(data: dict, cpe_names: set[str]) -> None:
+        """Extract CPE names from a CPE Match API response.
+
+        The response contains a list of matchStrings, each containing a match
+        criteria pattern and a list of concrete CPE matches with cpeName fields.
+        We only extract the concrete cpeName values from matches, not the
+        criteria pattern itself (which may contain wildcards or version ranges).
+
+        Args:
+            data: The JSON response from the CPE Match API.
+            cpe_names: A set to collect unique CPE name strings into.
+        """
+        for match_string in data.get("matchStrings", []):
+            match_criteria = match_string.get("matchString", {})
+            if "matches" not in match_criteria or len(match_criteria["matches"]) == 0:
+                cpe_names.add(match_criteria.get("criteria"))
+            else:
+                for match in match_criteria.get("matches", []):
+                    cpe_names.add(match.get("cpeName"))
+
+
+
+

--- a/external-import/cve/src/services/client/cpe_match.py
+++ b/external-import/cve/src/services/client/cpe_match.py
@@ -4,13 +4,13 @@ CPE_MATCH_BASE_URL = "https://services.nvd.nist.gov/rest/json/cpematch/2.0"
 
 
 class CPEMatchClient(CVEClient):
-    """Client for the NVD CPE Match API.
+    """Async client for the NVD CPE Match API.
 
     Resolves CPE names associated with a given CVE ID.
     API documentation: https://nvd.nist.gov/developers/products
     """
 
-    def get_cpes_for_cve(self, cve_id: str) -> list[str]:
+    async def get_cpes_for_cve(self, cve_id: str) -> list[str]:
         """Retrieve all unique CPE names associated with a CVE.
 
         Calls the NVD CPE Match API with the given CVE ID, handles pagination,
@@ -23,19 +23,21 @@ class CPEMatchClient(CVEClient):
             A deduplicated list of CPE Name strings (format cpe:2.3:...).
         """
         cpe_names: set[str] = set()
-        params = {"cveId": cve_id}
+        params: dict = {"cveId": cve_id}
 
         info_msg = f"[CPE MATCH API] Fetching CPE matches for {cve_id}"
         self.helper.connector_logger.info(info_msg)
 
         try:
-            first_response = self._request_data(self, CPE_MATCH_BASE_URL, params)
-            if first_response is None:
-                warn_msg = f"[CPE MATCH API] No response for {cve_id}, skipping CPE resolution."
+            data = await self.get_complete_collection(CPE_MATCH_BASE_URL, params)
+            if data is None:
+                warn_msg = (
+                    f"[CPE MATCH API] No response for {cve_id}, "
+                    f"skipping CPE resolution."
+                )
                 self.helper.connector_logger.warning(warn_msg)
                 return []
 
-            data = first_response.json()
             self._extract_cpe_names(data, cpe_names)
 
             # Handle pagination
@@ -49,12 +51,11 @@ class CPEMatchClient(CVEClient):
                     "startIndex": start_index,
                     "resultsPerPage": results_per_page,
                 }
-                response = self._request_data(
-                    self, CPE_MATCH_BASE_URL, paginated_params
+                page_data = await self.get_complete_collection(
+                    CPE_MATCH_BASE_URL, paginated_params
                 )
-                if response is None:
+                if page_data is None:
                     break
-                page_data = response.json()
                 self._extract_cpe_names(page_data, cpe_names)
                 results_per_page = page_data.get("resultsPerPage", 0)
                 start_index += results_per_page

--- a/external-import/cve/src/services/client/vulnerability.py
+++ b/external-import/cve/src/services/client/vulnerability.py
@@ -87,6 +87,9 @@ class CVEVulnerability(CVEClient):
         for cve_vulnerability in cve_vulnerabilities:
             metric_exist = cve_vulnerability["cve"]["metrics"]
             if metric_exist:
+                # Check if at least one supported CVSS metric exists.
+                # A CVE can have multiple CVSS types (V2 + V3.1 + V4.0),
+                # but should only be added once.
                 has_supported_cvss = any(
                     key in supported_cvss_keys for key in metric_exist
                 )

--- a/external-import/cve/src/services/client/vulnerability.py
+++ b/external-import/cve/src/services/client/vulnerability.py
@@ -71,17 +71,18 @@ class CVEVulnerability(CVEClient):
 
     def _filter_cvss(self, cve_vulnerabilities) -> list:
         cve_vulnerabilities_filtered = []
+        supported_cvss_keys = {"cvssMetricV31", "cvssMetricV40", "cvssMetricV2"}
         for cve_vulnerability in cve_vulnerabilities:
             metric_exist = cve_vulnerability["cve"]["metrics"]
             if metric_exist:
-                for key, value in metric_exist.items():
-                    # Filter on CVSS 2, 3.1, and 4.0. Don't include 3.0
-                    if (
-                        key == "cvssMetricV31"
-                        or key == "cvssMetricV40"
-                        or key == "cvssMetricV2"
-                    ):
-                        cve_vulnerabilities_filtered.append(cve_vulnerability)
+                # Check if at least one supported CVSS metric exists.
+                # A CVE can have multiple CVSS types (V2 + V3.1 + V4.0),
+                # but should only be added once.
+                has_supported_cvss = any(
+                    key in supported_cvss_keys for key in metric_exist
+                )
+                if has_supported_cvss:
+                    cve_vulnerabilities_filtered.append(cve_vulnerability)
 
         info_msg = (
             f"[API] Filter for only CVSS 2, 3.1, or 4.0 CVEs. "

--- a/external-import/cve/src/services/client/vulnerability.py
+++ b/external-import/cve/src/services/client/vulnerability.py
@@ -1,49 +1,60 @@
-from typing import Generator
+from typing import AsyncGenerator
 
 from src.services.client.api import CVEClient
+from src.services.client.endpoints import BASE_URL
 
 
 class CVEVulnerability(CVEClient):
-    def get_vulnerabilities(self, cve_params=None) -> Generator[list, None, None]:
+    async def get_vulnerabilities(
+        self, cve_params: dict | None = None
+    ) -> AsyncGenerator[list, None]:
         """
-        Get and filter CVE with scoring system V3
-        :param cve_params: Dict of params
-        :return: A generator for lists of dicts of CVE
+        Async generator that yields pages of filtered CVE vulnerabilities.
+        :param cve_params: Dict of query params for the NVD CVE API
+        :yields: Lists of vulnerability dicts (filtered by supported CVSS)
         """
 
-        cve_collection = self.get_complete_collection(cve_params)
+        cve_collection = await self.get_complete_collection(BASE_URL, cve_params)
 
         if cve_collection is None:
             raise Exception(
-                "Attempting to retrieve data failed. " "Wait for connector to re-run..."
+                "Attempting to retrieve data failed. Wait for connector to re-run..."
             )
 
         page_size = cve_collection["resultsPerPage"]
-        cve_vulnerabilities_total = cve_collection["vulnerabilities"]
         total_items = cve_collection["totalResults"]
 
         filtered_vulnerabilities = self._filter_cvss(cve_collection["vulnerabilities"])
 
         if page_size == 0:
-            msg = "[API] No Vulnerabilities to retrieve..."
-            self.helper.connector_logger.info(msg)
+            self.helper.connector_logger.info("[API] No Vulnerabilities to retrieve...")
             yield filtered_vulnerabilities
         elif page_size >= total_items:
             msg = f"[API] Received all {page_size} items. Pagination not required."
             self.helper.connector_logger.info(msg)
             yield filtered_vulnerabilities
         else:
-            msg = f"[API] Received first {page_size} items of {total_items} total items, start pagination..."
+            msg = (
+                f"[API] Received first {page_size} items of {total_items} "
+                f"total items, start pagination..."
+            )
             self.helper.connector_logger.info(msg)
+
+            # Yield the first page
+            yield filtered_vulnerabilities
 
             start_index = page_size
 
             while start_index < total_items:
-                cve_params.update(
-                    {"startIndex": start_index, "resultsPerPage": page_size}
-                )
+                paginated_params = {
+                    **(cve_params or {}),
+                    "startIndex": start_index,
+                    "resultsPerPage": page_size,
+                }
 
-                cve_collection = self.get_complete_collection(cve_params)
+                cve_collection = await self.get_complete_collection(
+                    BASE_URL, paginated_params
+                )
 
                 if cve_collection is None:
                     raise Exception(
@@ -55,7 +66,10 @@ class CVEVulnerability(CVEClient):
                 total_items = cve_collection["totalResults"]
                 start_index += page_size
 
-                msg = f"[API] Received next {page_size} items, currently received {start_index} items of {total_items} total items."
+                msg = (
+                    f"[API] Received next {page_size} items, currently received "
+                    f"{start_index} items of {total_items} total items."
+                )
                 self.helper.connector_logger.info(msg)
 
                 filtered_vulnerabilities = self._filter_cvss(
@@ -63,21 +77,16 @@ class CVEVulnerability(CVEClient):
                 )
                 yield filtered_vulnerabilities
 
-        info_msg = (
-            f"[API] All CVEs are retrieved. "
-            f"Got {len(cve_vulnerabilities_total)} vulnerabilities in total"
+        self.helper.connector_logger.info(
+            f"[API] All CVEs are retrieved. Got {total_items} vulnerabilities in total"
         )
-        self.helper.connector_logger.info(info_msg)
 
-    def _filter_cvss(self, cve_vulnerabilities) -> list:
+    def _filter_cvss(self, cve_vulnerabilities: list) -> list:
         cve_vulnerabilities_filtered = []
         supported_cvss_keys = {"cvssMetricV31", "cvssMetricV40", "cvssMetricV2"}
         for cve_vulnerability in cve_vulnerabilities:
             metric_exist = cve_vulnerability["cve"]["metrics"]
             if metric_exist:
-                # Check if at least one supported CVSS metric exists.
-                # A CVE can have multiple CVSS types (V2 + V3.1 + V4.0),
-                # but should only be added once.
                 has_supported_cvss = any(
                     key in supported_cvss_keys for key in metric_exist
                 )

--- a/external-import/cve/src/services/converter/vulnerability_to_stix2.py
+++ b/external-import/cve/src/services/converter/vulnerability_to_stix2.py
@@ -9,8 +9,8 @@ from pycti import (
     Vulnerability,
 )
 from src import ConfigLoader
-from src.services.client import CPEMatchClient, CVEVulnerability  # type: ignore
-from src.services.utils import (  # type: ignore
+from src.services.client import CPEMatchClient, CVEVulnerability
+from src.services.utils import (
     APP_VERSION,
     AsyncRateLimiter,
     parse_cpe_uri,
@@ -43,28 +43,77 @@ class CVEConverter:
         self.author = self._create_author()
 
     # ------------------------------------------------------------------
-    # Phase 1: CVE-only ingestion (fast path)
+    # Streaming pipeline: CVE + CPE processed concurrently
     # ------------------------------------------------------------------
 
-    async def send_cve_bundles(
-        self, cve_params: dict, work_id: str
-    ) -> list[tuple[dict, stix2.Vulnerability]]:
-        """Fetch CVEs, convert to STIX2, and send bundles immediately.
+    async def ingest(self, cve_params: dict, work_id: str) -> None:
+        """Streaming CVE+CPE pipeline.
 
-        Returns a list of (raw_vulnerability, stix_vulnerability) tuples
-        for CPE resolution in Phase 2 (only when import_software is True).
+        CVE bundles are sent immediately as pages arrive from the NVD API.
+        When import_software is enabled, CPE resolution tasks are spawned
+        concurrently as soon as each CVE page is received — there is no
+        need to wait for all CVEs before starting CPE work.
+
+        A TaskGroup manages all CPE resolve tasks; a separate consumer
+        task drains the result queue and sends CPE bundles in batches.
         """
-        cpe_work: list[tuple[dict, stix2.Vulnerability]] = []
+        if not self.import_software:
+            await self._ingest_cve_only(cve_params, work_id)
+            return
 
+        cpe_queue: asyncio.Queue[list | None] = asyncio.Queue()
+        semaphore = asyncio.Semaphore(self.cpe_max_concurrency)
+
+        # Consumer runs outside the TaskGroup so we can signal it after
+        # the group exits (= all resolve tasks finished).
+        consumer = asyncio.create_task(self._cpe_bundle_consumer(cpe_queue, work_id))
+
+        async with asyncio.TaskGroup() as tg:
+            async for vulnerabilities in self.client_api.get_vulnerabilities(
+                cve_params
+            ):
+                stix_objects: list = []
+
+                for vulnerability in vulnerabilities:
+                    vuln_stix = self._vulnerability_to_stix2(vulnerability)
+                    stix_objects.append(vuln_stix)
+
+                    tg.create_task(
+                        self._resolve_and_enqueue(
+                            semaphore, vulnerability, vuln_stix, cpe_queue
+                        )
+                    )
+
+                if not stix_objects:
+                    continue
+
+                stix_objects.append(self.author)
+                bundle = self._to_stix_bundle(stix_objects)
+                bundle_json = self._to_json_bundle(bundle)
+
+                info_msg = (
+                    f"[CONVERTER] Sending CVE bundle with {len(stix_objects)} objects"
+                )
+                self.helper.connector_logger.info(info_msg)
+
+                await asyncio.to_thread(
+                    self.helper.send_stix2_bundle,
+                    bundle_json,
+                    work_id=work_id,
+                )
+
+        # TaskGroup exited — all CPE resolve tasks are done
+        await cpe_queue.put(None)
+        await consumer
+
+    async def _ingest_cve_only(self, cve_params: dict, work_id: str) -> None:
+        """Fast path when import_software is disabled (no CPE resolution)."""
         async for vulnerabilities in self.client_api.get_vulnerabilities(cve_params):
             stix_objects: list = []
 
             for vulnerability in vulnerabilities:
                 vuln_stix = self._vulnerability_to_stix2(vulnerability)
                 stix_objects.append(vuln_stix)
-
-                if self.import_software:
-                    cpe_work.append((vulnerability, vuln_stix))
 
             if not stix_objects:
                 continue
@@ -84,61 +133,45 @@ class CVEConverter:
                 work_id=work_id,
             )
 
-        return cpe_work
-
-    # ------------------------------------------------------------------
-    # Phase 2: Parallel CPE resolution
-    # ------------------------------------------------------------------
-
-    async def send_cpe_bundles(
+    async def _resolve_and_enqueue(
         self,
-        cpe_work: list[tuple[dict, stix2.Vulnerability]],
-        work_id: str,
+        semaphore: asyncio.Semaphore,
+        vulnerability: dict,
+        vuln_stix: stix2.Vulnerability,
+        queue: asyncio.Queue,
     ) -> None:
-        """Resolve CPEs for collected CVEs concurrently and send bundles.
+        """Resolve CPEs for one CVE and push results onto the queue."""
+        async with semaphore:
+            result = await self._resolve_cpes_for_vulnerability(
+                vulnerability, vuln_stix
+            )
+            if result:
+                await queue.put(result)
 
-        Uses asyncio tasks bounded by a concurrency semaphore.  Results
-        are accumulated and sent in batches of ``cpe_bundle_batch_size``.
-        """
-        if not cpe_work:
-            return
-
-        self.helper.connector_logger.info(
-            f"[CONVERTER] Phase 2: Resolving CPEs for "
-            f"{len(cpe_work)} vulnerabilities "
-            f"(concurrency={self.cpe_max_concurrency})"
-        )
-
-        semaphore = asyncio.Semaphore(self.cpe_max_concurrency)
-
-        async def _bounded_resolve(vuln: dict, vuln_stix: stix2.Vulnerability) -> list:
-            async with semaphore:
-                return await self._resolve_cpes_for_vulnerability(vuln, vuln_stix)
-
-        tasks = [
-            asyncio.create_task(_bounded_resolve(vuln, vuln_stix))
-            for vuln, vuln_stix in cpe_work
-        ]
-
+    async def _cpe_bundle_consumer(self, queue: asyncio.Queue, work_id: str) -> None:
+        """Consume CPE STIX objects from the queue and send in batches."""
         batch: list = []
         resolved_count = 0
 
-        for coro in asyncio.as_completed(tasks):
-            result = await coro
-            batch.extend(result)
+        while True:
+            item = await queue.get()
+            if item is None:
+                break
+            batch.extend(item)
             resolved_count += 1
 
             if len(batch) >= self.cpe_bundle_batch_size:
                 await self._send_software_bundle(batch, work_id)
                 batch = []
 
-        # Send remaining items
         if batch:
             await self._send_software_bundle(batch, work_id)
 
-        self.helper.connector_logger.info(
-            f"[CONVERTER] CPE resolution complete for {resolved_count} vulnerabilities"
-        )
+        if resolved_count:
+            self.helper.connector_logger.info(
+                f"[CONVERTER] CPE resolution complete "
+                f"for {resolved_count} vulnerabilities"
+            )
 
     async def _send_software_bundle(self, stix_objects: list, work_id: str) -> None:
         """Send a bundle of Software + Relationship objects."""

--- a/external-import/cve/src/services/converter/vulnerability_to_stix2.py
+++ b/external-import/cve/src/services/converter/vulnerability_to_stix2.py
@@ -9,15 +9,21 @@ from pycti import (
     Vulnerability,
 )
 from src import ConfigLoader
-from src.services.client import CVEVulnerability
-from src.services.utils import APP_VERSION
+from src.services.client import CPEMatchClient, CVEVulnerability  # type: ignore
+from src.services.utils import APP_VERSION, parse_cpe_uri  # type: ignore
 
 
 class CVEConverter:
     def __init__(self, helper: OpenCTIConnectorHelper, config: ConfigLoader):
         self.config = config
         self.helper = helper
+        self.import_software = self.config.cve.import_software
         self.client_api = CVEVulnerability(
+            api_key=self.config.cve.api_key.get_secret_value(),
+            helper=self.helper,
+            header=f"OpenCTI-cve/{APP_VERSION}",
+        )
+        self.cpe_match_client = CPEMatchClient(
             api_key=self.config.cve.api_key.get_secret_value(),
             helper=self.helper,
             header=f"OpenCTI-cve/{APP_VERSION}",
@@ -41,9 +47,10 @@ class CVEConverter:
             vulnerabilities_to_json = self._to_json_bundle(vulnerabilities_bundle)
 
             # Retrieve the author object for the info message
+            len_vuln = len(vulnerabilities_bundle)
             info_msg = (
-                f"[CONVERTER] Sending bundle to server with {len(vulnerabilities_bundle)} objects, "
-                f"concerning {len(vulnerabilities_objects) - 1} vulnerabilities"
+                f"[CONVERTER] Sending bundle to server with {len_vuln} objects, "
+                f"concerning {len_vuln - 1} vulnerabilities"
             )
             self.helper.connector_logger.info(info_msg)
 
@@ -54,18 +61,27 @@ class CVEConverter:
 
     def vulnerabilities_to_stix2(self, cve_params: dict) -> Generator[list, None, None]:
         """
-        Retrieve all CVEs from NVD to convert into STIX2 format
+        Retrieve all CVEs from NVD to convert into STIX2 format.
+        When import_software is enabled, also creates Software objects and
+        'has' relationships for associated CPEs.
         :param cve_params: Dict of params
         :return: Generator of lists of data converted into STIX2
         """
         vulnerabilities_generator = self.client_api.get_vulnerabilities(cve_params)
 
         for vulnerabilities in vulnerabilities_generator:
-            vulnerabilities_stix2 = [
-                self._vulnerability_to_stix2(vulnerability)
-                for vulnerability in vulnerabilities
-            ]
-            yield vulnerabilities_stix2
+            stix_objects = []
+            for vulnerability in vulnerabilities:
+                vuln_stix = self._vulnerability_to_stix2(vulnerability)
+                stix_objects.append(vuln_stix)
+
+                if self.import_software:
+                    software_and_rels = self._resolve_cpes_for_vulnerability(
+                        vulnerability, vuln_stix
+                    )
+                    stix_objects.extend(software_and_rels)
+
+            yield stix_objects
 
     def _vulnerability_to_stix2(self, vulnerability) -> stix2.Vulnerability:
         # Getting different fields
@@ -210,6 +226,84 @@ class CVEConverter:
         )
 
         return vulnerability_to_stix2
+
+    def _resolve_cpes_for_vulnerability(
+        self, vulnerability: dict, vuln_stix: stix2.Vulnerability
+    ) -> list:
+        """
+        Resolve CPEs for a given vulnerability and create Software objects
+        with 'has' relationships.
+        :param vulnerability: Raw vulnerability dict from NVD API
+        :param vuln_stix: STIX2 Vulnerability object
+        :return: List of STIX2 Software objects and Relationship objects
+        """
+        cve_id = vulnerability["cve"]["id"]
+        stix_objects = []
+        seen_cpes = set()
+
+        cpe_names = self.cpe_match_client.get_cpes_for_cve(cve_id)
+
+        for cpe_name in cpe_names:
+            if cpe_name in seen_cpes:
+                continue
+            seen_cpes.add(cpe_name)
+
+            try:
+                software = self._create_software(cpe_name)
+                relationship = self._create_relationship(
+                    from_id=software.id,
+                    to_id=vuln_stix.id,
+                    relation="has",
+                )
+                stix_objects.append(software)
+                stix_objects.append(relationship)
+            except (ValueError, NotImplementedError) as err:
+                warn_msg = (
+                    f"[CONVERTER] Skipping CPE '{cpe_name}' for {cve_id}: {str(err)}"
+                )
+                self.helper.connector_logger.warning(warn_msg)
+                continue
+
+        if stix_objects:
+            info_msg = (
+                f"[CONVERTER] Created {len(seen_cpes)} Software objects "
+                f"for {cve_id}"
+            )
+            self.helper.connector_logger.info(info_msg)
+
+        return stix_objects
+
+    def _create_software(self, cpe_name: str) -> stix2.Software:
+        """
+        Create a STIX2 Software object from a CPE name string.
+        The stix2 library generates a deterministic ID for Software SCOs
+        based on contributing properties (name, cpe, vendor, version).
+        :param cpe_name: CPE name string (e.g. "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*")
+        :return: STIX2 Software object
+        """
+        cpe_dict = parse_cpe_uri(cpe_name)
+        vendor = cpe_dict["vendor"]
+        product = cpe_dict["product"]
+        version = cpe_dict["version"]
+
+        software_name = f"{vendor} {product}"
+        if version and version != "*":
+            software_name = f"{vendor} {product} {version}"
+
+        software_kwargs = {
+            "name": software_name,
+            "cpe": cpe_name,
+            "vendor": vendor,
+            "custom_properties": {
+                "x_opencti_created_by_ref": self.author.id,
+                "x_opencti_product": product,
+            },
+        }
+
+        if version and version != "*":
+            software_kwargs["version"] = version
+
+        return stix2.Software(**software_kwargs)
 
     def _create_relationship(self, from_id: str, to_id: str, relation):
         """

--- a/external-import/cve/src/services/converter/vulnerability_to_stix2.py
+++ b/external-import/cve/src/services/converter/vulnerability_to_stix2.py
@@ -26,8 +26,7 @@ class CVEConverter:
         self.cpe_bundle_batch_size = self.config.cve.cpe_bundle_batch_size
 
         api_key = self.config.cve.api_key.get_secret_value()
-        has_api_key = bool(api_key)
-        self._rate_limiter = AsyncRateLimiter.for_nvd(has_api_key)
+        self._rate_limiter = AsyncRateLimiter()
 
         self.client_api = CVEVulnerability(
             api_key=api_key,

--- a/external-import/cve/src/services/converter/vulnerability_to_stix2.py
+++ b/external-import/cve/src/services/converter/vulnerability_to_stix2.py
@@ -1,5 +1,5 @@
+import asyncio
 import datetime
-from typing import Generator
 
 import stix2
 from pycti import (
@@ -10,7 +10,11 @@ from pycti import (
 )
 from src import ConfigLoader
 from src.services.client import CPEMatchClient, CVEVulnerability  # type: ignore
-from src.services.utils import APP_VERSION, parse_cpe_uri  # type: ignore
+from src.services.utils import (  # type: ignore
+    APP_VERSION,
+    AsyncRateLimiter,
+    parse_cpe_uri,
+)
 
 
 class CVEConverter:
@@ -18,70 +22,143 @@ class CVEConverter:
         self.config = config
         self.helper = helper
         self.import_software = self.config.cve.import_software
+        self.cpe_max_concurrency = self.config.cve.cpe_max_concurrency
+        self.cpe_bundle_batch_size = self.config.cve.cpe_bundle_batch_size
+
+        api_key = self.config.cve.api_key.get_secret_value()
+        has_api_key = bool(api_key)
+        self._rate_limiter = AsyncRateLimiter.for_nvd(has_api_key)
+
         self.client_api = CVEVulnerability(
-            api_key=self.config.cve.api_key.get_secret_value(),
+            api_key=api_key,
             helper=self.helper,
             header=f"OpenCTI-cve/{APP_VERSION}",
+            rate_limiter=self._rate_limiter,
         )
         self.cpe_match_client = CPEMatchClient(
-            api_key=self.config.cve.api_key.get_secret_value(),
+            api_key=api_key,
             helper=self.helper,
             header=f"OpenCTI-cve/{APP_VERSION}",
+            rate_limiter=self._rate_limiter,
         )
         self.author = self._create_author()
 
-    def send_bundle(self, cve_params: dict, work_id: str) -> None:
+    # ------------------------------------------------------------------
+    # Phase 1: CVE-only ingestion (fast path)
+    # ------------------------------------------------------------------
+
+    async def send_cve_bundles(
+        self, cve_params: dict, work_id: str
+    ) -> list[tuple[dict, stix2.Vulnerability]]:
+        """Fetch CVEs, convert to STIX2, and send bundles immediately.
+
+        Returns a list of (raw_vulnerability, stix_vulnerability) tuples
+        for CPE resolution in Phase 2 (only when import_software is True).
         """
-        Send bundle to API
-        :param cve_params: Dict of params
-        :param work_id: work id in string
-        :return:
-        """
-        vulnerability_object_generator = self.vulnerabilities_to_stix2(cve_params)
-        for vulnerabilities_objects in vulnerability_object_generator:
-            if len(vulnerabilities_objects) == 0:
-                continue
+        cpe_work: list[tuple[dict, stix2.Vulnerability]] = []
 
-            vulnerabilities_objects.append(self.author)
-            vulnerabilities_bundle = self._to_stix_bundle(vulnerabilities_objects)
-            vulnerabilities_to_json = self._to_json_bundle(vulnerabilities_bundle)
+        async for vulnerabilities in self.client_api.get_vulnerabilities(cve_params):
+            stix_objects: list = []
 
-            # Retrieve the author object for the info message
-            len_vuln = len(vulnerabilities_bundle)
-            info_msg = (
-                f"[CONVERTER] Sending bundle to server with {len_vuln} objects, "
-                f"concerning {len_vuln - 1} vulnerabilities"
-            )
-            self.helper.connector_logger.info(info_msg)
-
-            self.helper.send_stix2_bundle(
-                vulnerabilities_to_json,
-                work_id=work_id,
-            )
-
-    def vulnerabilities_to_stix2(self, cve_params: dict) -> Generator[list, None, None]:
-        """
-        Retrieve all CVEs from NVD to convert into STIX2 format.
-        When import_software is enabled, also creates Software objects and
-        'has' relationships for associated CPEs.
-        :param cve_params: Dict of params
-        :return: Generator of lists of data converted into STIX2
-        """
-        vulnerabilities_generator = self.client_api.get_vulnerabilities(cve_params)
-
-        for vulnerabilities in vulnerabilities_generator:
-            stix_objects = []
             for vulnerability in vulnerabilities:
                 vuln_stix = self._vulnerability_to_stix2(vulnerability)
                 stix_objects.append(vuln_stix)
 
                 if self.import_software:
-                    software_and_rels = self._resolve_cpes_for_vulnerability(
-                        vulnerability, vuln_stix
-                    )
-                    stix_objects.extend(software_and_rels)
+                    cpe_work.append((vulnerability, vuln_stix))
 
-            yield stix_objects
+            if not stix_objects:
+                continue
+
+            stix_objects.append(self.author)
+            bundle = self._to_stix_bundle(stix_objects)
+            bundle_json = self._to_json_bundle(bundle)
+
+            info_msg = (
+                f"[CONVERTER] Sending CVE bundle with {len(stix_objects)} objects"
+            )
+            self.helper.connector_logger.info(info_msg)
+
+            await asyncio.to_thread(
+                self.helper.send_stix2_bundle,
+                bundle_json,
+                work_id=work_id,
+            )
+
+        return cpe_work
+
+    # ------------------------------------------------------------------
+    # Phase 2: Parallel CPE resolution
+    # ------------------------------------------------------------------
+
+    async def send_cpe_bundles(
+        self,
+        cpe_work: list[tuple[dict, stix2.Vulnerability]],
+        work_id: str,
+    ) -> None:
+        """Resolve CPEs for collected CVEs concurrently and send bundles.
+
+        Uses asyncio tasks bounded by a concurrency semaphore.  Results
+        are accumulated and sent in batches of ``cpe_bundle_batch_size``.
+        """
+        if not cpe_work:
+            return
+
+        self.helper.connector_logger.info(
+            f"[CONVERTER] Phase 2: Resolving CPEs for "
+            f"{len(cpe_work)} vulnerabilities "
+            f"(concurrency={self.cpe_max_concurrency})"
+        )
+
+        semaphore = asyncio.Semaphore(self.cpe_max_concurrency)
+
+        async def _bounded_resolve(vuln: dict, vuln_stix: stix2.Vulnerability) -> list:
+            async with semaphore:
+                return await self._resolve_cpes_for_vulnerability(vuln, vuln_stix)
+
+        tasks = [
+            asyncio.create_task(_bounded_resolve(vuln, vuln_stix))
+            for vuln, vuln_stix in cpe_work
+        ]
+
+        batch: list = []
+        resolved_count = 0
+
+        for coro in asyncio.as_completed(tasks):
+            result = await coro
+            batch.extend(result)
+            resolved_count += 1
+
+            if len(batch) >= self.cpe_bundle_batch_size:
+                await self._send_software_bundle(batch, work_id)
+                batch = []
+
+        # Send remaining items
+        if batch:
+            await self._send_software_bundle(batch, work_id)
+
+        self.helper.connector_logger.info(
+            f"[CONVERTER] CPE resolution complete for {resolved_count} vulnerabilities"
+        )
+
+    async def _send_software_bundle(self, stix_objects: list, work_id: str) -> None:
+        """Send a bundle of Software + Relationship objects."""
+        stix_objects.append(self.author)
+        bundle = self._to_stix_bundle(stix_objects)
+        bundle_json = self._to_json_bundle(bundle)
+
+        info_msg = f"[CONVERTER] Sending CPE bundle with {len(stix_objects)} objects"
+        self.helper.connector_logger.info(info_msg)
+
+        await asyncio.to_thread(
+            self.helper.send_stix2_bundle,
+            bundle_json,
+            work_id=work_id,
+        )
+
+    # ------------------------------------------------------------------
+    # STIX conversion helpers (sync — pure CPU, no I/O)
+    # ------------------------------------------------------------------
 
     def _vulnerability_to_stix2(self, vulnerability) -> stix2.Vulnerability:
         # Getting different fields
@@ -227,21 +304,19 @@ class CVEConverter:
 
         return vulnerability_to_stix2
 
-    def _resolve_cpes_for_vulnerability(
+    async def _resolve_cpes_for_vulnerability(
         self, vulnerability: dict, vuln_stix: stix2.Vulnerability
     ) -> list:
-        """
-        Resolve CPEs for a given vulnerability and create Software objects
+        """Resolve CPEs for a given vulnerability and create Software objects
         with 'has' relationships.
-        :param vulnerability: Raw vulnerability dict from NVD API
-        :param vuln_stix: STIX2 Vulnerability object
-        :return: List of STIX2 Software objects and Relationship objects
+
+        This is called concurrently from send_cpe_bundles().
         """
         cve_id = vulnerability["cve"]["id"]
         stix_objects = []
         seen_cpes = set()
 
-        cpe_names = self.cpe_match_client.get_cpes_for_cve(cve_id)
+        cpe_names = await self.cpe_match_client.get_cpes_for_cve(cve_id)
 
         for cpe_name in cpe_names:
             if cpe_name in seen_cpes:
@@ -266,8 +341,7 @@ class CVEConverter:
 
         if stix_objects:
             info_msg = (
-                f"[CONVERTER] Created {len(seen_cpes)} Software objects "
-                f"for {cve_id}"
+                f"[CONVERTER] Created {len(seen_cpes)} Software objects for {cve_id}"
             )
             self.helper.connector_logger.info(info_msg)
 
@@ -344,3 +418,8 @@ class CVEConverter:
         :return: STIX bundle as JSON format
         """
         return stix_bundle.serialize()
+
+    async def close(self) -> None:
+        """Clean up aiohttp sessions."""
+        await self.client_api.close()
+        await self.cpe_match_client.close()

--- a/external-import/cve/src/services/utils/__init__.py
+++ b/external-import/cve/src/services/utils/__init__.py
@@ -1,6 +1,13 @@
 from src.services.utils.common import convert_hours_to_seconds
 from src.services.utils.constants import MAX_AUTHORIZED  # noqa: F401
 from src.services.utils.cpe_parser import parse_cpe_uri  # noqa: F401
+from src.services.utils.rate_limiter import AsyncRateLimiter  # noqa: F401
 from src.services.utils.version import __version__ as APP_VERSION  # noqa: F401
 
-__all__ = ["MAX_AUTHORIZED", "convert_hours_to_seconds", "APP_VERSION", "parse_cpe_uri"]
+__all__ = [
+    "MAX_AUTHORIZED",
+    "convert_hours_to_seconds",
+    "APP_VERSION",
+    "parse_cpe_uri",
+    "AsyncRateLimiter",
+]

--- a/external-import/cve/src/services/utils/__init__.py
+++ b/external-import/cve/src/services/utils/__init__.py
@@ -1,5 +1,6 @@
 from src.services.utils.common import convert_hours_to_seconds
 from src.services.utils.constants import MAX_AUTHORIZED  # noqa: F401
+from src.services.utils.cpe_parser import parse_cpe_uri  # noqa: F401
 from src.services.utils.version import __version__ as APP_VERSION  # noqa: F401
 
-__all__ = ["MAX_AUTHORIZED", "convert_hours_to_seconds", "APP_VERSION"]
+__all__ = ["MAX_AUTHORIZED", "convert_hours_to_seconds", "APP_VERSION", "parse_cpe_uri"]

--- a/external-import/cve/src/services/utils/cpe_parser.py
+++ b/external-import/cve/src/services/utils/cpe_parser.py
@@ -1,0 +1,43 @@
+import re
+
+
+def parse_cpe_uri(cpe_str: str) -> dict[str, str]:
+    """Parse a CPE URI (format 1 or 2.3) and extract vendor, product, and version.
+
+    Args:
+        cpe_str: The CPE URI string (e.g. "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*")
+
+    Returns:
+        A dict with keys: part, vendor, product, version.
+
+    Raises:
+        ValueError: If the CPE URI is missing mandatory information.
+        NotImplementedError: If the CPE URI format is unknown.
+    """
+    supported_patterns = {
+        "cpe:/": (
+            r"^cpe:/(?P<part>[a-z]):"
+            r"(?P<vendor>[a-zA-Z0-9_\-]+):"
+            r"(?P<product>[a-zA-Z0-9_\-]+):"
+            r"(?P<version>[a-zA-Z0-9_\-]+)"
+        ),
+        "cpe:2.3": (
+            r"^cpe:2\.3:(?P<part>[a-z]+):"
+            r"(?P<vendor>[^:]+):"
+            r"(?P<product>[^:]+):"
+            r"(?P<version>[^:]+)"
+        ),
+    }
+    for key, supported_pattern in supported_patterns.items():
+        if cpe_str.startswith(key):
+            match = re.match(pattern=supported_pattern, string=cpe_str)
+            if match is not None:
+                return {
+                    "part": match.group("part"),
+                    "vendor": match.group("vendor"),
+                    "product": match.group("product"),
+                    "version": match.group("version"),
+                }
+            raise ValueError(f"CPE URI is missing mandatory information: {cpe_str}")
+    raise NotImplementedError(f"Unknown CPE URI format: {cpe_str}")
+

--- a/external-import/cve/src/services/utils/cpe_parser.py
+++ b/external-import/cve/src/services/utils/cpe_parser.py
@@ -40,4 +40,3 @@ def parse_cpe_uri(cpe_str: str) -> dict[str, str]:
                 }
             raise ValueError(f"CPE URI is missing mandatory information: {cpe_str}")
     raise NotImplementedError(f"Unknown CPE URI format: {cpe_str}")
-

--- a/external-import/cve/src/services/utils/rate_limiter.py
+++ b/external-import/cve/src/services/utils/rate_limiter.py
@@ -2,23 +2,22 @@ import asyncio
 import time
 from collections import deque
 
+# NVD rate limit with API key: 50 requests per rolling 30-second window.
+# See https://nvd.nist.gov/developers/start-here#rate-limits
+NVD_MAX_REQUESTS = 50
+NVD_INTERVAL_SECONDS = 30.0
+
 
 class AsyncRateLimiter:
     """Sliding-window rate limiter for asyncio.
 
     Tracks the timestamps of recent requests and ensures no more than
-    ``max_per_interval`` requests are made within any ``interval``-second
-    window.  Uses ``time.monotonic()`` so the state safely survives across
-    multiple ``asyncio.run()`` calls (no event-loop callbacks to leak).
-
-    NVD rate limits:
-      - With API key : 50 requests / 30 s
-      - Without      :  5 requests / 30 s
+    ``NVD_MAX_REQUESTS`` requests are made within any rolling
+    ``NVD_INTERVAL_SECONDS`` window.  Uses ``time.monotonic()`` so the
+    state safely survives across multiple ``asyncio.run()`` calls.
     """
 
-    def __init__(self, max_per_interval: int, interval: float) -> None:
-        self._max = max_per_interval
-        self._interval = interval
+    def __init__(self) -> None:
         self._timestamps: deque[float] = deque()
         self._lock: asyncio.Lock | None = None
 
@@ -34,15 +33,18 @@ class AsyncRateLimiter:
             async with lock:
                 now = time.monotonic()
                 # Purge timestamps outside the sliding window
-                while self._timestamps and now - self._timestamps[0] >= self._interval:
+                while (
+                    self._timestamps
+                    and now - self._timestamps[0] >= NVD_INTERVAL_SECONDS
+                ):
                     self._timestamps.popleft()
 
-                if len(self._timestamps) < self._max:
+                if len(self._timestamps) < NVD_MAX_REQUESTS:
                     self._timestamps.append(now)
                     return
 
                 # Calculate wait until oldest timestamp expires
-                wait_time = self._interval - (now - self._timestamps[0]) + 0.05
+                wait_time = NVD_INTERVAL_SECONDS - (now - self._timestamps[0]) + 0.05
 
             await asyncio.sleep(wait_time)
 
@@ -50,10 +52,3 @@ class AsyncRateLimiter:
         """Reset the limiter state (e.g. between asyncio.run() calls)."""
         self._timestamps.clear()
         self._lock = None
-
-    @classmethod
-    def for_nvd(cls, has_api_key: bool) -> "AsyncRateLimiter":
-        """Factory that selects the correct NVD rate limit."""
-        if has_api_key:
-            return cls(max_per_interval=50, interval=30.0)
-        return cls(max_per_interval=5, interval=30.0)

--- a/external-import/cve/src/services/utils/rate_limiter.py
+++ b/external-import/cve/src/services/utils/rate_limiter.py
@@ -1,0 +1,59 @@
+import asyncio
+import time
+from collections import deque
+
+
+class AsyncRateLimiter:
+    """Sliding-window rate limiter for asyncio.
+
+    Tracks the timestamps of recent requests and ensures no more than
+    ``max_per_interval`` requests are made within any ``interval``-second
+    window.  Uses ``time.monotonic()`` so the state safely survives across
+    multiple ``asyncio.run()`` calls (no event-loop callbacks to leak).
+
+    NVD rate limits:
+      - With API key : 50 requests / 30 s
+      - Without      :  5 requests / 30 s
+    """
+
+    def __init__(self, max_per_interval: int, interval: float) -> None:
+        self._max = max_per_interval
+        self._interval = interval
+        self._timestamps: deque[float] = deque()
+        self._lock: asyncio.Lock | None = None
+
+    def _get_lock(self) -> asyncio.Lock:
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        return self._lock
+
+    async def acquire(self) -> None:
+        """Block until a request slot is available."""
+        lock = self._get_lock()
+        while True:
+            async with lock:
+                now = time.monotonic()
+                # Purge timestamps outside the sliding window
+                while self._timestamps and now - self._timestamps[0] >= self._interval:
+                    self._timestamps.popleft()
+
+                if len(self._timestamps) < self._max:
+                    self._timestamps.append(now)
+                    return
+
+                # Calculate wait until oldest timestamp expires
+                wait_time = self._interval - (now - self._timestamps[0]) + 0.05
+
+            await asyncio.sleep(wait_time)
+
+    def reset(self) -> None:
+        """Reset the limiter state (e.g. between asyncio.run() calls)."""
+        self._timestamps.clear()
+        self._lock = None
+
+    @classmethod
+    def for_nvd(cls, has_api_key: bool) -> "AsyncRateLimiter":
+        """Factory that selects the correct NVD rate limit."""
+        if has_api_key:
+            return cls(max_per_interval=50, interval=30.0)
+        return cls(max_per_interval=5, interval=30.0)


### PR DESCRIPTION
### Proposed changes

* Add CPE/Software ingestion support: introduce `import_software` configuration option that resolves CPE names for each CVE via the NVD CPE Match API and imports them as STIX2 `Software` objects with `has` relationships to vulnerabilities. Configurable via `cpe_max_concurrency` and `cpe_bundle_batch_size` settings.
* Convert NVD API clients to async aiohttp: replace the synchronous `requests` + `HTTPAdapter` retry stack with an async `aiohttp.ClientSession`-based client. Retry logic (exponential backoff on 429/5xx) is now built directly into `CVEClient.request()`.
* Add async rate limiter for NVD API: implement a sliding-window `AsyncRateLimiter` that enforces the NVD rate limit (50 requests per 30-second rolling window) across all concurrent tasks sharing a single limiter instance.
* Implement streaming TaskGroup pipeline: CVE bundles are sent immediately as pages arrive from the NVD API. When `import_software` is enabled, CPE resolution tasks are spawned concurrently via `asyncio.TaskGroup` with a semaphore limiting concurrency, and a consumer task drains the result queue to send CPE bundles in configurable batches.
* Add new `CPEMatchClient`: a dedicated async client for the NVD CPE Match API (`/cpematch/2.0`) that handles pagination and deduplication of CPE names per CVE.
* Add CPE URI parser utility: new `parse_cpe_uri()` function that extracts vendor, product, and version from both CPE 1.0 (`cpe:/`) and CPE 2.3 (`cpe:2.3:`) URI formats.
* Fix duplicate CVE insertion bug: the CVSS filter (`_filter_cvss`) now uses a set-based check so CVEs with multiple supported CVSS metric types are only included once instead of being duplicated.
* Fix `get_vulnerabilities` first-page yield: the paginated path now yields the first page of results immediately instead of silently dropping it.
* Add documentation warning about `import_software` data volume risk.
* Improve string formatting: replace string concatenation with f-strings throughout the connector for consistency.
* Remove unused `BASE_URL` import from `api.py`.

### Related issues

* Closes #1604
* Closes #1949
* Closes #1449
* Fixes #5964

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The move from synchronous `requests` to async `aiohttp` is motivated by the CPE resolution workload. Each CVE can require a separate NVD CPE Match API call, which means the connector may need to make thousands of additional HTTP requests per run. Doing this synchronously with a 6-second sleep between requests would make runs prohibitively slow.

The architecture uses a single shared `AsyncRateLimiter` instance across both the `CVEVulnerability` and `CPEMatchClient` clients, ensuring the 50-requests-per-30-seconds NVD rate limit is respected globally regardless of how many concurrent tasks are in flight.

The `asyncio.TaskGroup` + `asyncio.Queue` streaming design means CPE resolution starts as soon as the first CVE page arrives — there is no two-phase "fetch all CVEs, then resolve all CPEs" bottleneck. A configurable semaphore (`cpe_max_concurrency`, default 10) caps the number of in-flight CPE resolution tasks, and a consumer task batches results into bundles of `cpe_bundle_batch_size` (default 100) before sending to OpenCTI, balancing throughput with memory usage.

When `import_software` is disabled (the default), the connector follows a fast path with zero CPE overhead — the async refactor still benefits from non-blocking I/O during pagination of the CVE API itself.