### PR TITLE
[connectors-sdk] Create `ConnectorStateManager` class

### DIFF
--- a/connectors-sdk/TDRs/2026-04-14-Typing_and_validation_of_connector_state_with_pydantic.md
+++ b/connectors-sdk/TDRs/2026-04-14-Typing_and_validation_of_connector_state_with_pydantic.md
@@ -1,0 +1,198 @@
+# TDR: Typing and validation of connector's state with Pydantic
+
+<br>
+
+## Overview
+
+This document describes the introduction of `ConnectorStateManager`, a Pydantic-based class added to the `connectors-sdk` under the `state_manager` module.  
+It provides a standardized, typed, and validated interface for loading and saving a connector's state to and from the OpenCTI platform, replacing the ad-hoc, per-connector state management patterns that currently exist across the repository.
+
+This work is a first step in building the `BaseConnector` module suite — a set of standardized SDK components designed to reduce the boilerplate each connector developer has to write and maintain.
+
+<br>
+
+## Motivation
+
+### The current state of state management
+
+Today, every connector in the repository manages its own state independently. The typical pattern looks like this:
+
+```python
+class Connector:
+    def run(self):
+        # At run's  start:
+        state = self.helper.get_state() or {}
+        last_run = state.get("last_run")
+        if last_run is not None:
+            last_run = datetime.fromisoformat(last_run)
+
+        # Execute any business logic specific to the connector...
+
+        # At the end of the run:
+        self.helper.set_state({"last_run": datetime.now(tz=timezone.utc).isoformat()})
+        self.helper.force_ping()
+```
+
+While simple in isolation, this pattern is repeated — with variations — across 200+ connectors. The consequences are:
+
+1. **Massive code duplication**. Every connector reimplements the same load/save cycle, often with subtle differences in key names, serialization format (timestamps vs. ISO strings), or error handling.
+
+2. **No typing or validation**. State is a raw `dict`. There is no guarantee that a value is present, that it has the correct type, or that it is valid before being used. Bugs surface at runtime, often silently (e.g. `None` passed to a function expecting a `datetime`).
+
+3. **Inconsistent serialization**. Some connectors store datetimes as Unix timestamps, others as ISO strings, others as formatted strings. There is no enforced contract, making cross-connector reasoning and debugging unnecessarily difficult.
+
+4. **No shared baseline**. There is no common field that all connectors are guaranteed to track (e.g. `last_run`), even though virtually every connector needs it.
+
+<br>
+
+## Proposed Solution
+
+### The `ConnectorStateManager` class
+
+`ConnectorStateManager` is a non-abstract Pydantic `BaseModel` that wraps the `OpenCTIConnectorHelper` state API. It can be used directly or subclassed to define connector-specific state fields.
+
+```python
+# connectors-sdk/connectors_sdk/state_manager/state_manager.py
+
+class ConnectorStateManager(BaseModel):
+    model_config = ConfigDict(
+        extra="allow",
+        validate_assignment=True,
+    )
+
+    last_run: datetime | None = Field(default=None)
+
+    def __init__(self, helper: OpenCTIConnectorHelper): ...
+
+    def load(self) -> None:
+        """Overwrite instance's fields with the connector's state stored on OpenCTI."""
+
+    def save(self) -> None:
+        """Save instance's fields as connector's state on OpenCTI."""
+```
+
+<br>
+
+### Key design decisions
+
+| Decision | Rationale |
+| --- | --- |
+| Inherits from `pydantic.BaseModel` | Consistent with `BaseConnectorSettings`; provides typing, validation, and JSON serialization for free. |
+| `extra="allow"` | Allows connectors to store additional state fields not declared in the base class, without breaking the model. |
+| `validate_assignment=True` | Ensures that any field update (via `setattr`) is validated immediately, not only at construction time. |
+| `last_run: datetime \| None` | Provides a common baseline field that virtually every connector needs, pre-typed as `datetime`. |
+| `load()` | Dynamically populates declared fields from the raw `dict` returned by OpenCTI, with Pydantic validation applied on assignment. |
+| `save()` uses `model_dump(mode="json")` | Serializes all fields to JSON-safe types automatically, removing the need for manual type
+conversions (e.g. converting a `datetime` to a string). |
+| Not abstract | Can be used as-is for simple connectors; subclassed for connectors with richer state needs. |
+
+<br>
+
+### Usage examples
+
+#### Simple usage (no subclassing needed):
+
+```python
+state_manager = ConnectorStateManager(helper=self.helper)
+state_manager.load()
+
+if state_manager.last_run:
+    self.helper.connector_logger.info("Last run:", {"last_run": state_manager.last_run})
+
+state_manager.last_run = datetime.now(tz=timezone.utc)
+state_manager.save()
+```
+
+#### Subclassed with connector-specific fields:
+
+```python
+class CustomConnectorState(ConnectorStateManager):
+    last_cursor: str | None = Field(default=None)
+    last_page: int = Field(default=0)
+
+state_manager = CustomConnectorState(helper=self.helper)
+state_manager.load()
+state_manager.last_cursor = "abc123"
+state_manager.last_page = 5
+state_manager.save()
+```
+
+<br>
+
+### Module location
+
+Consistent with the SDK folder structure agreed in the architecture decisions, the module lives at:
+
+```plaintext
+connectors-sdk/
+└── connectors_sdk/
+    └── state_manager/
+        ├── __init__.py
+        └── state_manager.py
+```
+
+The `state_manager` module has no dependency on other SDK modules (`settings`, `models`, etc) and can therefore be adopted by any connector, independently of the broader `BaseConnector` usage.
+
+<br>
+
+## Advantages
+
+- **Typed state with early validation**. Fields are declared with Python type annotations. Pydantic validates values at assignment time (`validate_assignment=True`), surfacing type errors before they can corrupt state on OpenCTI.
+
+- **Consistent JSON serialization**. `model_dump(mode="json")` ensures that all field types (including `datetime`) are serialized to JSON-safe representations, eliminating the inconsistency between types and/or formats across connectors.
+
+- **Common baseline field**. `last_run: datetime | None` is provided out of the box, with the correct type, for all connectors.
+
+- **Easy to extend**. Adding connector-specific state fields is a single-line declaration in a subclass. No changes to the loading or saving logic are required.
+
+- **Consistent with existing SDK patterns**. Reuses Pydantic, the same library already used for `BaseConnectorSettings` or OCTI models, keeping the SDK's dependency surface minimal and the developer experience uniform.
+
+- **Independent of other SDK modules**. Can be adopted incrementally, by any connector type, without waiting for the full `BaseExternalImportConnector` to be available.
+
+<br>
+
+## Disadvantages
+
+- **Pydantic dependency**. `ConnectorStateManager` inherits Pydantic's lifecycle and upgrade constraints. This is an accepted trade-off, consistent with the rest of the SDK.
+
+- **`extra="allow"` may mask errors**. Undeclared fields are silently accepted. A typo in a field name when subclassing would not raise an error — the value would be stored as an extra field rather than populating the intended declared field. This is mitigated by `validate_assignment=True` on declared fields and is a deliberate flexibility trade-off for backward compatibility.
+
+- **`save()` only persists declared fields**. Extra fields (those not explicitly declared in the model) are not persisted. This is intentional to avoid leaking internal attributes, but connector developers must declare every field they want to save.
+
+- **Learning curve**. Developers unfamiliar with Pydantic will need to understand the model declaration pattern. This is the same trade-off already accepted for `BaseConnectorSettings` or OCTI models.
+
+<br>
+
+## Alternatives Considered
+
+1. **Keep the current ad-hoc pattern (do nothing)**
+
+    Each connector continues to call `helper.get_state()` / `helper.set_state()` directly, with its own serialization logic.
+
+    **Rejected**. This is the root cause of the inconsistency, duplication, and bugs described in the "Motivation" section. The longer this is deferred, the more expensive any future cross-cutting change becomes.
+
+2. **A plain `dataclass` or `TypedDict`**
+
+    Use a `dataclass` or `TypedDict` to type the state, with manual serialization.
+
+    **Rejected**. Provides typing but no runtime validation, no automatic JSON serialization, and no `validate_assignment` semantics. It would also diverge from the Pydantic-first approach already established in the SDK.
+
+3. **A generic `StateManager[T]` with a separate `BaseState` model**
+
+    Define a generic container class `StateManager[T: BaseModel]` that wraps a separate state model `T`, with `load() -> T` and `save(state: T) -> None` as its interface.
+
+    **Considered**. This was one of the designs explored for this feature. It was ultimately set aside in favour of a simpler approach: having the manager _be_ the state (by inheriting from `BaseModel` directly) reduces the number of objects a connector developer must instantiate and reason about, and avoids the ergonomic overhead of passing a state object in and out of the manager on every call. The simpler design is easier to use correctly.
+
+4. **Abstract base class**
+
+    Make `ConnectorStateManager` abstract, forcing subclassing for every use.
+
+    **Rejected**. Many connectors only need `last_run`. Forcing them to subclass adds friction with no benefit. The non-abstract design follows the principle of opinionated defaults, override hooks where needed.
+
+<br>
+
+## References
+
+- Related TDR: [Typing and validation of configurations with Pydantic Settings](https://github.com/OpenCTI-Platform/connectors/blob/master/connectors-sdk/TDRs/2025-10-01-Typing_and_validation_of_configurations_with_Pydantic_Settings.md)
+- [Pydantic BaseModel documentation](https://docs.pydantic.dev/latest/concepts/models/)
+- [Pydantic serialization (JSON mode)](https://docs.pydantic.dev/latest/concepts/serialization/#json-mode)

--- a/connectors-sdk/connectors_sdk/__init__.py
+++ b/connectors-sdk/connectors_sdk/__init__.py
@@ -23,6 +23,7 @@ from connectors_sdk.settings.exceptions import (
     ConfigError,
     ConfigValidationError,
 )
+from connectors_sdk.state_manager.state_manager import ConnectorStateManager
 
 __all__ = [
     # Base Settings
@@ -43,4 +44,6 @@ __all__ = [
     # Deprecations
     "Deprecate",
     "DeprecatedField",
+    # Connector State
+    "ConnectorStateManager",
 ]

--- a/connectors-sdk/connectors_sdk/state_manager/__init__.py
+++ b/connectors-sdk/connectors_sdk/state_manager/__init__.py
@@ -1,0 +1,1 @@
+"""Module containing base class for connector's state management."""

--- a/connectors-sdk/connectors_sdk/state_manager/state_manager.py
+++ b/connectors-sdk/connectors_sdk/state_manager/state_manager.py
@@ -1,0 +1,58 @@
+"""State manager for connectors.
+
+This module is responsible for loading and saving a connector's state to OpenCTI.
+It provides a simple interface to manage the state and ensures that it's properly cached and updated.
+All connectors should use `ConnectorStateManager` to ensure consistency and reliability in state management.
+Can be used as-is (it's not an abstract class) or subclassed to fit specific needs.
+
+Architecture:
+- ConnectorStateManager: Load, validate and save connector's state
+- OpenCTIConnectorHelper: Communicate with OpenCTI platform (read/write state)
+"""
+
+from datetime import datetime
+
+from pycti import OpenCTIConnectorHelper
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConnectorStateManager(BaseModel):
+    """State manager for connectors.
+    This class inherits from `pydantic.BaseModel`. It can be used as-is (this is not an abstract class)
+    or subclassed with custom fields to fit specific connector needs.
+    All fields defined in the state manager MUST be JSON serializable as they will be stored as JSON
+    in OpenCTI (see https://docs.pydantic.dev/latest/concepts/serialization/#json-mode).
+    """
+
+    model_config = ConfigDict(
+        extra="allow",
+        validate_assignment=True,  # ensure model is revalidate when setting properties
+    )
+
+    last_run: datetime | None = Field(default=None)
+
+    def __init__(self, helper: OpenCTIConnectorHelper):
+        """Initialize the state manager with the connector helper.
+        By default, the fields of the state manager are not populated.
+        The `load` method must be called to populate the fields with the state stored on OpenCTI.
+
+        Arguments:
+            helper: The `OpenCTIConnectorHelper` instance to communicate with the OpenCTI platform.
+        """
+        super().__init__()
+
+        self.helper = helper
+
+    def load(self) -> None:
+        """Overwrite instance's fields with the connector's state stored on OpenCTI."""
+        state = self.helper.get_state() or {}
+        for key in state:
+            setattr(self, key, state[key])
+
+    def save(self) -> None:
+        """Save instance's fields as connector's state on OpenCTI."""
+        declared_fields = set(type(self).model_fields)
+        state_dict = self.model_dump(mode="json", include=declared_fields)
+
+        self.helper.set_state(state_dict)
+        self.helper.force_ping()  # ensure the state is updated immediately on OpenCTI

--- a/connectors-sdk/connectors_sdk/state_manager/state_manager.py
+++ b/connectors-sdk/connectors_sdk/state_manager/state_manager.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from typing import Any
 
 from pycti import OpenCTIConnectorHelper
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_serializer
 
 
 class ConnectorStateManager(BaseModel):
@@ -52,6 +52,17 @@ class ConnectorStateManager(BaseModel):
             )
 
         self._helper = helper
+
+    @field_serializer("*", mode="wrap", when_used="json")
+    def _serialize_datetimes(self, value: Any, handler: Any) -> Any:
+        """Replace the default JSON serializer, in order to use +00:00 offset instead of Z prefix.
+        This is convenient so `assert self.model_dump(mode="json")["last_run"] == self.last_run.isoformat()`
+        is `True` across both codebase and tests (using the same serializer).
+        Consistent with `DatetimeFromIsoString` in `connectors_sdk.settings.annotated_types` module too.
+        """
+        if isinstance(value, datetime):
+            return value.isoformat()  # Override default JSON serializer
+        return handler(value)
 
     def load(self) -> None:
         """Overwrite instance's fields with the connector's state stored on OpenCTI."""

--- a/connectors-sdk/connectors_sdk/state_manager/state_manager.py
+++ b/connectors-sdk/connectors_sdk/state_manager/state_manager.py
@@ -38,7 +38,7 @@ class ConnectorStateManager(BaseModel):
 
     # Private attributes (not validated, not serialized, not stored on OpenCTI)
     _helper: OpenCTIConnectorHelper = PrivateAttr()
-    _sync: bool = PrivateAttr(default=False)
+    _can_be_loaded: bool = PrivateAttr(default=False)
 
     # Declared fields (validated, serialized, stored on OpenCTI)
     last_run: datetime | None = Field(default=None)
@@ -61,21 +61,7 @@ class ConnectorStateManager(BaseModel):
             )
 
         self._helper = helper
-        self._sync = False
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        """Track (re)assignments of declared fields and mark the state as not synchronized.
-
-        Arguments:
-            name: The name of the attribute being set.
-            value: The value being assigned to the attribute.
-        """
-        super().__setattr__(name, value)
-
-        if self._sync and name in type(self).model_fields:
-            # Use `BaseModel.__setattr__` directly so updating `_sync`
-            # cannot re-trigger this custom `__setattr__`.
-            super().__setattr__("_sync", False)
+        self._can_be_loaded = True
 
     @field_serializer("*", mode="wrap", when_used="json")
     def _serialize_datetimes(self, value: Any, handler: Any) -> Any:
@@ -97,40 +83,44 @@ class ConnectorStateManager(BaseModel):
 
     def load(self, force: bool = False) -> None:
         """Overwrite instance's fields with the connector's state stored on OpenCTI.
+        If the state manager instance already has potential unsaved changes,
+        a warning will be raised and the state will NOT be loaded, to prevent unintentional data loss.
 
         Arguments:
-            force: If `True`, load the state from OpenCTI even if there are unsaved changes in the state manager instance.
+            force: If `True`, load the state from OpenCTI even if there are potential
+            unsaved changes in the state manager instance.
         """
-        if self._sync or force:
-            state = self._helper.get_state() or {}
-            for key in state:
-                # Prevent potential conflicts with private attributes (not likely but possible)
-                if key in ("_helper", "_sync"):
-                    continue
-
-                setattr(self, key, state[key])
-
-            # The state manager instance is now synchronized with OpenCTI
-            self._sync = True
-        else:
+        if not self._can_be_loaded and not force:
             warnings.warn(
-                "Loading connector's state from OpenCTI would overwrite unsaved changes in the state manager instance. "
+                "Loading connector's state from OpenCTI would overwrite potential unsaved changes in the state manager instance. "
                 "Save current changes by calling `save()` or use `force=True` to load the state anyway.",
                 UserWarning,
                 stacklevel=2,
             )
+            return
+
+        opencti_state = self._helper.get_state() or {}
+        for key, value in opencti_state.items():
+            # Prevent potential conflicts with private attributes (not likely but possible)
+            if key == "_helper":
+                continue
+
+            setattr(self, key, value)
+
+        # Prevent loading the state again before `save` is called
+        # (to avoid overwriting potential unsaved changes)
+        self._can_be_loaded = False
 
     def save(self) -> None:
         """Save instance's fields as connector's state on OpenCTI."""
         declared_fields = set(type(self).model_fields)
 
-        state_dict = self.model_dump(mode="json", include=declared_fields)
+        state_dump = self.model_dump(mode="json", include=declared_fields)
         # Send both declared _and_ extra fields to not delete any connector state's attributes on OpenCTI
         if self.model_extra:
-            state_dict.update(self.model_extra)
+            state_dump.update(self.model_extra)
 
-        self._helper.set_state(state_dict)
+        self._helper.set_state(state_dump)
         # Ensure the state is updated immediately on OpenCTI (instead of waiting for the next ping)
         self._helper.force_ping()
-        # OpenCTI is now synchronized with the state manager instance
-        self._sync = True
+        self._can_be_loaded = True

--- a/connectors-sdk/connectors_sdk/state_manager/state_manager.py
+++ b/connectors-sdk/connectors_sdk/state_manager/state_manager.py
@@ -10,6 +10,7 @@ Architecture:
 - OpenCTIConnectorHelper: Communicate with OpenCTI platform (read/write state)
 """
 
+import warnings
 from datetime import datetime
 from typing import Any
 
@@ -31,6 +32,7 @@ class ConnectorStateManager(BaseModel):
     )
 
     _helper: OpenCTIConnectorHelper = PrivateAttr()
+    _sync: bool = PrivateAttr(default=False)
 
     last_run: datetime | None = Field(default=None)
 
@@ -52,6 +54,21 @@ class ConnectorStateManager(BaseModel):
             )
 
         self._helper = helper
+        self._sync = False
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Track (re)assignments of declared fields and mark the state as not synchronized.
+
+        Arguments:
+            name: The name of the attribute being set.
+            value: The value being assigned to the attribute.
+        """
+        super().__setattr__(name, value)
+
+        if self._sync and name in type(self).model_fields:
+            # Use `BaseModel.__setattr__` directly so updating `_sync`
+            # cannot re-trigger this custom `__setattr__`.
+            super().__setattr__("_sync", False)
 
     @field_serializer("*", mode="wrap", when_used="json")
     def _serialize_datetimes(self, value: Any, handler: Any) -> Any:
@@ -64,15 +81,30 @@ class ConnectorStateManager(BaseModel):
             return value.isoformat()  # Override default JSON serializer
         return handler(value)
 
-    def load(self) -> None:
-        """Overwrite instance's fields with the connector's state stored on OpenCTI."""
-        state = self._helper.get_state() or {}
-        for key in state:
-            # Prevent potential conflicts with `_helper` private attribute (not likely but possible)
-            if key == "_helper":
-                continue
+    def load(self, force: bool = False) -> None:
+        """Overwrite instance's fields with the connector's state stored on OpenCTI.
 
-            setattr(self, key, state[key])
+        Arguments:
+            force: If `True`, load the state from OpenCTI even if there are unsaved changes in the state manager instance.
+        """
+        if self._sync or force:
+            state = self._helper.get_state() or {}
+            for key in state:
+                # Prevent potential conflicts with private attributes (not likely but possible)
+                if key in ("_helper", "_sync"):
+                    continue
+
+                setattr(self, key, state[key])
+
+            # The state manager instance is now synchronized with OpenCTI
+            self._sync = True
+        else:
+            warnings.warn(
+                "Loading connector's state from OpenCTI would overwrite unsaved changes in the state manager instance. "
+                "Save current changes by calling `save()` or use `force=True` to load the state anyway.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     def save(self) -> None:
         """Save instance's fields as connector's state on OpenCTI."""
@@ -85,3 +117,5 @@ class ConnectorStateManager(BaseModel):
 
         self._helper.set_state(state_dict)
         self._helper.force_ping()  # ensure the state is updated immediately on OpenCTI
+        # OpenCTI is now synchronized with the state manager instance
+        self._sync = True

--- a/connectors-sdk/connectors_sdk/state_manager/state_manager.py
+++ b/connectors-sdk/connectors_sdk/state_manager/state_manager.py
@@ -26,14 +26,21 @@ class ConnectorStateManager(BaseModel):
     in OpenCTI (see https://docs.pydantic.dev/latest/concepts/serialization/#json-mode).
     """
 
+    # ConnectorStateManager model configuration
     model_config = ConfigDict(
+        # Allow extra fields that could be stored on OpenCTI but not declared in the model
+        # (e.g. if the connector's state has evolved since the last time it was loaded)
         extra="allow",
-        validate_assignment=True,  # ensure model is revalidate when setting properties
+        # Ensure that the model is revalidated when setting properties,
+        # to keep the state consistent and avoid saving invalid data on OpenCTI
+        validate_assignment=True,
     )
 
+    # Private attributes (not validated, not serialized, not stored on OpenCTI)
     _helper: OpenCTIConnectorHelper = PrivateAttr()
     _sync: bool = PrivateAttr(default=False)
 
+    # Declared fields (validated, serialized, stored on OpenCTI)
     last_run: datetime | None = Field(default=None)
 
     def __init__(self, helper: OpenCTIConnectorHelper, **kwargs: Any) -> None:
@@ -76,6 +83,13 @@ class ConnectorStateManager(BaseModel):
         This is convenient so `assert self.model_dump(mode="json")["last_run"] == self.last_run.isoformat()`
         is `True` across both codebase and tests (using the same serializer).
         Consistent with `DatetimeFromIsoString` in `connectors_sdk.settings.annotated_types` module too.
+
+        Arguments:
+            value: The value to serialize.
+            handler: The default JSON serializer to use for non-datetime values.
+
+        Returns:
+            The serialized value.
         """
         if isinstance(value, datetime):
             return value.isoformat()  # Override default JSON serializer
@@ -111,11 +125,12 @@ class ConnectorStateManager(BaseModel):
         declared_fields = set(type(self).model_fields)
 
         state_dict = self.model_dump(mode="json", include=declared_fields)
-        # Send both declared _and_ extra fields (to not delete any connector state's attributes on OpenCTI)
+        # Send both declared _and_ extra fields to not delete any connector state's attributes on OpenCTI
         if self.model_extra:
             state_dict.update(self.model_extra)
 
         self._helper.set_state(state_dict)
-        self._helper.force_ping()  # ensure the state is updated immediately on OpenCTI
+        # Ensure the state is updated immediately on OpenCTI (instead of waiting for the next ping)
+        self._helper.force_ping()
         # OpenCTI is now synchronized with the state manager instance
         self._sync = True

--- a/connectors-sdk/connectors_sdk/state_manager/state_manager.py
+++ b/connectors-sdk/connectors_sdk/state_manager/state_manager.py
@@ -57,12 +57,20 @@ class ConnectorStateManager(BaseModel):
         """Overwrite instance's fields with the connector's state stored on OpenCTI."""
         state = self._helper.get_state() or {}
         for key in state:
+            # Prevent potential conflicts with `_helper` private attribute (not likely but possible)
+            if key == "_helper":
+                continue
+
             setattr(self, key, state[key])
 
     def save(self) -> None:
         """Save instance's fields as connector's state on OpenCTI."""
         declared_fields = set(type(self).model_fields)
+
         state_dict = self.model_dump(mode="json", include=declared_fields)
+        # Send both declared _and_ extra fields (to not delete any connector state's attributes on OpenCTI)
+        if self.model_extra:
+            state_dict.update(self.model_extra)
 
         self._helper.set_state(state_dict)
         self._helper.force_ping()  # ensure the state is updated immediately on OpenCTI

--- a/connectors-sdk/connectors_sdk/state_manager/state_manager.py
+++ b/connectors-sdk/connectors_sdk/state_manager/state_manager.py
@@ -11,9 +11,10 @@ Architecture:
 """
 
 from datetime import datetime
+from typing import Any
 
 from pycti import OpenCTIConnectorHelper
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 
 class ConnectorStateManager(BaseModel):
@@ -29,23 +30,32 @@ class ConnectorStateManager(BaseModel):
         validate_assignment=True,  # ensure model is revalidate when setting properties
     )
 
+    _helper: OpenCTIConnectorHelper = PrivateAttr()
+
     last_run: datetime | None = Field(default=None)
 
-    def __init__(self, helper: OpenCTIConnectorHelper):
+    def __init__(self, helper: OpenCTIConnectorHelper, **kwargs: Any) -> None:
         """Initialize the state manager with the connector helper.
         By default, the fields of the state manager are not populated.
         The `load` method must be called to populate the fields with the state stored on OpenCTI.
 
         Arguments:
             helper: The `OpenCTIConnectorHelper` instance to communicate with the OpenCTI platform.
+            **kwargs: Any fields to set on the state manager (these fields will also be stored on OpenCTI).
         """
-        super().__init__()
+        super().__init__(**kwargs)
 
-        self.helper = helper
+        # Validate `helper` argument as Pydantic will not do it since it's a private attribute
+        if not isinstance(helper, OpenCTIConnectorHelper):
+            raise ValueError(
+                "`helper` argument is required and must be an instance of `pycti.OpenCTIConnectorHelper`"
+            )
+
+        self._helper = helper
 
     def load(self) -> None:
         """Overwrite instance's fields with the connector's state stored on OpenCTI."""
-        state = self.helper.get_state() or {}
+        state = self._helper.get_state() or {}
         for key in state:
             setattr(self, key, state[key])
 
@@ -54,5 +64,5 @@ class ConnectorStateManager(BaseModel):
         declared_fields = set(type(self).model_fields)
         state_dict = self.model_dump(mode="json", include=declared_fields)
 
-        self.helper.set_state(state_dict)
-        self.helper.force_ping()  # ensure the state is updated immediately on OpenCTI
+        self._helper.set_state(state_dict)
+        self._helper.force_ping()  # ensure the state is updated immediately on OpenCTI

--- a/connectors-sdk/tests/test_api.py
+++ b/connectors-sdk/tests/test_api.py
@@ -18,6 +18,7 @@ def test_root_public_api_is_valid():
         "BaseStreamConnectorConfig",
         "ConfigError",
         "ConfigValidationError",
+        "ConnectorStateManager",
         "DatetimeFromIsoString",
         "ListFromString",
         "Deprecate",

--- a/connectors-sdk/tests/tests_state_manager/conftest.py
+++ b/connectors-sdk/tests/tests_state_manager/conftest.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pycti import OpenCTIConnectorHelper
+
+
+@pytest.fixture
+def mock_opencti_connector_helper() -> MagicMock:
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    mock_helper = MagicMock(spec=OpenCTIConnectorHelper)
+    mock_helper.killProgramHook = MagicMock()
+    mock_helper.sched = MagicMock()
+    mock_helper.ConnectorInfo = MagicMock()
+    mock_helper.OpenCTIApiClient = MagicMock()
+    mock_helper.OpenCTIConnector = MagicMock()
+    mock_helper.OpenCTIMetricHandler = MagicMock()
+    mock_helper.PingAlive = MagicMock()
+
+    # Mock config vars
+    mock_helper.connect_name = "Test Connector"
+    mock_helper.connect_id = "test_connector_id"
+    mock_helper.log_level = "debug"
+
+    return mock_helper

--- a/connectors-sdk/tests/tests_state_manager/test_state_manager.py
+++ b/connectors-sdk/tests/tests_state_manager/test_state_manager.py
@@ -73,40 +73,15 @@ def test_connector_state_manager_rejects_invalid_input(dummy_connector_state_man
         dummy_connector_state_manager.last_run = "not a datetime"
 
 
-def test_connector_state_manager_load_warns_when_not_synchronized(
+def test_connector_state_manager_load_after_init(
     dummy_connector_state_manager, mock_opencti_connector_helper
 ):
-    """Test that `ConnectorStateManager` instance does not load state from OpenCTI when not synchronized."""
-    # Given: a `ConnectorStateManager` instance that is not synchronized (default state after init)
+    """Test that `ConnectorStateManager` instance loads state from OpenCTI when states are equal."""
+    # Given: a `ConnectorStateManager` instance with the same state as OpenCTI
     mock_opencti_connector_helper.get_state.return_value = {
         "last_run": "2024-01-01T00:00:00+00:00",
         "test_field": "test",
     }
-    original_last_run = dummy_connector_state_manager.last_run
-    original_test_field = dummy_connector_state_manager.test_field
-
-    # When: loading the state without `force=True`
-    # Then: a `UserWarning` should be raised and the state should NOT be loaded
-    with pytest.warns(UserWarning):
-        dummy_connector_state_manager.load()
-
-    mock_opencti_connector_helper.get_state.assert_not_called()
-    assert dummy_connector_state_manager.last_run == original_last_run
-    assert dummy_connector_state_manager.test_field == original_test_field
-
-
-def test_connector_state_manager_load_when_synchronized(
-    dummy_connector_state_manager, mock_opencti_connector_helper
-):
-    """Test that `ConnectorStateManager` instance loads state from OpenCTI when synchronized."""
-    # Given: a `ConnectorStateManager` instance that is synchronized with OpenCTI
-    mock_opencti_connector_helper.get_state.return_value = {
-        "last_run": "2024-01-01T00:00:00+00:00",
-        "test_field": "test",
-    }
-    dummy_connector_state_manager.last_run = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    dummy_connector_state_manager.test_field = "test"
-    dummy_connector_state_manager._sync = True
 
     # When: loading the state
     dummy_connector_state_manager.load()
@@ -127,10 +102,14 @@ def test_connector_state_manager_load_with_force(
     mock_opencti_connector_helper.get_state.return_value = {
         "last_run": "2024-01-01T00:00:00+00:00",
         "test_field": "test",
-        "extra_field": "any value",
     }
+    # And: a first load already happened without a subsequent save after changes
+    dummy_connector_state_manager.load()
+    dummy_connector_state_manager.last_run = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    dummy_connector_state_manager.test_field = "test2"
+    mock_opencti_connector_helper.get_state.reset_mock()  # Reset mock to check calls only for the second load
 
-    # When: loading the state into a `ConnectorStateManager` instance
+    # When: force loading the state into a `ConnectorStateManager` instance
     dummy_connector_state_manager.load(force=True)
 
     # Then: `OpenCTIConnectorHelper.get_state` method should be called and
@@ -140,7 +119,33 @@ def test_connector_state_manager_load_with_force(
         2024, 1, 1, 0, 0, tzinfo=timezone.utc
     )
     assert dummy_connector_state_manager.test_field == "test"
-    assert dummy_connector_state_manager.extra_field == "any value"
+
+
+def test_connector_state_manager_load_warns_when_potential_unsaved_changes(
+    dummy_connector_state_manager, mock_opencti_connector_helper
+):
+    """Test that `ConnectorStateManager` instance warns when a second non-forced load is attempted."""
+    # Given: a state stored on OpenCTI
+    mock_opencti_connector_helper.get_state.return_value = {
+        "last_run": "2024-01-01T00:00:00+00:00",
+        "test_field": "test",
+    }
+    # And: a first load already happened without a subsequent save after changes
+    dummy_connector_state_manager.load()
+    dummy_connector_state_manager.last_run = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    dummy_connector_state_manager.test_field = "test2"
+    mock_opencti_connector_helper.get_state.reset_mock()  # Reset mock to check calls only for the second load
+
+    # When: loading the state without `force=True`
+    # Then: a `UserWarning` should be raised and the state should NOT be loaded
+    with pytest.warns(UserWarning):
+        dummy_connector_state_manager.load()
+
+    mock_opencti_connector_helper.get_state.assert_not_called()
+    assert dummy_connector_state_manager.last_run == datetime(
+        2024, 1, 2, tzinfo=timezone.utc
+    )
+    assert dummy_connector_state_manager.test_field == "test2"
 
 
 def test_connector_state_manager_load_ignores_helper_key(

--- a/connectors-sdk/tests/tests_state_manager/test_state_manager.py
+++ b/connectors-sdk/tests/tests_state_manager/test_state_manager.py
@@ -9,7 +9,13 @@ from pydantic import BaseModel
 @pytest.fixture
 def dummy_connector_state_manager(mock_opencti_connector_helper):
     """A dummy `ConnectorStateManager` instance for testing purposes."""
-    return ConnectorStateManager(helper=mock_opencti_connector_helper)
+
+    class DummyConnectorStateManager(ConnectorStateManager):
+        """A dummy `ConnectorStateManager` subclass with additional fields, for testing purposes."""
+
+        test_field: str | None = None
+
+    return DummyConnectorStateManager(helper=mock_opencti_connector_helper)  # type: ignore
 
 
 def test_connector_state_manager_is_pydantic_model():
@@ -43,13 +49,14 @@ def test_connector_state_manager_has_default_values(dummy_connector_state_manage
     # Given: a new instance of `ConnectorStateManager`
     # Then: it should have default values for its fields
     assert dummy_connector_state_manager.last_run is None
+    assert dummy_connector_state_manager.test_field is None
 
 
 def test_connector_state_manager_accepts_valid_input(dummy_connector_state_manager):
     """Test that `ConnectorStateManager` model accepts valid input."""
     # Given: an instance of `ConnectorStateManager`
     # When: setting a valid datetime string to the `last_run` field
-    dummy_connector_state_manager.last_run = "2024-01-01T00:00:00Z"
+    dummy_connector_state_manager.last_run = "2024-01-01T00:00:00+00:00"
 
     # Then: the field should be updated with the corresponding datetime object
     assert dummy_connector_state_manager.last_run == datetime(
@@ -72,8 +79,9 @@ def test_connector_state_manager_load(
     """Test that `ConnectorStateManager` instance loads state from OpenCTI correctly."""
     # Given: a state stored on OpenCTI
     mock_opencti_connector_helper.get_state.return_value = {
-        "last_run": "2024-01-01T00:00:00Z",
-        "custom_value": "test",
+        "last_run": "2024-01-01T00:00:00+00:00",
+        "test_field": "test",
+        "extra_field": "any value",
     }
 
     # When: loading the state into a `ConnectorStateManager` instance
@@ -85,7 +93,8 @@ def test_connector_state_manager_load(
     assert dummy_connector_state_manager.last_run == datetime(
         2024, 1, 1, 0, 0, tzinfo=timezone.utc
     )
-    assert dummy_connector_state_manager.custom_value == "test"
+    assert dummy_connector_state_manager.test_field == "test"
+    assert dummy_connector_state_manager.extra_field == "any value"
 
 
 def test_connector_state_manager_load_ignores_helper_key(
@@ -103,6 +112,7 @@ def test_connector_state_manager_load_ignores_helper_key(
     # the `dummy_connector_state_manager` fields should be updated with the loaded state
     mock_opencti_connector_helper.get_state.assert_called_once()
     assert dummy_connector_state_manager.last_run is None
+    assert dummy_connector_state_manager.test_field is None
     assert dummy_connector_state_manager._helper == original_helper
 
 
@@ -113,12 +123,13 @@ def test_connector_state_manager_save(
     # Given: an instance of `ConnectorStateManager`
     # When: saving a new `last_run` value to OpenCTI
     dummy_connector_state_manager.last_run = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    dummy_connector_state_manager.test_field = "test"
     dummy_connector_state_manager.save()
 
     # Then: `OpenCTIConnectorHelper.set_state` method should be called with the correct dict and
     # the state should be updated immediately on OpenCTI (`force_ping` called)
     mock_opencti_connector_helper.set_state.assert_called_once_with(
-        {"last_run": "2024-01-01T00:00:00Z"}
+        {"last_run": "2024-01-01T00:00:00+00:00", "test_field": "test"}
     )
     mock_opencti_connector_helper.force_ping.assert_called_once()
 
@@ -129,13 +140,18 @@ def test_connector_state_manager_save_sends_extra_fields(
     """Test that `ConnectorStateManager` instance saves extra fields onto OpenCTI correctly."""
     # Given: an instance of `ConnectorStateManager` with extra fields
     dummy_connector_state_manager.last_run = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    dummy_connector_state_manager.custom_value = "test"
+    dummy_connector_state_manager.test_field = "test"
+    dummy_connector_state_manager.extra_field = "any value"
 
     # When: saving the state to OpenCTI
     dummy_connector_state_manager.save()
 
     # Then: `OpenCTIConnectorHelper.set_state` method should be called with the correct dict including extra fields
     mock_opencti_connector_helper.set_state.assert_called_once_with(
-        {"last_run": "2024-01-01T00:00:00Z", "custom_value": "test"}
+        {
+            "last_run": "2024-01-01T00:00:00+00:00",
+            "test_field": "test",
+            "extra_field": "any value",
+        }
     )
     mock_opencti_connector_helper.force_ping.assert_called_once()

--- a/connectors-sdk/tests/tests_state_manager/test_state_manager.py
+++ b/connectors-sdk/tests/tests_state_manager/test_state_manager.py
@@ -73,7 +73,53 @@ def test_connector_state_manager_rejects_invalid_input(dummy_connector_state_man
         dummy_connector_state_manager.last_run = "not a datetime"
 
 
-def test_connector_state_manager_load(
+def test_connector_state_manager_load_warns_when_not_synchronized(
+    dummy_connector_state_manager, mock_opencti_connector_helper
+):
+    """Test that `ConnectorStateManager` instance does not load state from OpenCTI when not synchronized."""
+    # Given: a `ConnectorStateManager` instance that is not synchronized (default state after init)
+    mock_opencti_connector_helper.get_state.return_value = {
+        "last_run": "2024-01-01T00:00:00+00:00",
+        "test_field": "test",
+    }
+    original_last_run = dummy_connector_state_manager.last_run
+    original_test_field = dummy_connector_state_manager.test_field
+
+    # When: loading the state without `force=True`
+    # Then: a `UserWarning` should be raised and the state should NOT be loaded
+    with pytest.warns(UserWarning):
+        dummy_connector_state_manager.load()
+
+    mock_opencti_connector_helper.get_state.assert_not_called()
+    assert dummy_connector_state_manager.last_run == original_last_run
+    assert dummy_connector_state_manager.test_field == original_test_field
+
+
+def test_connector_state_manager_load_when_synchronized(
+    dummy_connector_state_manager, mock_opencti_connector_helper
+):
+    """Test that `ConnectorStateManager` instance loads state from OpenCTI when synchronized."""
+    # Given: a `ConnectorStateManager` instance that is synchronized with OpenCTI
+    mock_opencti_connector_helper.get_state.return_value = {
+        "last_run": "2024-01-01T00:00:00+00:00",
+        "test_field": "test",
+    }
+    dummy_connector_state_manager.last_run = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    dummy_connector_state_manager.test_field = "test"
+    dummy_connector_state_manager._sync = True
+
+    # When: loading the state
+    dummy_connector_state_manager.load()
+
+    # Then: the state should be loaded without warnings
+    mock_opencti_connector_helper.get_state.assert_called_once()
+    assert dummy_connector_state_manager.last_run == datetime(
+        2024, 1, 1, tzinfo=timezone.utc
+    )
+    assert dummy_connector_state_manager.test_field == "test"
+
+
+def test_connector_state_manager_load_with_force(
     dummy_connector_state_manager, mock_opencti_connector_helper
 ):
     """Test that `ConnectorStateManager` instance loads state from OpenCTI correctly."""
@@ -85,7 +131,7 @@ def test_connector_state_manager_load(
     }
 
     # When: loading the state into a `ConnectorStateManager` instance
-    dummy_connector_state_manager.load()
+    dummy_connector_state_manager.load(force=True)
 
     # Then: `OpenCTIConnectorHelper.get_state` method should be called and
     # the `dummy_connector_state_manager` fields should be updated with the loaded state
@@ -106,7 +152,7 @@ def test_connector_state_manager_load_ignores_helper_key(
 
     # When: loading the state into a `ConnectorStateManager` instance
     original_helper = dummy_connector_state_manager._helper
-    dummy_connector_state_manager.load()
+    dummy_connector_state_manager.load(force=True)
 
     # Then: `OpenCTIConnectorHelper.get_state` method should be called and
     # the `dummy_connector_state_manager` fields should be updated with the loaded state

--- a/connectors-sdk/tests/tests_state_manager/test_state_manager.py
+++ b/connectors-sdk/tests/tests_state_manager/test_state_manager.py
@@ -88,6 +88,24 @@ def test_connector_state_manager_load(
     assert dummy_connector_state_manager.custom_value == "test"
 
 
+def test_connector_state_manager_load_ignores_helper_key(
+    dummy_connector_state_manager, mock_opencti_connector_helper
+):
+    """Test that `ConnectorStateManager` instance loads state from OpenCTI correctly."""
+    # Given: a state stored on OpenCTI
+    mock_opencti_connector_helper.get_state.return_value = {"_helper": "test"}
+
+    # When: loading the state into a `ConnectorStateManager` instance
+    original_helper = dummy_connector_state_manager._helper
+    dummy_connector_state_manager.load()
+
+    # Then: `OpenCTIConnectorHelper.get_state` method should be called and
+    # the `dummy_connector_state_manager` fields should be updated with the loaded state
+    mock_opencti_connector_helper.get_state.assert_called_once()
+    assert dummy_connector_state_manager.last_run is None
+    assert dummy_connector_state_manager._helper == original_helper
+
+
 def test_connector_state_manager_save(
     dummy_connector_state_manager, mock_opencti_connector_helper
 ):
@@ -101,5 +119,23 @@ def test_connector_state_manager_save(
     # the state should be updated immediately on OpenCTI (`force_ping` called)
     mock_opencti_connector_helper.set_state.assert_called_once_with(
         {"last_run": "2024-01-01T00:00:00Z"}
+    )
+    mock_opencti_connector_helper.force_ping.assert_called_once()
+
+
+def test_connector_state_manager_save_sends_extra_fields(
+    dummy_connector_state_manager, mock_opencti_connector_helper
+):
+    """Test that `ConnectorStateManager` instance saves extra fields onto OpenCTI correctly."""
+    # Given: an instance of `ConnectorStateManager` with extra fields
+    dummy_connector_state_manager.last_run = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    dummy_connector_state_manager.custom_value = "test"
+
+    # When: saving the state to OpenCTI
+    dummy_connector_state_manager.save()
+
+    # Then: `OpenCTIConnectorHelper.set_state` method should be called with the correct dict including extra fields
+    mock_opencti_connector_helper.set_state.assert_called_once_with(
+        {"last_run": "2024-01-01T00:00:00Z", "custom_value": "test"}
     )
     mock_opencti_connector_helper.force_ping.assert_called_once()

--- a/connectors-sdk/tests/tests_state_manager/test_state_manager.py
+++ b/connectors-sdk/tests/tests_state_manager/test_state_manager.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 import pytest
 from connectors_sdk.state_manager.state_manager import ConnectorStateManager
+from pycti import OpenCTIConnectorHelper
 from pydantic import BaseModel
 
 
@@ -16,6 +17,25 @@ def test_connector_state_manager_is_pydantic_model():
     # Given: the `ConnectorStateManager` class
     # Then: it should be a subclass of pydantic.BaseModel
     assert issubclass(ConnectorStateManager, BaseModel)
+
+
+def test_connector_state_manager_has_helper_attribute(dummy_connector_state_manager):
+    """Test that `ConnectorStateManager` instance has a `_helper` attribute."""
+    # Given: an instance of `ConnectorStateManager`
+    # Then: it should have a `_helper` attribute that is an instance of `OpenCTIConnectorHelper`
+    assert hasattr(dummy_connector_state_manager, "_helper")
+    assert isinstance(dummy_connector_state_manager._helper, OpenCTIConnectorHelper)
+
+
+def test_connector_state_manager_validates_helper_argument():
+    """Test that `ConnectorStateManager` raises a `ValueError` if the `helper` argument is invalid."""
+    # Given: an invalid `helper` argument (not an instance of `OpenCTIConnectorHelper`)
+    invalid_helper = "not a helper"
+
+    # When: initializing a `ConnectorStateManager` instance with the invalid helper
+    # Then: it should raise a `ValueError`
+    with pytest.raises(ValueError):
+        ConnectorStateManager(helper=invalid_helper)  # type: ignore
 
 
 def test_connector_state_manager_has_default_values(dummy_connector_state_manager):

--- a/connectors-sdk/tests/tests_state_manager/test_state_manager.py
+++ b/connectors-sdk/tests/tests_state_manager/test_state_manager.py
@@ -1,0 +1,85 @@
+from datetime import datetime, timezone
+
+import pytest
+from connectors_sdk.state_manager.state_manager import ConnectorStateManager
+from pydantic import BaseModel
+
+
+@pytest.fixture
+def dummy_connector_state_manager(mock_opencti_connector_helper):
+    """A dummy `ConnectorStateManager` instance for testing purposes."""
+    return ConnectorStateManager(helper=mock_opencti_connector_helper)
+
+
+def test_connector_state_manager_is_pydantic_model():
+    """Test that `ConnectorStateManager` is a Pydantic model."""
+    # Given: the `ConnectorStateManager` class
+    # Then: it should be a subclass of pydantic.BaseModel
+    assert issubclass(ConnectorStateManager, BaseModel)
+
+
+def test_connector_state_manager_has_default_values(dummy_connector_state_manager):
+    """Test that `ConnectorStateManager` model initializes with default values."""
+    # Given: a new instance of `ConnectorStateManager`
+    # Then: it should have default values for its fields
+    assert dummy_connector_state_manager.last_run is None
+
+
+def test_connector_state_manager_accepts_valid_input(dummy_connector_state_manager):
+    """Test that `ConnectorStateManager` model accepts valid input."""
+    # Given: an instance of `ConnectorStateManager`
+    # When: setting a valid datetime string to the `last_run` field
+    dummy_connector_state_manager.last_run = "2024-01-01T00:00:00Z"
+
+    # Then: the field should be updated with the corresponding datetime object
+    assert dummy_connector_state_manager.last_run == datetime(
+        2024, 1, 1, tzinfo=timezone.utc
+    )
+
+
+def test_connector_state_manager_rejects_invalid_input(dummy_connector_state_manager):
+    """Test that `ConnectorStateManager` model rejects invalid input."""
+    # Given: an instance of `ConnectorStateManager`
+    # When: setting an invalid value to the `last_run` field
+    # Then: pydantic should raise a `ValueError` due to validation error
+    with pytest.raises(ValueError):
+        dummy_connector_state_manager.last_run = "not a datetime"
+
+
+def test_connector_state_manager_load(
+    dummy_connector_state_manager, mock_opencti_connector_helper
+):
+    """Test that `ConnectorStateManager` instance loads state from OpenCTI correctly."""
+    # Given: a state stored on OpenCTI
+    mock_opencti_connector_helper.get_state.return_value = {
+        "last_run": "2024-01-01T00:00:00Z",
+        "custom_value": "test",
+    }
+
+    # When: loading the state into a `ConnectorStateManager` instance
+    dummy_connector_state_manager.load()
+
+    # Then: `OpenCTIConnectorHelper.get_state` method should be called and
+    # the `dummy_connector_state_manager` fields should be updated with the loaded state
+    mock_opencti_connector_helper.get_state.assert_called_once()
+    assert dummy_connector_state_manager.last_run == datetime(
+        2024, 1, 1, 0, 0, tzinfo=timezone.utc
+    )
+    assert dummy_connector_state_manager.custom_value == "test"
+
+
+def test_connector_state_manager_save(
+    dummy_connector_state_manager, mock_opencti_connector_helper
+):
+    """Test that `ConnectorStateManager` instance saves its fields onto OpenCTI correctly."""
+    # Given: an instance of `ConnectorStateManager`
+    # When: saving a new `last_run` value to OpenCTI
+    dummy_connector_state_manager.last_run = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    dummy_connector_state_manager.save()
+
+    # Then: `OpenCTIConnectorHelper.set_state` method should be called with the correct dict and
+    # the state should be updated immediately on OpenCTI (`force_ping` called)
+    mock_opencti_connector_helper.set_state.assert_called_once_with(
+        {"last_run": "2024-01-01T00:00:00Z"}
+    )
+    mock_opencti_connector_helper.force_ping.assert_called_once()


### PR DESCRIPTION
### Proposed changes

* create `ConnectorStateManager` class (inherits from `pydantic.BaseModel`)
* create unit tests
* add TDR

### Related issues

* close #6206

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion) -> TDR
- [x] ~~Where necessary I refactored code to improve the overall quality~~


### Further comments

- I chose to use `helper.force_ping()` to update state immediately on OpenCTI, although it could be removed and the state will be updated on connector's heartbeats (approximately every 40 seconds).
- I kept the semantic of "state manager" to be compliant with the issue, but it might be confused with the concept of "state machines". Actually, `ConnectorStateManager` class could be called `ConnectorState` as it only defines the attributes of an object and some CRUD methods (read/update).
