### PR TITLE
[Google TI] Map alt_names_details field to Campaign aliases

### DIFF
--- a/external-import/google-ti-feeds/connector/src/custom/mappers/gti_campaigns/gti_campaign_to_stix_campaign.py
+++ b/external-import/google-ti-feeds/connector/src/custom/mappers/gti_campaigns/gti_campaign_to_stix_campaign.py
@@ -61,12 +61,16 @@ class GTICampaignToSTIXCampaign(BaseMapper):
         modified = datetime.fromtimestamp(
             attributes.last_modification_date, tz=timezone.utc
         )
+
+        aliases = self._extract_aliases(attributes)
+
         first_seen, last_seen = self._get_activity_timestamps(attributes)
         labels = self._extract_labels(attributes)
         external_references = self._build_external_references(attributes)
 
         campaign_model = OctiCampaignModel.create(
             name=name,
+            aliases=aliases,
             organization_id=self.organization.id,
             marking_ids=[self.tlp_marking.id],
             description=attributes.description,
@@ -81,6 +85,31 @@ class GTICampaignToSTIXCampaign(BaseMapper):
         )
 
         return campaign_model
+
+    @staticmethod
+    def _extract_aliases(attributes: CampaignModel) -> list[str] | None:
+        """Extract aliases from campaign attributes.
+
+        Args:
+            attributes: The campaign attributes
+
+        Returns:
+            list[str] | None: Extracted aliases or None if no aliases exist
+
+        """
+        if (
+                not hasattr(attributes, "alt_names_details")
+                or not attributes.alt_names_details
+        ):
+            return None
+
+        aliases = []
+        for alt_name in attributes.alt_names_details:
+            if hasattr(alt_name, "value") and alt_name.value:
+                alt_name = alt_name.value
+                aliases.append(alt_name)
+
+        return aliases if aliases else None
 
     @staticmethod
     def _get_activity_timestamps(

--- a/external-import/google-ti-feeds/connector/src/custom/mappers/gti_campaigns/gti_campaign_to_stix_campaign.py
+++ b/external-import/google-ti-feeds/connector/src/custom/mappers/gti_campaigns/gti_campaign_to_stix_campaign.py
@@ -98,8 +98,8 @@ class GTICampaignToSTIXCampaign(BaseMapper):
 
         """
         if (
-                not hasattr(attributes, "alt_names_details")
-                or not attributes.alt_names_details
+            not hasattr(attributes, "alt_names_details")
+            or not attributes.alt_names_details
         ):
             return None
 


### PR DESCRIPTION
### Proposed changes

* Map alt_names_details field to Campaign aliases

### Related issues

* Fixes https://github.com/OpenCTI-Platform/connectors/issues/5922

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
