### PR TITLE
[cpe] bug(connector): replacing unique UUID4 ID with deterministic ID for STIX software object (#6241)

### DIFF
--- a/external-import/cpe/src/cpe/connector.py
+++ b/external-import/cpe/src/cpe/connector.py
@@ -1,7 +1,6 @@
 import math
 import sys
 import time
-import uuid
 from datetime import datetime, timezone
 
 import langcodes
@@ -9,7 +8,6 @@ import requests
 import stix2
 from pycti import OpenCTIConnectorHelper
 from requests.adapters import HTTPAdapter
-from stix2.canonicalization.Canonicalize import canonicalize
 from urllib3.util import Retry
 
 from .settings import ConnectorSettings
@@ -112,22 +110,6 @@ class CPEConnector:
         """
         return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat()
 
-    def _get_software_id(self, cpename: str) -> str:
-        """
-        Generates a deterministic ID for a Software STIX2 object derived from a CPE
-
-        Args:
-            cpename (str): The cpename associated to the software in question
-
-        Returns:
-            str: A deterministic ID for the STIX object
-        """
-        cpename = cpename.lower().strip()
-        data = {"cpename": cpename}
-        data = canonicalize(data, utf8=False)
-        id = str(uuid.uuid5(uuid.UUID("00abedb4-aa42-466c-9c01-fed23315a9b7"), data))
-        return f"software--{id}"
-
     def _get_api_url(self, start_index, start_date, end_date) -> str:
         """
         Returns the API URL to use for the connector
@@ -212,7 +194,6 @@ class CPEConnector:
                 software = stix2.Software(
                     type="software",
                     spec_version="2.1",
-                    id=self._get_software_id(cpename),
                     name=self._get_cpe_title(json_objects["products"][i]["cpe"]),
                     cpe=cpename,
                     languages=cpe_infos["language"],

--- a/external-import/cpe/src/cpe/connector.py
+++ b/external-import/cpe/src/cpe/connector.py
@@ -1,14 +1,15 @@
 import math
 import sys
 import time
+import uuid
 from datetime import datetime, timezone
-from uuid import uuid4
 
 import langcodes
 import requests
 import stix2
 from pycti import OpenCTIConnectorHelper
 from requests.adapters import HTTPAdapter
+from stix2.canonicalization.Canonicalize import canonicalize
 from urllib3.util import Retry
 
 from .settings import ConnectorSettings
@@ -111,17 +112,21 @@ class CPEConnector:
         """
         return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat()
 
-    def _get_id(self, type: str) -> str:
+    def _get_software_id(self, cpename: str) -> str:
         """
-        Generates a unique ID for a STIX2 object
+        Generates a deterministic ID for a Software STIX2 object derived from a CPE
 
         Args:
-            type (str): The type of the object to generate an ID for
+            cpename (str): The cpename associated to the software in question
 
         Returns:
-            str: A unique ID for the STIX object
+            str: A deterministic ID for the STIX object
         """
-        return f"{type}--{str(uuid4())}"
+        cpename = cpename.lower().strip()
+        data = {"cpename": cpename}
+        data = canonicalize(data, utf8=False)
+        id = str(uuid.uuid5(uuid.UUID("00abedb4-aa42-466c-9c01-fed23315a9b7"), data))
+        return f"software--{id}"
 
     def _get_api_url(self, start_index, start_date, end_date) -> str:
         """
@@ -197,22 +202,19 @@ class CPEConnector:
         nb_results = json_objects["resultsPerPage"]
         stix_objects = []
         for i in range(nb_results):
-            cpe_infos = self._get_cpe_infos(
-                json_objects["products"][i]["cpe"]["cpeName"]
-            )
+            cpename = json_objects["products"][i]["cpe"]["cpeName"]
+            cpe_infos = self._get_cpe_infos(cpename)
             if (
                 json_objects["products"][i]["cpe"]["deprecated"] is False
                 and cpe_infos["is_hardware"] is False
             ):
-                self.helper.log_debug(
-                    f"Creating a software for the CPE: {json_objects['products'][i]['cpe']['cpeName']}"
-                )
+                self.helper.log_debug(f"Creating a software for the CPE: {cpename}")
                 software = stix2.Software(
                     type="software",
                     spec_version="2.1",
-                    id=self._get_id("software"),
+                    id=self._get_software_id(cpename),
                     name=self._get_cpe_title(json_objects["products"][i]["cpe"]),
-                    cpe=json_objects["products"][i]["cpe"]["cpeName"],
+                    cpe=cpename,
                     languages=cpe_infos["language"],
                     vendor=cpe_infos["vendor"],
                     version=cpe_infos["version"],

--- a/external-import/cpe/tests/test_main.py
+++ b/external-import/cpe/tests/test_main.py
@@ -97,3 +97,56 @@ def test_connector_is_instantiated(mock_opencti_connector_helper):
 
     assert connector.config == settings
     assert connector.helper == helper
+
+
+def test_deterministic_id(mock_opencti_connector_helper):
+    """
+    testing that two identical CPE provide the same STIX object,
+    while two different CPE do not provide the same STIX object
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    _json_object = {
+        "cpe": {
+            "cpeName": "cpe:2.3:a:adobe:flash_player:18.0:*:*:*:*:internet_explorer_10:*:*",
+            "deprecated": False,
+            "titles": [
+                {
+                    "title": "Adobe Flash Player 18.0 for Internet Explorer 10",
+                    "lang": "en",
+                }
+            ],
+        }
+    }
+    _other_json_object = {
+        "cpe": {
+            "cpeName": "cpe:2.3:a:microsoft:internet_explorer:5.5:sp2:*:*:*:*:*:*",
+            "deprecated": False,
+            "titles": [
+                {
+                    "title": "Microsoft Internet Explorer 5.5 Service Pack 2",
+                    "lang": "en",
+                }
+            ],
+        }
+    }
+    json_objects = {
+        "resultsPerPage": 3,
+        "products": [
+            _json_object,
+            _json_object,
+            _other_json_object,
+        ],
+    }
+    connector = CPEConnector(config=settings, helper=helper)
+
+    stix_objects = connector._json_to_stix(json_objects)
+
+    assert len(stix_objects) == 3
+    assert stix_objects[0] == stix_objects[1]
+    assert stix_objects[0].id == stix_objects[1].id
+    assert stix_objects[0] != stix_objects[2]
+    assert stix_objects[0].id != stix_objects[2].id


### PR DESCRIPTION
### Proposed changes

* Transforming the `_get_id` (generating UUID4-based unique ID) with `_get_software_id` (generating UUID5-based deterministic ID using cpe name for software designation) 

### Related issues

* Closes #6241 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

New test before bugfix

<img width="1900" height="235" alt="before_bugfix" src="https://github.com/user-attachments/assets/1ef2e5b1-a2f0-4e7d-a0b8-e0533c14118d" />

New test after bugfix

<img width="1053" height="675" alt="after_bugfix" src="https://github.com/user-attachments/assets/a511bdb7-79de-4ebc-bc3b-e77e1c6b5e5f" />
