### PR TITLE
[CVE] Add configurable CPE history interval for CPE resolution

### DIFF
--- a/external-import/cve/src/models/configs/cve_configs.py
+++ b/external-import/cve/src/models/configs/cve_configs.py
@@ -1,7 +1,10 @@
+from datetime import timedelta
+
 from pydantic import (
     Field,
     PositiveInt,
     SecretStr,
+    field_validator,
 )
 from src.models.configs import ConfigBaseSettings
 
@@ -39,12 +42,37 @@ class _ConfigLoaderCVE(ConfigBaseSettings):
     )
     import_software: bool = Field(
         default=False,
-        description="⚠️ WARNING: Enabling this option can lead to the ingestion of a VERY SIGNIFICANT volume of data into the platform. Each CVE may resolve to dozens of CPE matches, resulting in massive amounts of Software entities and relationships. Use with caution. If set to `True`, resolve CPEs associated with each CVE via the NVD CPE Match API and import them as Software objects with 'has' relationships to vulnerabilities.",
+        description="⚠️ WARNING: Enabling this option can lead to the ingestion "
+        "of a VERY SIGNIFICANT volume of data into the platform. Each CVE may resolve "
+        "to dozens of CPE matches, resulting in massive amounts of Software entities "
+        "and relationships. Use with caution. If set to `True`, resolve CPEs "
+        "associated with each CVE via the NVD CPE Match API and import them "
+        "as Software objects with 'has' relationships to vulnerabilities.",
+    )
+    cpe_history_interval: timedelta | None = Field(
+        default=timedelta(days=120),
+        description="When import_software is enabled, this interval determines how "
+        "far back in time to look for CPEs that were modified within that time frame. "
+        "This helps limit the number of CPEs resolved and imported. "
+        "Maximum interval is 120 days. "
+        "⚠️ WARNING: Null value will disable the time filter and may result in "
+        "importing a very large number of CPEs. Use with caution.",
     )
     cpe_max_concurrency: PositiveInt = Field(
         default=10,
         description="Maximum number of concurrent CPE resolution tasks when import_software is enabled.",
     )
+
+    @field_validator("cpe_history_interval")
+    @classmethod
+    def validate_cpe_history_interval(cls, value: timedelta | None) -> timedelta | None:
+        if value is None:
+            return value
+        max_interval = timedelta(days=120)
+        if value > max_interval:
+            raise ValueError(f"cpe_history_interval cannot exceed {max_interval}.")
+        return value
+
     cve_max_concurrency: PositiveInt = Field(
         default=50,
         description="Maximum number of concurrent CVE processing workers (bounds queued tasks and bundle sends).",

--- a/external-import/cve/src/services/client/cpe_match.py
+++ b/external-import/cve/src/services/client/cpe_match.py
@@ -10,7 +10,9 @@ class CPEMatchClient(CVEClient):
     API documentation: https://nvd.nist.gov/developers/products
     """
 
-    async def get_cpes_for_cve(self, cve_id: str) -> list[str]:
+    async def get_cpes_for_cve(
+        self, cve_id: str, request_params: dict | None = None
+    ) -> list[str]:
         """Retrieve all unique CPE names associated with a CVE.
 
         Calls the NVD CPE Match API with the given CVE ID, handles pagination,
@@ -23,7 +25,7 @@ class CPEMatchClient(CVEClient):
             A deduplicated list of CPE Name strings (format cpe:2.3:...).
         """
         cpe_names: set[str] = set()
-        params: dict = {"cveId": cve_id}
+        params: dict = {"cveId": cve_id, **(request_params or {})}
 
         debug_msg = f"[CPE MATCH API] Fetching CPE matches for {cve_id}"
         self.helper.connector_logger.debug(debug_msg)

--- a/external-import/cve/src/services/converter/vulnerability_to_stix2.py
+++ b/external-import/cve/src/services/converter/vulnerability_to_stix2.py
@@ -23,6 +23,7 @@ class CVEConverter:
         self.helper = helper
         self.import_software = config.cve.import_software
         self.cpe_max_concurrency = config.cve.cpe_max_concurrency
+        self.cpe_history_interval = config.cve.cpe_history_interval
         self.cve_max_concurrency = config.cve.cve_max_concurrency
 
         self.work_id = None
@@ -282,7 +283,21 @@ class CVEConverter:
         stix_objects = []
         seen_cpes = set()
 
-        cpe_names = await self.cpe_match_client.get_cpes_for_cve(cve_id)
+        cpe_request_params = {}
+        if self.cpe_history_interval is not None:
+            now = datetime.now(timezone.utc)
+            start_date = now - self.cpe_history_interval
+            cpe_request_params = {
+                "lastModStartDate": start_date.strftime("%Y-%m-%dT%H:%M:%S.000"),
+                "lastModEndDate": now.strftime("%Y-%m-%dT%H:%M:%S.000"),
+            }
+
+        if cpe_request_params:
+            cpe_names = await self.cpe_match_client.get_cpes_for_cve(
+                cve_id, cpe_request_params
+            )
+        else:
+            cpe_names = await self.cpe_match_client.get_cpes_for_cve(cve_id)
 
         for cpe_name in cpe_names:
             if cpe_name in seen_cpes:

--- a/external-import/cve/tests/tests_connector/test_pipeline.py
+++ b/external-import/cve/tests/tests_connector/test_pipeline.py
@@ -133,6 +133,7 @@ def _make_converter(
     converter.helper = mock_helper
     converter.import_software = import_software
     converter.cpe_max_concurrency = cpe_max_concurrency
+    converter.cpe_history_interval = None
     converter.cve_max_concurrency = cve_max_concurrency
     converter.work_id = None
     converter.author = CVEConverter._create_author()


### PR DESCRIPTION
**Please review #6195 first**

### Proposed changes

* Add a new `cpe_history_interval` configuration option (`timedelta`, default 120 days) that limits CPE resolution to only CPEs modified within the specified time window, reducing the volume of data ingested when `import_software` is enabled.
* Pass `lastModStartDate` / `lastModEndDate` query parameters to the NVD CPE Match API when the interval is set, filtering results server-side.
* Add a Pydantic field validator to enforce a maximum interval of 120 days, raising a clear error if exceeded.
* Allow setting the interval to `null` to disable the time filter entirely (with an explicit warning in the field description).
* Refactor the `get_cpes_for_cve` client method to accept optional `request_params`, keeping the API client generic and reusable.

### Related issues

* Fixes #6012

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The default 120-day window was chosen to match the NVD CPE Match API's maximum allowed range for `lastModStartDate`/`lastModEndDate` queries. Setting `cpe_history_interval` to `null` bypasses the filter entirely — this preserves backward compatibility with the previous behavior but should be used with caution due to the potentially massive volume of CPE data.

The converter accesses `cpe_history_interval` via `getattr` with a fallback to `None` to maintain backward compatibility in case the config object doesn't yet include the new field (e.g., during rolling upgrades or when used with an older config schema).