### PR TITLE
[tenable-vuln-management] Fix pydantic models

### DIFF
--- a/external-import/tenable-vuln-management/src/tenable_vuln_management/models/opencti.py
+++ b/external-import/tenable-vuln-management/src/tenable_vuln_management/models/opencti.py
@@ -270,9 +270,6 @@ class Hostname(Observable):
     """Represents a hostname observable."""
 
     value: str = Field(..., description="The hostname.", min_length=1)
-    __value_validator = field_validator("value", mode="after")(
-        make_validator("value", validators.hostname)
-    )
 
     def to_stix2_object(self) -> Any:
         return PyCTIHostname(

--- a/external-import/tenable-vuln-management/src/tenable_vuln_management/models/tenable.py
+++ b/external-import/tenable-vuln-management/src/tenable_vuln_management/models/tenable.py
@@ -262,8 +262,8 @@ class Asset(FrozenBaseModelWithWarnedExtra):
     """
 
     bios_uuid: Optional[str] = Field(None, description="The BIOS UUID of the asset.")
-    device_type: str = Field(
-        ..., description="The type of device (e.g., hypervisor, general-purpose)."
+    device_type: Optional[str] = Field(
+        None, description="The type of device (e.g., hypervisor, general-purpose)."
     )
     fqdn: Optional[str] = Field(
         None, description="The fully qualified domain name of the asset."


### PR DESCRIPTION
### Proposed changes

* make `Asset.device_type` optional (prevent `ValidationError` on Tenable API response parsing)
* make `Hostname.value` accept any `str` (`stix2` lib is now responsible of the validation)

### Related issues

* close #6194 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] ~~I added/update the relevant documentation (either on github or on notion)~~
- [x] ~~Where necessary I refactored code to improve the overall quality~~
