### PR TITLE
[Google TI] Bug: Malware first_seen/last_seen always null due to field name mismatch

### DIFF
--- a/external-import/google-ti-feeds/connector/src/custom/mappers/gti_malwares/gti_malware_family_to_stix_malware.py
+++ b/external-import/google-ti-feeds/connector/src/custom/mappers/gti_malwares/gti_malware_family_to_stix_malware.py
@@ -198,18 +198,18 @@ class GTIMalwareFamilyToSTIXMalware(BaseMapper):
             hasattr(attributes, "first_seen_details")
             and attributes.first_seen_details
             and len(attributes.first_seen_details) > 0
-            and hasattr(attributes.first_seen_details[0], "values")
+            and hasattr(attributes.first_seen_details[0], "value")
         ):
-            first_seen = attributes.first_seen_details[0].values
+            first_seen = attributes.first_seen_details[0].value
 
         last_seen = None
         if (
             hasattr(attributes, "last_seen_details")
             and attributes.last_seen_details
             and len(attributes.last_seen_details) > 0
-            and hasattr(attributes.last_seen_details[0], "values")
+            and hasattr(attributes.last_seen_details[0], "value")
         ):
-            last_seen = attributes.last_seen_details[0].values
+            last_seen = attributes.last_seen_details[0].value
 
         return first_seen, last_seen
 

--- a/external-import/google-ti-feeds/tests/custom/mappers/gti_malwares/test_gti_malware_family_to_stix_composite_relationships.py
+++ b/external-import/google-ti-feeds/tests/custom/mappers/gti_malwares/test_gti_malware_family_to_stix_composite_relationships.py
@@ -9,6 +9,7 @@ from connector.src.custom.mappers.gti_malwares.gti_malware_family_to_stix_compos
 from connector.src.custom.models.gti.gti_malware_family_model import (
     GTIMalwareFamilyData,
     MalwareFamilyModel,
+    SeenDetail,
     SourceRegion,
     TargetedIndustry,
     TargetedRegion,
@@ -40,10 +41,21 @@ class TargetedIndustryFactory(ModelFactory[TargetedIndustry]):
     __model__ = TargetedIndustry
 
 
+class SeenDetailFactory(ModelFactory[SeenDetail]):
+    """Factory for SeenDetail model."""
+
+    __model__ = SeenDetail
+    first_seen = 1747094400
+    last_seen = 1747094400
+    value = "2025-05-13T00:00:00Z"
+
+
 class MalwareFamilyModelFactory(ModelFactory[MalwareFamilyModel]):
     """Factory for MalwareFamilyModel."""
 
     __model__ = MalwareFamilyModel
+    first_seen_details = [SeenDetailFactory.build()]
+    last_seen_details = [SeenDetailFactory.build()]
 
 
 class GTIMalwareFamilyDataFactory(ModelFactory[GTIMalwareFamilyData]):

--- a/external-import/google-ti-feeds/tests/custom/mappers/gti_malwares/test_gti_malware_family_to_stix_malware.py
+++ b/external-import/google-ti-feeds/tests/custom/mappers/gti_malwares/test_gti_malware_family_to_stix_malware.py
@@ -40,6 +40,9 @@ class SeenDetailFactory(ModelFactory[SeenDetail]):
     """Factory for SeenDetail model."""
 
     __model__ = SeenDetail
+    first_seen = 1747094400
+    last_seen = 1747094400
+    value = "2025-05-13T00:00:00Z"
 
 
 class TagDetailFactory(ModelFactory[TagDetail]):
@@ -58,6 +61,8 @@ class MalwareFamilyModelFactory(ModelFactory[MalwareFamilyModel]):
     """Factory for MalwareFamilyModel."""
 
     __model__ = MalwareFamilyModel
+    first_seen_details = [SeenDetailFactory.build()]
+    last_seen_details = [SeenDetailFactory.build()]
 
 
 class GTIMalwareFamilyDataFactory(ModelFactory[GTIMalwareFamilyData]):
@@ -703,16 +708,16 @@ def test_extract_seen_dates_with_valid_data(mock_organization, mock_tlp_marking)
     if (
         attributes.first_seen_details
         and len(attributes.first_seen_details) > 0
-        and hasattr(attributes.first_seen_details[0], "values")
+        and hasattr(attributes.first_seen_details[0], "value")
     ):
-        expected_first_seen = attributes.first_seen_details[0].values
+        expected_first_seen = attributes.first_seen_details[0].value
 
     if (
         attributes.last_seen_details
         and len(attributes.last_seen_details) > 0
-        and hasattr(attributes.last_seen_details[0], "values")
+        and hasattr(attributes.last_seen_details[0], "value")
     ):
-        expected_last_seen = attributes.last_seen_details[0].values
+        expected_last_seen = attributes.last_seen_details[0].value
 
     assert first_seen == expected_first_seen  # noqa: S101
     assert last_seen == expected_last_seen  # noqa: S101


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

The GTI connector's malware mapper reads .values (plural) but the GTI API model defines .value (singular) for the first_seen_details and last_seen_details fields, causing first_seen and last_seen to always be null on imported Malware objects.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/6099

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
