### PR TITLE
[checkfirst] Remove start_time attribute on relationships (deduplication)

### DIFF
--- a/external-import/checkfirst-import-connector/src/connector/converter_to_stix.py
+++ b/external-import/checkfirst-import-connector/src/connector/converter_to_stix.py
@@ -176,7 +176,6 @@ class ConverterToStix:
             markings=[self.tlp_marking],
         )
 
-    @lru_cache  # same infrastructure shared by many articles from the same domain
     def create_infrastructure(
         self, name: str, first_seen: datetime | str | None = None
     ) -> Infrastructure:

--- a/external-import/checkfirst-import-connector/src/connector/converter_to_stix.py
+++ b/external-import/checkfirst-import-connector/src/connector/converter_to_stix.py
@@ -176,6 +176,7 @@ class ConverterToStix:
             markings=[self.tlp_marking],
         )
 
+    @lru_cache  # same infrastructure shared by many articles from the same domain
     def create_infrastructure(
         self, name: str, first_seen: datetime | str | None = None
     ) -> Infrastructure:
@@ -318,10 +319,12 @@ class ConverterToStix:
             article_domain = urlparse(article.url).netloc
             domain_name = self.create_domain_name(value=article_domain)
             # --- Infrastructure wrapping the publishing domain ---
-            infrastructure = self.create_infrastructure(
-                name=article_domain,
-                first_seen=article.published_date,
-            )
+            # No first_seen: the connector deduplicates objects via a set (connector.py)
+            # using model_dump_json() as hash. Passing article.published_date as first_seen
+            # would produce different JSON per article for the same domain, bypassing
+            # set dedup and flooding OpenCTI with near-duplicate updates.
+            # Known domains already have correct first_seen from the infrastructure bundle.
+            infrastructure = self.create_infrastructure(name=article_domain)
             # --- Channel as website (the publishing domain/subdomain) ---
             channel = self.create_channel(
                 name=article_domain,
@@ -348,11 +351,13 @@ class ConverterToStix:
                 target=infrastructure,
             )
             # Campaign → uses → Channel as website
+            # No start_time: this is a structural relationship shared across articles.
+            # Using article.published_date would produce a unique STIX ID per article,
+            # flooding OpenCTI's Redis stream with thousands of create/upsert events.
             campaign_uses_channel = self.create_relationship(
                 source=campaign,
                 relationship_type="uses",
                 target=channel,
-                start_time=article.published_date,
             )
             # Infrastructure → consists-of → DomainName
             infra_consists_of_domain = self.create_relationship(
@@ -365,35 +370,30 @@ class ConverterToStix:
                 source=channel,
                 relationship_type="related-to",
                 target=infrastructure,
-                start_time=article.published_date,
             )
             # DomainName → related-to → Channel as website
             domain_related_to_channel = self.create_relationship(
                 source=domain_name,
                 relationship_type="related-to",
                 target=channel,
-                start_time=article.published_date,
             )
             # Channel as website → publishes → Content
             publishes = self.create_relationship(
                 source=channel,
                 relationship_type="publishes",
                 target=content,
-                start_time=article.published_date,
             )
             # Channel as website → related-to → Source as Channel
             channel_uses_source = self.create_relationship(
                 source=channel,
                 relationship_type="related-to",
                 target=source_channel,
-                start_time=article.published_date,
             )
             # Content → related-to → Source as Channel
             content_related_to_source = self.create_relationship(
                 source=content,
                 relationship_type="related-to",
                 target=source_channel,
-                start_time=article.published_date,
             )
 
             octi_objects.extend(
@@ -425,7 +425,6 @@ class ConverterToStix:
                         source=channel,
                         relationship_type="related-to",
                         target=parent_domain_name,
-                        start_time=article.published_date,
                     )
                 )
 
@@ -436,7 +435,6 @@ class ConverterToStix:
                     source=content,
                     relationship_type="related-to",
                     target=alt_url,
-                    start_time=article.published_date,
                 )
                 octi_objects.extend([alt_url, alt_rel])
 

--- a/external-import/checkfirst-import-connector/src/connector/converter_to_stix.py
+++ b/external-import/checkfirst-import-connector/src/connector/converter_to_stix.py
@@ -344,6 +344,9 @@ class ConverterToStix:
             )
 
             # --- Relationships ---
