### PR TITLE
[s3/connectors-sdk] Pass abstract to Note.generate_id for dedup alignment (opencti#15493)

### DIFF
--- a/connectors-sdk/connectors_sdk/models/note.py
+++ b/connectors-sdk/connectors_sdk/models/note.py
@@ -62,6 +62,7 @@ class Note(BaseIdentifiedEntity):
             id=PyctiNote.generate_id(
                 content=self.content,
                 created=self.publication_date,
+                abstract=self.abstract,
             ),
             abstract=self.abstract,
             content=self.content,

--- a/connectors-sdk/connectors_sdk/models/note.py
+++ b/connectors-sdk/connectors_sdk/models/note.py
@@ -1,6 +1,5 @@
 """Note."""
 
-import inspect
 from collections import OrderedDict
 
 import stix2.properties
@@ -10,10 +9,6 @@ from connectors_sdk.models.reference import Reference
 from pycti import Note as PyctiNote
 from pydantic import AwareDatetime, Field
 from stix2.v21 import Note as Stix2Note
-
-_GENERATE_ID_SUPPORTS_ABSTRACT = (
-    "abstract" in inspect.signature(PyctiNote.generate_id).parameters
-)
 
 
 class NoteStix(Stix2Note):  # type: ignore[misc]
@@ -63,14 +58,19 @@ class Note(BaseIdentifiedEntity):
 
     def to_stix2_object(self) -> Stix2Note:
         """Make stix object."""
-        generate_id_kwargs: dict = {
-            "content": self.content,
-            "created": self.publication_date,
-        }
-        if _GENERATE_ID_SUPPORTS_ABSTRACT:
-            generate_id_kwargs["abstract"] = self.abstract
+        try:
+            note_id = PyctiNote.generate_id(
+                content=self.content,
+                created=self.publication_date,
+                abstract=self.abstract,
+            )
+        except TypeError:
+            note_id = PyctiNote.generate_id(
+                content=self.content,
+                created=self.publication_date,
+            )
         return NoteStix(
-            id=PyctiNote.generate_id(**generate_id_kwargs),
+            id=note_id,
             abstract=self.abstract,
             content=self.content,
             labels=self.labels,

--- a/connectors-sdk/connectors_sdk/models/note.py
+++ b/connectors-sdk/connectors_sdk/models/note.py
@@ -58,19 +58,12 @@ class Note(BaseIdentifiedEntity):
 
     def to_stix2_object(self) -> Stix2Note:
         """Make stix object."""
-        try:
-            note_id = PyctiNote.generate_id(
+        return NoteStix(
+            id=PyctiNote.generate_id(
                 content=self.content,
                 created=self.publication_date,
                 abstract=self.abstract,
-            )
-        except TypeError:
-            note_id = PyctiNote.generate_id(
-                content=self.content,
-                created=self.publication_date,
-            )
-        return NoteStix(
-            id=note_id,
+            ),
             abstract=self.abstract,
             content=self.content,
             labels=self.labels,

--- a/connectors-sdk/connectors_sdk/models/note.py
+++ b/connectors-sdk/connectors_sdk/models/note.py
@@ -58,19 +58,11 @@ class Note(BaseIdentifiedEntity):
 
     def to_stix2_object(self) -> Stix2Note:
         """Make stix object."""
-        try:
-            note_id = PyctiNote.generate_id(
-                content=self.content,
-                created=self.publication_date,
-                abstract=self.abstract,
-            )
-        except TypeError:
-            note_id = PyctiNote.generate_id(
-                content=self.content,
-                created=self.publication_date,
-            )
         return NoteStix(
-            id=note_id,
+            id=PyctiNote.generate_id(
+                content=self.content,
+                created=self.publication_date,
+            ),
             abstract=self.abstract,
             content=self.content,
             labels=self.labels,

--- a/connectors-sdk/connectors_sdk/models/note.py
+++ b/connectors-sdk/connectors_sdk/models/note.py
@@ -58,11 +58,19 @@ class Note(BaseIdentifiedEntity):
 
     def to_stix2_object(self) -> Stix2Note:
         """Make stix object."""
-        return NoteStix(
-            id=PyctiNote.generate_id(
+        try:
+            note_id = PyctiNote.generate_id(
                 content=self.content,
                 created=self.publication_date,
-            ),
+                abstract=self.abstract,
+            )
+        except TypeError:
+            note_id = PyctiNote.generate_id(
+                content=self.content,
+                created=self.publication_date,
+            )
+        return NoteStix(
+            id=note_id,
             abstract=self.abstract,
             content=self.content,
             labels=self.labels,

--- a/connectors-sdk/connectors_sdk/models/note.py
+++ b/connectors-sdk/connectors_sdk/models/note.py
@@ -1,5 +1,6 @@
 """Note."""
 
+import inspect
 from collections import OrderedDict
 
 import stix2.properties
@@ -9,6 +10,10 @@ from connectors_sdk.models.reference import Reference
 from pycti import Note as PyctiNote
 from pydantic import AwareDatetime, Field
 from stix2.v21 import Note as Stix2Note
+
+_GENERATE_ID_SUPPORTS_ABSTRACT = (
+    "abstract" in inspect.signature(PyctiNote.generate_id).parameters
+)
 
 
 class NoteStix(Stix2Note):  # type: ignore[misc]
@@ -58,12 +63,14 @@ class Note(BaseIdentifiedEntity):
 
     def to_stix2_object(self) -> Stix2Note:
         """Make stix object."""
+        generate_id_kwargs: dict = {
+            "content": self.content,
+            "created": self.publication_date,
+        }
+        if _GENERATE_ID_SUPPORTS_ABSTRACT:
+            generate_id_kwargs["abstract"] = self.abstract
         return NoteStix(
-            id=PyctiNote.generate_id(
-                content=self.content,
-                created=self.publication_date,
-                abstract=self.abstract,
-            ),
+            id=PyctiNote.generate_id(**generate_id_kwargs),
             abstract=self.abstract,
             content=self.content,
             labels=self.labels,

--- a/external-import/s3/src/s3.py
+++ b/external-import/s3/src/s3.py
@@ -587,9 +587,7 @@ class S3Connector:
                 else:
                     note_key = obj.get("x_acti_uuid") + " - " + obj_name + " - Title"
                 note = stix2.Note(
-                    id=Note.generate_id(
-                        obj["created"], note_key, abstract=note_abstract
-                    ),
+                    id=Note.generate_id(obj["created"], note_key),
                     created=obj["created"],
                     abstract=note_abstract,
                     content=obj.get("x_title"),
@@ -618,9 +616,7 @@ class S3Connector:
                 else:
                     note_key = obj.get("x_acti_uuid") + " - " + obj_name + " - Analysis"
                 note = stix2.Note(
-                    id=Note.generate_id(
-                        obj["created"], note_key, abstract=note_abstract
-                    ),
+                    id=Note.generate_id(obj["created"], note_key),
                     created=obj["created"],
                     abstract=note_abstract,
                     content=obj["x_analysis"],
@@ -660,7 +656,7 @@ class S3Connector:
                 else:
                     note_key = obj.get("x_acti_uuid") + " - " + obj_name + " - History"
                 note = stix2.Note(
-                    id=Note.generate_id(obj["created"], note_key, abstract=abstract),
+                    id=Note.generate_id(obj["created"], note_key),
                     created=obj["created"],
                     abstract=abstract,
                     content=note_content,

--- a/external-import/s3/src/s3.py
+++ b/external-import/s3/src/s3.py
@@ -587,7 +587,9 @@ class S3Connector:
                 else:
                     note_key = obj.get("x_acti_uuid") + " - " + obj_name + " - Title"
                 note = stix2.Note(
-                    id=Note.generate_id(obj["created"], note_key, abstract=note_abstract),
+                    id=Note.generate_id(
+                        obj["created"], note_key, abstract=note_abstract
+                    ),
                     created=obj["created"],
                     abstract=note_abstract,
                     content=obj.get("x_title"),
@@ -616,7 +618,9 @@ class S3Connector:
                 else:
                     note_key = obj.get("x_acti_uuid") + " - " + obj_name + " - Analysis"
                 note = stix2.Note(
-                    id=Note.generate_id(obj["created"], note_key, abstract=note_abstract),
+                    id=Note.generate_id(
+                        obj["created"], note_key, abstract=note_abstract
+                    ),
                     created=obj["created"],
                     abstract=note_abstract,
                     content=obj["x_analysis"],

--- a/external-import/s3/src/s3.py
+++ b/external-import/s3/src/s3.py
@@ -587,7 +587,7 @@ class S3Connector:
                 else:
                     note_key = obj.get("x_acti_uuid") + " - " + obj_name + " - Title"
                 note = stix2.Note(
-                    id=Note.generate_id(obj["created"], note_key),
+                    id=Note.generate_id(obj["created"], note_key, abstract=note_abstract),
                     created=obj["created"],
                     abstract=note_abstract,
                     content=obj.get("x_title"),
@@ -616,7 +616,7 @@ class S3Connector:
                 else:
                     note_key = obj.get("x_acti_uuid") + " - " + obj_name + " - Analysis"
                 note = stix2.Note(
-                    id=Note.generate_id(obj["created"], note_key),
+                    id=Note.generate_id(obj["created"], note_key, abstract=note_abstract),
                     created=obj["created"],
                     abstract=note_abstract,
                     content=obj["x_analysis"],
@@ -656,7 +656,7 @@ class S3Connector:
                 else:
                     note_key = obj.get("x_acti_uuid") + " - " + obj_name + " - History"
                 note = stix2.Note(
-                    id=Note.generate_id(obj["created"], note_key),
+                    id=Note.generate_id(obj["created"], note_key, abstract=abstract),
                     created=obj["created"],
                     abstract=abstract,
                     content=note_content,

--- a/internal-enrichment/censys-enrichment/tests/censys_enrichment/test_converter.py
+++ b/internal-enrichment/censys-enrichment/tests/censys_enrichment/test_converter.py
@@ -224,7 +224,7 @@ def test_converter_ipv4(host_ipv4: Host) -> None:
     assert entity.authors == ["Censys Enrichment Connector"]
     assert entity.content == "HTTP/1.1 301 Moved Permanently"
     assert entity.created_by_ref == "identity--6f9f67f6-7eb2-5397-a02f-d8130aadb954"
-    assert entity.id == "note--ec194bf2-4ee0-5338-857f-4c3f727b8ebf"
+    assert entity.id == "note--57d22a6d-39ea-591e-b86e-a40d31540c14"
     assert entity.object_marking_refs == [
         "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9"
     ]


### PR DESCRIPTION
### Proposed changes

* Update S3 connector to pass the `abstract` parameter to `Note.generate_id()` for all three note types (Title, Analysis, History), aligning connector STIX IDs with the platform's updated `standard_id` computation
* Update connectors-sdk `Note.to_stix2_object()` to pass `self.abstract` to `PyctiNote.generate_id()`

### Related issues

* Closes #6226
* Related to OpenCTI-Platform/opencti#15493
* Companion to OpenCTI-Platform/opencti#15494

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This is the connector-side companion to OpenCTI-Platform/opencti#15494, which adds `attribute_abstract` to the Note `standard_id` contribution on the platform.

The pycti `Note.generate_id()` now accepts an optional `abstract` parameter (backward-compatible, defaults to `None`). This PR updates the two places in the connectors repo that create Notes to pass the abstract through, so the connector-generated STIX IDs incorporate the abstract field.

**Note:** This PR depends on the pycti change in OpenCTI-Platform/opencti#15494 being released. Until then, the `abstract` keyword argument is simply ignored by the current pycti version (it will raise a `TypeError`), so this should be merged after the platform PR.
