### PR TITLE
[Doppel] Make user_api_key and organization_code optional

### DIFF
--- a/external-import/doppel/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/doppel/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,25 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'flashpoint'. |
+| DOPPEL_API_KEY | `string` | ✅ | string |  | API key for authentication. |
+| CONNECTOR_NAME | `string` |  | string | `"Doppel Threat Intelligence"` | The name of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
+| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"PT1H"` | The period of time to await between two runs of the connector. |
+| DOPPEL_API_BASE_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"https://api.doppel.com/v1"` | API base URL. |
+| DOPPEL_USER_API_KEY | `string` |  | string | `null` | Used for user-specific identity |
+| DOPPEL_ORGANIZATION_CODE | `string` |  | string | `null` | Identifies the specific organizational workspace for multi-tenant keys |
+| DOPPEL_TLP_LEVEL | `string` |  | `clear` `white` `green` `amber` `amber+strict` `red` | `"clear"` | Default TLP level of the imported entities. |
+| DOPPEL_ALERTS_ENDPOINT | `string` |  | string | `"/alerts"` | Specifies the API resource path for alert ingestion |
+| DOPPEL_HISTORICAL_POLLING_DAYS | `integer` |  | integer | `30` | Determines the time-window for initial data fetching |
+| DOPPEL_MAX_RETRIES | `integer` |  | integer | `3` | Configures automated error recovery from transient failures |
+| DOPPEL_RETRY_DELAY | `integer` |  | integer | `30` | Controls the frequency of requests during error recovery |
+| DOPPEL_PAGE_SIZE | `integer` |  | integer | `100` | Optimizes request volume and memory usage per fetch |

--- a/external-import/doppel/__metadata__/connector_config_schema.json
+++ b/external-import/doppel/__metadata__/connector_config_schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/doppel_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Doppel Threat Intelligence",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "description": "The scope of the connector, e.g. 'flashpoint'.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT1H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "DOPPEL_API_BASE_URL": {
+      "default": "https://api.doppel.com/v1",
+      "description": "API base URL.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "DOPPEL_API_KEY": {
+      "description": "API key for authentication.",
+      "type": "string"
+    },
+    "DOPPEL_USER_API_KEY": {
+      "default": null,
+      "description": "Used for user-specific identity",
+      "type": "string"
+    },
+    "DOPPEL_ORGANIZATION_CODE": {
+      "default": null,
+      "description": "Identifies the specific organizational workspace for multi-tenant keys",
+      "type": "string"
+    },
+    "DOPPEL_TLP_LEVEL": {
+      "default": "clear",
+      "description": "Default TLP level of the imported entities.",
+      "enum": [
+        "clear",
+        "white",
+        "green",
+        "amber",
+        "amber+strict",
+        "red"
+      ],
+      "type": "string"
+    },
+    "DOPPEL_ALERTS_ENDPOINT": {
+      "default": "/alerts",
+      "description": "Specifies the API resource path for alert ingestion",
+      "type": "string"
+    },
+    "DOPPEL_HISTORICAL_POLLING_DAYS": {
+      "default": 30,
+      "description": "Determines the time-window for initial data fetching",
+      "type": "integer"
+    },
+    "DOPPEL_MAX_RETRIES": {
+      "default": 3,
+      "description": "Configures automated error recovery from transient failures",
+      "type": "integer"
+    },
+    "DOPPEL_RETRY_DELAY": {
+      "default": 30,
+      "description": "Controls the frequency of requests during error recovery",
+      "type": "integer"
+    },
+    "DOPPEL_PAGE_SIZE": {
+      "default": 100,
+      "description": "Optimizes request volume and memory usage per fetch",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_SCOPE",
+    "DOPPEL_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/doppel/__metadata__/connector_manifest.json
+++ b/external-import/doppel/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">= 6.5.1",
   "subscription_link": "https://www.doppel.com",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/doppel",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-doppel",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/doppel/src/config.yml.sample
+++ b/external-import/doppel/src/config.yml.sample
@@ -13,8 +13,8 @@ connector:
 doppel:
   api_base_url: 'https://api.doppel.com/v1'
   api_key: 'ChangeMe'
-  user_api_key: 'ChangeMe'
-  organization_code: 'ChangeMe'
+  user_api_key: null
+  organization_code: null
   tlp_level: 'clear'  # available values are: clear, white, green, amber, amber+strict, red
   alerts_endpoint: '/alerts'
   historical_polling_days: 30

--- a/external-import/doppel/src/doppel/client_api.py
+++ b/external-import/doppel/src/doppel/client_api.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import requests
 from doppel.constants import RETRYABLE_REQUEST_ERRORS
@@ -11,9 +11,13 @@ from tenacity import (
     wait_fixed,
 )
 
+if TYPE_CHECKING:
+    from doppel import ConnectorSettings
+    from pycti import OpenCTIConnectorHelper
+
 
 class ConnectorClient:
-    def __init__(self, helper, config):
+    def __init__(self, helper: "OpenCTIConnectorHelper", config: "ConnectorSettings"):
         """
         Initialize the client with necessary configurations
         """

--- a/external-import/doppel/src/doppel/settings.py
+++ b/external-import/doppel/src/doppel/settings.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Literal, Optional
+from typing import Literal
 
 from connectors_sdk import (
     BaseConfigModel,
@@ -31,15 +31,18 @@ class DoppelConfig(BaseConfigModel):
     """
 
     api_base_url: HttpUrl = Field(
-        description="API base URL.", default="https://api.doppel.com/v1"
+        description="API base URL.", default=HttpUrl("https://api.doppel.com/v1")
     )
 
     api_key: str = Field(description="API key for authentication.")
 
-    user_api_key: Optional[str] = Field(description="Used for user-specific identity")
+    user_api_key: str | None = Field(
+        description="Used for user-specific identity", default=None
+    )
 
-    organization_code: Optional[str] = Field(
-        description="Identifies the specific organizational workspace for multi-tenant keys"
+    organization_code: str | None = Field(
+        description="Identifies the specific organizational workspace for multi-tenant keys",
+        default=None,
     )
 
     tlp_level: Literal[


### PR DESCRIPTION
### Proposed changes

* Make `user_api_key` and `organization_code` fields optional (`str | None` with `default=None`) — these credentials are not required for all deployment scenarios and should not block connector startup when absent.
* Update `config.yml.sample` to reflect `null` defaults for both optional fields, so the sample configuration accurately represents their optional nature.
* Add a `TYPE_CHECKING` guard around `pycti` and `ConnectorSettings` imports in `client_api.py` to prevent circular imports at runtime while preserving full static type-checking support.

### Related issues

* Closes #6289

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The `str | None` union syntax (PEP 604) replaces `Optional[str]` for consistency with modern Python 3.10+ style. The `HttpUrl("https://api.doppel.com/v1")` explicit constructor in the `api_base_url` default ensures Pydantic v2 compatibility, where bare string defaults for `HttpUrl` fields are no longer accepted.