### PR TITLE
[chapsvision] bug(connector): deterministic ID for media-content (#6242)

### DIFF
--- a/external-import/chapsvision/src/chapsvision.py
+++ b/external-import/chapsvision/src/chapsvision.py
@@ -3,7 +3,6 @@ import json
 import os
 import sys
 import time
-import uuid
 from datetime import datetime, timedelta
 
 import pytz
@@ -11,8 +10,11 @@ import requests
 import stix2
 import yaml
 from dateutil.parser import parse
-from pycti import OpenCTIConnectorHelper, get_config_variable
-from stix2.canonicalization.Canonicalize import canonicalize
+from pycti import (
+    CustomObservableMediaContent,
+    OpenCTIConnectorHelper,
+    get_config_variable,
+)
 
 
 class Chapsvision:
@@ -99,11 +101,7 @@ class Chapsvision:
         :return: STIX ID for the Media Content
         :rtype: str
         """
-        url = url.lower().strip()
-        data = {"url": url}
-        data = canonicalize(data, utf8=False)
-        id = str(uuid.uuid5(uuid.UUID("00abedb4-aa42-466c-9c01-fed23315a9b7"), data))
-        return "media-content--" + id
+        return CustomObservableMediaContent(url=url).id
 
     def generate_micro_blogging(self, doc):
         objects = []

--- a/external-import/chapsvision/src/chapsvision.py
+++ b/external-import/chapsvision/src/chapsvision.py
@@ -12,6 +12,7 @@ import stix2
 import yaml
 from dateutil.parser import parse
 from pycti import OpenCTIConnectorHelper, get_config_variable
+from stix2.canonicalization.Canonicalize import canonicalize
 
 
 class Chapsvision:
@@ -90,6 +91,20 @@ class Chapsvision:
         except Exception as e:
             self.helper.log_error(f"Error while sending bundle: {e}")
 
+    def _generate_id_for_media_content(self, url: str) -> str:
+        """Generate deterministic STIX ID for a Media Content object
+
+        :param url: the URL of the Media Content
+        :type url: str
+        :return: STIX ID for the Media Content
+        :rtype: str
+        """
+        url = url.lower().strip()
+        data = {"url": url}
+        data = canonicalize(data, utf8=False)
+        id = str(uuid.uuid5(uuid.UUID("00abedb4-aa42-466c-9c01-fed23315a9b7"), data))
+        return "media-content--" + id
+
     def generate_micro_blogging(self, doc):
         objects = []
         channel = None
@@ -114,7 +129,7 @@ class Chapsvision:
                 for hashtag in doc["hashtag"]:
                     labels.append(hashtag.replace("#", ""))
             media_content = {
-                "id": "media-content--" + str(uuid.uuid4()),
+                "id": self._generate_id_for_media_content(doc["link"]),
                 "type": "media-content",
                 "media_category": doc["broadcaster_category"],
                 "url": doc["link"],
@@ -158,7 +173,7 @@ class Chapsvision:
                 for hashtag in doc["hashtag"]:
                     labels.append(hashtag.replace("#", ""))
             media_content = {
-                "id": "media-content--" + str(uuid.uuid4()),
+                "id": self._generate_id_for_media_content(doc["link"]),
                 "type": "media-content",
                 "media_category": doc["broadcaster_category"],
                 "url": doc["link"],
@@ -202,7 +217,7 @@ class Chapsvision:
                 for hashtag in doc["hashtag"]:
                     labels.append(hashtag.replace("#", ""))
             media_content = {
-                "id": "media-content--" + str(uuid.uuid4()),
+                "id": self._generate_id_for_media_content(doc["link"]),
                 "type": "media-content",
                 "media_category": doc["broadcaster_category"],
                 "url": doc["link"],

--- a/external-import/chapsvision/src/tests/test_chapvision.py
+++ b/external-import/chapsvision/src/tests/test_chapvision.py
@@ -6,12 +6,27 @@ import chapsvision as module
 
 @patch.object(module, "base64")
 @patch.object(module, "OpenCTIConnectorHelper")
-@patch.object(module.Chapsvision, "_generate_id_for_media_content")
 @patch.object(module, "os")
 class ChapsvisionTest(unittest.TestCase):
+    def test_generate_id_for_media_content_determinism(self, m_os, m_helper, m_base64):
+        """testing duplicate content provide identical ID for media-content"""
+        _url = "https://foo.bar"
+        _other_url = "https://foo.bar/error"
 
+        m_os.path.isfile.return_value = False
+        with patch("builtins.open", mock_open()) as _:
+            _connector = module.Chapsvision()
+
+        first_id = _connector._generate_id_for_media_content(_url)
+        second_id = _connector._generate_id_for_media_content(_url)
+        other_id = _connector._generate_id_for_media_content(_other_url)
+
+        self.assertEqual(first_id, second_id)
+        self.assertNotEqual(first_id, other_id)
+
+    @patch.object(module.Chapsvision, "_generate_id_for_media_content")
     def test_generate_micro_blogging_link_only_single(
-        self, m_os, m_gen_id, m_helper, m_base64
+        self, m_gen_id, m_os, m_helper, m_base64
     ):
         """testing serialization by generate_micro_blogging for link only data (single)"""
         _link = sentinel.link
@@ -23,7 +38,7 @@ class ChapsvisionTest(unittest.TestCase):
         }
 
         m_os.path.isfile.return_value = False
-        with patch("builtins.open", mock_open()) as m_open:
+        with patch("builtins.open", mock_open()) as _:
             _connector = module.Chapsvision()
 
         objects = _connector.generate_micro_blogging(_doc)
@@ -33,8 +48,9 @@ class ChapsvisionTest(unittest.TestCase):
         self.assertEqual(objects[0]["media_category"], sentinel.broadcaster_category)
         self.assertEqual(objects[0]["url"], sentinel.link)
 
+    @patch.object(module.Chapsvision, "_generate_id_for_media_content")
     def test_generate_micro_blogging_link_only_duplicate(
-        self, m_os, m_gen_id, m_helper, m_base64
+        self, m_gen_id, m_os, m_helper, m_base64
     ):
         """testing serialization by generate_micro_blogging for link only data (duplicate)"""
         _link = sentinel.link
@@ -46,7 +62,7 @@ class ChapsvisionTest(unittest.TestCase):
         }
 
         m_os.path.isfile.return_value = False
-        with patch("builtins.open", mock_open()) as m_open:
+        with patch("builtins.open", mock_open()) as _:
             _connector = module.Chapsvision()
 
         objects_first_run = _connector.generate_micro_blogging(_doc)
@@ -66,7 +82,8 @@ class ChapsvisionTest(unittest.TestCase):
         self.assertEqual(objects_first_run[0]["url"], objects_second_run[0]["url"])
         self.assertEqual(objects_first_run[0]["id"], objects_second_run[0]["id"])
 
-    def test_generate_website_single(self, m_os, m_gen_id, m_helper, m_base64):
+    @patch.object(module.Chapsvision, "_generate_id_for_media_content")
+    def test_generate_website_single(self, m_gen_id, m_os, m_helper, m_base64):
         """testing serialization by generate_website (single)"""
         _link = sentinel.link
         _broadcaster_category = sentinel.broadcaster_category
@@ -77,7 +94,7 @@ class ChapsvisionTest(unittest.TestCase):
         }
 
         m_os.path.isfile.return_value = False
-        with patch("builtins.open", mock_open()) as m_open:
+        with patch("builtins.open", mock_open()) as _:
             _connector = module.Chapsvision()
 
         objects = _connector.generate_website(_doc)
@@ -87,7 +104,8 @@ class ChapsvisionTest(unittest.TestCase):
         self.assertEqual(objects[0]["media_category"], sentinel.broadcaster_category)
         self.assertEqual(objects[0]["url"], sentinel.link)
 
-    def test_generate_website_duplicate(self, m_os, m_gen_id, m_helper, m_base64):
+    @patch.object(module.Chapsvision, "_generate_id_for_media_content")
+    def test_generate_website_duplicate(self, m_gen_id, m_os, m_helper, m_base64):
         """testing serialization by generate_website (duplicate)"""
         _link = sentinel.link
         _broadcaster_category = sentinel.broadcaster_category
@@ -98,7 +116,7 @@ class ChapsvisionTest(unittest.TestCase):
         }
 
         m_os.path.isfile.return_value = False
-        with patch("builtins.open", mock_open()) as m_open:
+        with patch("builtins.open", mock_open()) as _:
             _connector = module.Chapsvision()
 
         objects_first_run = _connector.generate_website(_doc)
@@ -118,8 +136,9 @@ class ChapsvisionTest(unittest.TestCase):
         self.assertEqual(objects_first_run[0]["url"], objects_second_run[0]["url"])
         self.assertEqual(objects_first_run[0]["id"], objects_second_run[0]["id"])
 
+    @patch.object(module.Chapsvision, "_generate_id_for_media_content")
     def test_generate_messaging_link_only_single(
-        self, m_os, m_gen_id, m_helper, m_base64
+        self, m_gen_id, m_os, m_helper, m_base64
     ):
         """testing serialization by generate_messaging_link for link only data (single)"""
         _link = sentinel.link
@@ -131,7 +150,7 @@ class ChapsvisionTest(unittest.TestCase):
         }
 
         m_os.path.isfile.return_value = False
-        with patch("builtins.open", mock_open()) as m_open:
+        with patch("builtins.open", mock_open()) as _:
             _connector = module.Chapsvision()
 
         objects = _connector.generate_messaging(_doc)
@@ -141,8 +160,9 @@ class ChapsvisionTest(unittest.TestCase):
         self.assertEqual(objects[0]["media_category"], sentinel.broadcaster_category)
         self.assertEqual(objects[0]["url"], sentinel.link)
 
+    @patch.object(module.Chapsvision, "_generate_id_for_media_content")
     def test_generate_messaging_link_only_duplicate(
-        self, m_os, m_gen_id, m_helper, m_base64
+        self, m_gen_id, m_os, m_helper, m_base64
     ):
         """testing serialization by generate_messaging_link for link only data (duplicate)"""
         _link = sentinel.link
@@ -154,7 +174,7 @@ class ChapsvisionTest(unittest.TestCase):
         }
 
         m_os.path.isfile.return_value = False
-        with patch("builtins.open", mock_open()) as m_open:
+        with patch("builtins.open", mock_open()) as _:
             _connector = module.Chapsvision()
 
         objects_first_run = _connector.generate_messaging(_doc)

--- a/external-import/chapsvision/src/tests/test_chapvision.py
+++ b/external-import/chapsvision/src/tests/test_chapvision.py
@@ -1,0 +1,175 @@
+import unittest
+from unittest.mock import MagicMock, mock_open, patch, sentinel
+
+import chapsvision as module
+
+
+@patch.object(module, "base64")
+@patch.object(module, "OpenCTIConnectorHelper")
+@patch.object(module.Chapsvision, "_generate_id_for_media_content")
+@patch.object(module, "os")
+class ChapsvisionTest(unittest.TestCase):
+
+    def test_generate_micro_blogging_link_only_single(
+        self, m_os, m_gen_id, m_helper, m_base64
+    ):
+        """testing serialization by generate_micro_blogging for link only data (single)"""
+        _link = sentinel.link
+        _broadcaster_category = sentinel.broadcaster_category
+        _doc = {
+            "link": _link,
+            "broadcaster": MagicMock(),
+            "broadcaster_category": _broadcaster_category,
+        }
+
+        m_os.path.isfile.return_value = False
+        with patch("builtins.open", mock_open()) as m_open:
+            _connector = module.Chapsvision()
+
+        objects = _connector.generate_micro_blogging(_doc)
+
+        m_gen_id.assert_called_once_with(sentinel.link)
+        self.assertEqual(len(objects), 1)
+        self.assertEqual(objects[0]["media_category"], sentinel.broadcaster_category)
+        self.assertEqual(objects[0]["url"], sentinel.link)
+
+    def test_generate_micro_blogging_link_only_duplicate(
+        self, m_os, m_gen_id, m_helper, m_base64
+    ):
+        """testing serialization by generate_micro_blogging for link only data (duplicate)"""
+        _link = sentinel.link
+        _broadcaster_category = sentinel.broadcaster_category
+        _doc = {
+            "link": _link,
+            "broadcaster": MagicMock(),
+            "broadcaster_category": _broadcaster_category,
+        }
+
+        m_os.path.isfile.return_value = False
+        with patch("builtins.open", mock_open()) as m_open:
+            _connector = module.Chapsvision()
+
+        objects_first_run = _connector.generate_micro_blogging(_doc)
+        objects_second_run = _connector.generate_micro_blogging(_doc)
+
+        self.assertEqual(m_gen_id._mock_call_count, 2)
+        self.assertEqual(len(objects_first_run), 1)
+        self.assertEqual(len(objects_second_run), 1)
+        self.assertEqual(
+            objects_first_run[0]["media_category"], sentinel.broadcaster_category
+        )
+        self.assertEqual(
+            objects_first_run[0]["media_category"],
+            objects_second_run[0]["media_category"],
+        )
+        self.assertEqual(objects_first_run[0]["url"], sentinel.link)
+        self.assertEqual(objects_first_run[0]["url"], objects_second_run[0]["url"])
+        self.assertEqual(objects_first_run[0]["id"], objects_second_run[0]["id"])
+
+    def test_generate_website_single(self, m_os, m_gen_id, m_helper, m_base64):
+        """testing serialization by generate_website (single)"""
+        _link = sentinel.link
+        _broadcaster_category = sentinel.broadcaster_category
+        _doc = {
+            "link": _link,
+            "content_provider": MagicMock(),
+            "broadcaster_category": _broadcaster_category,
+        }
+
+        m_os.path.isfile.return_value = False
+        with patch("builtins.open", mock_open()) as m_open:
+            _connector = module.Chapsvision()
+
+        objects = _connector.generate_website(_doc)
+
+        m_gen_id.assert_called_once_with(sentinel.link)
+        self.assertEqual(len(objects), 1)
+        self.assertEqual(objects[0]["media_category"], sentinel.broadcaster_category)
+        self.assertEqual(objects[0]["url"], sentinel.link)
+
+    def test_generate_website_duplicate(self, m_os, m_gen_id, m_helper, m_base64):
+        """testing serialization by generate_website (duplicate)"""
+        _link = sentinel.link
+        _broadcaster_category = sentinel.broadcaster_category
+        _doc = {
+            "link": _link,
+            "content_provider": MagicMock(),
+            "broadcaster_category": _broadcaster_category,
+        }
+
+        m_os.path.isfile.return_value = False
+        with patch("builtins.open", mock_open()) as m_open:
+            _connector = module.Chapsvision()
+
+        objects_first_run = _connector.generate_website(_doc)
+        objects_second_run = _connector.generate_website(_doc)
+
+        self.assertEqual(m_gen_id._mock_call_count, 2)
+        self.assertEqual(len(objects_first_run), 1)
+        self.assertEqual(len(objects_second_run), 1)
+        self.assertEqual(
+            objects_first_run[0]["media_category"], sentinel.broadcaster_category
+        )
+        self.assertEqual(
+            objects_first_run[0]["media_category"],
+            objects_second_run[0]["media_category"],
+        )
+        self.assertEqual(objects_first_run[0]["url"], sentinel.link)
+        self.assertEqual(objects_first_run[0]["url"], objects_second_run[0]["url"])
+        self.assertEqual(objects_first_run[0]["id"], objects_second_run[0]["id"])
+
+    def test_generate_messaging_link_only_single(
+        self, m_os, m_gen_id, m_helper, m_base64
+    ):
+        """testing serialization by generate_messaging_link for link only data (single)"""
+        _link = sentinel.link
+        _broadcaster_category = sentinel.broadcaster_category
+        _doc = {
+            "link": _link,
+            "broadcaster": MagicMock(),
+            "broadcaster_category": _broadcaster_category,
+        }
+
+        m_os.path.isfile.return_value = False
+        with patch("builtins.open", mock_open()) as m_open:
+            _connector = module.Chapsvision()
+
+        objects = _connector.generate_messaging(_doc)
+
+        m_gen_id.assert_called_once_with(sentinel.link)
+        self.assertEqual(len(objects), 1)
+        self.assertEqual(objects[0]["media_category"], sentinel.broadcaster_category)
+        self.assertEqual(objects[0]["url"], sentinel.link)
+
+    def test_generate_messaging_link_only_duplicate(
+        self, m_os, m_gen_id, m_helper, m_base64
+    ):
+        """testing serialization by generate_messaging_link for link only data (duplicate)"""
+        _link = sentinel.link
+        _broadcaster_category = sentinel.broadcaster_category
+        _doc = {
+            "link": _link,
+            "broadcaster": MagicMock(),
+            "broadcaster_category": _broadcaster_category,
+        }
+
+        m_os.path.isfile.return_value = False
+        with patch("builtins.open", mock_open()) as m_open:
+            _connector = module.Chapsvision()
+
+        objects_first_run = _connector.generate_messaging(_doc)
+        objects_second_run = _connector.generate_messaging(_doc)
+
+        self.assertEqual(m_gen_id._mock_call_count, 2)
+        self.assertEqual(len(objects_first_run), 1)
+        self.assertEqual(len(objects_second_run), 1)
+        self.assertEqual(
+            objects_first_run[0]["media_category"], sentinel.broadcaster_category
+        )
+        self.assertEqual(
+            objects_first_run[0]["media_category"],
+            objects_second_run[0]["media_category"],
+        )
+        self.assertEqual(objects_first_run[0]["url"], sentinel.link)
+        self.assertEqual(objects_first_run[0]["url"], objects_second_run[0]["url"])
+        self.assertEqual(objects_first_run[0]["id"], objects_second_run[0]["id"])


### PR DESCRIPTION
### Proposed changes

* Creating a `_generate_id_for_media_content` function for deterministic ID generation (based on `uuid5` and STIX documentation for custom objects)
* Use it in `generate_micro_blogging`, `generate_website` and `generate_messaging` instead of `uuid4`
* Started the unit test folder under `src/tests` (not the best practice but make do with current project structure)

### Related issues

* Closes #6242 

### Checklist

- [ ] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Screenshots

New tests before bugfix

<img width="1417" height="1081" alt="before_bugfix" src="https://github.com/user-attachments/assets/f48546a5-f5de-43e2-a6ef-b27cd0e2634e" />

New tests after bugfix

<img width="1183" height="265" alt="after_bugfix" src="https://github.com/user-attachments/assets/bcc9cdcb-2f76-4152-a540-70c2541ca1e2" />
