### PR TITLE
[group-ib] Support running as an arbitrary user (OpenShift)

### DIFF
--- a/external-import/group-ib/Dockerfile
+++ b/external-import/group-ib/Dockerfile
@@ -12,6 +12,9 @@ WORKDIR /opt/connector/src
 RUN pip3 install --no-cache-dir -r /opt/connector/src/requirements.txt
 RUN rm -rf /var/cache/apk/*
 
+# Support arbitrary user id
+RUN chown -R :root /opt/connector && chmod -R g+rwX /opt/connector
+
 # Expose and entrypoint
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
This PR fixes  errors cause by OCP running container using an arbitrarily assigned user ID (I fixed same errors in other connectors in #2507).

group-ib uses file as cache storage (https://github.com/OpenCTI-Platform/connectors/blob/7292475289046df7ed243f6464f8c931e6654cbd/external-import/group-ib/src/lib/external_import.py#L14-L17).

### Proposed changes
* Change group for `/opt/connector` directory to `root`
* Modify group permissions for `/opt/connector` directory

### Related issues
* Fixes #2507 for group-ib connector  


### Checklist
- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