+            # No start_time/stop_time on relationships shared across articles.
+            # Using article.published_date would produce a unique STIX ID per article,
+            # flooding OpenCTI's Redis stream with thousands of create/upsert events.
             # Campaign → uses → Infrastructure
             campaign_uses_infra = self.create_relationship(
                 source=campaign,
@@ -351,9 +354,6 @@ class ConverterToStix:
                 target=infrastructure,
             )
             # Campaign → uses → Channel as website
-            # No start_time: this is a structural relationship shared across articles.
-            # Using article.published_date would produce a unique STIX ID per article,
-            # flooding OpenCTI's Redis stream with thousands of create/upsert events.
             campaign_uses_channel = self.create_relationship(
                 source=campaign,
                 relationship_type="uses",

--- a/external-import/checkfirst-import-connector/src/connector/converter_to_stix.py
+++ b/external-import/checkfirst-import-connector/src/connector/converter_to_stix.py
@@ -323,7 +323,10 @@ class ConverterToStix:
             # would produce different JSON per article for the same domain, bypassing
             # set dedup and flooding OpenCTI with near-duplicate updates.
             # Known domains already have correct first_seen from the infrastructure bundle.
-            infrastructure = self.create_infrastructure(name=article_domain)
+            infrastructure = self.create_infrastructure(
+                name=article_domain,
+                first_seen=article.published_date,
+            )
             # --- Channel as website (the publishing domain/subdomain) ---
             channel = self.create_channel(
                 name=article_domain,

--- a/external-import/checkfirst-import-connector/tests/tests_connector/test_converter_to_stix.py
+++ b/external-import/checkfirst-import-connector/tests/tests_connector/test_converter_to_stix.py
@@ -79,17 +79,6 @@ class TestArticleConversion:
     while allowing per-article objects (MediaContent and its relationships) to differ.
     """
 
-    def test_article_infrastructure_has_no_first_seen(self, converter):
-        """Infrastructure created in the article path should not have first_seen."""
-        campaign, _ = converter.get_campaign_for_year(2025)
-        article = _make_article()
-
-        objects = converter.convert_article(article, campaign)
-
-        infra_objects = [o for o in objects if o.id.startswith("infrastructure--")]
-        assert len(infra_objects) == 1
-        assert infra_objects[0].first_seen is None
-
     def test_article_shared_objects_are_identical(self, converter):
         """Two same-domain articles should have an identical structural subset."""
         campaign, attributed_to = converter.get_campaign_for_year(2025)

--- a/external-import/checkfirst-import-connector/tests/tests_connector/test_converter_to_stix.py
+++ b/external-import/checkfirst-import-connector/tests/tests_connector/test_converter_to_stix.py
@@ -1,0 +1,214 @@
+"""Tests for ConverterToStix — validates that structural relationships
+produce stable STIX IDs across articles and that Infrastructure objects are cached."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from checkfirst_client.api_models import Article
+from connector.converter_to_stix import ConverterToStix
+
+
+@pytest.fixture
+def converter():
+    helper = MagicMock()
+    helper.connector_logger = MagicMock()
+    return ConverterToStix(helper=helper, tlp_level="clear")
+
+
+def _make_article(
+    url: str = "https://france.news-pravda.com/article-1",
+    source_title: str = "Telegram Source",
+    source_url: str = "https://t.me/source",
+    published_date: datetime | None = None,
+    row_number: int = 1,
+    article_id: str = "abc123",
+) -> Article:
+    return Article(
+        _id=article_id,
+        row_number=row_number,
+        url=url,
+        source_title=source_title,
+        source_url=source_url,
+        published_date=published_date or datetime(2025, 3, 15, tzinfo=timezone.utc),
+        title="Test Article",
+    )
+
+
+class TestStructuralRelationshipsAreStable:
+    """Structural relationships (Campaign→Channel, Channel→Infra, etc.) should produce
+    the same STIX ID regardless of which article triggers them, because they must NOT
+    include article-specific start_time in their ID hash."""
+
+    def test_campaign_uses_channel_same_stix_id_across_articles(self, converter):
+        """Two articles from the same domain should produce identical
+        Campaign→uses→Channel relationships."""
+        campaign, _ = converter.get_campaign_for_year(2025)
+
+        article_1 = _make_article(
+            published_date=datetime(2025, 1, 10, tzinfo=timezone.utc),
+            article_id="a1",
+        )
+        article_2 = _make_article(
+            published_date=datetime(2025, 6, 20, tzinfo=timezone.utc),
+            article_id="a2",
+        )
+
+        objects_1 = converter.convert_article(article_1, campaign)
+        objects_2 = converter.convert_article(article_2, campaign)
+
+        # Find campaign→uses→channel relationships
+        rels_1 = [
+            o
+            for o in objects_1
+            if hasattr(o, "type")
+            and o.type == "uses"
+            and o.source.id == campaign.id
+            and o.target.id.startswith("channel--")
+        ]
+        rels_2 = [
+            o
+            for o in objects_2
+            if hasattr(o, "type")
+            and o.type == "uses"
+            and o.source.id == campaign.id
+            and o.target.id.startswith("channel--")
+        ]
+
+        assert len(rels_1) == 1
+        assert len(rels_2) == 1
+        assert (
+            rels_1[0].id == rels_2[0].id
+        ), "Campaign→uses→Channel should have identical STIX IDs across articles"
+
+    def test_structural_relationships_have_no_start_time(self, converter):
+        """Structural relationships should not carry article-specific start_time."""
+        campaign, _ = converter.get_campaign_for_year(2025)
+        article = _make_article()
+
+        objects = converter.convert_article(article, campaign)
+
+        for obj in objects:
+            if not hasattr(obj, "type") or not hasattr(obj, "source"):
+                continue
+
+            is_campaign_source = obj.source.id.startswith("campaign--")
+            is_content_involved = obj.source.id.startswith(
+                "media-content--"
+            ) or obj.target.id.startswith("media-content--")
+
+            # Per-article relationships (involving MediaContent) may have start_time
+            if is_content_involved:
+                continue
+
+            # Structural relationships should NOT have start_time
+            if is_campaign_source or obj.type in ("consists-of",):
+                assert obj.start_time is None, (
+                    f"Structural relationship {obj.type} from {obj.source.id[:20]}... "
+                    f"should not have start_time, got {obj.start_time}"
+                )
+
+
+class TestInfrastructureCaching:
+    """Infrastructure objects should be cached by name to ensure identical
+    Python objects across articles from the same domain."""
+
+    def test_same_domain_returns_same_infrastructure_object(self, converter):
+        """create_infrastructure() with same name should return the same cached object."""
+        infra_1 = converter.create_infrastructure(name="example.com")
+        infra_2 = converter.create_infrastructure(name="example.com")
+
+        assert (
+            infra_1 is infra_2
+        ), "create_infrastructure should return cached instance for same domain"
+
+    def test_article_infrastructure_has_no_first_seen(self, converter):
+        """Infrastructure created in the article path should not have first_seen."""
+        campaign, _ = converter.get_campaign_for_year(2025)
+        article = _make_article()
+
+        objects = converter.convert_article(article, campaign)
+
+        infra_objects = [o for o in objects if o.id.startswith("infrastructure--")]
+        assert len(infra_objects) == 1
+        assert infra_objects[0].first_seen is None
+
+    def test_infrastructure_bundle_preserves_first_seen(self, converter):
+        """Infrastructure created by the pravda bundle should keep its first_seen."""
+        campaign, _ = converter.get_campaign_for_year(2023)
+        objects = converter.convert_pravda_network_infrastructure(campaign)
+
+        infra_objects = [o for o in objects if o.id.startswith("infrastructure--")]
+        assert len(infra_objects) > 0
+        for infra in infra_objects:
+            assert (
+                infra.first_seen is not None
+            ), f"Pravda infrastructure {infra.name} should have first_seen"
+
+
+class TestDeduplicationEfficiency:
+    """The connector's set-based deduplication should work correctly after the fix.
+    Objects that are structurally identical across articles should deduplicate in a set.
+    """
+
+    def test_structural_objects_deduplicate_in_set(self, converter):
+        """Two articles from the same domain should produce mostly identical structural
+        objects that deduplicate when added to a set."""
+        campaign, attributed_to = converter.get_campaign_for_year(2025)
+
+        article_1 = _make_article(
+            url="https://france.news-pravda.com/article-1",
+            published_date=datetime(2025, 1, 10, tzinfo=timezone.utc),
+            article_id="a1",
+        )
+        article_2 = _make_article(
+            url="https://france.news-pravda.com/article-2",
+            published_date=datetime(2025, 6, 20, tzinfo=timezone.utc),
+            article_id="a2",
+        )
+
+        objects_1 = converter.convert_article(article_1, campaign)
+        objects_2 = converter.convert_article(article_2, campaign)
+
+        # Simulate the connector's dedup
+        octi_set: set = set()
+        for obj in [campaign, attributed_to] + objects_1:
+            octi_set.add(obj)
+        for obj in [campaign, attributed_to] + objects_2:
+            octi_set.add(obj)
+
+        # The set should be significantly smaller than the raw sum
+        raw_count = (
+            len(objects_1) + len(objects_2) + 4
+        )  # +4 for campaign+attributed_to twice
+        assert len(octi_set) < raw_count, (
+            f"Set ({len(octi_set)}) should be smaller than raw count ({raw_count}) "
+            "due to deduplication of structural objects"
+        )
+
+    def test_per_article_objects_remain_unique(self, converter):
+        """MediaContent and its relationships should remain unique per article."""
+        campaign, _ = converter.get_campaign_for_year(2025)
+
+        article_1 = _make_article(
+            url="https://france.news-pravda.com/article-1",
+            published_date=datetime(2025, 1, 10, tzinfo=timezone.utc),
+            article_id="a1",
+        )
+        article_2 = _make_article(
+            url="https://france.news-pravda.com/article-2",
+            published_date=datetime(2025, 6, 20, tzinfo=timezone.utc),
+            article_id="a2",
+        )
+
+        objects_1 = converter.convert_article(article_1, campaign)
+        objects_2 = converter.convert_article(article_2, campaign)
+
+        content_1 = [o for o in objects_1 if o.id.startswith("media-content--")]
+        content_2 = [o for o in objects_2 if o.id.startswith("media-content--")]
+
+        assert len(content_1) == 1
+        assert len(content_2) == 1
+        assert (
+            content_1[0].id != content_2[0].id
+        ), "Different articles should produce different MediaContent STIX IDs"

--- a/external-import/checkfirst-import-connector/tests/tests_connector/test_converter_to_stix.py
+++ b/external-import/checkfirst-import-connector/tests/tests_connector/test_converter_to_stix.py
@@ -35,83 +35,18 @@ def _make_article(
     )
 
 
-class TestStructuralRelationshipsAreStable:
-    """Structural relationships (Campaign→Channel, Channel→Infra, etc.) should produce
-    the same STIX ID regardless of which article triggers them, because they must NOT
-    include article-specific start_time in their ID hash."""
+class TestConverterCache:
+    """DomainName, Infrastructure and Campaign should be cached for performance issues
+    (many objects are shared across different articles)."""
 
-    def test_campaign_uses_channel_same_stix_id_across_articles(self, converter):
-        """Two articles from the same domain should produce identical
-        Campaign→uses→Channel relationships."""
-        campaign, _ = converter.get_campaign_for_year(2025)
+    def test_same_domain_returns_same_domain_name_object(self, converter):
+        """create_domain_name() with same value should return the same cached object."""
+        domain_1 = converter.create_domain_name(value="example.com")
+        domain_2 = converter.create_domain_name(value="example.com")
 
-        article_1 = _make_article(
-            published_date=datetime(2025, 1, 10, tzinfo=timezone.utc),
-            article_id="a1",
-        )
-        article_2 = _make_article(
-            published_date=datetime(2025, 6, 20, tzinfo=timezone.utc),
-            article_id="a2",
-        )
-
-        objects_1 = converter.convert_article(article_1, campaign)
-        objects_2 = converter.convert_article(article_2, campaign)
-
-        # Find campaign→uses→channel relationships
-        rels_1 = [
-            o
-            for o in objects_1
-            if hasattr(o, "type")
-            and o.type == "uses"
-            and o.source.id == campaign.id
-            and o.target.id.startswith("channel--")
-        ]
-        rels_2 = [
-            o
-            for o in objects_2
-            if hasattr(o, "type")
-            and o.type == "uses"
-            and o.source.id == campaign.id
-            and o.target.id.startswith("channel--")
-        ]
-
-        assert len(rels_1) == 1
-        assert len(rels_2) == 1
         assert (
-            rels_1[0].id == rels_2[0].id
-        ), "Campaign→uses→Channel should have identical STIX IDs across articles"
-
-    def test_structural_relationships_have_no_start_time(self, converter):
-        """Structural relationships should not carry article-specific start_time."""
-        campaign, _ = converter.get_campaign_for_year(2025)
-        article = _make_article()
-
-        objects = converter.convert_article(article, campaign)
-
-        for obj in objects:
-            if not hasattr(obj, "type") or not hasattr(obj, "source"):
-                continue
-
-            is_campaign_source = obj.source.id.startswith("campaign--")
-            is_content_involved = obj.source.id.startswith(
-                "media-content--"
-            ) or obj.target.id.startswith("media-content--")
-
-            # Per-article relationships (involving MediaContent) may have start_time
-            if is_content_involved:
-                continue
-
-            # Structural relationships should NOT have start_time
-            if is_campaign_source or obj.type in ("consists-of",):
-                assert obj.start_time is None, (
-                    f"Structural relationship {obj.type} from {obj.source.id[:20]}... "
-                    f"should not have start_time, got {obj.start_time}"
-                )
-
-
-class TestInfrastructureCaching:
-    """Infrastructure objects should be cached by name to ensure identical
-    Python objects across articles from the same domain."""
+            domain_1 is domain_2
+        ), "create_domain_name should return cached instance for same domain"
 
     def test_same_domain_returns_same_infrastructure_object(self, converter):
         """create_infrastructure() with same name should return the same cached object."""
@@ -121,6 +56,37 @@ class TestInfrastructureCaching:
         assert (
             infra_1 is infra_2
         ), "create_infrastructure should return cached instance for same domain"
+
+    def test_same_year_returns_same_campaign_object(self, converter):
+        """get_campaign_for_year() with same year should return the same cached object."""
+        campaign_1, _ = converter.get_campaign_for_year(2025)
+        campaign_2, _ = converter.get_campaign_for_year(2025)
+
+        assert (
+            campaign_1 is campaign_2
+        ), "get_campaign_for_year should return cached instance for same year"
+
+
+class TestPravdaInfrastructure:
+    """Test Infrastructure objects created for the Pravda bundle (created on connector's first run)."""
+
+    def test_infrastructure_bundle_contains_first_seen(self, converter):
+        """Infrastructure objects created for the Pravda bundle should contain first_seen attribute."""
+        campaign, _ = converter.get_campaign_for_year(2023)
+        objects = converter.convert_pravda_network_infrastructure(campaign)
+
+        infra_objects = [o for o in objects if o.id.startswith("infrastructure--")]
+        assert len(infra_objects) > 0
+        for infra in infra_objects:
+            assert (
+                infra.first_seen is not None
+            ), f"Pravda infrastructure {infra.name} should have first_seen"
+
+
+class TestArticleConversion:
+    """Articles conversion should produce a structural subset of STIX objects that is identical for same-domain articles,
+    while allowing per-article objects (MediaContent and its relationships) to differ.
+    """
 
     def test_article_infrastructure_has_no_first_seen(self, converter):
         """Infrastructure created in the article path should not have first_seen."""
@@ -133,27 +99,8 @@ class TestInfrastructureCaching:
         assert len(infra_objects) == 1
         assert infra_objects[0].first_seen is None
 
-    def test_infrastructure_bundle_preserves_first_seen(self, converter):
-        """Infrastructure created by the pravda bundle should keep its first_seen."""
-        campaign, _ = converter.get_campaign_for_year(2023)
-        objects = converter.convert_pravda_network_infrastructure(campaign)
-
-        infra_objects = [o for o in objects if o.id.startswith("infrastructure--")]
-        assert len(infra_objects) > 0
-        for infra in infra_objects:
-            assert (
-                infra.first_seen is not None
-            ), f"Pravda infrastructure {infra.name} should have first_seen"
-
-
-class TestDeduplicationEfficiency:
-    """The connector's set-based deduplication should work correctly after the fix.
-    Objects that are structurally identical across articles should deduplicate in a set.
-    """
-
-    def test_structural_objects_deduplicate_in_set(self, converter):
-        """Two articles from the same domain should produce mostly identical structural
-        objects that deduplicate when added to a set."""
+    def test_article_shared_objects_are_identical(self, converter):
+        """Two same-domain articles should have an identical structural subset."""
         campaign, attributed_to = converter.get_campaign_for_year(2025)
 
         article_1 = _make_article(
@@ -170,21 +117,38 @@ class TestDeduplicationEfficiency:
         objects_1 = converter.convert_article(article_1, campaign)
         objects_2 = converter.convert_article(article_2, campaign)
 
-        # Simulate the connector's dedup
-        octi_set: set = set()
-        for obj in [campaign, attributed_to] + objects_1:
-            octi_set.add(obj)
-        for obj in [campaign, attributed_to] + objects_2:
-            octi_set.add(obj)
+        all_ids_1 = {obj.id for obj in [campaign, attributed_to] + objects_1}
+        all_ids_2 = {obj.id for obj in [campaign, attributed_to] + objects_2}
 
-        # The set should be significantly smaller than the raw sum
-        raw_count = (
-            len(objects_1) + len(objects_2) + 4
-        )  # +4 for campaign+attributed_to twice
-        assert len(octi_set) < raw_count, (
-            f"Set ({len(octi_set)}) should be smaller than raw count ({raw_count}) "
-            "due to deduplication of structural objects"
-        )
+        def _is_per_article_object(obj) -> bool:
+            # Only MediaContent and its relationships should be considered per-article objects.
+            if obj.id.startswith("media-content--"):
+                return True
+            if obj.id.startswith("relationship--") and (
+                obj.source.id.startswith("media-content--")
+                or obj.target.id.startswith("media-content--")
+            ):
+                return True
+
+            return False
+
+        per_article_ids_1 = {
+            obj.id
+            for obj in [campaign, attributed_to] + objects_1
+            if _is_per_article_object(obj)
+        }
+        per_article_ids_2 = {
+            obj.id
+            for obj in [campaign, attributed_to] + objects_2
+            if _is_per_article_object(obj)
+        }
+
+        structural_ids_1 = all_ids_1 - per_article_ids_1
+        structural_ids_2 = all_ids_2 - per_article_ids_2
+
+        # Structural subset should be identical for same-domain articles.
+        assert len(structural_ids_1) > 0
+        assert structural_ids_1 == structural_ids_2
 
     def test_per_article_objects_remain_unique(self, converter):
         """MediaContent and its relationships should remain unique per article."""
@@ -212,3 +176,30 @@ class TestDeduplicationEfficiency:
         assert (
             content_1[0].id != content_2[0].id
         ), "Different articles should produce different MediaContent STIX IDs"
+
+    def test_structural_relationships_have_no_start_time(self, converter):
+        """Structural relationships should not carry article-specific start_time."""
+        campaign, _ = converter.get_campaign_for_year(2025)
+        article = _make_article()
+
+        objects = converter.convert_article(article, campaign)
+
+        for obj in objects:
+            if not obj.id.startswith("relationship--"):
+                continue
+
+            is_campaign_source = obj.source.id.startswith("campaign--")
+            is_content_involved = obj.source.id.startswith(
+                "media-content--"
+            ) or obj.target.id.startswith("media-content--")
+
+            # Per-article relationships (involving MediaContent) may have start_time
+            if is_content_involved:
+                continue
+
+            # Structural relationships should NOT have start_time
+            if is_campaign_source or obj.type in ("consists-of",):
+                assert obj.start_time is None, (
+                    f"Structural relationship {obj.type} from {obj.source.id[:20]}... "
+                    f"should not have start_time, got {obj.start_time}"
+                )

--- a/external-import/checkfirst-import-connector/tests/tests_connector/test_converter_to_stix.py
+++ b/external-import/checkfirst-import-connector/tests/tests_connector/test_converter_to_stix.py
@@ -48,15 +48,6 @@ class TestConverterCache:
             domain_1 is domain_2
         ), "create_domain_name should return cached instance for same domain"
 
-    def test_same_domain_returns_same_infrastructure_object(self, converter):
-        """create_infrastructure() with same name should return the same cached object."""
-        infra_1 = converter.create_infrastructure(name="example.com")
-        infra_2 = converter.create_infrastructure(name="example.com")
-
-        assert (
-            infra_1 is infra_2
-        ), "create_infrastructure should return cached instance for same domain"
-
     def test_same_year_returns_same_campaign_object(self, converter):
         """get_campaign_for_year() with same year should return the same cached object."""
         campaign_1, _ = converter.get_campaign_for_year(2025)


### PR DESCRIPTION
### Proposed changes

* ~~remove `first_seen` attribute on per-article Infrastructure~~
* remove `start_time` on per-article relationship (stop flooding OCTI's stream)
* add unit tests for `converter_to_stix`

### Related issues

* close #6204
* close #6276 (stale PR)

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


