### PR TITLE
[Connector-linter]: add VC1xx config and VC2xx metadata checks [2/4]

### DIFF
--- a/shared/connector_linter/README.md
+++ b/shared/connector_linter/README.md
@@ -338,7 +338,6 @@ from connector_linter.checks.vc1xx_config._helpers import (
     extract_env_vars_from_docker_compose,
     extract_env_vars_from_env_sample,
     derive_connector_prefixes,   # dirname → ["ABUSE_SSL", "ABUSESSL"]
-    find_config_yml_sample,      # Returns path to config.yml.sample
     find_bad_changeme_values,    # Finds wrong-case ChangeMe
 )
 ```

--- a/shared/connector_linter/connector_linter/checks/vc1xx_config/__init__.py
+++ b/shared/connector_linter/connector_linter/checks/vc1xx_config/__init__.py
@@ -1,0 +1,11 @@
+"""VC1xx — Configuration checks.
+
+Validates connector configuration files (docker-compose.yml, .env.sample,
+config.yml.sample) for compliance with OpenCTI conventions.
+
+VC101  config-token-default        OPENCTI_TOKEN must default to ChangeMe
+VC102  config-url-default          OPENCTI_URL must default to http://localhost
+VC103  config-variable-prefix      Env vars must use OPENCTI_, CONNECTOR_, or <NAME>_ prefix
+VC104  config-file-samples         config.yml.sample + docker-compose/env must exist
+VC105  no-absolute-import-date     Import dates must use ISO duration, not absolute dates
+"""

--- a/shared/connector_linter/connector_linter/checks/vc1xx_config/_helpers.py
+++ b/shared/connector_linter/connector_linter/checks/vc1xx_config/_helpers.py
@@ -1,0 +1,188 @@
+"""Helpers for configuration-file parsing.
+
+Extracts environment variables from ``docker-compose.yml`` and
+``.env.sample`` files, including commented-out lines.  Also locates
+``config.yml.sample`` and scans for ``ChangeMe`` placeholder values.
+"""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from connector_linter.models import ConnectorContext
+
+
+@dataclass
+class EnvVar:
+    """A parsed environment variable."""
+
+    name: str
+    value: str
+    line: int
+    file_path: Path
+    is_commented: bool
+
+
+# ---------------------------------------------------------------------------
+# Regex: docker-compose.yml environment lines
+#
+# Matches lines like:
+#     - OPENCTI_URL=http://localhost       (uncommented)
+#   #   - OPENCTI_URL=http://localhost     (commented out)
+#
+# Capture groups:
+#   commented — leading "#" (present when the line is commented out)
+#   name      — uppercase env var name (e.g. OPENCTI_TOKEN)
+#   value     — everything after "=" up to an optional inline comment
+#
+# Trailing inline comments (# …) are stripped from the value.
+# ---------------------------------------------------------------------------
+_COMPOSE_ENV_RE = re.compile(
+    r"^(?P<commented>\s*#)?\s*-\s*(?P<name>[A-Z][A-Z0-9_]*)=(?P<value>[^#\n]*?)(?:\s*#.*)?\s*$",
+)
+
+# ---------------------------------------------------------------------------
+# Regex: .env.sample (dotenv-style) lines
+#
+# Matches lines like:
+#   OPENCTI_TOKEN=ChangeMe               (uncommented)
+#   # OPENCTI_TOKEN=ChangeMe             (commented out)
+#
+# Same capture groups as _COMPOSE_ENV_RE (commented, name, value).
+# The difference is the absence of the YAML list marker "- ".
+# ---------------------------------------------------------------------------
+_DOTENV_RE = re.compile(
+    r"^(?P<commented>\s*#)?\s*(?P<name>[A-Z][A-Z0-9_]*)=(?P<value>[^#\n]*?)(?:\s*#.*)?\s*$",
+)
+
+
+def _parse_lines(
+    file_path: Path,
+    lines: list[str],
+    pattern: re.Pattern[str],
+) -> list[EnvVar]:
+    """Extract EnvVar entries from raw lines.
+
+    Iterates line-by-line, applying the given regex ``pattern`` to each line.
+    Both commented and uncommented matches are captured — the ``is_commented``
+    flag lets callers decide which to keep or skip.
+    """
+    results: list[EnvVar] = []
+    for line_no, line in enumerate(lines, 1):
+        m = pattern.match(line)
+        if m:
+            results.append(
+                EnvVar(
+                    name=m.group("name"),
+                    value=m.group("value").strip(),
+                    line=line_no,
+                    file_path=file_path,
+                    is_commented=bool(m.group("commented")),
+                ),
+            )
+    return results
+
+
+def extract_env_vars_from_docker_compose(ctx: ConnectorContext) -> list[EnvVar]:
+    """Extract environment variables from docker-compose.yml."""
+    compose_path = ctx.path / "docker-compose.yml"
+    if not compose_path.is_file():
+        return []
+    with compose_path.open(encoding="utf-8") as f:
+        return _parse_lines(compose_path, f.readlines(), _COMPOSE_ENV_RE)
+
+
+def extract_env_vars_from_env_sample(ctx: ConnectorContext) -> list[EnvVar]:
+    """Extract environment variables from .env.sample."""
+    env_path = ctx.path / ".env.sample"
+    if not env_path.is_file():
+        return []
+    with env_path.open(encoding="utf-8") as f:
+        return _parse_lines(env_path, f.readlines(), _DOTENV_RE)
+
+
+def extract_all_env_vars(ctx: ConnectorContext) -> list[EnvVar]:
+    """Extract env vars from docker-compose.yml and .env.sample."""
+    return extract_env_vars_from_docker_compose(ctx) + extract_env_vars_from_env_sample(
+        ctx,
+    )
+
+
+def derive_connector_prefixes(ctx: ConnectorContext) -> str:
+    """Derive valid connector-specific prefixes from the directory name.
+
+    Examples:
+      ``mandiant``         → ``"MANDIANT"``
+      ``abuse-ssl``        → ``"ABUSE_SSL"``
+      ``recorded-future``  → ``"RECORDED_FUTURE"``
+
+    """
+    dirname = ctx.path.name
+    # Hyphen → underscore:  "abuse-ssl" → "ABUSE_SSL"
+    return dirname.upper().replace("-", "_")
+
+
+def has_docker_compose_env(ctx: ConnectorContext) -> bool:
+    """Return True if docker-compose.yml exists with environment variables."""
+    return bool(extract_env_vars_from_docker_compose(ctx))
+
+
+def has_env_sample(ctx: ConnectorContext) -> bool:
+    """Return True if .env.sample exists."""
+    return (ctx.path / ".env.sample").is_file()
+
+
+@dataclass
+class ChangeMeHit:
+    """A ChangeMe value found in a config file with wrong case."""
+
+    file_path: Path
+    line: int
+    raw_value: str
+
+
+# ---------------------------------------------------------------------------
+# Regex: case-insensitive "ChangeMe" placeholder detector
+#
+# Matches the word "ChangeMe" regardless of case (CHANGEME, changeme, etc.)
+# appearing as a YAML value (after ":") or env value (after "="):
+#   OPENCTI_TOKEN=changeme         → matches "changeme"
+#   token: 'CHANGEME'              → matches "CHANGEME"
+#
+# Optional surrounding quotes (' or ") and trailing inline comments are
+# tolerated but not captured.
+# ---------------------------------------------------------------------------
+_CHANGEME_LINE_RE = re.compile(
+    r"(?:^|[=:]\s*['\"]?)(?P<value>change\s*me)['\"]?\s*(?:#.*)?$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+
+def find_bad_changeme_values(file_path: Path) -> list[ChangeMeHit]:
+    """Find ChangeMe values with wrong case in any config file.
+
+    A "bad" value is any case variant of ChangeMe that is *not* the
+    canonical form ``ChangeMe`` (e.g. ``CHANGEME``, ``changeme``).
+
+    Commented lines (starting with ``#``) are skipped because they are
+    inactive — fixing their case would be noise, and some commented lines
+    may intentionally use a different casing as documentation.
+    """
+    if not file_path.is_file():
+        return []
+    with file_path.open(encoding="utf-8") as f:
+        lines = f.readlines()
+
+    hits: list[ChangeMeHit] = []
+    for line_no, line in enumerate(lines, 1):
+        # Skip fully commented lines — only active values matter for casing
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        m = _CHANGEME_LINE_RE.search(line)
+        if m:
+            raw = m.group("value").strip()
+            # Only flag if casing does not match the canonical "ChangeMe"
+            if raw != "ChangeMe":
+                hits.append(ChangeMeHit(file_path, line_no, raw))
+    return hits

--- a/shared/connector_linter/connector_linter/checks/vc1xx_config/vc101_config_token.py
+++ b/shared/connector_linter/connector_linter/checks/vc1xx_config/vc101_config_token.py
@@ -47,7 +47,7 @@ def check_config_token(ctx: ConnectorContext) -> list[CheckFinding]:
             CheckFinding(
                 message="OPENCTI_TOKEN not found in configuration files",
                 severity=Severity.ERROR,
-                suggestion="Add OPENCTI_TOKEN=ChangeMe to docker-compose.yml.",
+                suggestion="Uncomment or add OPENCTI_TOKEN=ChangeMe to docker-compose.yml.",
             ),
         ]
 

--- a/shared/connector_linter/connector_linter/checks/vc1xx_config/vc101_config_token.py
+++ b/shared/connector_linter/connector_linter/checks/vc1xx_config/vc101_config_token.py
@@ -1,0 +1,130 @@
+"""VC101 — OPENCTI_TOKEN must default to ``ChangeMe``.
+
+Following the January 2026 alignment commit, all configuration files
+must use exactly ``ChangeMe`` as the placeholder value for
+``OPENCTI_TOKEN`` (not ``CHANGEME``, ``changeme``, or a real token).
+
+Environment-variable references like ``${OPENCTI_TOKEN}`` are acceptable.
+
+Scope: Common (all connector types).
+"""
+
+from connector_linter.checks.vc1xx_config._helpers import extract_all_env_vars
+from connector_linter.models import CheckFinding, ConnectorContext, Severity
+from connector_linter.registry import CheckRegistry
+
+_VALID_PLACEHOLDER = "ChangeMe"
+
+
+@CheckRegistry.register(
+    code="VC101",
+    name="config-token-default",
+    description="OPENCTI_TOKEN must default to ChangeMe",
+    severity=Severity.ERROR,
+)
+def check_config_token(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check OPENCTI_TOKEN placeholder value in configuration files."""
+    # Step 1: Gather all env vars from docker-compose.yml and .env.sample
+    all_vars = extract_all_env_vars(ctx)
+
+    if not all_vars:
+        return [
+            CheckFinding(
+                message="No configuration file found (docker-compose.yml or .env.sample)",
+                severity=Severity.ERROR,
+                suggestion="Add a docker-compose.yml with environment variables.",
+            ),
+        ]
+
+    # Step 2: Keep only uncommented OPENCTI_TOKEN entries.
+    # Commented-out lines are informational — only active values matter.
+    token_vars = [
+        v for v in all_vars if v.name == "OPENCTI_TOKEN" and not v.is_commented
+    ]
+
+    if not token_vars:
+        return [
+            CheckFinding(
+                message="OPENCTI_TOKEN not found in configuration files",
+                severity=Severity.ERROR,
+                suggestion="Add OPENCTI_TOKEN=ChangeMe to docker-compose.yml.",
+            ),
+        ]
+
+    # Step 3: Validate each OPENCTI_TOKEN occurrence.
+    #
+    # Decision tree for each value:
+    #   ${...}      → PASS  (env reference — delegated to runtime)
+    #   ChangeMe    → PASS  (canonical placeholder, exact case)
+    #   changeme/*  → FAIL  (wrong case — must match Jan 2026 alignment)
+    #   (empty)     → FAIL  (must have a placeholder)
+    #   anything    → FAIL  (likely a real token committed by mistake)
+    results: list[CheckFinding] = []
+    for var in token_vars:
+        value = var.value
+
+        # ---------------------------------------------------------------------------
+        # Environment variable reference — e.g. ${OPENCTI_TOKEN}
+        #
+        # docker-compose files often delegate to the host environment via
+        # ${VAR} syntax.  This is perfectly fine — the actual secret is
+        # never stored in the repo.
+        # ---------------------------------------------------------------------------
+        if value.startswith("${") and value.endswith("}"):
+            results.append(
+                CheckFinding(
+                    message=f"OPENCTI_TOKEN uses env reference ({value})",
+                    severity=Severity.INFO,
+                    file_path=var.file_path,
+                    line=var.line,
+                ),
+            )
+            continue
+
+        if value == _VALID_PLACEHOLDER:
+            results.append(
+                CheckFinding(
+                    message="OPENCTI_TOKEN=ChangeMe ✓",
+                    severity=Severity.INFO,
+                    file_path=var.file_path,
+                    line=var.line,
+                ),
+            )
+        elif value.lower() == "changeme":
+            # Case mismatch — the Jan 2026 alignment mandates exact "ChangeMe"
+            results.append(
+                CheckFinding(
+                    message=f"OPENCTI_TOKEN={value} — wrong case",
+                    severity=Severity.ERROR,
+                    file_path=var.file_path,
+                    line=var.line,
+                    suggestion=f"Change from '{value}' to 'ChangeMe' (exact case).",
+                ),
+            )
+        elif not value:
+            results.append(
+                CheckFinding(
+                    message="OPENCTI_TOKEN has empty value",
+                    severity=Severity.ERROR,
+                    file_path=var.file_path,
+                    line=var.line,
+                    suggestion="Set OPENCTI_TOKEN=ChangeMe as the placeholder value.",
+                ),
+            )
+        else:
+            # Non-standard value — could be a real token accidentally committed.
+            # Truncate to 20 chars to avoid leaking secrets in the output.
+            results.append(
+                CheckFinding(
+                    message=f"OPENCTI_TOKEN has non-standard value: {value[:20]}{'...' if len(value) > 20 else ''}",
+                    severity=Severity.ERROR,
+                    file_path=var.file_path,
+                    line=var.line,
+                    suggestion=(
+                        "Use 'ChangeMe' as the placeholder value. "
+                        "Never commit real tokens."
+                    ),
+                ),
+            )
+
+    return results

--- a/shared/connector_linter/connector_linter/checks/vc1xx_config/vc102_config_url.py
+++ b/shared/connector_linter/connector_linter/checks/vc1xx_config/vc102_config_url.py
@@ -1,0 +1,128 @@
+"""VC102 — OPENCTI_URL must default to ``http://localhost``.
+
+Following the January 2026 alignment commit, the default value for
+``OPENCTI_URL`` must be ``http://localhost`` — no port, no path suffix,
+and using ``localhost`` as the hostname (not ``opencti``).
+
+Environment-variable references like ``${OPENCTI_URL}`` are acceptable.
+
+Scope: Common (all connector types).
+"""
+
+from urllib.parse import urlparse
+
+from connector_linter.checks.vc1xx_config._helpers import extract_all_env_vars
+from connector_linter.models import CheckFinding, ConnectorContext, Severity
+from connector_linter.registry import CheckRegistry
+
+# ---------------------------------------------------------------------------
+# The canonical default URL: http://localhost
+#
+# Why exactly this value?
+# - No port: the platform port varies per deployment; including one (e.g.
+#   :8080) couples the sample to a specific setup.
+# - No path: trailing paths like /graphql are added by pycti internally.
+# - "localhost": the sample is a local-dev starting point; Docker service
+#   names like "opencti" belong in overrides, not defaults.
+# ---------------------------------------------------------------------------
+_VALID_URL = "http://localhost"
+
+
+@CheckRegistry.register(
+    code="VC102",
+    name="config-url-default",
+    description=f"OPENCTI_URL must default to {_VALID_URL}",
+    severity=Severity.ERROR,
+)
+def check_config_url(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check OPENCTI_URL default value in configuration files."""
+    all_vars = extract_all_env_vars(ctx)
+
+    if not all_vars:
+        return [
+            CheckFinding(
+                message="No configuration file found (docker-compose.yml or .env.sample)",
+                severity=Severity.ERROR,
+                suggestion="Add a docker-compose.yml with environment variables.",
+            ),
+        ]
+
+    url_vars = [v for v in all_vars if v.name == "OPENCTI_URL" and not v.is_commented]
+
+    if not url_vars:
+        return [
+            CheckFinding(
+                message="OPENCTI_URL not found in configuration files",
+                severity=Severity.ERROR,
+                suggestion=f"Add OPENCTI_URL={_VALID_URL} to docker-compose.yml.",
+            ),
+        ]
+
+    results: list[CheckFinding] = []
+    for var in url_vars:
+        value = var.value
+
+        # Environment variable reference — acceptable
+        if value.startswith("${") and value.endswith("}"):
+            results.append(
+                CheckFinding(
+                    message=f"OPENCTI_URL uses env reference ({value})",
+                    file_path=var.file_path,
+                    line=var.line,
+                    severity=Severity.INFO,
+                ),
+            )
+            continue
+
+        # ---------------------------------------------------------------------------
+        # Validate the URL structure with urlparse.
+        #
+        # Each component is checked independently so we can give targeted
+        # feedback (e.g. "remove the port" vs. "use http"):
+        #   scheme   — must be "http" (not https, ftp, etc.)
+        #   hostname — must be "localhost" (not "opencti" or an IP)
+        #   port     — must be absent (None)
+        #   path     — must be empty or "/" (no trailing path like /graphql)
+        # ---------------------------------------------------------------------------
+        parsed = urlparse(value)
+        is_valid = (
+            parsed.scheme == "http"
+            and parsed.hostname == "localhost"
+            and (parsed.port is None)
+            and (parsed.path in ("", "/"))
+        )
+
+        if is_valid:
+            results.append(
+                CheckFinding(
+                    message=f"OPENCTI_URL={_VALID_URL} ✓",
+                    severity=Severity.INFO,
+                    file_path=var.file_path,
+                    line=var.line,
+                ),
+            )
+        else:
+            # Build a targeted suggestion listing only the specific issues,
+            # so the developer knows exactly what to fix.
+            suggestion_parts = []
+            if parsed.port is not None:
+                suggestion_parts.append("Remove the port number")
+            if parsed.hostname and parsed.hostname != "localhost":
+                suggestion_parts.append("Use 'localhost' as the hostname")
+            if parsed.scheme != "http":
+                suggestion_parts.append("Use 'http' as the scheme")
+            if parsed.path not in ("", "/"):
+                suggestion_parts.append("Remove the path suffix")
+            suggestion_parts.append(f"Set to {_VALID_URL}")
+
+            results.append(
+                CheckFinding(
+                    message=f"OPENCTI_URL={value} — expected {_VALID_URL}",
+                    severity=Severity.ERROR,
+                    file_path=var.file_path,
+                    line=var.line,
+                    suggestion=". ".join(suggestion_parts).capitalize() + ".",
+                ),
+            )
+
+    return results

--- a/shared/connector_linter/connector_linter/checks/vc1xx_config/vc103_config_variable_prefix.py
+++ b/shared/connector_linter/connector_linter/checks/vc1xx_config/vc103_config_variable_prefix.py
@@ -1,0 +1,100 @@
+"""VC103 — Configuration variables must use proper prefixes.
+
+Every environment variable in ``docker-compose.yml`` and ``.env.sample``
+must be prefixed with one of:
+
+- ``OPENCTI_`` — platform connection variables
+- ``CONNECTOR_`` — pycti connector variables
+- ``<CONNECTOR_NAME>_`` — connector-specific variables
+
+The connector name prefix is derived from the directory name
+(uppercased, hyphens converted to underscores or removed).
+
+Scope: Common (all connector types).
+"""
+
+from pathlib import Path
+
+from connector_linter.checks.vc1xx_config._helpers import (
+    derive_connector_prefixes,
+    extract_all_env_vars,
+)
+from connector_linter.models import CheckFinding, ConnectorContext, Severity
+from connector_linter.registry import CheckRegistry
+
+# ---------------------------------------------------------------------------
+# Standard env-var prefixes used by all connectors:
+#   OPENCTI_   — platform connection settings (URL, token)
+#   CONNECTOR_ — pycti framework settings (id, name, scope, log_level)
+#
+# Connector-specific variables use a prefix derived from the directory name
+# (e.g. MANDIANT_, ABUSE_SSL_).  See derive_connector_prefixes().
+# ---------------------------------------------------------------------------
+_STANDARD_PREFIXES = ("OPENCTI_", "CONNECTOR_")
+
+
+@CheckRegistry.register(
+    code="VC103",
+    name="config-variable-prefix",
+    description="Env vars must use OPENCTI_, CONNECTOR_, or <CONNECTOR_NAME>_ prefix",
+    severity=Severity.WARNING,  # this is a warning because it's a style issue, not a correctness issue
+)
+def check_config_variable_prefix(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check that all env vars use valid prefixes."""
+    all_vars = extract_all_env_vars(ctx)
+
+    if not all_vars:
+        return [
+            CheckFinding(
+                message="No configuration file found (docker-compose.yml or .env.sample)",
+                severity=Severity.WARNING,
+                suggestion="Add a docker-compose.yml with environment variables.",
+            ),
+        ]
+
+    # Build the full list of valid prefixes:
+    #   ["OPENCTI_", "CONNECTOR_"] + ["MANDIANT_"] (or ["ABUSE_SSL_", "ABUSESSL_"])
+    # An underscore is appended to each connector prefix so the match is
+    # strict — "MANDIANT" alone should not pass, only "MANDIANT_<setting>".
+    connector_prefixes = derive_connector_prefixes(ctx)
+    valid_prefixes = list(_STANDARD_PREFIXES) + [f"{connector_prefixes}_"]
+
+    bad_vars: list[tuple[str, Path, int]] = []  # (name, path, line)
+
+    # Check every env var against ALL valid prefixes.
+    # A var is valid if it starts with at least one of them.
+    for var in all_vars:
+        if any(var.name.startswith(prefix) for prefix in valid_prefixes):
+            continue
+        bad_vars.append((var.name, var.file_path, var.line))
+
+    if not bad_vars:
+        prefix_display = f"{connector_prefixes}_"
+        return [
+            CheckFinding(
+                message=f"All env vars use valid prefixes (OPENCTI_, CONNECTOR_, {prefix_display})",
+                severity=Severity.INFO,
+            ),
+        ]
+
+    results: list[CheckFinding] = []
+    # Prefer the underscore form (e.g. ABUSE_SSL over ABUSESSL) as the
+    # canonical prefix for suggestions.  The underscore variant is always
+    # the dirname with hyphens replaced by underscores.
+    canonical = ctx.path.name.upper().replace("-", "_")
+    for var_name, file_path, line in bad_vars:
+        results.append(
+            CheckFinding(
+                message=f"{var_name} has no valid connector prefix",
+                severity=Severity.WARNING,  # this is technically a pass since the var is valid, just not styled correctly
+                file_path=file_path,
+                line=line,
+                suggestion=(
+                    f"Prefix with {canonical}_ "
+                    f"(e.g. {canonical}_{var_name}). "
+                    f"Accepted prefixes: OPENCTI_, CONNECTOR_, {canonical}_."
+                ),
+            ),
+        )
+
+    return results

--- a/shared/connector_linter/connector_linter/checks/vc1xx_config/vc104_config_file_samples.py
+++ b/shared/connector_linter/connector_linter/checks/vc1xx_config/vc104_config_file_samples.py
@@ -1,0 +1,322 @@
+"""VC104 — Configuration file samples must exist and follow conventions.
+
+A verified connector **must** provide:
+
+1. ``config.yml.sample`` (at root or under ``src/``).
+2. **Either** ``.env.sample`` **or** ``docker-compose.yml`` with an
+   ``environment:`` section.
+3. All placeholder values use exact ``ChangeMe`` case (not ``CHANGEME``).
+4. Configuration is **not** hardcoded in a Python file.
+5. Settings **with** defaults must be **commented** out.
+6. Settings **without** defaults must use ``ChangeMe`` (uncommented).
+
+Scope: Common (all connector types).
+"""
+
+import ast
+import re
+from pathlib import Path
+
+from connector_linter.checks.vc1xx_config._helpers import (
+    extract_env_vars_from_docker_compose,
+    find_bad_changeme_values,
+    has_docker_compose_env,
+    has_env_sample,
+)
+from connector_linter.models import CheckFinding, ConnectorContext, Severity
+from connector_linter.registry import CheckRegistry
+
+# ---------------------------------------------------------------------------
+# Regex: config-like variable names that should NOT be hardcoded in Python.
+#
+# Matches uppercase identifiers ending with common config suffixes:
+#   URL, TOKEN, KEY, SECRET, PASSWORD, HOST, PORT, API, ENDPOINT, BASE_URL
+# The optional trailing "s" handles plurals (e.g. ENDPOINTS).
+# Case-insensitive so it also catches mixed-case Python names.
+#
+# Examples that match: API_KEY, BASE_URL, OPENCTI_TOKEN, MY_SECRETS
+# ---------------------------------------------------------------------------
+_CONFIG_NAME_RE = re.compile(
+    r"^[A-Z_]*(?:URL|TOKEN|KEY|SECRET|PASSWORD|HOST|PORT|API|ENDPOINT|BASE_URL)s?$",
+    re.IGNORECASE,
+)
+
+# ---------------------------------------------------------------------------
+# Variables that must ALWAYS remain uncommented in docker-compose.yml.
+#
+# OPENCTI_URL and OPENCTI_TOKEN are required for every connector to connect
+# to the platform.  Unlike optional settings (which should be commented out
+# when they have sane defaults), these two must always be visible and active
+# so the user immediately knows they need to set them.
+# ---------------------------------------------------------------------------
+_ALWAYS_UNCOMMENTED = {"OPENCTI_URL", "OPENCTI_TOKEN"}
+
+
+def _find_hardcoded_python_config(ctx: ConnectorContext) -> list[tuple[Path, int, str]]:
+    """Detect module-level hardcoded config assignments in Python files.
+
+    Returns (file_path, line, variable_name) for each suspicious assignment.
+    Excludes settings.py and files that import pydantic / os.environ.
+    """
+    src_dir = ctx.path / "src"
+    if not src_dir.is_dir():
+        return []
+
+    hits: list[tuple[Path, int, str]] = []
+
+    for py_file in src_dir.rglob("*.py"):
+        fname = py_file.name
+        # settings.py is the *expected* place for config-variable declarations
+        # (Pydantic settings classes).  Skip it — it's not "hardcoded".
+        if fname == "settings.py":
+            continue
+        try:
+            source = py_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        # ---------------------------------------------------------------------------
+        # Skip files that already use a proper config-loading mechanism.
+        #
+        # If the file references BaseSettings, get_config_variable, os.environ,
+        # etc., the developer is loading config at runtime — not hardcoding it.
+        # Flagging these would produce false positives.
+        # ---------------------------------------------------------------------------
+        if any(
+            kw in source
+            for kw in (
+                "BaseSettings",
+                "BaseConnectorSettings",
+                "get_config_variable",
+                "os.environ",
+                "os.getenv",
+                "pydantic_settings",
+            )
+        ):
+            continue
+
+        try:
+            tree = ast.parse(source, filename=str(py_file))
+        except SyntaxError:
+            continue
+
+        # Walk only top-level assignments (module scope) — nested assignments
+        # inside functions are less suspicious (they may be local defaults).
+        for node in ast.iter_child_nodes(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                if not isinstance(target, ast.Name):
+                    continue
+                name = target.id
+                if not _CONFIG_NAME_RE.match(name):
+                    continue
+                # Only flag hardcoded string/number values (not function
+                # calls, attribute lookups, or other dynamic expressions).
+                if isinstance(node.value, ast.Constant) and isinstance(
+                    node.value.value,
+                    (str, int, float),
+                ):
+                    rel = py_file.relative_to(ctx.path)
+                    hits.append((rel, node.lineno, name))
+
+    return hits
+
+
+def _check_config_yml_sample_exists(ctx: ConnectorContext) -> CheckFinding:
+    """Check that config.yml.sample exists at root"""
+    config_yml = ctx.path / "config.yml.sample"
+    if config_yml.is_file():
+        rel = config_yml.relative_to(ctx.path)
+        return CheckFinding(
+            message=f"config.yml.sample found at {rel} (root)",
+            severity=Severity.INFO,
+            file_path=config_yml,
+            line=1,
+        )
+    elif (ctx.path / "src/config.yml.sample").is_file():
+        rel = Path("src/config.yml.sample")
+        return CheckFinding(
+            message=f"config.yml.sample found at {rel} (src/)",
+            severity=Severity.WARNING,
+            file_path=ctx.path / rel,
+            line=1,
+            suggestion="Move config.yml.sample to root directory for better "
+            "visibility and convention.",
+        )
+    else:
+        return CheckFinding(
+            message="config.yml.sample not found",
+            severity=Severity.ERROR,
+            suggestion="Add a config.yml.sample at root.",
+        )
+
+
+def check_docker_compose_or_env_sample_exists(ctx: ConnectorContext) -> CheckFinding:
+    """Check that either docker-compose.yml (with env) or .env.sample exists."""
+    has_compose = has_docker_compose_env(ctx)
+    has_env = has_env_sample(ctx)
+
+    if has_compose or has_env:
+        source = "docker-compose.yml" if has_compose else ".env.sample"
+        return CheckFinding(
+            message=f"Environment config available via {source}",
+            severity=Severity.INFO,
+        )
+    else:
+        return CheckFinding(
+            message="No docker-compose.yml (with env vars) or .env.sample found",
+            severity=Severity.ERROR,
+            suggestion=(
+                "Add a docker-compose.yml with an environment section "
+                "or an .env.sample file."
+            ),
+        )
+
+
+def check_change_me_consistency(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check that all placeholder values use exact ChangeMe case."""
+    config_yml = ctx.path / "config.yml.sample"
+    files_to_check: list[Path] = []
+    compose_path = ctx.path / "docker-compose.yml"
+    if compose_path.is_file():
+        files_to_check.append(compose_path)
+    env_path = ctx.path / ".env.sample"
+    if env_path.is_file():
+        files_to_check.append(env_path)
+    if config_yml.is_file():
+        files_to_check.append(config_yml)
+
+    bad_hits: list[tuple[Path, int, str]] = []
+    for fpath in files_to_check:
+        bad_hits.extend(
+            (hit.file_path, hit.line, hit.raw_value)
+            for hit in find_bad_changeme_values(fpath)
+        )
+
+    if bad_hits:
+        results: list[CheckFinding] = []
+        for fpath, line_no, raw_val in bad_hits:
+            results.append(
+                CheckFinding(
+                    message=f"'{raw_val}' should be 'ChangeMe'",
+                    severity=Severity.ERROR,
+                    file_path=fpath,
+                    line=line_no,
+                    suggestion="Use exact 'ChangeMe' (not CHANGEME or changeme).",
+                ),
+            )
+        return results
+    else:
+        return [
+            CheckFinding(
+                message="All placeholder values use correct ChangeMe case",
+                severity=Severity.INFO,
+            ),
+        ]
+
+
+def check_commented_convention(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check that settings with defaults are commented out, and without defaults use ChangeMe.
+
+    Convention for docker-compose.yml environment sections:
+      - Variables WITH a default value (e.g. ``LOG_LEVEL=info``) should be
+        commented out.  The user uncomments them only when they want to
+        override the built-in default.
+      - Variables WITHOUT a default (e.g. ``API_KEY=ChangeMe``) must be
+        uncommented so the user immediately sees they need to fill them in.
+
+    OPENCTI_URL and OPENCTI_TOKEN are exempt — they are always uncommented
+    because every connector needs them regardless of defaults.
+    """
+    compose_vars = extract_env_vars_from_docker_compose(ctx)
+    if not compose_vars:
+        return []
+
+    results: list[CheckFinding] = []
+    for var in compose_vars:
+        is_changeme = var.value.lower() == "changeme"
+        is_env_ref = var.value.startswith("${") and var.value.endswith("}")
+
+        if var.name in _ALWAYS_UNCOMMENTED:
+            continue
+
+        # Setting is neither:
+        #  - 'ChangeMe'
+        #  - an environment reference
+        #  - not commented out
+        # → it has a default value but is not following the convention of being commented out.
+        if not is_changeme and not is_env_ref and not var.is_commented:
+            rel = var.file_path.relative_to(ctx.path)
+            results.append(
+                CheckFinding(
+                    message=(
+                        f"{rel}:{var.line}: {var.name}={var.value} has a "
+                        f"default — should be commented out"
+                    ),
+                    severity=Severity.WARNING,
+                    file_path=var.file_path,
+                    line=var.line,
+                    suggestion=(
+                        f"Comment out {var.name} since it has a default "
+                        f"value. Users can uncomment to override."
+                    ),
+                ),
+            )
+
+    return results
+
+
+@CheckRegistry.register(
+    code="VC104",
+    name="config-file-samples",
+    description="Config samples (config.yml.sample + docker-compose/env) must exist",
+    severity=Severity.ERROR,
+)
+def check_config_file_samples(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Validate configuration file samples exist and follow conventions."""
+    results: list[CheckFinding] = []
+
+    # --- Sub-check A: config.yml.sample exists ---
+    # Every connector must ship a YAML config sample so users can run
+    # the connector outside Docker (e.g. direct Python invocation).
+    results.append(_check_config_yml_sample_exists(ctx))
+
+    # --- Sub-check B: docker-compose.yml or .env.sample exists ---
+    # At least one Docker-friendly config file must be present so
+    # users can deploy via docker-compose without extra steps.
+    results.append(check_docker_compose_or_env_sample_exists(ctx))
+
+    # --- Sub-check C: ChangeMe case consistency ---
+    # All placeholder values must use exact "ChangeMe" casing per the
+    # January 2026 alignment (not CHANGEME, changeme, etc.).
+    results.extend(check_change_me_consistency(ctx))
+
+    # --- Sub-check D: commented/uncommented convention (docker-compose.yml) ---
+    # Settings WITH defaults → must be commented out (user uncomments to override)
+    # Settings WITHOUT defaults → must use ChangeMe (uncommented, user fills in)
+    # This makes docker-compose samples self-documenting.
+    results.extend(check_commented_convention(ctx))
+
+    # --- Sub-check E: No hardcoded Python configuration ---
+    # Config values (URLs, tokens, keys) must come from env vars or settings
+    # classes, never from hardcoded constants in Python source files.
+    # Severity is WARNING because this is a best-practice
+    # recommendation, not a hard blocker.
+    hardcoded = _find_hardcoded_python_config(ctx)
+    if hardcoded:
+        for fpath, line_no, var_name in hardcoded:
+            results.append(
+                CheckFinding(
+                    message=f"{var_name} appears hardcoded in Python",
+                    severity=Severity.WARNING,
+                    file_path=fpath,
+                    line=line_no,
+                    suggestion=(
+                        "Move configuration to environment variables or "
+                        "connectors-sdk settings, not hardcoded Python constants."
+                    ),
+                ),
+            )
+
+    return results

--- a/shared/connector_linter/connector_linter/checks/vc1xx_config/vc105_no_absolute_date.py
+++ b/shared/connector_linter/connector_linter/checks/vc1xx_config/vc105_no_absolute_date.py
@@ -1,0 +1,176 @@
+"""VC105 — Import start dates must use ISO duration, not absolute dates.
+
+When a connector supports configuring the historical import window
+(``start_date``, ``import_start_date``, etc.), it must accept ISO 8601
+**duration** strings (e.g. ``P30D``, ``P6M``) rather than hardcoded
+absolute dates like ``2020-05-01T00:00:00``.
+
+The connectors-sdk provides ``DatetimeFromIsoString`` which automatically
+handles both absolute ISO dates and relative durations.
+
+Scope: Common (all connector types).
+"""
+
+import ast
+import re
+from datetime import date, datetime
+
+from connector_linter.checks.vc1xx_config._helpers import extract_all_env_vars
+from connector_linter.models import (
+    CheckFinding,
+    ConnectorContext,
+    Severity,
+)
+from connector_linter.registry import CheckRegistry
+
+# ---------------------------------------------------------------------------
+# Regex: env var names that indicate a start/import date setting.
+#
+# Matches substrings like START_DATE, START_TIMESTAMP, IMPORT_DATE,
+# IMPORT_START inside variable names.  Case-insensitive to catch both
+# env var names (uppercase) and Python field names (snake_case).
+#
+# Examples that match:
+#   CONNECTOR_START_DATE, import_start_date, MY_IMPORT_DATE
+# ---------------------------------------------------------------------------
+_DATE_VAR_NAMES = re.compile(
+    r"(?:START_DATE|START_TIMESTAMP|IMPORT_DATE|IMPORT_START|SINCE)",
+    re.IGNORECASE,
+)
+
+
+def _is_absolute_iso_datetime(value: str) -> bool:
+    """Return True when value is an absolute ISO date/datetime string.
+
+    Accepts quoted and unquoted values. Durations (e.g. P30D), env var
+    placeholders (e.g. ${START_DATE}), and invalid date strings return False.
+    """
+    normalized = value.strip().strip("\"'")
+    if not normalized:
+        return False
+
+    # Python's fromisoformat accepts +00:00 but not every trailing "Z" form.
+    normalized = normalized.replace("Z", "+00:00")
+
+    for parser in (datetime.fromisoformat, date.fromisoformat):
+        try:
+            parser(normalized)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _check_config_files(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check config files for absolute dates in start_date-like variables.
+
+    Detection flow:
+      1. Extract all env vars from docker-compose.yml / .env.sample.
+      2. Skip commented-out lines (inactive config).
+      3. Keep only variables whose name contains a date-like keyword.
+      4. Flag any whose value looks like an absolute ISO date (20xx-…).
+    """
+    results: list[CheckFinding] = []
+    env_vars = extract_all_env_vars(ctx)
+
+    for var in env_vars:
+        # Commented-out vars are informational — skip them
+        if var.is_commented:
+            continue
+        # Only inspect variables with date-related names
+        if not _DATE_VAR_NAMES.search(var.name):
+            continue
+        # Flag values that look like absolute dates (e.g. "2020-05-01")
+        if _is_absolute_iso_datetime(var.value):
+            rel = var.file_path.relative_to(ctx.path)
+            results.append(
+                CheckFinding(
+                    message=(
+                        f"{rel}:{var.line}: {var.name}={var.value} uses absolute date"
+                    ),
+                    severity=Severity.WARNING,
+                    file_path=var.file_path,
+                    line=var.line,
+                    suggestion=(
+                        "Use an ISO 8601 duration (e.g. P30D for 30 days ago) "
+                        "instead of a fixed date. The SDK's DatetimeFromIsoString "
+                        "type accepts both formats."
+                    ),
+                ),
+            )
+
+    return results
+
+
+def _check_code_defaults(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check Python code for hardcoded date defaults in Field() or assignments.
+
+    Looks for AST patterns like:
+        Field(default="2020-05-01T00:00:00Z")
+
+    where a keyword argument ``default`` is set to a string constant
+    matching an absolute date.  This catches Pydantic settings fields
+    that should use ISO durations instead.
+    """
+    sources = ctx.python_sources
+    if not sources:
+        return []
+
+    trees = ctx.python_trees
+    results: list[CheckFinding] = []
+
+    for file_path, tree in trees.items():
+        for node in ast.walk(tree):
+            # Check Field(default="2020-...") or direct assignment
+            if (
+                isinstance(node, ast.keyword)
+                and node.arg == "default"
+                and (
+                    isinstance(node.value, ast.Constant)
+                    and isinstance(node.value.value, str)
+                    and _is_absolute_iso_datetime(node.value.value)
+                )
+            ):
+                # Walk up to find the field name context
+                results.append(
+                    CheckFinding(
+                        message=(
+                            f'Field default="{node.value.value}" '
+                            f"is a hardcoded absolute date"
+                        ),
+                        severity=Severity.WARNING,
+                        file_path=file_path,
+                        line=node.value.lineno,
+                        suggestion=(
+                            'Use an ISO duration default (e.g. "P30D") '
+                            "and type the field as DatetimeFromIsoString "
+                            "from connectors-sdk."
+                        ),
+                    ),
+                )
+
+    return results
+
+
+@CheckRegistry.register(
+    code="VC105",
+    name="no-absolute-import-date",
+    description="Import start dates must use ISO duration, not absolute dates",
+    severity=Severity.WARNING,
+)
+def check_no_absolute_import_date(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check that no absolute dates are used for import start configuration."""
+    config_results = _check_config_files(ctx)
+    code_results = _check_code_defaults(ctx)
+
+    all_results = config_results + code_results
+
+    if not all_results:
+        return [
+            CheckFinding(
+                message="No hardcoded absolute import dates found ✓",
+                severity=Severity.INFO,
+            ),
+        ]
+
+    return all_results

--- a/shared/connector_linter/connector_linter/checks/vc1xx_config/vc105_no_absolute_date.py
+++ b/shared/connector_linter/connector_linter/checks/vc1xx_config/vc105_no_absolute_date.py
@@ -155,7 +155,7 @@ def _check_code_defaults(ctx: ConnectorContext) -> list[CheckFinding]:
 @CheckRegistry.register(
     code="VC105",
     name="no-absolute-import-date",
-    description="Import start dates must use ISO duration, not absolute dates",
+    description="Import start dates should use ISO duration, not absolute dates",
     severity=Severity.WARNING,
 )
 def check_no_absolute_import_date(ctx: ConnectorContext) -> list[CheckFinding]:

--- a/shared/connector_linter/connector_linter/checks/vc2xx_metadata/__init__.py
+++ b/shared/connector_linter/connector_linter/checks/vc2xx_metadata/__init__.py
@@ -1,0 +1,8 @@
+"""VC2xx — Metadata checks.
+
+Validates connector metadata (manifest, connector identity) for
+compliance with OpenCTI verified-connector conventions.
+
+VC201  manifest-verified-date     Manifest must have verified=true and last_verified_date
+VC202  manifest-container-image  container_version must be rolling, container_image must match dirname
+"""

--- a/shared/connector_linter/connector_linter/checks/vc2xx_metadata/vc201_manifest_verified.py
+++ b/shared/connector_linter/connector_linter/checks/vc2xx_metadata/vc201_manifest_verified.py
@@ -1,0 +1,120 @@
+"""VC201 — Connector manifest must declare verified status and date.
+
+A verified connector must have both fields in
+``__metadata__/connector_manifest.json``:
+
+- ``"verified": true``
+- ``"last_verified_date": "YYYY-MM-DD"`` (non-null, valid ISO date)
+
+Scope: Common (all connector types).
+"""
+
+from datetime import date
+
+from connector_linter.models import CheckFinding, ConnectorContext, Severity
+from connector_linter.registry import CheckRegistry
+
+
+@CheckRegistry.register(
+    code="VC201",
+    name="manifest-verified-date",
+    description="Manifest must have verified=true and a valid last_verified_date",
+    severity=Severity.ERROR,
+)
+def check_manifest_verified_date(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check verified flag and last_verified_date in manifest."""
+    manifest_path = ctx.path / "__metadata__" / "connector_manifest.json"
+
+    if not ctx.manifest:
+        return [
+            CheckFinding(
+                message="No connector_manifest.json found in __metadata__/",
+                severity=Severity.ERROR,
+                file_path=manifest_path,
+                suggestion="Add __metadata__/connector_manifest.json with verified fields.",
+            ),
+        ]
+
+    results: list[CheckFinding] = []
+
+    # --- Sub-check A: verified flag ---
+    # Three-way branch:
+    #   True   → PASS: connector is marked as verified
+    #   False  → FAIL: explicitly marked as not verified
+    #   missing/None → FAIL: field is absent from the manifest
+    verified = ctx.manifest.get("verified")
+    if verified is True:
+        results.append(
+            CheckFinding(
+                message='"verified": true ✓',
+                severity=Severity.INFO,
+                file_path=manifest_path,
+            ),
+        )
+    elif verified is False:
+        results.append(
+            CheckFinding(
+                message='"verified" is false',
+                severity=Severity.ERROR,
+                file_path=manifest_path,
+                suggestion='Set "verified": true in connector_manifest.json.',
+            ),
+        )
+    else:
+        results.append(
+            CheckFinding(
+                message='"verified" field is missing from manifest',
+                severity=Severity.ERROR,
+                file_path=manifest_path,
+                suggestion='Add "verified": true to connector_manifest.json.',
+            ),
+        )
+
+    # --- Sub-check B: last_verified_date ---
+    # Must be a non-null string in YYYY-MM-DD format and a real ISO date.
+    # This records when the connector was last reviewed for verified
+    # compliance.
+    date_val = ctx.manifest.get("last_verified_date")
+    if date_val is None:
+        results.append(
+            CheckFinding(
+                message='"last_verified_date" is null or missing',
+                severity=Severity.ERROR,
+                file_path=manifest_path,
+                suggestion=(
+                    'Set "last_verified_date": "YYYY-MM-DD" '
+                    "(e.g. today's date) in connector_manifest.json."
+                ),
+            ),
+        )
+    elif not isinstance(date_val, str):
+        results.append(
+            CheckFinding(
+                message=f'"last_verified_date": "{date_val}" — invalid format',
+                severity=Severity.ERROR,
+                file_path=manifest_path,
+                suggestion='Use YYYY-MM-DD format (e.g. "2025-08-18").',
+            ),
+        )
+    else:
+        try:
+            date.fromisoformat(date_val)
+        except ValueError:
+            results.append(
+                CheckFinding(
+                    message=f'"last_verified_date": "{date_val}" — invalid format',
+                    severity=Severity.ERROR,
+                    file_path=manifest_path,
+                    suggestion='Use YYYY-MM-DD format (e.g. "2025-08-18").',
+                ),
+            )
+        else:
+            results.append(
+                CheckFinding(
+                    message=f'"last_verified_date": "{date_val}" ✓',
+                    severity=Severity.INFO,
+                    file_path=manifest_path,
+                ),
+            )
+
+    return results

--- a/shared/connector_linter/connector_linter/checks/vc2xx_metadata/vc202_container_image.py
+++ b/shared/connector_linter/connector_linter/checks/vc2xx_metadata/vc202_container_image.py
@@ -1,0 +1,110 @@
+"""VC202 — Manifest container fields must be correct.
+
+In ``__metadata__/connector_manifest.json``:
+
+- ``container_version`` must be ``"rolling"`` (not a pinned version).
+- ``container_image`` must be ``"opencti/connector-<dirname>"`` where
+  ``<dirname>`` is the connector directory name.
+
+Scope: Common (all connector types).
+"""
+
+from connector_linter.models import CheckFinding, ConnectorContext, Severity
+from connector_linter.registry import CheckRegistry
+
+
+@CheckRegistry.register(
+    code="VC202",
+    name="manifest-container-image",
+    description="Manifest container_version must be rolling, container_image must match dirname",
+    severity=Severity.ERROR,
+)
+def check_manifest_container_image(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check container_version and container_image in manifest."""
+    if not ctx.manifest:
+        return [
+            CheckFinding(
+                message="No connector_manifest.json found in __metadata__/",
+                severity=Severity.ERROR,
+                suggestion="Add __metadata__/connector_manifest.json.",
+            ),
+        ]
+
+    results: list[CheckFinding] = []
+    manifest_path = ctx.path / "__metadata__" / "connector_manifest.json"
+
+    # --- Sub-check A: container_version must be "rolling" ---
+    #
+    # Docker Hub images for verified connectors are built automatically
+    # by CI on every release.  The manifest must declare "rolling" (not a
+    # pinned version like "6.7.7") so the platform always pulls the latest
+    # compatible image without manual version bumps.
+    version = ctx.manifest.get("container_version")
+    if version == "rolling":
+        results.append(
+            CheckFinding(
+                message='"container_version": "rolling" ✓',
+                severity=Severity.INFO,
+                file_path=manifest_path,
+            ),
+        )
+    elif version is None:
+        results.append(
+            CheckFinding(
+                message='"container_version" is missing from manifest',
+                severity=Severity.ERROR,
+                file_path=manifest_path,
+                suggestion='Add "container_version": "rolling" to connector_manifest.json.',
+            ),
+        )
+    else:
+        results.append(
+            CheckFinding(
+                message=f'"container_version": "{version}" — must be "rolling"',
+                severity=Severity.ERROR,
+                file_path=manifest_path,
+                suggestion='Set "container_version": "rolling" in connector_manifest.json.',
+            ),
+        )
+
+    # --- Sub-check B: container_image must match opencti/connector-<dirname> ---
+    #
+    # Convention: the Docker Hub image name is always derived from the
+    # connector's directory name:
+    #   directory "mandiant"     → image "opencti/connector-mandiant"
+    #   directory "abuse-ssl"    → image "opencti/connector-abuse-ssl"
+    #
+    # This ensures Docker Hub automation and the OpenCTI platform can
+    # resolve the correct image without per-connector configuration.
+    dirname = ctx.path.name
+    expected_image = f"opencti/connector-{dirname}"
+    image = ctx.manifest.get("container_image")
+
+    if image == expected_image:
+        results.append(
+            CheckFinding(
+                message=f'"container_image": "{image}" ✓',
+                severity=Severity.INFO,
+                file_path=manifest_path,
+            ),
+        )
+    elif image is None:
+        results.append(
+            CheckFinding(
+                message='"container_image" is missing from manifest',
+                severity=Severity.ERROR,
+                file_path=manifest_path,
+                suggestion=f'Add "container_image": "{expected_image}" to connector_manifest.json.',
+            ),
+        )
+    else:
+        results.append(
+            CheckFinding(
+                message=f'"container_image": "{image}" — expected "{expected_image}"',
+                severity=Severity.ERROR,
+                file_path=manifest_path,
+                suggestion=f'Set "container_image": "{expected_image}" to match the directory name.',
+            ),
+        )
+
+    return results

--- a/shared/connector_linter/tests/conftest.py
+++ b/shared/connector_linter/tests/conftest.py
@@ -10,6 +10,7 @@ from connector_linter.models import (
     Severity,
 )
 from connector_linter.registry import CheckRegistry
+from connector_linter.runner import _import_checks_modules
 
 
 @pytest.fixture()
@@ -18,6 +19,7 @@ def _clean_registry():
 
     Tests that register throwaway checks won't leak into other tests.
     """
+    _import_checks_modules()  # ensure all real checks are loaded before saving
     saved = dict(CheckRegistry._checks)
     yield
     CheckRegistry._checks.clear()


### PR DESCRIPTION
### Proposed changes

* Add VC1xx configuration validation checks (7 files, ~845 lines)
* Add VC2xx metadata validation checks (3 files, ~201 lines)

> **Part 2 of 4** — Stacked on `feat/connector-linter-1-foundation`. Review only the top commit.

### Related issues

* Part of #5989

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Stacked PR series:
1. **#6293:** Foundation — scaffold + core engine + README
2. **#6292 (this):** VC1xx config + VC2xx metadata checks
3. **#6291:** VC3xx code checks
4. **#6294:** VC4xx docker + VC5xx deprecation checks