### PR TITLE
[all] Fix dynamic defaults for import start dates

### DIFF
--- a/external-import/checkfirst-import-connector/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/checkfirst-import-connector/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -16,7 +16,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
 | CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"P7D"` | The period of time to await between two runs of the connector. |
 | CHECKFIRST_API_ENDPOINT | `string` |  | string | `"/v1/articles"` | API endpoint path (e.g., /v1/articles). |
-| CHECKFIRST_SINCE | `string` |  | Format: [`date-time`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"2025-04-17T08:55:42.486050Z"` | Only ingest articles published on or after this date. Accepts ISO 8601 absolute dates (e.g., 2024-01-01T00:00:00Z) or durations relative to now (e.g., P365D, P1Y, P6M, P4W). Defaults to 1 year ago. |
+| CHECKFIRST_SINCE | `string` |  | Format: [`date-time`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"P1Y"` | Only ingest articles published on or after this date. Accepts ISO 8601 absolute dates (e.g., 2024-01-01T00:00:00Z) or durations relative to now (e.g., P365D, P1Y, P6M, P4W). Defaults to 1 year ago. |
 | CHECKFIRST_FORCE_REPROCESS | `boolean` |  | boolean | `false` | If true, ignore any saved connector state and start from page 1. Useful for debugging or re-importing all data. |
 | CHECKFIRST_TLP_LEVEL | `string` |  | `clear` `white` `green` `amber` `amber+strict` `red` | `"clear"` | TLP marking level applied to created STIX entities. |
 | CHECKFIRST_MAX_ROW_BYTES | `integer` |  | integer | `null` | Skip any API row larger than this approximate number of bytes. |

--- a/external-import/checkfirst-import-connector/__metadata__/connector_config_schema.json
+++ b/external-import/checkfirst-import-connector/__metadata__/connector_config_schema.json
@@ -71,7 +71,7 @@
       "writeOnly": true
     },
     "CHECKFIRST_SINCE": {
-      "default": "2025-04-17T08:55:42.486050Z",
+      "default": "P1Y",
       "description": "Only ingest articles published on or after this date. Accepts ISO 8601 absolute dates (e.g., 2024-01-01T00:00:00Z) or durations relative to now (e.g., P365D, P1Y, P6M, P4W). Defaults to 1 year ago.",
       "format": "date-time",
       "type": "string"

--- a/external-import/checkfirst-import-connector/src/connector/settings.py
+++ b/external-import/checkfirst-import-connector/src/connector/settings.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 
 from connectors_sdk import (
     BaseConfigModel,
@@ -8,7 +8,7 @@ from connectors_sdk import (
     ListFromString,
 )
 from connectors_sdk.models.enums import TLPLevel
-from pydantic import Field, HttpUrl, SecretStr
+from pydantic import Field, HttpUrl, SecretStr, TypeAdapter
 
 
 class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
@@ -57,7 +57,12 @@ class CheckfirstImportConnectorConfig(BaseConfigModel):
             "or durations relative to now (e.g., P365D, P1Y, P6M, P4W). "
             "Defaults to 1 year ago."
         ),
-        default=datetime.now(tz=timezone.utc) - timedelta(days=365),
+        # `default_factory` is used to set a dynamic default value (datetime) at runtime
+        default_factory=lambda: TypeAdapter(DatetimeFromIsoString).validate_python(
+            "P1Y"
+        ),
+        # but a fixed default value (ISO string) must be used in the schema for documentation purposes
+        json_schema_extra={"default": "P1Y"},
     )
     force_reprocess: bool = Field(
         description=(

--- a/external-import/dragos/src/dragos/settings.py
+++ b/external-import/dragos/src/dragos/settings.py
@@ -92,7 +92,10 @@ class DragosConfig(BaseConfigModel):
     )
     import_start_date: DatetimeFromIsoString = Field(
         description="Start date of first import (ISO format). Can be a relative or an absolute date.",
+        # `default_factory` is used to set a dynamic default value (datetime) at runtime
         default_factory=lambda: iso_string_validator("P30D"),  # 30 days ago
+        # but a fixed default value (ISO string) must be used in the schema for documentation purposes
+        json_schema_extra={"default": "P30D"},
     )
     tlp_level: Literal[
         "white",

--- a/external-import/flashpoint/src/flashpoint_connector/config_loader.py
+++ b/external-import/flashpoint/src/flashpoint_connector/config_loader.py
@@ -171,7 +171,10 @@ class FlashpointConfig(ConfigBaseModel):
     api_key: SecretStr = Field(description="The API key to connect to Flashpoint.")
     import_start_date: DatetimeFromIsoString = Field(
         description="The date from which to start importing data.",
+        # `default_factory` is used to set a dynamic default value (datetime) at runtime
         default_factory=lambda: iso_string_validator("P30D"),  # 30 days ago
+        # but a fixed default value (ISO string) must be used in the schema for documentation purposes
+        json_schema_extra={"default": "P30D"},
     )
     import_reports: bool = Field(
         description="Whether to import reports from Flashpoint or not.",

--- a/external-import/greynoise-feed/src/connector/config_loader.py
+++ b/external-import/greynoise-feed/src/connector/config_loader.py
@@ -1,6 +1,6 @@
 import os
 import warnings
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 from typing import Annotated, Literal, Optional
 
@@ -12,7 +12,6 @@ from pydantic import (
     HttpUrl,
     PlainSerializer,
     SecretStr,
-    TypeAdapter,
     model_validator,
 )
 from pydantic_core.core_schema import SerializationInfo
@@ -66,30 +65,6 @@ def comma_separated_list_validator(value: str | list[str]) -> list[str]:
     return value
 
 
-def iso_string_validator(value: str) -> datetime:
-    """
-    Convert ISO string into a datetime object.
-
-    Example:
-        > value = iso_string_validator("2023-10-01T00:00:00Z")
-        > print(value) # 2023-10-01 00:00:00+00:00
-
-        # If today is 2023-10-01:
-        > value = iso_string_validator("P30D")
-        > print(value) # 2023-09-01 00:00:00+00:00
-    """
-    if isinstance(value, str):
-        try:
-            # Convert presumed ISO string to datetime object
-            return datetime.fromisoformat(value).astimezone(tz=timezone.utc)
-        except ValueError:
-            # If not a datetime ISO string, try to parse it as timedelta with pydantic first
-            duration = TypeAdapter(timedelta).validate_python(value)
-            # Then return a datetime minus the value
-            return datetime.now(timezone.utc) - duration
-    return value
-
-
 def pycti_list_serializer(value: list[str], info: SerializationInfo) -> str | list[str]:
     """
     Serialize list of values as comma-separated string.
@@ -107,13 +82,6 @@ ListFromString = Annotated[
     list[str],
     BeforeValidator(comma_separated_list_validator),
     PlainSerializer(pycti_list_serializer, when_used="json"),
-]
-
-DatetimeFromIsoString = Annotated[
-    datetime,
-    BeforeValidator(iso_string_validator),
-    # Replace the default serializer as it uses Z prefix instead of +00:00 offset
-    PlainSerializer(datetime.isoformat, when_used="json"),
 ]
 
 


### PR DESCRIPTION
### Proposed changes

* use `default_factory` when using a dynamic default
* use `json_schema_extra` to produce deterministic config JSON schemas **with** a default

### Related issues

* close #6257 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

