### PR TITLE
[Google TI] Remove MITRE ATT&CK external reference generation

### DIFF
--- a/external-import/google-ti-feeds/connector/src/custom/mappers/gti_attack_techniques/gti_attack_technique_ids_to_stix_attack_patterns.py
+++ b/external-import/google-ti-feeds/connector/src/custom/mappers/gti_attack_techniques/gti_attack_technique_ids_to_stix_attack_patterns.py
@@ -100,8 +100,6 @@ class GTIAttackTechniqueIDsToSTIXAttackPatterns(BaseMapper):
 
             name = technique_id
 
-            external_references = self._create_minimal_external_references(technique_id)
-
             attack_pattern_model = OctiAttackPatternModel.create(
                 name=name,
                 mitre_id=technique_id,
@@ -112,7 +110,6 @@ class GTIAttackTechniqueIDsToSTIXAttackPatterns(BaseMapper):
                 first_seen=None,
                 last_seen=None,
                 kill_chain_phases=None,
-                external_references=external_references,
                 created=current_time,
                 modified=current_time,
             )
@@ -120,26 +117,3 @@ class GTIAttackTechniqueIDsToSTIXAttackPatterns(BaseMapper):
             attack_patterns.append(attack_pattern_model)
 
         return attack_patterns
-
-    def _create_minimal_external_references(
-        self, technique_id: str
-    ) -> list[dict[str, str]] | None:
-        """Create minimal external references with only MITRE reference.
-
-        Args:
-            technique_id: The attack technique ID
-
-        Returns:
-            list[dict[str, str]] | None: Minimal external references with MITRE reference
-
-        """
-        if not technique_id:
-            return None
-
-        mitre_reference = {
-            "source_name": "mitre-attack",
-            "external_id": technique_id,
-            "url": f"https://attack.mitre.org/techniques/{technique_id}/",
-        }
-
-        return [mitre_reference]


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* MITRE ATT&CK external references should not be created by the Google TI connector. This information is provided by the MITRE connector and must not be duplicated here. 

### Related issues

* Fixes https://github.com/OpenCTI-Platform/connectors/issues/5762

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
