### PR TITLE
[Connector-linter]: add VC4xx docker and VC5xx deprecation checks [4/4]

### DIFF
--- a/shared/connector_linter/README.md
+++ b/shared/connector_linter/README.md
@@ -84,6 +84,30 @@ connector-linter check ./connector --severity error     # errors only
 connector-linter check ./connector --abspath
 ```
 
+### Project-level configuration (`pyproject.toml`)
+
+Configure the linter at project level via `[tool.connector-linter]` in `pyproject.toml`. The file is auto-discovered by walking up from the connector directory (like Ruff).
+
+```toml
+[tool.connector-linter]
+# Only run these checks/prefixes (same as --select)
+select = ["VC1xx", "VC3xx"]
+
+# Skip these checks (same as --ignore, merged with CLI --ignore)
+ignore = ["VC306", "VC307"]
+
+# Skip specific checks for files matching a glob pattern
+[tool.connector-linter.per-file-ignores]
+"tests/*.py" = ["VC309", "VC313"]
+"src/main.py" = ["VC308"]
+```
+
+**Precedence rules** (inspired by Ruff):
+- CLI `--select` overrides `select` from pyproject.toml
+- CLI `--ignore` is merged with `ignore` from pyproject.toml (union of both)
+- `per-file-ignores` applies after check execution and before inline `# noqa`
+- Use `--config path/to/pyproject.toml` to specify an explicit config file
+
 ### Inline suppression (`# noqa`)
 
 Suppress specific checks on individual lines using `# noqa` comments — same syntax as flake8:

--- a/shared/connector_linter/connector_linter/__main__.py
+++ b/shared/connector_linter/connector_linter/__main__.py
@@ -1,19 +1,18 @@
 """CLI entry point for the connector linter."""
 
-import ast
-import inspect
 import sys
 from pathlib import Path
 
 import click
 from connector_linter import __version__
+from connector_linter._doc_generator import generate_rules_markdown
 from connector_linter.formatters import (
     format_github,
     format_json,
     format_markdown,
     format_text,
 )
-from connector_linter.models import Severity
+from connector_linter.models import SEVERITY_COLOR, Severity
 from connector_linter.registry import CheckRegistry
 from connector_linter.runner import _import_checks_modules, run_checks
 
@@ -147,11 +146,8 @@ def check(
 
     # Filter by severity if requested
     if severity:
-        severity_order = {Severity.INFO: 0, Severity.WARNING: 1, Severity.ERROR: 2}
         min_sev = Severity(severity)
-        results = [
-            r for r in results if severity_order[r.severity] >= severity_order[min_sev]
-        ]
+        results = [r for r in results if r.severity.rank() >= min_sev.rank()]
 
     # Format output
     if output_format == "text":
@@ -177,52 +173,21 @@ def list_checks() -> None:
         click.echo("No checks registered yet.")
         return
 
-    click.echo(f"{'Code':<8} {'Sev':<5} {'Name':<30} Description")
-    click.echo(f"{'─' * 8} {'─' * 5} {'─' * 30} {'─' * 40}")
+    click.echo(f"{'Code':<8} {'Sev':<5} {'Name':<30} {'Scope':<28} Description")
+    click.echo(f"{'─' * 8} {'─' * 5} {'─' * 30} {'─' * 28} {'─' * 40}")
     for code in sorted(checks.keys()):
         desc = checks[code]
-        sev_color = {"E": "red", "W": "yellow", "I": "cyan"}[desc.severity.symbol()]
+        sev_color = SEVERITY_COLOR[desc.severity]
+        if desc.applicable_types:
+            scope = ",".join(sorted(t.label for t in desc.applicable_types))
+        else:
+            scope = "All"
         click.echo(
             f"{code:<8} "
             f"{click.style(desc.severity.symbol(), fg=sev_color):<14} "
-            f"{desc.name:<30} {desc.description}",
+            f"{desc.name:<30} "
+            f"{scope:<28} {desc.description}",
         )
-
-
-def _extract_check_docstring(func: object) -> str | None:
-    """Extract the module-level docstring from the file defining *func*."""
-    source_file = inspect.getfile(func)  # type: ignore[arg-type]
-    with open(source_file) as f:
-        tree = ast.parse(f.read())
-    return ast.get_docstring(tree)
-
-
-def _extract_applicable_types(func: object) -> list[str] | None:
-    """Extract ``_APPLICABLE_TYPES`` set literal from the check's source file."""
-    source_file = inspect.getfile(func)  # type: ignore[arg-type]
-    with open(source_file) as f:
-        tree = ast.parse(f.read())
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == "_APPLICABLE_TYPES":
-                    if isinstance(node.value, ast.Set):
-                        return sorted(
-                            elt.value
-                            for elt in node.value.elts
-                            if isinstance(elt, ast.Constant)
-                        )
-    return None
-
-
-# Mapping from internal type constants to human-readable labels
-_TYPE_LABELS = {
-    "EXTERNAL_IMPORT": "External Import",
-    "INTERNAL_ENRICHMENT": "Internal Enrichment",
-    "INTERNAL_EXPORT_FILE": "Internal Export File",
-    "INTERNAL_IMPORT_FILE": "Internal Import File",
-    "STREAM": "Stream",
-}
 
 
 @cli.command()
@@ -246,72 +211,7 @@ def docs(output: str | None) -> None:
         click.echo("No checks registered yet.", err=True)
         return
 
-    # Group checks by category prefix
-    categories: dict[str, list[str]] = {}
-    for code in sorted(checks.keys()):
-        prefix = code[:3]  # "VC1", "VC2", …
-        categories.setdefault(prefix, []).append(code)
-
-    category_titles = {
-        "VC1": "VC1xx — Configuration",
-        "VC2": "VC2xx — Metadata",
-        "VC3": "VC3xx — Code Quality",
-        "VC4": "VC4xx — Docker",
-        "VC5": "VC5xx — Deprecation",
-    }
-
-    lines: list[str] = []
-    lines.append("# Connector Linter — Rules Reference\n")
-    lines.append(f"Total rules: **{len(checks)}**\n")
-
-    # Summary table
-    lines.append("## Summary\n")
-    lines.append("| Code | Severity | Name | Scope |")
-    lines.append("|------|----------|------|-------|")
-    for code in sorted(checks.keys()):
-        desc = checks[code]
-        sev_icon = {"E": "🔴", "W": "🟡", "I": "🔵"}[desc.severity.symbol()]
-        applicable = _extract_applicable_types(desc.func)
-        if applicable:
-            scope = ", ".join(_TYPE_LABELS.get(t, t) for t in applicable)
-        else:
-            scope = "All"
-        lines.append(
-            f"| {code} | {sev_icon} {desc.severity.value.capitalize()} | {desc.name} | {scope} |"
-        )
-
-    lines.append("")
-
-    # Detailed sections per category
-    for prefix in sorted(categories.keys()):
-        title = category_titles.get(prefix, f"{prefix}xx")
-        lines.append(f"## {title}\n")
-
-        for code in categories[prefix]:
-            desc = checks[code]
-            sev_icon = {"E": "🔴", "W": "🟡", "I": "🔵"}[desc.severity.symbol()]
-            lines.append(f"### {code} — {desc.name}\n")
-            lines.append(
-                f"- **Severity:** {sev_icon} {desc.severity.value.capitalize()}"
-            )
-
-            applicable = _extract_applicable_types(desc.func)
-            if applicable:
-                scope = ", ".join(_TYPE_LABELS.get(t, t) for t in applicable)
-            else:
-                scope = "All connector types"
-            lines.append(f"- **Scope:** {scope}")
-            lines.append(f"- **Description:** {desc.description}\n")
-
-            docstring = _extract_check_docstring(desc.func)
-            if docstring:
-                # Strip the first line (title, usually "VCxxx — ...")
-                doc_lines = docstring.strip().split("\n")
-                body = "\n".join(doc_lines[1:]).strip()
-                if body:
-                    lines.append(f"{body}\n")
-
-    content = "\n".join(lines)
+    content = generate_rules_markdown(checks)
 
     if output:
         out_path = Path(output)

--- a/shared/connector_linter/connector_linter/__main__.py
+++ b/shared/connector_linter/connector_linter/__main__.py
@@ -88,6 +88,13 @@ def _resolve_connector_root(file_path: Path) -> Path | None:
     default=False,
     help="Show absolute file paths in text output (JSON always uses absolute paths).",
 )
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help="Path to pyproject.toml (auto-detected if not specified).",
+)
 def check(
     connector_path: str,
     output_format: str,
@@ -97,6 +104,7 @@ def check(
     verbose: bool,
     disable_noqa: bool,
     abspath: bool,
+    config_path: str | None,
 ) -> None:
     r"""Check a connector against Verified criteria.
 
@@ -134,6 +142,7 @@ def check(
         select=list(select) if select else None,
         ignore=list(ignore) if ignore else None,
         disable_noqa=disable_noqa,
+        config_path=Path(config_path) if config_path else None,
     )
 
     # When a specific file was targeted, keep only findings for that file

--- a/shared/connector_linter/connector_linter/_doc_generator.py
+++ b/shared/connector_linter/connector_linter/_doc_generator.py
@@ -1,0 +1,110 @@
+"""Documentation generator for connector-linter rules.
+
+Extracts check metadata (code, severity, scope, description, docstring)
+from the registry and renders a Markdown reference document suitable for
+import into Notion, GitHub wikis, or any Markdown viewer.
+
+Separated from ``__main__.py`` to keep the CLI entry-point focused on
+argument parsing and output routing.
+"""
+
+import importlib
+import pkgutil
+from pathlib import Path
+
+import connector_linter.checks as _checks_pkg
+from connector_linter.models import SEVERITY_EMOJI
+from connector_linter.registry import CheckDescriptor
+
+
+def load_category_titles() -> dict[str, str]:
+    """Build category title map from check sub-package docstrings.
+
+    Reads the first docstring line of each ``vc<N>xx_*`` sub-package so the
+    map is automatically up-to-date when new categories are added.
+
+    Example output::
+
+        {"VC1": "VC1xx — Configuration checks.",
+         "VC2": "VC2xx — Metadata checks.", ...}
+    """
+    titles: dict[str, str] = {}
+    pkg_path = Path(_checks_pkg.__file__).parent
+    for _finder, name, is_pkg in pkgutil.iter_modules([str(pkg_path)]):
+        if not is_pkg:
+            continue
+        prefix = name[:3].upper()  # "vc1" → "VC1"
+        mod = importlib.import_module(f"connector_linter.checks.{name}")
+        first_line = (mod.__doc__ or "").strip().splitlines()[0] if mod.__doc__ else ""
+        if first_line:
+            titles[prefix] = first_line.rstrip(".")
+    return titles
+
+
+def generate_rules_markdown(checks: dict[str, CheckDescriptor]) -> str:
+    """Render a Markdown reference document for all provided checks.
+
+    Args:
+        checks: Mapping of code → CheckDescriptor (e.g. from CheckRegistry.get_all()).
+
+    Returns:
+        A Markdown string ready to write to a file or stdout.
+    """
+    # Group checks by category prefix ("VC1", "VC2", …)
+    categories: dict[str, list[str]] = {}
+    for code in sorted(checks.keys()):
+        prefix = code[:3]
+        categories.setdefault(prefix, []).append(code)
+
+    category_titles = load_category_titles()
+
+    lines: list[str] = []
+    lines.append("# Connector Linter — Rules Reference\n")
+    lines.append(f"Total rules: **{len(checks)}**\n")
+
+    # Summary table
+    lines.append("## Summary\n")
+    lines.append("| Code | Severity | Name | Scope |")
+    lines.append("|------|----------|------|-------|")
+    for code in sorted(checks.keys()):
+        desc = checks[code]
+        sev_icon = SEVERITY_EMOJI[desc.severity]
+        if desc.applicable_types:
+            scope = ", ".join(t.label for t in sorted(desc.applicable_types))
+        else:
+            scope = "All"
+        lines.append(
+            f"| {code} | {sev_icon} {desc.severity.value.capitalize()} | {desc.name} | {scope} |"
+        )
+
+    lines.append("")
+
+    # Detailed sections per category
+    for prefix in sorted(categories.keys()):
+        title = category_titles.get(prefix, f"{prefix}xx")
+        lines.append(f"## {title}\n")
+
+        for code in categories[prefix]:
+            desc = checks[code]
+            sev_icon = SEVERITY_EMOJI[desc.severity]
+            lines.append(f"### {code} — {desc.name}\n")
+            lines.append(
+                f"- **Severity:** {sev_icon} {desc.severity.value.capitalize()}"
+            )
+
+            if desc.applicable_types:
+                scope = ", ".join(t.label for t in sorted(desc.applicable_types))
+            else:
+                scope = "All connector types"
+            lines.append(f"- **Scope:** {scope}")
+            lines.append(f"- **Description:** {desc.description}\n")
+
+            docstring = desc.module_doc
+            if docstring:
+                # Strip the first line (title, usually "VCxxx — ...")
+                doc_lines = docstring.strip().split("\n")
+                body = "\n".join(doc_lines[1:]).strip()
+                if body:
+                    lines.append(f"{body}\n")
+
+    return "\n".join(lines)

--- a/shared/connector_linter/connector_linter/checks/vc4xx_docker/__init__.py
+++ b/shared/connector_linter/connector_linter/checks/vc4xx_docker/__init__.py
@@ -1,0 +1,8 @@
+"""VC4xx — Docker checks.
+
+Validates Docker configuration (Dockerfile, docker-compose.yml) for
+compliance with OpenCTI verified-connector conventions.
+
+VC401  docker-compose-image       Image must use :latest tag and match directory name
+VC402  no-entrypoint-sh           Dockerfile must not use entrypoint.sh
+"""

--- a/shared/connector_linter/connector_linter/checks/vc4xx_docker/vc401_docker_compose_image.py
+++ b/shared/connector_linter/connector_linter/checks/vc4xx_docker/vc401_docker_compose_image.py
@@ -1,0 +1,149 @@
+"""VC401 — docker-compose.yml image must use ``latest`` tag and match directory name.
+
+The ``image:`` line in ``docker-compose.yml`` must follow the pattern::
+
+    image: opencti/connector-<dirname>:latest
+
+Rules:
+
+1. Tag must be ``:latest`` (not a pinned version like ``6.7.7``).
+2. Image name must be ``opencti/connector-<dirname>`` where ``<dirname>``
+   is the connector's directory name (for Docker Hub automation).
+
+Scope: Common (all connector types).
+"""
+
+import re
+
+from connector_linter.models import CheckFinding, ConnectorContext, Severity
+from connector_linter.registry import CheckRegistry
+
+# ---------------------------------------------------------------------------
+# Regex: YAML image: line in docker-compose.yml
+#
+# Matches lines like:
+#   image: opencti/connector-mandiant:latest
+#     image:  opencti/connector-abuse-ssl:6.7.7
+#
+# Capture group "image" grabs everything after "image:" up to whitespace
+# or an inline comment.  Leading whitespace is tolerated (YAML indentation).
+#
+# NOTE: This is a simple regex, not a full YAML parser — it works because
+# docker-compose files have a predictable structure for image: lines.
+# ---------------------------------------------------------------------------
+_IMAGE_RE = re.compile(
+    r"^\s*image:\s*(?P<image>[^\s#]+)",
+    re.MULTILINE,
+)
+
+
+@CheckRegistry.register(
+    code="VC401",
+    name="docker-compose-image",
+    description="docker-compose.yml image must use :latest and match directory name",
+    severity=Severity.ERROR,
+)
+def check_docker_compose_image(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check docker-compose.yml image tag and naming."""
+    compose_path = ctx.path / "docker-compose.yml"
+    if not compose_path.is_file():
+        return [
+            CheckFinding(
+                message="docker-compose.yml not found",
+                severity=Severity.ERROR,
+                suggestion="Add a docker-compose.yml file.",
+            ),
+        ]
+
+    with compose_path.open(encoding="utf-8") as f:
+        content = f.read()
+
+    m = _IMAGE_RE.search(content)
+    if not m:
+        return [
+            CheckFinding(
+                message="No 'image:' line found in docker-compose.yml",
+                severity=Severity.ERROR,
+                suggestion="Add an 'image:' line (e.g. opencti/connector-<name>:latest).",
+            ),
+        ]
+
+    image_full = m.group("image").strip()
+    # Find line number
+    line_no = content[: m.start()].count("\n") + 1
+
+    results: list[CheckFinding] = []
+    dirname = ctx.path.name
+    expected_image = f"opencti/connector-{dirname}"
+    expected_full = f"{expected_image}:latest"
+
+    # ---------------------------------------------------------------------------
+    # Split the image string into name and tag.
+    #
+    # Use rsplit(":", 1) to split from the right — this correctly handles
+    # registry prefixes that contain colons (e.g. registry.io:5000/image:tag).
+    # If there is no ":", the image has no tag (tag = "").
+    #
+    # NOTE: VC401 checks for ":latest" in docker-compose.yml, while VC202
+    # checks for "rolling" in the manifest.  These are different contexts:
+    #   docker-compose.yml → users pull ":latest" from Docker Hub
+    #   connector_manifest.json → CI uses "rolling" as a build policy marker
+    # ---------------------------------------------------------------------------
+    if ":" in image_full:
+        image_name, tag = image_full.rsplit(":", 1)
+    else:
+        image_name, tag = image_full, ""
+
+    # --- Sub-check A: tag must be :latest ---
+    # Pinned tags (e.g. :6.7.7) prevent users from getting updates
+    # automatically.  The sample should always use :latest.
+    if tag == "latest":
+        results.append(
+            CheckFinding(
+                message="Image uses :latest tag ✓",
+                severity=Severity.INFO,
+                file_path=compose_path,
+                line=line_no,
+            ),
+        )
+    else:
+        results.append(
+            CheckFinding(
+                message=f"Image tag is :{tag or '(none)'} — must be :latest",
+                severity=Severity.ERROR,
+                file_path=compose_path,
+                line=line_no,
+                suggestion=f"Change to {expected_full} for stable deployment.",
+            ),
+        )
+
+    # --- Sub-check B: image name must match directory ---
+    # The image name must follow the convention opencti/connector-<dirname>
+    # so Docker Hub automation and platform discovery work correctly.
+    if image_name == expected_image:
+        results.append(
+            CheckFinding(
+                message=f"Image name matches directory: {expected_image} ✓",
+                severity=Severity.INFO,
+                file_path=compose_path,
+                line=line_no,
+            ),
+        )
+    else:
+        results.append(
+            CheckFinding(
+                message=(
+                    f"Image name '{image_name}' does not match "
+                    f"expected '{expected_image}'"
+                ),
+                severity=Severity.ERROR,
+                file_path=compose_path,
+                line=line_no,
+                suggestion=(
+                    f"Use {expected_full} — image name must match the "
+                    f"directory name for Docker Hub automation."
+                ),
+            ),
+        )
+
+    return results

--- a/shared/connector_linter/connector_linter/checks/vc4xx_docker/vc402_no_entrypoint_sh.py
+++ b/shared/connector_linter/connector_linter/checks/vc4xx_docker/vc402_no_entrypoint_sh.py
@@ -1,0 +1,118 @@
+"""VC402 — Dockerfile must not use entrypoint.sh.
+
+Modern connectors should use a direct ``ENTRYPOINT`` command::
+
+    ENTRYPOINT ["python", "main.py"]
+
+The legacy ``entrypoint.sh`` wrapper (which just ``cd`` + ``python3 main.py``)
+adds unnecessary indirection and an extra file to maintain.
+
+Scope: Common (all connector types).
+"""
+
+import re
+
+from connector_linter.models import CheckFinding, ConnectorContext, Severity
+from connector_linter.registry import CheckRegistry
+
+# ---------------------------------------------------------------------------
+# Regex: references to entrypoint.sh anywhere in a Dockerfile line.
+#
+# Matches any line that mentions "entrypoint.sh" (case-insensitive).
+# Used to detect the legacy pattern:
+#   COPY entrypoint.sh /
+#   ENTRYPOINT ["/entrypoint.sh"]
+# ---------------------------------------------------------------------------
+_ENTRYPOINT_SH_RE = re.compile(r"entrypoint\.sh", re.IGNORECASE)
+
+# ---------------------------------------------------------------------------
+# Regex: direct Python ENTRYPOINT (the preferred modern pattern).
+#
+# Matches lines like:
+#   ENTRYPOINT ["python", "-m", "connector"]
+#   ENTRYPOINT ["python3", "main.py"]
+#
+# The key requirement is the JSON-exec form with "python" as the first
+# argument.  This avoids the unnecessary entrypoint.sh wrapper script.
+# ---------------------------------------------------------------------------
+_ENTRYPOINT_DIRECT_RE = re.compile(r'ENTRYPOINT\s+\[.*"python"', re.IGNORECASE)
+
+
+@CheckRegistry.register(
+    code="VC402",
+    name="no-entrypoint-sh",
+    description="Dockerfile must not use entrypoint.sh — use direct ENTRYPOINT",
+    severity=Severity.ERROR,
+)
+def check_no_entrypoint_sh(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check that Dockerfile does not reference entrypoint.sh."""
+    dockerfile_path = ctx.path / "Dockerfile"
+    if not dockerfile_path.is_file():
+        return [
+            CheckFinding(
+                message="No Dockerfile found",
+                severity=Severity.ERROR,
+                suggestion="Add a Dockerfile to the connector.",
+            ),
+        ]
+
+    with dockerfile_path.open(encoding="utf-8") as f:
+        content = f.read()
+
+    lines = content.splitlines()
+
+    # ---------------------------------------------------------------------------
+    # Detection priority:
+    #   1. First, scan for entrypoint.sh references (the "bad" pattern).
+    #      Commented-out lines (# COPY entrypoint.sh) are skipped — they are
+    #      remnants of a migration and not active.
+    #   2. If no entrypoint.sh found, check for a direct Python ENTRYPOINT
+    #      (the "good" pattern) and report it as passing.
+    #   3. Fallback: no entrypoint.sh AND no direct ENTRYPOINT — still PASS
+    #      because the absence of entrypoint.sh is the primary goal.
+    # ---------------------------------------------------------------------------
+    sh_hits: list[tuple[int, str]] = []
+    for i, line in enumerate(lines, 1):
+        # Skip commented Dockerfile lines — they don't affect the build
+        if _ENTRYPOINT_SH_RE.search(line) and not line.lstrip().startswith("#"):
+            sh_hits.append((i, line.strip()))
+
+    if sh_hits:
+        first = sh_hits[0]
+        return [
+            CheckFinding(
+                message=f"Dockerfile uses entrypoint.sh at line {first[0]}",
+                severity=Severity.ERROR,
+                file_path=dockerfile_path,
+                line=first[0],
+                suggestion=(
+                    "Remove entrypoint.sh and use "
+                    'ENTRYPOINT ["python", "main.py"] '
+                    "or similar direct Python invocation."
+                ),
+            ),
+        ]
+
+    # No entrypoint.sh found — check for the preferred direct ENTRYPOINT
+    if _ENTRYPOINT_DIRECT_RE.search(content):
+        for i, line in enumerate(lines, 1):
+            if _ENTRYPOINT_DIRECT_RE.search(line):
+                return [
+                    CheckFinding(
+                        message="Dockerfile uses direct Python ENTRYPOINT ✓",
+                        severity=Severity.INFO,
+                        file_path=dockerfile_path,
+                        line=i,
+                    ),
+                ]
+
+    # Fallback: no entrypoint.sh reference at all — this is fine.
+    # The connector might use CMD or some other mechanism; the key
+    # requirement is just the absence of the legacy entrypoint.sh wrapper.
+    return [
+        CheckFinding(
+            message="No entrypoint.sh reference found ✓",
+            severity=Severity.INFO,
+            file_path=dockerfile_path,
+        ),
+    ]

--- a/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/__init__.py
+++ b/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/__init__.py
@@ -1,0 +1,12 @@
+"""VC5xx — Deprecation checks.
+
+Detects usage of deprecated patterns, configuration variables, and APIs
+that must be migrated for verified-connector status.
+
+VC501  no-legacy-interval          Must use duration_period (ISO 8601), not interval
+VC502  no-deprecated-report-status Must not use deprecated x_opencti_report_status
+VC503  no-deprecated-helper-logger Must use connector_logger instead of helper.log_{level}()
+VC504  no-deprecated-confidence    Must not use deprecated confidence level (since 6.0)
+VC505  no-direct-api-calls        Connector should not use direct GraphQL API calls
+VC506  no-update-existing-data    Must not use deprecated UPDATE_EXISTING_DATA
+"""

--- a/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/_helpers.py
+++ b/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/_helpers.py
@@ -1,0 +1,21 @@
+"""Shared AST helpers for vc5xx deprecation checks."""
+
+import ast
+
+# Known helper variable names across the connector codebase.
+_HELPER_NAMES = frozenset({"helper", "_helper"})
+
+
+def is_helper_node(node: ast.expr) -> bool:
+    """Return True if *node* refers to a helper variable.
+
+    Accepts:
+    - ``ast.Name(id="helper")`` / ``ast.Name(id="_helper")``  (bare name)
+    - ``ast.Attribute(attr="helper")`` / ``ast.Attribute(attr="_helper")``
+      (qualified, e.g. ``self.helper``)
+    """
+    if isinstance(node, ast.Name) and node.id in _HELPER_NAMES:
+        return True
+    if isinstance(node, ast.Attribute) and node.attr in _HELPER_NAMES:
+        return True
+    return False

--- a/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/vc501_no_legacy_interval.py
+++ b/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/vc501_no_legacy_interval.py
@@ -1,0 +1,136 @@
+"""VC501 — Connectors must use ``duration_period`` (ISO 8601), not legacy interval.
+
+The legacy ``*_INTERVAL`` configuration pattern (minutes, hours, days as
+plain integers) and ``schedule_unit()`` are deprecated. Connectors must
+migrate to:
+
+- ``CONNECTOR_DURATION_PERIOD`` (ISO 8601 format, e.g. ``PT30M``, ``P7D``)
+- ``self.helper.schedule_iso()`` or ``schedule_process()`` for scheduling
+
+The SDK's deprecation mechanism (``DeprecatedField``) should be used to
+provide backwards compatibility during the migration window.
+
+Scope: EXTERNAL_IMPORT (scheduling is only relevant for importers).
+"""
+
+import ast
+import re
+
+from connector_linter.checks.vc1xx_config._helpers import extract_all_env_vars
+from connector_linter.models import (
+    CheckFinding,
+    ConnectorContext,
+    ConnectorType,
+    Severity,
+)
+from connector_linter.registry import CheckRegistry
+
+# ---------------------------------------------------------------------------
+# Regex: detect legacy interval configuration variable names
+#
+# Two patterns are flagged:
+#   1. *_INTERVAL$        — any env var ending in _INTERVAL
+#      e.g. CONNECTOR_INTERVAL, DOPPEL_INTERVAL, IMPORT_INTERVAL
+#   2. ^CONNECTOR_RUN_EVERY$ — another legacy naming convention
+#
+# The modern replacement is CONNECTOR_DURATION_PERIOD using ISO 8601
+# duration format (e.g. PT30M = 30 minutes, PT2H = 2 hours, P7D = 7 days).
+# The numeric interval approach (minutes/hours/days as plain integers) is
+# error-prone and does not encode the time unit in the value itself.
+# ---------------------------------------------------------------------------
+_INTERVAL_VAR_RE = re.compile(r"_INTERVAL$|^CONNECTOR_RUN_EVERY$")
+
+
+def _check_interval_config(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Detect legacy _INTERVAL config variables.
+
+    Scans all env vars extracted from docker-compose.yml and .env files
+    for variable names that match the legacy interval naming pattern.
+    """
+    results: list[CheckFinding] = []
+    env_vars = extract_all_env_vars(ctx)
+
+    for var in env_vars:
+        if var.is_commented:
+            continue
+        if _INTERVAL_VAR_RE.search(var.name):
+            results.append(
+                CheckFinding(
+                    message=(f"{var.name}={var.value} — legacy interval variable"),
+                    severity=Severity.ERROR,
+                    file_path=var.file_path,
+                    line=var.line,
+                    suggestion=(
+                        "Replace with CONNECTOR_DURATION_PERIOD using ISO 8601 "
+                        "format (e.g. PT30M, PT2H, P7D). Use SDK DeprecatedField "
+                        "for backwards compatibility."
+                    ),
+                ),
+            )
+
+    return results
+
+
+def _check_schedule_unit(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Detect schedule_unit() calls (deprecated).
+
+    Uses AST analysis to find *.schedule_unit() method calls.  The
+    schedule_unit() method was used with the legacy interval pattern
+    to convert numeric intervals with a unit (minutes, hours, days)
+    into seconds.  It is replaced by schedule_iso() or schedule_process()
+    which work directly with ISO 8601 duration strings.
+    """
+    sources = ctx.python_sources
+    if not sources:
+        return []
+
+    trees = ctx.python_trees
+    results: list[CheckFinding] = []
+
+    for file_path, tree in trees.items():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr == "schedule_unit":
+                results.append(
+                    CheckFinding(
+                        message="uses deprecated schedule_unit()",
+                        severity=Severity.ERROR,
+                        file_path=file_path,
+                        line=node.lineno,
+                        suggestion=(
+                            "Replace schedule_unit() with schedule_iso() or "
+                            "schedule_process(). Use duration_period (ISO 8601) "
+                            "instead of numeric intervals with time units."
+                        ),
+                    ),
+                )
+
+    return results
+
+
+@CheckRegistry.register(
+    code="VC501",
+    name="no-legacy-interval",
+    description="Must use duration_period (ISO 8601), not legacy interval config",
+    severity=Severity.ERROR,
+    applicable_types={ConnectorType.EXTERNAL_IMPORT},
+)
+def check_no_legacy_interval(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check for deprecated interval patterns."""
+    # Two detection strategies: config files (env vars) and code (AST)
+    config_results = _check_interval_config(ctx)
+    code_results = _check_schedule_unit(ctx)
+
+    all_results = config_results + code_results
+
+    if not all_results:
+        return [
+            CheckFinding(
+                message="No legacy interval patterns found ✓",
+                severity=Severity.INFO,
+            ),
+        ]
+
+    return all_results

--- a/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/vc502_no_report_status.py
+++ b/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/vc502_no_report_status.py
@@ -1,0 +1,122 @@
+"""VC502 — No use of deprecated ``x_opencti_report_status``.
+
+The custom STIX property ``x_opencti_report_status`` is deprecated and
+no longer functional.  Connectors must not set it on any STIX object.
+
+Note: ``x_opencti_workflow_id`` *works* but is fragile because the UUID
+is unique per installation; it is flagged as a WARNING.
+
+Reference: https://github.com/OpenCTI-Platform/connectors/issues/1830
+"""
+
+import ast
+from pathlib import Path
+
+from connector_linter.models import (
+    CheckFinding,
+    ConnectorContext,
+    Severity,
+)
+from connector_linter.registry import CheckRegistry
+
+# Fully deprecated — this property is non-functional in current OpenCTI.
+# Using it has no effect; the platform ignores it entirely.
+_DEPRECATED_PROP = "x_opencti_report_status"
+
+# Fragile but functional — x_opencti_workflow_id works but the UUID
+# is unique per OpenCTI installation.  A hardcoded UUID will break when
+# the connector is deployed on a different platform instance.
+_FRAGILE_PROP = "x_opencti_workflow_id"
+
+
+def _scan_with_lines(
+    trees: dict[Path, ast.Module],
+    prop_name: str,
+) -> list[tuple[Path, int]]:
+    """Return (file, line) pairs for all keyword-arg or string-literal uses.
+
+    Two detection patterns (both via AST):
+      1. ast.keyword with arg == prop_name
+         Catches: SomeObject(x_opencti_report_status=value)
+      2. ast.Constant with value == prop_name
+         Catches: string literals like "x_opencti_report_status" used as
+         dict keys, get_config_variable args, etc.
+    """
+    hits: list[tuple[Path, int]] = []
+    for file_path, tree in trees.items():
+        for node in ast.walk(tree):
+            if isinstance(node, ast.keyword) and node.arg == prop_name:
+                # ast.keyword may not have lineno in all Python versions,
+                # so we use getattr with a fallback to 0 for safety.
+                line = getattr(node, "lineno", 0) or 0
+                hits.append((file_path, line))
+            elif isinstance(node, ast.Constant) and node.value == prop_name:
+                hits.append((file_path, node.lineno))
+    return hits
+
+
+@CheckRegistry.register(
+    code="VC502",
+    name="no-deprecated-report-status",
+    description="Must not use deprecated x_opencti_report_status custom property",
+    severity=Severity.ERROR,
+)
+def check_no_deprecated_report_status(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Detect usage of x_opencti_report_status (ERROR) and warn about
+    x_opencti_workflow_id (WARNING).
+    """
+    sources = ctx.python_sources
+    if not sources:
+        return [
+            CheckFinding(
+                message="No Python sources found — skipped",
+                severity=Severity.ERROR,
+            ),
+        ]
+
+    trees = ctx.python_trees
+    results: list[CheckFinding] = []
+
+    # ERROR: x_opencti_report_status is fully deprecated and non-functional.
+    # Any usage is dead code that should be removed.
+    for file_path, line in _scan_with_lines(trees, _DEPRECATED_PROP):
+        results.append(
+            CheckFinding(
+                message="uses deprecated x_opencti_report_status",
+                severity=Severity.ERROR,
+                file_path=file_path,
+                line=line,
+                suggestion=(
+                    "Remove x_opencti_report_status — it is deprecated and "
+                    "non-functional. Use workflow status changes via the "
+                    "platform UI or API instead."
+                ),
+            ),
+        )
+
+    # WARNING (not ERROR): x_opencti_workflow_id works but the UUID is
+    # install-specific.  Hardcoding it makes the connector non-portable.
+    for file_path, line in _scan_with_lines(trees, _FRAGILE_PROP):
+        results.append(
+            CheckFinding(
+                message=("uses x_opencti_workflow_id — UUID is install-specific"),
+                severity=Severity.WARNING,
+                file_path=file_path,
+                line=line,
+                suggestion=(
+                    "x_opencti_workflow_id works but the UUID is unique per "
+                    "installation. Consider managing workflow status via the "
+                    "platform instead of hardcoding in the connector."
+                ),
+            ),
+        )
+
+    if not results:
+        return [
+            CheckFinding(
+                message="No deprecated report status properties found ✓",
+                severity=Severity.INFO,
+            ),
+        ]
+
+    return results

--- a/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/vc503_no_helper_logger.py
+++ b/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/vc503_no_helper_logger.py
@@ -1,0 +1,151 @@
+"""VC503 — No use of deprecated helper logger ``helper.log_{level}()``.
+
+The legacy logging methods on ``OpenCTIConnectorHelper``:
+
+- ``helper.log_debug()``
+- ``helper.log_info()``
+- ``helper.log_warning()`` / ``helper.log_warn()``
+- ``helper.log_error()``
+
+are deprecated. Connectors must use the structured ``connector_logger``
+instead::
+
+    self.helper.connector_logger.debug("message", {"key": "value"})
+    self.helper.connector_logger.info("message")
+    self.helper.connector_logger.warning("message")
+    self.helper.connector_logger.error("message", {"error": str(e)})
+
+Matched patterns:
+
+- ``self.helper.log_*()`` — qualified attribute
+- ``self._helper.log_*()`` — private helper attribute
+- ``helper.log_*()`` — bare helper name (common in utility functions)
+
+Reference: https://github.com/OpenCTI-Platform/connectors/pull/3948
+
+Scope: Common (all connector types).
+"""
+
+import ast
+from pathlib import Path
+
+from connector_linter.checks.vc5xx_deprecation._helpers import is_helper_node
+from connector_linter.models import (
+    CheckFinding,
+    ConnectorContext,
+    Severity,
+)
+from connector_linter.registry import CheckRegistry
+
+# ---------------------------------------------------------------------------
+# Full list of deprecated helper logging methods.
+#
+# These methods were the original logging API on OpenCTIConnectorHelper:
+#   log_debug   → replaced by connector_logger.debug()
+#   log_info    → replaced by connector_logger.info()
+#   log_warning → replaced by connector_logger.warning()
+#   log_warn    → alias for log_warning, also deprecated
+#   log_error   → replaced by connector_logger.error()
+#
+# The new connector_logger supports structured metadata as a second arg:
+#   self.helper.connector_logger.info("msg", {"key": "value"})
+# ---------------------------------------------------------------------------
+_DEPRECATED_LOG_METHODS = frozenset(
+    {
+        "log_debug",
+        "log_info",
+        "log_warning",
+        "log_warn",
+        "log_error",
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# AST detection: find deprecated helper.log_*() calls
+#
+# Matches three patterns (all ending in .log_*(...)):
+#
+#   Pattern 1 — qualified attribute:
+#     X.helper.log_debug(...)    (e.g. self.helper.log_info())
+#     X._helper.log_info(...)   (e.g. self._helper.log_error())
+#
+#   Pattern 2 — bare name:
+#     helper.log_debug(...)     (e.g. helper.log_info())
+#     _helper.log_info(...)     (e.g. _helper.log_error())
+#
+# The chain is: Call → Attribute(attr=log_*) → <helper_node>
+# Only methods in _DEPRECATED_LOG_METHODS are flagged.
+# ---------------------------------------------------------------------------
+def _find_deprecated_log_calls(
+    trees: dict[Path, ast.Module],
+) -> list[tuple[Path, int, str]]:
+    """Return (file, line, method_name) for deprecated helper.log_*() calls."""
+    hits: list[tuple[Path, int, str]] = []
+    for file_path, tree in trees.items():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            # Match: <helper>.log_debug(), <helper>.log_info(), etc.
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr in _DEPRECATED_LOG_METHODS
+                and is_helper_node(func.value)
+            ):
+                hits.append((file_path, node.lineno, func.attr))
+    return hits
+
+
+@CheckRegistry.register(
+    code="VC503",
+    name="no-deprecated-helper-logger",
+    description="Must use connector_logger instead of deprecated helper.log_{level}()",
+    severity=Severity.ERROR,
+)
+def check_no_deprecated_helper_logger(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Detect deprecated helper.log_*() calls."""
+    sources = ctx.python_sources
+    if not sources:
+        return [
+            CheckFinding(
+                message="No Python sources found — skipped",
+                severity=Severity.ERROR,
+            ),
+        ]
+
+    trees = ctx.python_trees
+    hits = _find_deprecated_log_calls(trees)
+
+    if not hits:
+        return [
+            CheckFinding(
+                message="No deprecated helper.log_*() calls found ✓",
+                severity=Severity.INFO,
+            ),
+        ]
+
+    results: list[CheckFinding] = []
+    for file_path, line, method in hits:
+        # Map deprecated method name to the new connector_logger equivalent.
+        # Strip the "log_" prefix: log_debug → debug, log_info → info, etc.
+        # Special case: log_warn → "warning" (Python logging uses "warning",
+        # not "warn").
+        level = method.replace("log_", "")
+        if level == "warn":
+            level = "warning"
+        results.append(
+            CheckFinding(
+                message=f"uses deprecated helper.{method}()",
+                severity=Severity.ERROR,
+                file_path=file_path,
+                line=line,
+                suggestion=(
+                    f"Replace with self.helper.connector_logger.{level}(). "
+                    f"The connector_logger supports structured metadata as "
+                    f'a second argument: .{level}("message", {{"key": val}})'
+                ),
+            ),
+        )
+
+    return results

--- a/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/vc504_no_confidence_level.py
+++ b/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/vc504_no_confidence_level.py
@@ -1,0 +1,168 @@
+"""VC504 — No use of deprecated ``CONFIDENCE_LEVEL`` configuration.
+
+Since OpenCTI 6.0, the confidence level is managed via user/group
+confidence policies on the platform. It must **not** be set:
+
+1. In configuration files (``CONNECTOR_CONFIDENCE_LEVEL``, ``*_CONFIDENCE*``
+   env vars in docker-compose.yml / .env.sample)
+2. In code via ``self.helper.connect_confidence_level``
+3. As ``confidence=`` keyword argument on STIX objects
+
+Passing ``confidence`` on STIX objects prevents the platform from managing
+it correctly through confidence policies.
+
+References:
+- https://github.com/OpenCTI-Platform/connectors/pull/3316
+- https://github.com/OpenCTI-Platform/connectors/issues/1816
+- https://docs.opencti.io/latest/usage/reliability-confidence/
+
+Scope: Common (all connector types).
+
+"""
+
+import ast
+import re
+
+from connector_linter.checks.vc1xx_config._helpers import extract_all_env_vars
+from connector_linter.models import (
+    CheckFinding,
+    ConnectorContext,
+    Severity,
+)
+from connector_linter.registry import CheckRegistry
+
+# ---------------------------------------------------------------------------
+# Regex: targeted match for CONFIDENCE_LEVEL or CONFIDENCE_SCORE env var names
+#
+# Matches env vars whose name contains "CONFIDENCE_LEVEL" or
+# "CONFIDENCE_SCORE" (case-insensitive), e.g.:
+#   CONNECTOR_CONFIDENCE_LEVEL
+#   CONNECTOR_CONFIDENCE_SCORE
+#
+# Deliberately excludes bare "CONFIDENCE" to avoid false positives on
+# unrelated env vars (e.g. SELF_CONFIDENCE, CONFIDENCE_THRESHOLD).
+#
+# Since OpenCTI 6.0, the platform manages confidence via user/group
+# confidence policies.  Connectors must not set it because:
+#   1. Config var is ignored by the new connector helper
+#   2. Setting confidence= on STIX objects prevents the platform from
+#      applying its own confidence policies correctly
+# ---------------------------------------------------------------------------
+_CONFIDENCE_VAR_RE = re.compile(r"CONFIDENCE_(LEVEL|SCORE)", re.IGNORECASE)
+
+
+def _check_config_vars(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Detect CONFIDENCE-related env vars in config files.
+
+    Scans all env vars from docker-compose.yml and .env files for names
+    containing "CONFIDENCE" (case-insensitive).
+    """
+    results: list[CheckFinding] = []
+    env_vars = extract_all_env_vars(ctx)
+
+    for var in env_vars:
+        if var.is_commented:
+            continue
+        if _CONFIDENCE_VAR_RE.search(var.name):
+            results.append(
+                CheckFinding(
+                    message=(
+                        f"{var.name}={var.value} — confidence level in config is deprecated"
+                    ),
+                    severity=Severity.ERROR,
+                    file_path=var.file_path,
+                    line=var.line,
+                    suggestion=(
+                        "Remove confidence level from configuration. Since "
+                        "OpenCTI 6.0, confidence is managed via user/group "
+                        "confidence policies on the platform."
+                    ),
+                ),
+            )
+
+    return results
+
+
+def _check_code_usage(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Detect connect_confidence_level and confidence= kwarg in code.
+
+    Two detection patterns via AST:
+      1. Attribute access: *.connect_confidence_level
+         Catches: self.helper.connect_confidence_level
+      2. Keyword argument: confidence=<value>
+         Catches: SomeSTIXObject(confidence=80) in STIX object constructors
+    """
+    sources = ctx.python_sources
+    if not sources:
+        return []
+
+    trees = ctx.python_trees
+    results: list[CheckFinding] = []
+
+    for file_path, tree in trees.items():
+        for node in ast.walk(tree):
+            # Pattern 1: *.connect_confidence_level attribute access
+            if (
+                isinstance(node, ast.Attribute)
+                and node.attr == "connect_confidence_level"
+            ):
+                results.append(
+                    CheckFinding(
+                        message="uses deprecated connect_confidence_level",
+                        severity=Severity.ERROR,
+                        file_path=file_path,
+                        line=node.lineno,
+                        suggestion=(
+                            "Remove connect_confidence_level usage. Confidence "
+                            "is now managed by user/group policies on the "
+                            "platform, not by the connector."
+                        ),
+                    ),
+                )
+
+            # Pattern 2: confidence= keyword arg in STIX object construction.
+            # ast.keyword may lack lineno in some Python versions — use
+            # getattr with fallback to 0 for safety.
+            if isinstance(node, ast.keyword) and node.arg == "confidence":
+                line = getattr(node, "lineno", 0) or 0
+                results.append(
+                    CheckFinding(
+                        message=(
+                            "sets confidence= on STIX object — deprecated since 6.0"
+                        ),
+                        severity=Severity.ERROR,
+                        file_path=file_path,
+                        line=line,
+                        suggestion=(
+                            "Remove the confidence= argument. Let the platform "
+                            "manage confidence via user/group confidence "
+                            "policies instead of setting it on STIX objects."
+                        ),
+                    ),
+                )
+
+    return results
+
+
+@CheckRegistry.register(
+    code="VC504",
+    name="no-deprecated-confidence",
+    description="Must not use deprecated confidence level (removed since OpenCTI 6.0)",
+    severity=Severity.ERROR,
+)
+def check_no_deprecated_confidence(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Detect deprecated confidence level patterns."""
+    config_results = _check_config_vars(ctx)
+    code_results = _check_code_usage(ctx)
+
+    all_results = config_results + code_results
+
+    if not all_results:
+        return [
+            CheckFinding(
+                message="No deprecated confidence level usage found ✓",
+                severity=Severity.INFO,
+            ),
+        ]
+
+    return all_results

--- a/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/vc505_no_direct_api.py
+++ b/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/vc505_no_direct_api.py
@@ -1,0 +1,149 @@
+"""VC505 — No direct GraphQL API calls via ``helper.api.*``.
+
+Connectors should send STIX bundles to OpenCTI workers rather than
+making direct GraphQL API calls (e.g. ``self.helper.api.campaign.read``).
+
+Matched patterns:
+
+- ``self.helper.api.<submodule>`` — qualified attribute
+- ``self._helper.api.<submodule>`` — private helper attribute
+- ``helper.api.<submodule>`` — bare helper name (common in utility functions)
+
+**Allowed exceptions** (not flagged):
+
+- ``self.helper.api.work.*`` — required for work lifecycle management
+- ``self.helper.api.vocabulary.*`` — needed for vocabulary management
+- ``self.helper.api.label.*`` — needed for label/tag color management
+- ``self.helper.api.marking_definition.*`` — needed for marking lookups
+- ``self.helper.api.fetch_opencti_file`` — needed for file retrieval
+- ``self.helper.api.stix2.*`` — STIX2 utility methods
+
+This check emits WARNINGs since some edge cases legitimately need
+direct API access.
+
+Scope: Common (all connector types).
+"""
+
+import ast
+from pathlib import Path
+
+from connector_linter.checks.vc5xx_deprecation._helpers import is_helper_node
+from connector_linter.models import (
+    CheckFinding,
+    ConnectorContext,
+    Severity,
+    no_python_sources_finding,
+)
+from connector_linter.registry import CheckRegistry
+
+# ---------------------------------------------------------------------------
+# API submodules that are allowed (not flagged)
+#
+# These submodules have legitimate use cases that cannot be replaced by
+# sending STIX bundles:
+#   - work          — work lifecycle management (initiate, close, report)
+#   - vocabulary    — vocabulary/dropdown management, no STIX equivalent
+#   - label         — label/tag color management, STIX labels lack colors
+#   - marking_definition — TLP marking lookups for access control
+#   - fetch_opencti_file — file retrieval, no bundle equivalent
+#   - stix2         — STIX2 utility methods (conversion helpers)
+#
+# The architectural principle: connectors should send STIX bundles to
+# OpenCTI workers for ingestion rather than making direct GraphQL API
+# calls.  Direct API calls bypass the worker pipeline (deduplication,
+# dependency resolution, etc.) and create tight coupling to the API schema.
+# ---------------------------------------------------------------------------
+_ALLOWED_API_SUBMODULES = frozenset(
+    {
+        "work",
+        "vocabulary",
+        "label",
+        "marking_definition",
+        "fetch_opencti_file",
+        "stix2",
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# AST detection: find direct helper.api.* attribute access
+#
+# Matches three patterns (all ending in .api.<submodule>):
+#
+#   Pattern 1 — qualified attribute:
+#     X.helper.api.<submodule>   (e.g. self.helper.api.campaign)
+#     X._helper.api.<submodule>  (e.g. self._helper.api.work)
+#
+#   Pattern 2 — bare name:
+#     helper.api.<submodule>     (e.g. helper.api.work)
+#     _helper.api.<submodule>    (e.g. _helper.api.identity)
+#
+# Only submodules NOT in _ALLOWED_API_SUBMODULES are flagged.
+# ---------------------------------------------------------------------------
+def _find_direct_api_calls(
+    trees: dict[Path, ast.Module],
+) -> list[tuple[Path, int, str]]:
+    """Return (file, line, submodule) for helper.api.* attribute access."""
+    hits: list[tuple[Path, int, str]] = []
+    for file_path, tree in trees.items():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Attribute):
+                continue
+            # Match: <helper>.api.<submodule>
+            parent = node.value
+            if (
+                isinstance(parent, ast.Attribute)
+                and parent.attr == "api"
+                and is_helper_node(parent.value)
+            ):
+                submodule = node.attr
+                if submodule not in _ALLOWED_API_SUBMODULES:
+                    hits.append((file_path, node.lineno, submodule))
+    return hits
+
+
+@CheckRegistry.register(
+    code="VC505",
+    name="no-direct-api-calls",
+    description="Connector should not use direct GraphQL API calls (helper.api.*)",
+    severity=Severity.WARNING,
+)
+def check_no_direct_api_calls(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Detect direct API calls via helper.api.* (WARNING).
+
+    Severity is WARNING (not ERROR) because some edge cases legitimately
+    need direct API access — e.g. reading entity relationships that cannot
+    be expressed in a STIX bundle query.
+    """
+    sources = ctx.python_sources
+    if not sources:
+        return [no_python_sources_finding()]
+
+    trees = ctx.python_trees
+    hits = _find_direct_api_calls(trees)
+
+    if not hits:
+        return [
+            CheckFinding(
+                message="No direct API calls found ✓",
+                severity=Severity.INFO,
+            ),
+        ]
+
+    results: list[CheckFinding] = []
+    for file_path, line, submodule in hits:
+        results.append(
+            CheckFinding(
+                message=(f"direct API call helper.api.{submodule}"),
+                severity=Severity.WARNING,
+                file_path=file_path,
+                line=line,
+                suggestion=(
+                    "Avoid direct GraphQL API calls. Send STIX bundles to "
+                    "OpenCTI workers instead. helper.api.work is allowed "
+                    "for work lifecycle management."
+                ),
+            ),
+        )
+
+    return results

--- a/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/vc506_no_update_existing_data.py
+++ b/shared/connector_linter/connector_linter/checks/vc5xx_deprecation/vc506_no_update_existing_data.py
@@ -1,0 +1,168 @@
+"""VC506 — No use of deprecated ``UPDATE_EXISTING_DATA``.
+
+The ``update_existing_data`` setting no longer exists in the connector
+helper and must be removed from configuration files and code.
+
+Detection:
+1. Config: ``*UPDATE_EXISTING_DATA*`` env vars in docker-compose / .env
+2. Code: ``update_existing_data`` attribute access and string literals
+
+**Exception**: The ``opencti`` datasets connector (external-import/opencti)
+is explicitly exempt from this check.
+
+Reference:
+- https://github.com/OpenCTI-Platform/connectors/commit/efb345a5
+
+Scope: Common (all connector types).
+"""
+
+import ast
+import re
+
+from connector_linter.checks.vc1xx_config._helpers import extract_all_env_vars
+from connector_linter.models import (
+    CheckFinding,
+    ConnectorContext,
+    Severity,
+)
+from connector_linter.registry import CheckRegistry
+
+_UPDATE_VAR_RE = re.compile(r"UPDATE_EXISTING_DATA", re.IGNORECASE)
+
+# The opencti datasets connector (external-import/opencti) is explicitly
+# exempt because it is a special-purpose connector that manages platform
+# reference data and legitimately needs update_existing_data for its
+# dataset seeding workflow.
+_EXEMPT_DIRNAMES = {"opencti"}
+
+
+def _is_exempt(ctx: ConnectorContext) -> bool:
+    dirname = ctx.path.name
+    return dirname in _EXEMPT_DIRNAMES
+
+
+def _check_config_vars(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Detect UPDATE_EXISTING_DATA in config files.
+
+    Scans env vars from docker-compose.yml and .env files for variable
+    names containing UPDATE_EXISTING_DATA (case-insensitive).
+    """
+    results: list[CheckFinding] = []
+    env_vars = extract_all_env_vars(ctx)
+
+    for var in env_vars:
+        if var.is_commented:
+            continue
+        if _UPDATE_VAR_RE.search(var.name):
+            results.append(
+                CheckFinding(
+                    message=(f"{var.name}={var.value} — deprecated setting"),
+                    severity=Severity.ERROR,
+                    file_path=var.file_path,
+                    line=var.line,
+                    suggestion=(
+                        "Remove UPDATE_EXISTING_DATA from configuration. "
+                        "This setting no longer exists in the connector helper."
+                    ),
+                ),
+            )
+
+    return results
+
+
+def _check_code_usage(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Detect update_existing_data usage in Python code.
+
+    Two detection patterns via AST:
+      1. Attribute access: ``*.update_existing_data``
+         Catches: ``self.update_existing_data``, ``config.update_existing_data``
+      2. String literal containing ``"UPDATE_EXISTING_DATA"``
+         Catches: ``get_config_variable("CONNECTOR_UPDATE_EXISTING_DATA")``,
+         ``os.environ["UPDATE_EXISTING_DATA"]``, etc.
+
+    Limitations:
+      - Plain variable names (``ast.Name``) like ``update_existing_data = ...``
+        are not detected. This is intentional to avoid false positives on
+        function parameters or local variables that happen to share the name.
+
+    The setting no longer exists in the connector helper — it was removed
+    and any reference to it is dead code.
+    """
+    sources = ctx.python_sources
+    if not sources:
+        return []
+
+    trees = ctx.python_trees
+    results: list[CheckFinding] = []
+
+    for file_path, tree in trees.items():
+        for node in ast.walk(tree):
+            # Attribute access: self.update_existing_data, *.update_existing_data
+            if isinstance(node, ast.Attribute) and node.attr == "update_existing_data":
+                results.append(
+                    CheckFinding(
+                        message=("uses deprecated update_existing_data"),
+                        severity=Severity.ERROR,
+                        file_path=file_path,
+                        line=node.lineno,
+                        suggestion=(
+                            "Remove update_existing_data — this setting no "
+                            "longer exists in the connector helper."
+                        ),
+                    ),
+                )
+
+            # String literal: "UPDATE_EXISTING_DATA" / "update_existing_data"
+            # This includes docstrings — if a docstring mentions this setting,
+            # the docstring itself is outdated and should be updated.
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and _UPDATE_VAR_RE.search(node.value)
+            ):
+                results.append(
+                    CheckFinding(
+                        message=(f'references deprecated "{node.value}"'),
+                        severity=Severity.ERROR,
+                        file_path=file_path,
+                        line=node.lineno,
+                        suggestion=(
+                            "Remove UPDATE_EXISTING_DATA references — this "
+                            "setting no longer exists in the connector helper."
+                        ),
+                    ),
+                )
+
+    return results
+
+
+@CheckRegistry.register(
+    code="VC506",
+    name="no-update-existing-data",
+    description="Must not use deprecated UPDATE_EXISTING_DATA setting",
+    severity=Severity.ERROR,
+)
+def check_no_update_existing_data(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Detect deprecated UPDATE_EXISTING_DATA patterns."""
+    if _is_exempt(ctx):
+        return [
+            CheckFinding(
+                message="Exempt — opencti datasets connector may use this ✓",
+                severity=Severity.INFO,
+            ),
+        ]
+
+    config_results = _check_config_vars(ctx)
+    code_results = _check_code_usage(ctx)
+
+    all_results = config_results + code_results
+
+    if not all_results:
+        return [
+            CheckFinding(
+                message="No deprecated UPDATE_EXISTING_DATA usage found ✓",
+                severity=Severity.INFO,
+            ),
+        ]
+
+    return all_results

--- a/shared/connector_linter/connector_linter/config.py
+++ b/shared/connector_linter/connector_linter/config.py
@@ -1,0 +1,152 @@
+"""Project-level configuration via ``pyproject.toml``.
+
+Reads ``[tool.connector-linter]`` from the connector's ``pyproject.toml`` (or
+a parent directory) and exposes it as a typed :class:`LinterConfig` object.
+
+Inspired by Ruff's configuration model::
+
+    [tool.connector-linter]
+    select = ["VC1xx", "VC3xx"]        # only run these checks/prefixes
+    ignore = ["VC306", "VC307"]        # skip these checks
+    per-file-ignores = {"tests/*.py" = ["VC309"]}
+
+CLI flags always take precedence over ``pyproject.toml`` values.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomllib  # type: ignore[import]
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore[import,no-redef]
+
+
+@dataclass
+class LinterConfig:
+    """Parsed project-level linter configuration."""
+
+    select: list[str] = field(default_factory=list)
+    ignore: list[str] = field(default_factory=list)
+    per_file_ignores: dict[str, list[str]] = field(default_factory=dict)
+
+    @property
+    def is_empty(self) -> bool:
+        """Return True if no configuration was specified."""
+        return not self.select and not self.ignore and not self.per_file_ignores
+
+
+def _find_pyproject(start: Path) -> Path | None:
+    """Walk up from *start* looking for ``pyproject.toml``.
+
+    Stops at the filesystem root. Returns ``None`` if not found.
+    """
+    candidate = start.resolve()
+    while True:
+        pyproject = candidate / "pyproject.toml"
+        if pyproject.is_file():
+            return pyproject
+        parent = candidate.parent
+        if parent == candidate:
+            break
+        candidate = parent
+    return None
+
+
+def _parse_table(table: dict[str, Any]) -> LinterConfig:
+    """Parse a ``[tool.connector-linter]`` table into :class:`LinterConfig`."""
+    select = table.get("select", [])
+    ignore = table.get("ignore", [])
+    raw_pfi = table.get("per-file-ignores", {})
+
+    if not isinstance(select, list):
+        select = []
+    if not isinstance(ignore, list):
+        ignore = []
+    if not isinstance(raw_pfi, dict):
+        raw_pfi = {}
+
+    per_file_ignores: dict[str, list[str]] = {}
+    for pattern, codes in raw_pfi.items():
+        if isinstance(codes, list):
+            per_file_ignores[pattern] = [str(c) for c in codes]
+
+    return LinterConfig(
+        select=[str(s) for s in select],
+        ignore=[str(i) for i in ignore],
+        per_file_ignores=per_file_ignores,
+    )
+
+
+def load_config(connector_path: Path, config_path: Path | None = None) -> LinterConfig:
+    """Load linter configuration from ``pyproject.toml``.
+
+    Args:
+        connector_path: Root directory of the connector being checked.
+        config_path: Explicit path to a ``pyproject.toml`` file. If ``None``,
+            searches upward from *connector_path*.
+
+    Returns:
+        Parsed :class:`LinterConfig`. Returns an empty config if no file
+        is found or the ``[tool.connector-linter]`` section is missing.
+    """
+    if config_path is not None:
+        pyproject = config_path.resolve()
+        if not pyproject.is_file():
+            return LinterConfig()
+    else:
+        pyproject = _find_pyproject(connector_path)
+
+    if pyproject is None:
+        return LinterConfig()
+
+    try:
+        with open(pyproject, "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        return LinterConfig()
+
+    tool_table = data.get("tool", {})
+    linter_table = tool_table.get("connector-linter", None)
+    if linter_table is None:
+        return LinterConfig()
+
+    return _parse_table(linter_table)
+
+
+def get_per_file_ignores(
+    config: LinterConfig,
+    file_path: Path,
+    connector_root: Path,
+) -> set[str]:
+    """Return the set of check codes to ignore for a specific file.
+
+    Glob patterns in ``per-file-ignores`` are matched against the file path
+    relative to the connector root. Both forward-slash and OS-native separators
+    are supported.
+    """
+    if not config.per_file_ignores:
+        return set()
+
+    try:
+        rel = file_path.relative_to(connector_root)
+    except ValueError:
+        rel = file_path
+
+    rel_str = str(rel)
+    # Normalise to forward-slash for consistent glob matching
+    rel_posix = rel_str.replace("\\", "/")
+
+    codes: set[str] = set()
+    for pattern, pattern_codes in config.per_file_ignores.items():
+        if fnmatch(rel_posix, pattern) or fnmatch(rel_posix, f"**/{pattern}"):
+            codes.update(pattern_codes)
+    return codes

--- a/shared/connector_linter/connector_linter/runner.py
+++ b/shared/connector_linter/connector_linter/runner.py
@@ -5,6 +5,7 @@ import pkgutil
 from pathlib import Path
 
 from connector_linter import checks as checks_package
+from connector_linter.config import get_per_file_ignores, load_config
 from connector_linter.models import CheckResult, ConnectorContext, Severity
 from connector_linter.noqa import filter_noqa
 from connector_linter.registry import CheckRegistry
@@ -46,36 +47,48 @@ def run_checks(
     select: list[str] | None = None,
     ignore: list[str] | None = None,
     disable_noqa: bool = False,
+    config_path: Path | None = None,
 ) -> list[CheckResult]:
     """Run all registered checks against a connector.
 
     Args:
         connector_path: Path to the connector directory.
         select: If provided, only run checks matching these codes/prefixes.
+            Overrides ``select`` from pyproject.toml.
         ignore: If provided, skip checks matching these codes/prefixes.
+            Merged with ``ignore`` from pyproject.toml (CLI wins on conflicts).
         disable_noqa: If True, ignore all ``# noqa`` inline suppressions.
+        config_path: Explicit path to a ``pyproject.toml`` file. If ``None``,
+            searches upward from *connector_path*.
 
     Returns:
         List of CheckResult objects.
     """
     _import_checks_modules()
 
+    # Load project-level config from pyproject.toml
+    config = load_config(connector_path, config_path=config_path)
+
+    # Merge: CLI flags take precedence over pyproject.toml
+    effective_select = select if select else (config.select or None)
+    effective_ignore = list(set((ignore or []) + config.ignore))
+
     ctx = ConnectorContext.load(connector_path)
     all_checks = CheckRegistry.get_all()
 
     checks_to_run = all_checks
-    if select:
+    if effective_select:
         filtered = {}
-        for pattern in select:
+        for pattern in effective_select:
             if pattern in all_checks:
                 filtered[pattern] = all_checks[pattern]
             else:
                 filtered.update(CheckRegistry.get_by_prefix(pattern))
         checks_to_run = filtered
 
-    if ignore:
+    if effective_ignore:
         ignore_codes = set()
-        for pattern in ignore:
+        for pattern in effective_ignore:
             if pattern in checks_to_run:
                 ignore_codes.add(pattern)
             else:
@@ -120,6 +133,17 @@ def run_checks(
                     severity=Severity.ERROR,
                 ),
             )
+
+    # Apply per-file-ignores from pyproject.toml
+    if config.per_file_ignores:
+        pfi_filtered: list[CheckResult] = []
+        for result in results:
+            if result.file_path is not None:
+                pfi_codes = get_per_file_ignores(config, result.file_path, ctx.path)
+                if result.code in pfi_codes:
+                    continue
+            pfi_filtered.append(result)
+        results = pfi_filtered
 
     if not disable_noqa:
         results = filter_noqa(results, connector_path)

--- a/shared/connector_linter/tests/conftest.py
+++ b/shared/connector_linter/tests/conftest.py
@@ -4,11 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
-from connector_linter.models import (
-    CheckFinding,
-    ConnectorContext,
-    Severity,
-)
+from connector_linter.models import CheckFinding, ConnectorContext, Severity
 from connector_linter.registry import CheckRegistry
 from connector_linter.runner import _import_checks_modules
 
@@ -28,10 +24,7 @@ def _clean_registry():
 
 @pytest.fixture()
 def dummy_checks(_clean_registry):
-    """Register three dummy checks: VC901 (ERROR), VC902 (WARNING), VC903 (ERROR).
-
-    Returns the codes for easy reference.
-    """
+    """Register three dummy checks: VC901 (ERROR pass), VC902 (WARNING), VC903 (ERROR fail)."""
 
     @CheckRegistry.register(
         code="VC901",
@@ -59,11 +52,7 @@ def dummy_checks(_clean_registry):
     )
     def _vc903(ctx: ConnectorContext) -> list[CheckFinding]:
         return [
-            CheckFinding(
-                message="broken",
-                severity=Severity.ERROR,
-                suggestion="fix it",
-            )
+            CheckFinding(message="broken", severity=Severity.ERROR, suggestion="fix it")
         ]
 
     return ["VC901", "VC902", "VC903"]
@@ -71,21 +60,9 @@ def dummy_checks(_clean_registry):
 
 @pytest.fixture()
 def minimal_connector(tmp_path: Path) -> Path:
-    """Create a minimal connector directory that ConnectorContext.load() can parse.
-
-    Layout::
-
-        <tmp>/external-import/test-connector/
-            __metadata__/connector_manifest.json
-            src/main.py
-            docker-compose.yml
-            Dockerfile
-            README.md
-    """
-    # Nest under external-import/ so connector_type detection works
+    """Create a minimal connector directory that ConnectorContext.load() can parse."""
     connector_dir = tmp_path / "external-import" / "test-connector"
 
-    # __metadata__
     meta_dir = connector_dir / "__metadata__"
     meta_dir.mkdir(parents=True)
     manifest = {
@@ -98,14 +75,12 @@ def minimal_connector(tmp_path: Path) -> Path:
         json.dumps(manifest), encoding="utf-8"
     )
 
-    # src/
     src_dir = connector_dir / "src"
     src_dir.mkdir()
     (src_dir / "main.py").write_text(
         'if __name__ == "__main__":\n    pass\n', encoding="utf-8"
     )
 
-    # Config files
     (connector_dir / "docker-compose.yml").write_text(
         "services:\n  connector:\n    image: opencti/connector-test-connector:latest\n"
         "    environment:\n      - OPENCTI_URL=http://localhost\n"

--- a/shared/connector_linter/tests/tests_checks/conftest.py
+++ b/shared/connector_linter/tests/tests_checks/conftest.py
@@ -1,0 +1,83 @@
+"""Shared fixtures for per-check unit tests.
+
+Each test in tests_checks/ focuses on a single check, exercising it with
+hand-crafted Python source snippets rather than running the full suite.
+
+Core fixture: ``connector_src`` — a factory that builds a minimal connector
+directory with the given Python source files and returns the connector path.
+"""
+
+import json
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Connector type directories used by ConnectorContext.load() to detect type
+# ---------------------------------------------------------------------------
+_TYPE_DIRS: dict[str, str] = {
+    "EXTERNAL_IMPORT": "external-import",
+    "INTERNAL_ENRICHMENT": "internal-enrichment",
+    "STREAM": "stream",
+}
+
+
+@pytest.fixture()
+def connector_src(tmp_path: Path) -> Callable:
+    """Factory fixture: build a minimal connector with custom Python source.
+
+    Usage::
+
+        def test_something(connector_src):
+            path = connector_src("src/main.py", "x = stix2.Identity(name='test')")
+            results = run_checks(path, select=["VC313"])
+            assert any(not r.passed for r in results)
+
+    Args:
+        *src_files: Alternating (relative_path, content) pairs under src/.
+        connector_type: Optional connector type string (default: EXTERNAL_IMPORT).
+
+    Returns:
+        The connector root Path.
+    """
+
+    def _make(
+        *src_files: tuple[str, str],
+        connector_type: str = "EXTERNAL_IMPORT",
+    ) -> Path:
+        type_dir = _TYPE_DIRS.get(connector_type, "external-import")
+        connector_dir = tmp_path / type_dir / "test-connector"
+
+        # __metadata__
+        meta_dir = connector_dir / "__metadata__"
+        meta_dir.mkdir(parents=True)
+        (meta_dir / "connector_manifest.json").write_text(
+            json.dumps(
+                {
+                    "verified": True,
+                    "last_verified_date": "2026-01-01",
+                    "container_version": "rolling",
+                    "container_image": "opencti/connector-test",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        # src/ + requested files
+        src_dir = connector_dir / "src"
+        src_dir.mkdir()
+        for rel_path, content in src_files:
+            dest = connector_dir / rel_path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(content, encoding="utf-8")
+
+        # Minimal Dockerfile so ConnectorContext sees the dir
+        (connector_dir / "Dockerfile").write_text(
+            'FROM python:3.12-alpine\nENTRYPOINT ["python", "main.py"]\n',
+            encoding="utf-8",
+        )
+
+        return connector_dir
+
+    return _make

--- a/shared/connector_linter/tests/tests_checks/test_vc105_no_absolute_date.py
+++ b/shared/connector_linter/tests/tests_checks/test_vc105_no_absolute_date.py
@@ -1,0 +1,72 @@
+"""Tests for VC105 (no absolute import date)."""
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+
+class TestVC105ConfigDetection:
+    def test_flags_absolute_date_in_docker_compose(self, minimal_connector):
+        compose = minimal_connector / "docker-compose.yml"
+        compose.write_text(
+            "services:\n"
+            "  connector:\n"
+            "    image: opencti/connector-test-connector:latest\n"
+            "    environment:\n"
+            "      - IMPORT_START_DATE=2020-05-01\n",
+            encoding="utf-8",
+        )
+
+        results = run_checks(minimal_connector, select=["VC105"])
+
+        assert len(results) == 1
+        assert results[0].severity is Severity.WARNING
+        assert "IMPORT_START_DATE=2020-05-01 uses absolute date" in results[0].message
+
+    def test_does_not_flag_iso_duration_in_docker_compose(self, minimal_connector):
+        compose = minimal_connector / "docker-compose.yml"
+        compose.write_text(
+            "services:\n"
+            "  connector:\n"
+            "    image: opencti/connector-test-connector:latest\n"
+            "    environment:\n"
+            "      - IMPORT_START_DATE=P30D\n",
+            encoding="utf-8",
+        )
+
+        results = run_checks(minimal_connector, select=["VC105"])
+
+        assert len(results) == 1
+        assert results[0].severity is Severity.INFO
+        assert "No hardcoded absolute import dates found" in results[0].message
+
+
+class TestVC105CodeDefaultDetection:
+    def test_flags_field_default_iso_datetime(self, minimal_connector):
+        source = minimal_connector / "src" / "settings.py"
+        source.write_text(
+            "from pydantic import Field\n\n"
+            "class Settings:\n"
+            '    import_start_date: str = Field(default="2020-05-01T00:00:00Z")\n',
+            encoding="utf-8",
+        )
+
+        results = run_checks(minimal_connector, select=["VC105"])
+
+        assert len(results) == 1
+        assert results[0].severity is Severity.WARNING
+        assert 'Field default="2020-05-01T00:00:00Z"' in results[0].message
+
+    def test_does_not_flag_field_default_iso_duration(self, minimal_connector):
+        source = minimal_connector / "src" / "settings.py"
+        source.write_text(
+            "from pydantic import Field\n\n"
+            "class Settings:\n"
+            '    import_start_date: str = Field(default="P30D")\n',
+            encoding="utf-8",
+        )
+
+        results = run_checks(minimal_connector, select=["VC105"])
+
+        assert len(results) == 1
+        assert results[0].severity is Severity.INFO
+        assert "No hardcoded absolute import dates found" in results[0].message

--- a/shared/connector_linter/tests/tests_checks/test_vc301_author_defined.py
+++ b/shared/connector_linter/tests/tests_checks/test_vc301_author_defined.py
@@ -1,0 +1,81 @@
+"""Unit tests for VC301 — connector must define an author identity."""
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+_STIX2_IDENTITY = """\
+import stix2
+
+author = stix2.Identity(
+    name="ACME Corp",
+    identity_class="organization",
+)
+"""
+
+_ORGANIZATION_AUTHOR = """\
+from connectors_sdk.models.author import OrganizationAuthor
+
+author = OrganizationAuthor(name="ACME Corp")
+"""
+
+_PYCTI_API = """\
+class Connector:
+    def __init__(self, helper):
+        self.author = helper.api.identity.create(
+            type="Organization",
+            name="ACME Corp",
+        )
+"""
+
+_IDENTITY_FROM_PYCTI = """\
+from pycti import Identity
+
+author = Identity(name="ACME Corp", identity_class="organization")
+"""
+
+_NO_AUTHOR = """\
+def process():
+    pass
+"""
+
+_UNRELATED_IDENTITY = """\
+# Identity imported from a custom, unrelated module
+from mymodule import Identity
+
+x = Identity(name="test")
+"""
+
+
+class TestVC301AuthorDefined:
+    """VC301 detects author identity definitions across all recognized patterns."""
+
+    def test_passes_stix2_identity(self, connector_src):
+        path = connector_src(("src/main.py", _STIX2_IDENTITY))
+        results = run_checks(path, select=["VC301"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_passes_organization_author(self, connector_src):
+        path = connector_src(("src/main.py", _ORGANIZATION_AUTHOR))
+        results = run_checks(path, select=["VC301"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_passes_pycti_api_create(self, connector_src):
+        path = connector_src(("src/main.py", _PYCTI_API))
+        results = run_checks(path, select=["VC301"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_passes_identity_from_pycti(self, connector_src):
+        path = connector_src(("src/main.py", _IDENTITY_FROM_PYCTI))
+        results = run_checks(path, select=["VC301"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_fails_no_author(self, connector_src):
+        path = connector_src(("src/main.py", _NO_AUTHOR))
+        results = run_checks(path, select=["VC301"])
+        assert any(r.severity == Severity.ERROR for r in results)
+
+    def test_fails_unrelated_identity_import(self, connector_src):
+        """Identity() called but not imported from stix2/pycti — should fail."""
+        path = connector_src(("src/main.py", _UNRELATED_IDENTITY))
+        results = run_checks(path, select=["VC301"])
+        assert any(r.severity == Severity.ERROR for r in results)

--- a/shared/connector_linter/tests/tests_checks/test_vc303_connector_type.py
+++ b/shared/connector_linter/tests/tests_checks/test_vc303_connector_type.py
@@ -1,0 +1,79 @@
+"""Unit tests for VC303 — CONNECTOR_TYPE must be hardcoded, not read from env."""
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+_SDK_BASED = """\
+from connectors_sdk.config import BaseExternalImportConnectorConfig
+
+class ConnectorConfig(BaseExternalImportConnectorConfig):
+    pass
+"""
+
+_PYCTI_HARDCODED = """\
+config = {
+    "connector": {
+        "type": "EXTERNAL_IMPORT",
+    }
+}
+"""
+
+_ENV_READ_OS = """\
+import os
+connector_type = os.environ["CONNECTOR_TYPE"]
+"""
+
+_ENV_READ_GETENV = """\
+import os
+connector_type = os.getenv("CONNECTOR_TYPE")
+"""
+
+_ENV_READ_GET_CONFIG = """\
+connector_type = self.helper.get_config_variable("CONNECTOR_TYPE", ["connector", "type"])
+"""
+
+_PYDANTIC_LITERAL = """\
+from typing import Literal
+from pydantic import Field
+
+class ConnectorSettings:
+    type: Literal["EXTERNAL_IMPORT"] = Field(default="EXTERNAL_IMPORT")
+"""
+
+
+class TestVC303ConnectorType:
+    """VC303 detects env reads and accepts hardcoded type definitions."""
+
+    def test_passes_sdk_base_config(self, connector_src):
+        path = connector_src(("src/main.py", _SDK_BASED))
+        results = run_checks(path, select=["VC303"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_passes_pycti_hardcoded_dict(self, connector_src):
+        path = connector_src(("src/main.py", _PYCTI_HARDCODED))
+        results = run_checks(path, select=["VC303"])
+        assert all(r.severity == Severity.WARNING for r in results)
+
+    def test_passes_pydantic_literal(self, connector_src):
+        path = connector_src(("src/main.py", _PYDANTIC_LITERAL))
+        results = run_checks(path, select=["VC303"])
+        assert all(r.severity == Severity.WARNING for r in results)
+
+    def test_flags_os_environ_read(self, connector_src):
+        path = connector_src(("src/main.py", _ENV_READ_OS))
+        results = run_checks(path, select=["VC303"])
+        failed = [r for r in results if r.severity == Severity.ERROR]
+        assert len(failed) == 1
+        assert "environment" in failed[0].message.lower()
+
+    def test_flags_os_getenv_read(self, connector_src):
+        path = connector_src(("src/main.py", _ENV_READ_GETENV))
+        results = run_checks(path, select=["VC303"])
+        failed = [r for r in results if r.severity == Severity.ERROR]
+        assert len(failed) == 1
+
+    def test_flags_get_config_variable(self, connector_src):
+        path = connector_src(("src/main.py", _ENV_READ_GET_CONFIG))
+        results = run_checks(path, select=["VC303"])
+        failed = [r for r in results if r.severity == Severity.ERROR]
+        assert len(failed) == 1

--- a/shared/connector_linter/tests/tests_checks/test_vc305_sdk_base_settings.py
+++ b/shared/connector_linter/tests/tests_checks/test_vc305_sdk_base_settings.py
@@ -1,0 +1,62 @@
+"""Unit tests for VC305 — connector must use connectors-sdk BaseConnectorSettings."""
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+_SDK_SETTINGS = """\
+from connectors_sdk.models.octi import BaseConnectorSettings
+
+class ConnectorSettings(BaseConnectorSettings):
+    my_api_key: str
+"""
+
+_CUSTOM_PYDANTIC_OK = """\
+from pydantic_settings import BaseSettings
+
+class ConnectorSettings(BaseSettings):
+    opencti_url: str
+    opencti_token: str
+    connector_id: str
+    connector_name: str
+    connector_type: str
+    connector_scope: str
+    connector_log_level: str
+"""
+
+_LEGACY_DICT_OK = """\
+# Legacy pycti-style: config dict loaded from YAML
+import yaml
+
+with open("config.yml") as f:
+    config = yaml.load(f, Loader=yaml.FullLoader)
+"""
+
+_NO_SETTINGS = """\
+import os
+
+url = os.environ["OPENCTI_URL"]
+token = os.environ["OPENCTI_TOKEN"]
+"""
+
+
+class TestVC305SdkBaseSettings:
+    """VC305 checks for connectors-sdk or equivalent settings pattern."""
+
+    def test_passes_sdk_base_settings(self, connector_src):
+        path = connector_src(("src/main.py", _SDK_SETTINGS))
+        results = run_checks(path, select=["VC305"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_passes_custom_pydantic(self, connector_src):
+        """Custom BaseSettings subclass is acceptable (with WARNING)."""
+        path = connector_src(("src/main.py", _CUSTOM_PYDANTIC_OK))
+        results = run_checks(path, select=["VC305"])
+        # Should pass — pydantic approach is acceptable
+        errors = [r for r in results if r.severity == Severity.ERROR]
+        assert len(errors) == 0
+
+    def test_fails_no_settings(self, connector_src):
+        """Bare os.environ usage without any settings class should fail."""
+        path = connector_src(("src/main.py", _NO_SETTINGS))
+        results = run_checks(path, select=["VC305"])
+        assert any(r.severity == Severity.ERROR for r in results)

--- a/shared/connector_linter/tests/tests_checks/test_vc306_log_level_default.py
+++ b/shared/connector_linter/tests/tests_checks/test_vc306_log_level_default.py
@@ -1,0 +1,82 @@
+"""Unit tests for VC306 — connector log level should default to 'error'."""
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+_CORRECT_DEFAULT = """\
+from pydantic_settings import BaseSettings
+
+class ConnectorSettings(BaseSettings):
+    log_level: str = "error"
+"""
+
+_WRONG_DEFAULT_DEBUG = """\
+from pydantic_settings import BaseSettings
+
+class ConnectorSettings(BaseSettings):
+    log_level: str = "debug"
+"""
+
+_WRONG_DEFAULT_INFO = """\
+from pydantic_settings import BaseSettings
+
+class ConnectorSettings(BaseSettings):
+    log_level: str = "info"
+"""
+
+_SDK_INHERITS_DEFAULT = """\
+from connectors_sdk.models.connector import BaseExternalImportConnectorConfig
+
+class ConnectorSettings(BaseExternalImportConnectorConfig):
+    my_api_key: str
+"""
+
+_NO_LOG_LEVEL = """\
+class ConnectorSettings:
+    pass
+"""
+
+
+class TestVC306LogLevelDefault:
+    """VC306 flags log levels that are not 'error'."""
+
+    def test_passes_error_default(self, connector_src):
+        path = connector_src(("src/main.py", _CORRECT_DEFAULT))
+        results = run_checks(path, select=["VC306"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_fails_debug_default(self, connector_src):
+        """A debug default is flagged as advisory — WARNING, passed=True."""
+        path = connector_src(("src/main.py", _WRONG_DEFAULT_DEBUG))
+        results = run_checks(path, select=["VC306"])
+        # WARNINGs are advisory (passed=True); detect by file_path presence
+        flagged = [
+            r
+            for r in results
+            if r.severity == Severity.WARNING and r.file_path is not None
+        ]
+        assert len(flagged) >= 1
+
+    def test_fails_info_default(self, connector_src):
+        path = connector_src(("src/main.py", _WRONG_DEFAULT_INFO))
+        results = run_checks(path, select=["VC306"])
+        flagged = [
+            r
+            for r in results
+            if r.severity == Severity.WARNING and r.file_path is not None
+        ]
+        assert len(flagged) >= 1
+
+    def test_passes_sdk_inherits_default(self, connector_src):
+        """SDK base configs already default to 'error' — should pass."""
+        path = connector_src(("src/main.py", _SDK_INHERITS_DEFAULT))
+        results = run_checks(path, select=["VC306"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_advisory_when_no_log_level(self, connector_src):
+        """No log_level field found → advisory pass (can't verify)."""
+        path = connector_src(("src/main.py", _NO_LOG_LEVEL))
+        results = run_checks(path, select=["VC306"])
+        # No ERROR failures — just an advisory at most
+        errors = [r for r in results if r.severity == Severity.ERROR]
+        assert len(errors) == 0

--- a/shared/connector_linter/tests/tests_checks/test_vc307_except_logging.py
+++ b/shared/connector_linter/tests/tests_checks/test_vc307_except_logging.py
@@ -1,0 +1,90 @@
+"""Unit tests for VC307 — except blocks should use error/warning logging."""
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+_GOOD_EXCEPT = """\
+import logging
+logger = logging.getLogger(__name__)
+
+try:
+    risky()
+except Exception as e:
+    logger.error("Something failed: %s", e)
+"""
+
+_BAD_EXCEPT_DEBUG_ONLY = """\
+import logging
+logger = logging.getLogger(__name__)
+
+try:
+    risky()
+except Exception as e:
+    logger.debug("Caught: %s", e)
+"""
+
+_SUPPLEMENTARY_OK = """\
+import logging
+logger = logging.getLogger(__name__)
+
+try:
+    risky()
+except Exception as e:
+    logger.debug("Details: %s", e)
+    logger.error("Operation failed")
+"""
+
+_KEYBOARD_INTERRUPT_EXEMPT = """\
+import logging
+logger = logging.getLogger(__name__)
+
+try:
+    run()
+except KeyboardInterrupt:
+    logger.info("Shutting down")
+"""
+
+_NO_LOGGING_IN_EXCEPT = """\
+try:
+    risky()
+except Exception as e:
+    pass
+"""
+
+
+class TestVC307ExceptLogging:
+    """VC307 warns when except blocks only use debug/info logging."""
+
+    def test_passes_with_error_logging(self, connector_src):
+        path = connector_src(("src/main.py", _GOOD_EXCEPT))
+        results = run_checks(path, select=["VC307"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_warns_debug_only(self, connector_src):
+        path = connector_src(("src/main.py", _BAD_EXCEPT_DEBUG_ONLY))
+        results = run_checks(path, select=["VC307"])
+        # WARNINGs stay passed=True (advisory); detect by file_path presence
+        flagged = [
+            r
+            for r in results
+            if r.severity == Severity.WARNING and r.file_path is not None
+        ]
+        assert len(flagged) >= 1
+
+    def test_passes_when_debug_plus_error(self, connector_src):
+        """debug() alongside error() is fine — error takes care of alerting."""
+        path = connector_src(("src/main.py", _SUPPLEMENTARY_OK))
+        results = run_checks(path, select=["VC307"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_keyboard_interrupt_exempt(self, connector_src):
+        """KeyboardInterrupt is expected control flow — info/debug is fine."""
+        path = connector_src(("src/main.py", _KEYBOARD_INTERRUPT_EXEMPT))
+        results = run_checks(path, select=["VC307"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_no_logging_in_except_not_flagged(self, connector_src):
+        """VC307 only checks blocks that DO log — silent except is a different issue."""
+        path = connector_src(("src/main.py", _NO_LOGGING_IN_EXCEPT))
+        results = run_checks(path, select=["VC307"])
+        assert all(r.severity == Severity.INFO for r in results)

--- a/shared/connector_linter/tests/tests_checks/test_vc309_absolute_imports.py
+++ b/shared/connector_linter/tests/tests_checks/test_vc309_absolute_imports.py
@@ -1,0 +1,51 @@
+"""Unit tests for VC309 — absolute imports only."""
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+
+class TestVC309AbsoluteImports:
+    """VC309 flags relative imports and passes on absolute ones."""
+
+    def test_passes_on_absolute_imports(self, connector_src):
+        path = connector_src(
+            ("src/main.py", "import os\nfrom pathlib import Path\n"),
+        )
+        results = run_checks(path, select=["VC309"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_flags_relative_import(self, connector_src):
+        path = connector_src(
+            ("src/main.py", "from . import utils\n"),
+        )
+        results = run_checks(path, select=["VC309"])
+        failed = [r for r in results if r.severity == Severity.ERROR]
+        assert len(failed) == 1
+        assert "from . import utils" in failed[0].message
+
+    def test_flags_parent_relative_import(self, connector_src):
+        path = connector_src(
+            ("src/main.py", "from ..base import Base\n"),
+        )
+        results = run_checks(path, select=["VC309"])
+        failed = [r for r in results if r.severity == Severity.ERROR]
+        assert len(failed) == 1
+        assert "from ..base import Base" in failed[0].message
+
+    def test_multiple_relative_imports_each_reported(self, connector_src):
+        path = connector_src(
+            (
+                "src/main.py",
+                "from . import a\nfrom . import b\nfrom .. import c\n",
+            ),
+        )
+        results = run_checks(path, select=["VC309"])
+        failed = [r for r in results if r.severity == Severity.ERROR]
+        assert len(failed) == 3
+
+    def test_no_src_dir_is_not_a_failure(self, connector_src):
+        """If there are no Python sources at all, VC309 returns a finding."""
+        path = connector_src()  # no src files
+        results = run_checks(path, select=["VC309"])
+        # Should get exactly one finding (no sources) — not a crash
+        assert len(results) == 1

--- a/shared/connector_linter/tests/tests_checks/test_vc313_pycti_generate_id.py
+++ b/shared/connector_linter/tests/tests_checks/test_vc313_pycti_generate_id.py
@@ -1,0 +1,109 @@
+"""Unit tests for VC313 — STIX SDO/SRO must use pycti.XXX.generate_id()."""
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+_STIX_WITH_ID = """\
+import stix2
+
+identity = stix2.Identity(
+    id=pycti.Identity.generate_id(name="Acme"),
+    name="Acme",
+    identity_class="organization",
+)
+"""
+
+_STIX_MISSING_ID = """\
+import stix2
+
+identity = stix2.Identity(
+    name="Acme",
+    identity_class="organization",
+)
+"""
+
+_STIX_FROM_IMPORT_WITH_ID = """\
+from stix2 import Identity
+
+identity = Identity(
+    id=pycti.Identity.generate_id(name="Acme"),
+    name="Acme",
+    identity_class="organization",
+)
+"""
+
+_STIX_FROM_IMPORT_MISSING_ID = """\
+from stix2 import Identity
+
+identity = Identity(
+    name="Acme",
+    identity_class="organization",
+)
+"""
+
+_SCO_NO_ID_NEEDED = """\
+import stix2
+
+# SCOs have deterministic IDs — no id= required
+ip = stix2.IPv4Address(value="1.2.3.4")
+domain = stix2.DomainName(value="example.com")
+"""
+
+_SDK_CONNECTOR = """\
+from connectors_sdk.models import BaseExternalImportConnector
+
+class MyConnector(BaseExternalImportConnector):
+    pass
+"""
+
+
+class TestVC313PyctiGenerateId:
+    """VC313 flags stix2 SDO/SRO constructors without explicit id=."""
+
+    def test_passes_when_id_present_qualified(self, connector_src):
+        path = connector_src(("src/main.py", _STIX_WITH_ID))
+        results = run_checks(path, select=["VC313"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_flags_missing_id_qualified(self, connector_src):
+        path = connector_src(("src/main.py", _STIX_MISSING_ID))
+        results = run_checks(path, select=["VC313"])
+        failed = [r for r in results if r.severity == Severity.ERROR]
+        assert len(failed) == 1
+        assert "Identity" in failed[0].message
+
+    def test_passes_when_id_present_from_import(self, connector_src):
+        path = connector_src(("src/main.py", _STIX_FROM_IMPORT_WITH_ID))
+        results = run_checks(path, select=["VC313"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_flags_missing_id_from_import(self, connector_src):
+        path = connector_src(("src/main.py", _STIX_FROM_IMPORT_MISSING_ID))
+        results = run_checks(path, select=["VC313"])
+        failed = [r for r in results if r.severity == Severity.ERROR]
+        assert len(failed) == 1
+
+    def test_sco_exempt_no_flag(self, connector_src):
+        """SCOs (IPv4Address, DomainName…) are exempt — stix2 makes them deterministic."""
+        path = connector_src(("src/main.py", _SCO_NO_ID_NEEDED))
+        results = run_checks(path, select=["VC313"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_multiple_violations_each_reported(self, connector_src):
+        src = """\
+import stix2
+a = stix2.Identity(name="A", identity_class="organization")
+b = stix2.Malware(name="Evil", is_family=False)
+"""
+        path = connector_src(("src/main.py", src))
+        results = run_checks(path, select=["VC313"])
+        failed = [r for r in results if r.severity == Severity.ERROR]
+        assert len(failed) == 2
+
+    def test_file_path_and_line_populated(self, connector_src):
+        path = connector_src(("src/main.py", _STIX_MISSING_ID))
+        results = run_checks(path, select=["VC313"])
+        failed = [r for r in results if r.severity == Severity.ERROR]
+        assert failed[0].file_path is not None
+        assert failed[0].line is not None
+        assert failed[0].line > 0

--- a/shared/connector_linter/tests/tests_checks/test_vc315_work_initiated.py
+++ b/shared/connector_linter/tests/tests_checks/test_vc315_work_initiated.py
@@ -1,0 +1,65 @@
+"""Unit tests for VC315 — connector must call initiate_work before processing."""
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+_WITH_INITIATE_WORK = """\
+class Connector:
+    def process(self, work_id):
+        work_id = self.helper.api.work.initiate_work(
+            self.helper.connect_id, "Processing"
+        )
+        self._do_work()
+"""
+
+_WITHOUT_INITIATE_WORK = """\
+class Connector:
+    def process(self):
+        self._do_work()
+        self.helper.api.work.to_processed(self.work_id, "Done")
+"""
+
+_INITIATE_WORK_IN_HELPER = """\
+def run_import(helper):
+    wid = helper.api.work.initiate_work(helper.connect_id, "Import")
+    return wid
+"""
+
+
+class TestVC315WorkInitiated:
+    """VC315 applies to EXTERNAL_IMPORT connectors only."""
+
+    def test_passes_with_initiate_work(self, connector_src):
+        path = connector_src(
+            ("src/main.py", _WITH_INITIATE_WORK),
+            connector_type="EXTERNAL_IMPORT",
+        )
+        results = run_checks(path, select=["VC315"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_fails_without_initiate_work(self, connector_src):
+        path = connector_src(
+            ("src/main.py", _WITHOUT_INITIATE_WORK),
+            connector_type="EXTERNAL_IMPORT",
+        )
+        results = run_checks(path, select=["VC315"])
+        assert any(r.severity == Severity.ERROR for r in results)
+
+    def test_passes_when_in_helper_function(self, connector_src):
+        """initiate_work in any function of any file is enough."""
+        path = connector_src(
+            ("src/utils.py", _INITIATE_WORK_IN_HELPER),
+            connector_type="EXTERNAL_IMPORT",
+        )
+        results = run_checks(path, select=["VC315"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_skipped_for_stream_connector(self, connector_src):
+        """VC315 is EXTERNAL_IMPORT-only — stream connectors skip it."""
+        path = connector_src(
+            ("src/main.py", _WITHOUT_INITIATE_WORK),
+            connector_type="STREAM",
+        )
+        results = run_checks(path, select=["VC315"])
+        # No findings at all (check is skipped for other types)
+        assert len(results) == 0

--- a/shared/connector_linter/tests/tests_checks/test_vc316_work_closed.py
+++ b/shared/connector_linter/tests/tests_checks/test_vc316_work_closed.py
@@ -1,0 +1,71 @@
+"""Unit tests for VC316 — connector must close work with to_processed."""
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+_WITH_TO_PROCESSED_AND_ERROR = """\
+class Connector:
+    def process(self, work_id):
+        try:
+            self._do_work()
+            self.helper.api.work.to_processed(work_id, "Done")
+        except Exception as e:
+            self.helper.api.work.to_processed(work_id, str(e), in_error=True)
+"""
+
+_WITH_TO_PROCESSED_NO_IN_ERROR = """\
+class Connector:
+    def process(self, work_id):
+        self._do_work()
+        self.helper.api.work.to_processed(work_id, "Done")
+"""
+
+_WITHOUT_TO_PROCESSED = """\
+class Connector:
+    def process(self):
+        self._do_work()
+"""
+
+
+class TestVC316WorkClosed:
+    """VC316 checks that work is closed with to_processed (EXTERNAL_IMPORT only)."""
+
+    def test_passes_with_to_processed_and_in_error(self, connector_src):
+        path = connector_src(
+            ("src/main.py", _WITH_TO_PROCESSED_AND_ERROR),
+            connector_type="EXTERNAL_IMPORT",
+        )
+        results = run_checks(path, select=["VC316"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_warns_missing_in_error_kwarg(self, connector_src):
+        """to_processed exists but without in_error= — advisory WARNING (passed=True)."""
+        path = connector_src(
+            ("src/main.py", _WITH_TO_PROCESSED_NO_IN_ERROR),
+            connector_type="EXTERNAL_IMPORT",
+        )
+        results = run_checks(path, select=["VC316"])
+        # WARNINGs are advisory: passed=True; detect by severity + suggestion
+        advisories = [
+            r
+            for r in results
+            if r.severity == Severity.WARNING and r.suggestion is not None
+        ]
+        assert len(advisories) >= 1
+
+    def test_fails_without_to_processed(self, connector_src):
+        path = connector_src(
+            ("src/main.py", _WITHOUT_TO_PROCESSED),
+            connector_type="EXTERNAL_IMPORT",
+        )
+        results = run_checks(path, select=["VC316"])
+        assert any(r.severity == Severity.ERROR for r in results)
+
+    def test_skipped_for_stream_connector(self, connector_src):
+        """VC316 only applies to EXTERNAL_IMPORT."""
+        path = connector_src(
+            ("src/main.py", _WITHOUT_TO_PROCESSED),
+            connector_type="STREAM",
+        )
+        results = run_checks(path, select=["VC316"])
+        assert len(results) == 0

--- a/shared/connector_linter/tests/tests_checks/test_vc318_helper_listen.py
+++ b/shared/connector_linter/tests/tests_checks/test_vc318_helper_listen.py
@@ -1,0 +1,85 @@
+"""Unit tests for VC318 — enrichment connectors must use helper.listen()."""
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+_WITH_LISTEN = """\
+class MyConnector:
+    def run(self):
+        self.helper.listen(message_callback=self.process_message)
+"""
+
+_WITHOUT_LISTEN = """\
+class MyConnector:
+    def run(self):
+        while True:
+            self.process()
+"""
+
+_BARE_HELPER_LISTEN = """\
+def run(helper):
+    helper.listen(message_callback=process)
+"""
+
+
+class TestVC318HelperListen:
+    """VC318 is scoped to INTERNAL_ENRICHMENT only."""
+
+    def test_passes_when_listen_present(self, connector_src):
+        path = connector_src(
+            ("src/main.py", _WITH_LISTEN),
+            connector_type="INTERNAL_ENRICHMENT",
+        )
+        results = run_checks(path, select=["VC318"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_flags_when_listen_missing(self, connector_src):
+        path = connector_src(
+            ("src/main.py", _WITHOUT_LISTEN),
+            connector_type="INTERNAL_ENRICHMENT",
+        )
+        results = run_checks(path, select=["VC318"])
+        failed = [r for r in results if r.severity == Severity.ERROR]
+        assert len(failed) == 1
+
+    def test_skipped_for_external_import(self, connector_src):
+        """VC318 does not apply to EXTERNAL_IMPORT connectors."""
+        path = connector_src(
+            ("src/main.py", _WITHOUT_LISTEN),
+            connector_type="EXTERNAL_IMPORT",
+        )
+        results = run_checks(path, select=["VC318"])
+        # Scoped check — should produce no results for wrong type
+        assert len(results) == 0
+
+    def test_skipped_for_stream(self, connector_src):
+        path = connector_src(
+            ("src/main.py", _WITHOUT_LISTEN),
+            connector_type="STREAM",
+        )
+        results = run_checks(path, select=["VC318"])
+        assert len(results) == 0
+
+    def test_bare_helper_listen_accepted(self, connector_src):
+        """helper.listen(...) without self. qualifier is also valid."""
+        path = connector_src(
+            ("src/main.py", _BARE_HELPER_LISTEN),
+            connector_type="INTERNAL_ENRICHMENT",
+        )
+        results = run_checks(path, select=["VC318"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_unrelated_listen_not_matched(self, connector_src):
+        """socket.listen() or other .listen() calls must not trigger VC318."""
+        src = """\
+import socket
+s = socket.socket()
+s.listen(5)
+"""
+        path = connector_src(
+            ("src/main.py", src),
+            connector_type="INTERNAL_ENRICHMENT",
+        )
+        results = run_checks(path, select=["VC318"])
+        failed = [r for r in results if r.severity == Severity.ERROR]
+        assert len(failed) == 1  # no helper.listen → still flagged

--- a/shared/connector_linter/tests/tests_checks/test_vc325_minimal_settings_tests.py
+++ b/shared/connector_linter/tests/tests_checks/test_vc325_minimal_settings_tests.py
@@ -1,0 +1,257 @@
+"""Tests for VC325 (minimal settings tests)."""
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+
+class TestVC325NoTestsDirectory:
+    def test_fails_when_no_tests_directory(self, minimal_connector):
+        results = run_checks(minimal_connector, select=["VC325"])
+
+        assert len(results) == 1
+        assert results[0].severity is Severity.ERROR
+        assert "No tests/ directory found" in results[0].message
+
+    def test_fails_when_tests_directory_is_empty(self, minimal_connector):
+        (minimal_connector / "tests").mkdir()
+
+        results = run_checks(minimal_connector, select=["VC325"])
+
+        assert len(results) == 1
+        assert results[0].severity is Severity.ERROR
+        assert "No test files (test_*.py) found in tests/" in results[0].message
+
+    def test_fails_when_tests_directory_has_no_test_files(self, minimal_connector):
+        tests_dir = minimal_connector / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "conftest.py").write_text("# no tests here\n", encoding="utf-8")
+
+        results = run_checks(minimal_connector, select=["VC325"])
+
+        assert len(results) == 1
+        assert results[0].severity is Severity.ERROR
+        assert "No test files (test_*.py) found in tests/" in results[0].message
+
+
+class TestVC325NoSettingsTest:
+    def test_fails_when_no_settings_test_file(self, minimal_connector):
+        tests_dir = minimal_connector / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "test_something_else.py").write_text(
+            "def test_dummy():\n    pass\n", encoding="utf-8"
+        )
+
+        results = run_checks(minimal_connector, select=["VC325"])
+
+        assert len(results) == 1
+        # Advisory: other tests exist, but settings coverage is missing → warn, not fail.
+        assert results[0].severity == Severity.WARNING
+        assert "No settings test file found" in results[0].message
+
+    def test_detects_settings_test_by_filename(self, minimal_connector):
+        """A file named test_settings.py is recognised even without ConnectorSettings import."""
+        tests_dir = minimal_connector / "tests" / "tests_connector"
+        tests_dir.mkdir(parents=True)
+        (tests_dir / "test_settings.py").write_text(
+            "from connector import ConnectorSettings\n"
+            "from connectors_sdk import ConfigValidationError\n\n"
+            "def test_valid():\n"
+            "    class FakeSettings(ConnectorSettings):\n"
+            "        pass\n"
+            "    settings = FakeSettings()\n"
+            "    assert settings is not None\n\n"
+            "def test_invalid():\n"
+            "    import pytest\n"
+            "    with pytest.raises(ConfigValidationError):\n"
+            "        ConnectorSettings()\n",
+            encoding="utf-8",
+        )
+
+        results = run_checks(minimal_connector, select=["VC325"])
+
+        assert len(results) == 1
+        assert results[0].severity is Severity.INFO
+
+    def test_detects_settings_test_by_connector_settings_import(
+        self, minimal_connector
+    ):
+        """A file importing ConnectorSettings is recognised as a settings test."""
+        tests_dir = minimal_connector / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "test_config.py").write_text(
+            "from connector import ConnectorSettings\n"
+            "from connectors_sdk import ConfigValidationError\n\n"
+            "import pytest\n\n"
+            "def test_valid():\n"
+            "    class FakeSettings(ConnectorSettings):\n"
+            "        pass\n"
+            "    s = FakeSettings()\n"
+            "    assert s\n\n"
+            "def test_invalid():\n"
+            "    with pytest.raises(ConfigValidationError):\n"
+            "        ConnectorSettings()\n",
+            encoding="utf-8",
+        )
+
+        results = run_checks(minimal_connector, select=["VC325"])
+
+        assert len(results) == 1
+        assert results[0].severity is Severity.INFO
+
+
+class TestVC325IncompleteSettingsTest:
+    def _make_tests_dir(self, connector):
+        tests_dir = connector / "tests" / "tests_connector"
+        tests_dir.mkdir(parents=True)
+        return tests_dir
+
+    def test_fails_when_missing_valid_input_test(self, minimal_connector):
+        tests_dir = self._make_tests_dir(minimal_connector)
+        (tests_dir / "test_settings.py").write_text(
+            "import pytest\n"
+            "from connector import ConnectorSettings\n"
+            "from connectors_sdk import ConfigValidationError\n\n"
+            "def test_invalid():\n"
+            "    with pytest.raises(ConfigValidationError):\n"
+            "        ConnectorSettings()\n",
+            encoding="utf-8",
+        )
+
+        results = run_checks(minimal_connector, select=["VC325"])
+
+        assert len(results) == 1
+        assert results[0].severity == Severity.ERROR
+        assert "do not cover valid input" in results[0].message
+
+    def test_fails_when_missing_error_input_test(self, minimal_connector):
+        tests_dir = self._make_tests_dir(minimal_connector)
+        (tests_dir / "test_settings.py").write_text(
+            "from connector import ConnectorSettings\n\n"
+            "def test_valid():\n"
+            "    class FakeSettings(ConnectorSettings):\n"
+            "        pass\n"
+            "    s = FakeSettings()\n"
+            "    assert s is not None\n",
+            encoding="utf-8",
+        )
+
+        results = run_checks(minimal_connector, select=["VC325"])
+
+        assert len(results) == 1
+        assert results[0].severity == Severity.WARNING
+        assert "do not cover missing required fields" in results[0].message
+
+    def test_fails_when_both_coverage_missing(self, minimal_connector):
+        tests_dir = self._make_tests_dir(minimal_connector)
+        (tests_dir / "test_settings.py").write_text(
+            "from connector import ConnectorSettings\n\n"
+            "def test_placeholder():\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+
+        results = run_checks(minimal_connector, select=["VC325"])
+
+        assert len(results) == 2
+        messages = " ".join(r.message for r in results)
+        assert "valid input" in messages
+        assert "missing required fields" in messages
+        # valid-input gap is an ERROR; error-input gap is advisory WARNING
+        valid_result = next(r for r in results if "valid input" in r.message)
+        error_result = next(
+            r for r in results if "missing required fields" in r.message
+        )
+        assert valid_result.severity == Severity.ERROR
+        assert error_result.severity == Severity.WARNING
+
+
+class TestVC325FullCompliance:
+    def test_passes_with_template_style_test(self, minimal_connector):
+        """Simulate the exact pattern from templates/external-import/tests/."""
+        tests_dir = minimal_connector / "tests" / "tests_connector"
+        tests_dir.mkdir(parents=True)
+        (tests_dir / "test_settings.py").write_text(
+            "from typing import Any\n\n"
+            "import pytest\n"
+            "from connector import ConnectorSettings\n"
+            "from connectors_sdk import BaseConfigModel, ConfigValidationError\n\n\n"
+            "@pytest.mark.parametrize(\n"
+            '    "settings_dict",\n'
+            "    [\n"
+            "        pytest.param(\n"
+            "            {\n"
+            '                "opencti": {"url": "http://localhost:8080", "token": "t"},\n'
+            '                "connector": {"id": "id", "scope": "x"},\n'
+            '                "myconn": {"api_key": "k"},\n'
+            "            },\n"
+            '            id="full_valid",\n'
+            "        ),\n"
+            "        pytest.param(\n"
+            "            {\n"
+            '                "opencti": {"url": "http://localhost:8080", "token": "t"},\n'
+            '                "connector": {"id": "id", "scope": "x"},\n'
+            '                "myconn": {},\n'
+            "            },\n"
+            '            id="minimal_valid",\n'
+            "        ),\n"
+            "    ],\n"
+            ")\n"
+            "def test_settings_should_accept_valid_input(settings_dict):\n"
+            "    class FakeConnectorSettings(ConnectorSettings):\n"
+            "        @classmethod\n"
+            "        def _load_config_dict(cls, _, handler) -> dict[str, Any]:\n"
+            "            return handler(settings_dict)\n\n"
+            "    settings = FakeConnectorSettings()\n"
+            "    assert isinstance(settings.opencti, BaseConfigModel)\n\n\n"
+            "@pytest.mark.parametrize(\n"
+            '    "settings_dict, field_name",\n'
+            "    [\n"
+            '        pytest.param({}, "settings", id="empty"),\n'
+            "    ],\n"
+            ")\n"
+            "def test_settings_should_raise_when_invalid_input(settings_dict, field_name):\n"
+            "    class FakeConnectorSettings(ConnectorSettings):\n"
+            "        @classmethod\n"
+            "        def _load_config_dict(cls, _, handler) -> dict[str, Any]:\n"
+            "            return handler(settings_dict)\n\n"
+            "    with pytest.raises(ConfigValidationError) as err:\n"
+            "        FakeConnectorSettings()\n"
+            '    assert "Error validating configuration" in str(err)\n',
+            encoding="utf-8",
+        )
+
+        results = run_checks(minimal_connector, select=["VC325"])
+
+        assert len(results) == 1
+        assert results[0].severity is Severity.INFO
+        assert "test_settings.py" in results[0].message
+
+    def test_passes_when_coverage_split_across_multiple_test_files(
+        self, minimal_connector
+    ):
+        """Valid-input and error-input tests may live in separate files."""
+        tests_dir = minimal_connector / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "test_settings_valid.py").write_text(
+            "from connector import ConnectorSettings\n\n"
+            "def test_valid():\n"
+            "    class FakeSettings(ConnectorSettings):\n"
+            "        pass\n"
+            "    s = FakeSettings()\n"
+            "    assert s\n",
+            encoding="utf-8",
+        )
+        (tests_dir / "test_settings_errors.py").write_text(
+            "import pytest\n"
+            "from connector import ConnectorSettings\n"
+            "from connectors_sdk import ConfigValidationError\n\n"
+            "def test_missing_required():\n"
+            "    with pytest.raises(ConfigValidationError):\n"
+            "        ConnectorSettings()\n",
+            encoding="utf-8",
+        )
+
+        results = run_checks(minimal_connector, select=["VC325"])
+
+        assert len(results) == 1
+        assert results[0].severity is Severity.INFO

--- a/shared/connector_linter/tests/tests_checks/test_vc505_no_direct_api.py
+++ b/shared/connector_linter/tests/tests_checks/test_vc505_no_direct_api.py
@@ -1,0 +1,82 @@
+"""Unit tests for VC505 — no direct GraphQL API calls via helper.api.*."""
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+_CLEAN_BUNDLE_SEND = """\
+class Connector:
+    def process(self):
+        bundle = self._build_bundle()
+        self.helper.send_stix2_bundle(bundle)
+"""
+
+_DIRECT_API_CAMPAIGN = """\
+class Connector:
+    def process(self):
+        result = self.helper.api.campaign.read(id="xxx")
+        return result
+"""
+
+_DIRECT_API_MULTIPLE = """\
+class Connector:
+    def process(self):
+        r1 = self.helper.api.campaign.read(id="xxx")
+        r2 = self.helper.api.malware.create(name="test")
+"""
+
+_ALLOWED_WORK_API = """\
+class Connector:
+    def process(self):
+        work_id = self.helper.api.work.initiate_work(self.helper.connect_id, "test")
+        self.helper.api.work.to_processed(work_id, "done")
+"""
+
+_ALLOWED_VOCAB_API = """\
+class Connector:
+    def setup(self):
+        self.helper.api.vocabulary.list(filters=[])
+        self.helper.api.marking_definition.read(id="xxx")
+"""
+
+
+class TestVC505NoDirectApi:
+    """VC505 warns on direct helper.api.* calls outside allowed submodules."""
+
+    def test_passes_bundle_send(self, connector_src):
+        path = connector_src(("src/main.py", _CLEAN_BUNDLE_SEND))
+        results = run_checks(path, select=["VC505"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_fails_direct_campaign_api(self, connector_src):
+        """helper.api.campaign is advisory — WARNING with passed=True."""
+        path = connector_src(("src/main.py", _DIRECT_API_CAMPAIGN))
+        results = run_checks(path, select=["VC505"])
+        advisories = [
+            r
+            for r in results
+            if r.severity == Severity.WARNING and r.file_path is not None
+        ]
+        assert len(advisories) >= 1
+
+    def test_fails_multiple_direct_calls(self, connector_src):
+        """Each direct API call produces a separate advisory finding."""
+        path = connector_src(("src/main.py", _DIRECT_API_MULTIPLE))
+        results = run_checks(path, select=["VC505"])
+        advisories = [
+            r
+            for r in results
+            if r.severity == Severity.WARNING and r.file_path is not None
+        ]
+        assert len(advisories) >= 2
+
+    def test_passes_work_api_allowed(self, connector_src):
+        """helper.api.work is whitelisted — should not be flagged."""
+        path = connector_src(("src/main.py", _ALLOWED_WORK_API))
+        results = run_checks(path, select=["VC505"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_passes_vocab_marking_allowed(self, connector_src):
+        """vocabulary and marking_definition are whitelisted."""
+        path = connector_src(("src/main.py", _ALLOWED_VOCAB_API))
+        results = run_checks(path, select=["VC505"])
+        assert all(r.severity == Severity.INFO for r in results)

--- a/shared/connector_linter/tests/tests_linter/test_config.py
+++ b/shared/connector_linter/tests/tests_linter/test_config.py
@@ -1,0 +1,163 @@
+"""Tests for config.py: pyproject.toml configuration loading."""
+
+import textwrap
+from pathlib import Path
+
+from connector_linter.config import (
+    LinterConfig,
+    _find_pyproject,
+    _parse_table,
+    get_per_file_ignores,
+    load_config,
+)
+
+
+class TestFindPyproject:
+    def test_finds_in_same_dir(self, tmp_path: Path):
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        assert _find_pyproject(tmp_path) == tmp_path / "pyproject.toml"
+
+    def test_finds_in_parent(self, tmp_path: Path):
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        child = tmp_path / "sub" / "deep"
+        child.mkdir(parents=True)
+        assert _find_pyproject(child) == tmp_path / "pyproject.toml"
+
+    def test_returns_none_when_missing(self, tmp_path: Path):
+        child = tmp_path / "sub"
+        child.mkdir()
+        # No pyproject.toml anywhere in tmp_path hierarchy
+        # (tmp_path itself is under /tmp which won't have one either)
+        result = _find_pyproject(child)
+        # Either None or finds one in a real parent — just test the method runs
+        assert result is None or result.name == "pyproject.toml"
+
+
+class TestParseTable:
+    def test_empty_table(self):
+        cfg = _parse_table({})
+        assert cfg.select == []
+        assert cfg.ignore == []
+        assert cfg.per_file_ignores == {}
+        assert cfg.is_empty
+
+    def test_select_and_ignore(self):
+        cfg = _parse_table({"select": ["VC1xx", "VC3xx"], "ignore": ["VC306"]})
+        assert cfg.select == ["VC1xx", "VC3xx"]
+        assert cfg.ignore == ["VC306"]
+        assert not cfg.is_empty
+
+    def test_per_file_ignores(self):
+        cfg = _parse_table(
+            {"per-file-ignores": {"tests/*.py": ["VC309"], "src/main.py": ["VC308"]}}
+        )
+        assert cfg.per_file_ignores == {
+            "tests/*.py": ["VC309"],
+            "src/main.py": ["VC308"],
+        }
+
+    def test_invalid_types_fallback(self):
+        cfg = _parse_table(
+            {"select": "not-a-list", "ignore": 42, "per-file-ignores": "bad"}
+        )
+        assert cfg.select == []
+        assert cfg.ignore == []
+        assert cfg.per_file_ignores == {}
+
+
+class TestLoadConfig:
+    def _write_pyproject(self, path: Path, content: str) -> Path:
+        pyproject = path / "pyproject.toml"
+        pyproject.write_text(textwrap.dedent(content))
+        return pyproject
+
+    def test_loads_from_connector_dir(self, tmp_path: Path):
+        self._write_pyproject(
+            tmp_path,
+            """\
+            [tool.connector-linter]
+            ignore = ["VC306", "VC307"]
+            """,
+        )
+        cfg = load_config(tmp_path)
+        assert cfg.ignore == ["VC306", "VC307"]
+
+    def test_no_linter_section(self, tmp_path: Path):
+        self._write_pyproject(tmp_path, "[tool.black]\nline-length = 88\n")
+        cfg = load_config(tmp_path)
+        assert cfg.is_empty
+
+    def test_no_pyproject(self, tmp_path: Path):
+        cfg = load_config(tmp_path)
+        assert cfg.is_empty
+
+    def test_explicit_config_path(self, tmp_path: Path):
+        custom = tmp_path / "custom" / "pyproject.toml"
+        custom.parent.mkdir()
+        custom.write_text(
+            '[tool.connector-linter]\nselect = ["VC101"]\n', encoding="utf-8"
+        )
+        cfg = load_config(tmp_path, config_path=custom)
+        assert cfg.select == ["VC101"]
+
+    def test_explicit_config_path_missing(self, tmp_path: Path):
+        cfg = load_config(tmp_path, config_path=tmp_path / "nope.toml")
+        assert cfg.is_empty
+
+    def test_malformed_toml(self, tmp_path: Path):
+        (tmp_path / "pyproject.toml").write_text("not valid toml [[[")
+        cfg = load_config(tmp_path)
+        assert cfg.is_empty
+
+    def test_full_config(self, tmp_path: Path):
+        self._write_pyproject(
+            tmp_path,
+            """\
+            [tool.connector-linter]
+            select = ["VC1xx", "VC3xx"]
+            ignore = ["VC306"]
+
+            [tool.connector-linter.per-file-ignores]
+            "tests/*.py" = ["VC309", "VC313"]
+            "src/main.py" = ["VC308"]
+            """,
+        )
+        cfg = load_config(tmp_path)
+        assert cfg.select == ["VC1xx", "VC3xx"]
+        assert cfg.ignore == ["VC306"]
+        assert cfg.per_file_ignores["tests/*.py"] == ["VC309", "VC313"]
+        assert cfg.per_file_ignores["src/main.py"] == ["VC308"]
+
+
+class TestGetPerFileIgnores:
+    def test_matching_glob(self, tmp_path: Path):
+        cfg = LinterConfig(per_file_ignores={"src/*.py": ["VC309"]})
+        codes = get_per_file_ignores(cfg, tmp_path / "src" / "main.py", tmp_path)
+        assert codes == {"VC309"}
+
+    def test_no_match(self, tmp_path: Path):
+        cfg = LinterConfig(per_file_ignores={"tests/*.py": ["VC309"]})
+        codes = get_per_file_ignores(cfg, tmp_path / "src" / "main.py", tmp_path)
+        assert codes == set()
+
+    def test_multiple_patterns(self, tmp_path: Path):
+        cfg = LinterConfig(
+            per_file_ignores={
+                "src/*.py": ["VC309"],
+                "src/main.py": ["VC308"],
+            }
+        )
+        codes = get_per_file_ignores(cfg, tmp_path / "src" / "main.py", tmp_path)
+        assert codes == {"VC308", "VC309"}
+
+    def test_empty_config(self, tmp_path: Path):
+        cfg = LinterConfig()
+        codes = get_per_file_ignores(cfg, tmp_path / "src" / "main.py", tmp_path)
+        assert codes == set()
+
+    def test_deep_glob(self, tmp_path: Path):
+        cfg = LinterConfig(per_file_ignores={"src/**/*.py": ["VC301"]})
+        codes = get_per_file_ignores(
+            cfg, tmp_path / "src" / "connector" / "deep.py", tmp_path
+        )
+        assert codes == {"VC301"}

--- a/shared/connector_linter/tests/tests_linter/test_exit_code.py
+++ b/shared/connector_linter/tests/tests_linter/test_exit_code.py
@@ -1,9 +1,4 @@
-"""Tests for exit-code semantics.
-
-Rules:
-- exit 1 if any ERROR-severity check FAILED
-- exit 0 otherwise (all pass, or only warnings/info fail)
-"""
+"""Tests for exit-code semantics."""
 
 from connector_linter.models import (
     CheckFinding,
@@ -22,12 +17,10 @@ def _has_errors(results: list[CheckResult]) -> bool:
 
 class TestExitCode:
     def test_all_pass_exit_0(self, dummy_checks, minimal_connector):
-        results = run_checks(minimal_connector, select=["VC901", "VC902"])
-        assert not _has_errors(results)
+        assert not _has_errors(run_checks(minimal_connector, select=["VC901", "VC902"]))
 
     def test_error_fail_exit_1(self, dummy_checks, minimal_connector):
-        results = run_checks(minimal_connector, select=["VC903"])
-        assert _has_errors(results)
+        assert _has_errors(run_checks(minimal_connector, select=["VC903"]))
 
     def test_warning_only_exit_0(self, _clean_registry, minimal_connector):
         @CheckRegistry.register(
@@ -39,15 +32,12 @@ class TestExitCode:
         def _warn(ctx: ConnectorContext) -> list[CheckFinding]:
             return [CheckFinding(message="not great", severity=Severity.WARNING)]
 
-        results = run_checks(minimal_connector, select=["VC960"])
-        assert not _has_errors(results)
+        assert not _has_errors(run_checks(minimal_connector, select=["VC960"]))
 
     def test_mixed_with_error_exit_1(self, dummy_checks, minimal_connector):
-        results = run_checks(minimal_connector, select=["VC901", "VC902", "VC903"])
-        # VC903 fails with ERROR severity → exit 1
-        assert _has_errors(results)
+        assert _has_errors(
+            run_checks(minimal_connector, select=["VC901", "VC902", "VC903"])
+        )
 
     def test_empty_results_exit_0(self, _clean_registry, minimal_connector):
-        # No checks selected → no results → exit 0
-        results = run_checks(minimal_connector, select=["VC000"])
-        assert not _has_errors(results)
+        assert not _has_errors(run_checks(minimal_connector, select=["VC000"]))

--- a/shared/connector_linter/tests/tests_linter/test_registry.py
+++ b/shared/connector_linter/tests/tests_linter/test_registry.py
@@ -1,31 +1,35 @@
-"""Tests for the CheckRegistry: select/ignore filtering and prefix matching."""
+"""Tests for the CheckRegistry."""
 
 from connector_linter.registry import CheckRegistry
 
 
 class TestGetByPrefix:
-    """CheckRegistry.get_by_prefix() strips trailing 'x' chars and prefix-matches."""
-
     def test_exact_code(self, dummy_checks):
-        result = CheckRegistry.get_by_prefix("VC901")
-        assert list(result.keys()) == ["VC901"]
+        assert list(CheckRegistry.get_by_prefix("VC901").keys()) == ["VC901"]
 
     def test_category_prefix(self, dummy_checks):
-        result = CheckRegistry.get_by_prefix("VC9")
-        assert sorted(result.keys()) == ["VC901", "VC902", "VC903"]
+        assert sorted(CheckRegistry.get_by_prefix("VC9").keys()) == [
+            "VC901",
+            "VC902",
+            "VC903",
+        ]
 
     def test_xx_suffix_stripped(self, dummy_checks):
-        # "VC9xx" → prefix "VC9" → matches all VC9* codes
-        result = CheckRegistry.get_by_prefix("VC9xx")
-        assert sorted(result.keys()) == ["VC901", "VC902", "VC903"]
+        assert sorted(CheckRegistry.get_by_prefix("VC9xx").keys()) == [
+            "VC901",
+            "VC902",
+            "VC903",
+        ]
 
     def test_no_match(self, dummy_checks):
-        result = CheckRegistry.get_by_prefix("VC0")
-        assert result == {}
+        assert CheckRegistry.get_by_prefix("VC0") == {}
 
     def test_partial_prefix(self, dummy_checks):
-        result = CheckRegistry.get_by_prefix("VC90")
-        assert sorted(result.keys()) == ["VC901", "VC902", "VC903"]
+        assert sorted(CheckRegistry.get_by_prefix("VC90").keys()) == [
+            "VC901",
+            "VC902",
+            "VC903",
+        ]
 
 
 class TestGetAll:

--- a/shared/connector_linter/tests/tests_linter/test_runner.py
+++ b/shared/connector_linter/tests/tests_linter/test_runner.py
@@ -186,3 +186,101 @@ class TestNoqaIntegration:
         results = run_checks(minimal_connector, select=["VC952"], disable_noqa=False)
         assert len(results) == 1
         assert results[0].severity == Severity.ERROR
+
+
+class TestPyprojectConfig:
+    """pyproject.toml [tool.connector-linter] integration."""
+
+    def test_ignore_from_pyproject(self, dummy_checks, minimal_connector):
+        (minimal_connector / "pyproject.toml").write_text(
+            '[tool.connector-linter]\nignore = ["VC903"]\n', encoding="utf-8"
+        )
+        results = run_checks(minimal_connector, select=["VC9xx"])
+        codes = {r.code for r in results}
+        assert "VC903" not in codes
+        assert "VC901" in codes
+
+    def test_select_from_pyproject(self, dummy_checks, minimal_connector):
+        (minimal_connector / "pyproject.toml").write_text(
+            '[tool.connector-linter]\nselect = ["VC901"]\n', encoding="utf-8"
+        )
+        results = run_checks(minimal_connector)
+        codes = {r.code for r in results}
+        assert codes == {"VC901"}
+
+    def test_cli_select_overrides_pyproject(self, dummy_checks, minimal_connector):
+        (minimal_connector / "pyproject.toml").write_text(
+            '[tool.connector-linter]\nselect = ["VC901"]\n', encoding="utf-8"
+        )
+        results = run_checks(minimal_connector, select=["VC902"])
+        codes = {r.code for r in results}
+        assert codes == {"VC902"}
+
+    def test_cli_ignore_merges_with_pyproject(self, dummy_checks, minimal_connector):
+        (minimal_connector / "pyproject.toml").write_text(
+            '[tool.connector-linter]\nignore = ["VC901"]\n', encoding="utf-8"
+        )
+        results = run_checks(minimal_connector, select=["VC9xx"], ignore=["VC902"])
+        codes = {r.code for r in results}
+        assert "VC901" not in codes
+        assert "VC902" not in codes
+        assert "VC903" in codes
+
+    def test_per_file_ignores(self, _clean_registry, minimal_connector):
+        (minimal_connector / "src" / "target.py").write_text(
+            "x = 1\n", encoding="utf-8"
+        )
+        (minimal_connector / "pyproject.toml").write_text(
+            '[tool.connector-linter.per-file-ignores]\n"src/target.py" = ["VC960"]\n',
+            encoding="utf-8",
+        )
+
+        @CheckRegistry.register(
+            code="VC960",
+            name="test-pfi",
+            description="Check for per-file-ignores test",
+            severity=Severity.ERROR,
+        )
+        def _check(ctx: ConnectorContext) -> list[CheckFinding]:
+            return [
+                CheckFinding(
+                    message="flagged",
+                    severity=Severity.ERROR,
+                    file_path=ctx.path / "src" / "target.py",
+                    line=1,
+                )
+            ]
+
+        results = run_checks(minimal_connector, select=["VC960"])
+        assert len(results) == 0
+
+    def test_per_file_ignores_no_match(self, _clean_registry, minimal_connector):
+        (minimal_connector / "src" / "other.py").write_text("x = 1\n", encoding="utf-8")
+        (minimal_connector / "pyproject.toml").write_text(
+            '[tool.connector-linter.per-file-ignores]\n"src/target.py" = ["VC961"]\n',
+            encoding="utf-8",
+        )
+
+        @CheckRegistry.register(
+            code="VC961",
+            name="test-pfi-no-match",
+            description="Per-file-ignores miss test",
+            severity=Severity.ERROR,
+        )
+        def _check(ctx: ConnectorContext) -> list[CheckFinding]:
+            return [
+                CheckFinding(
+                    message="flagged",
+                    severity=Severity.ERROR,
+                    file_path=ctx.path / "src" / "other.py",
+                    line=1,
+                )
+            ]
+
+        results = run_checks(minimal_connector, select=["VC961"])
+        assert len(results) == 1
+
+    def test_no_pyproject_runs_all(self, dummy_checks, minimal_connector):
+        results = run_checks(minimal_connector, select=["VC9xx"])
+        codes = {r.code for r in results}
+        assert codes == {"VC901", "VC902", "VC903"}

--- a/shared/connector_linter/tests/tests_linter/test_runner.py
+++ b/shared/connector_linter/tests/tests_linter/test_runner.py
@@ -26,17 +26,13 @@ class TestSelectIgnore:
 
     def test_ignore_prefix(self, dummy_checks, minimal_connector):
         results = run_checks(minimal_connector, select=["VC9xx"], ignore=["VC90"])
-        codes = {r.code for r in results}
-        assert codes == set()
+        assert {r.code for r in results} == set()
 
     def test_select_and_ignore_combined(self, dummy_checks, minimal_connector):
         results = run_checks(
-            minimal_connector,
-            select=["VC901", "VC902", "VC903"],
-            ignore=["VC902"],
+            minimal_connector, select=["VC901", "VC902", "VC903"], ignore=["VC902"]
         )
-        codes = {r.code for r in results}
-        assert codes == {"VC901", "VC903"}
+        assert {r.code for r in results} == {"VC901", "VC903"}
 
 
 class TestCheckExecution:
@@ -78,8 +74,6 @@ class TestExceptionHandling:
         assert "kaboom" in results[0].message
 
     def test_exception_always_error_severity(self, _clean_registry, minimal_connector):
-        """A crashing WARNING check is escalated to ERROR so CI won't silently pass."""
-
         @CheckRegistry.register(
             code="VC998",
             name="test-warn-boom",
@@ -95,11 +89,10 @@ class TestExceptionHandling:
 
 
 class TestNoqaIntegration:
-    """Noqa directives suppress results when enabled."""
-
     def test_noqa_suppresses_result(self, _clean_registry, minimal_connector):
-        src_file = minimal_connector / "src" / "target.py"
-        src_file.write_text("x = 1  # noqa: VC950\n", encoding="utf-8")
+        (minimal_connector / "src" / "target.py").write_text(
+            "x = 1  # noqa: VC950\n", encoding="utf-8"
+        )
 
         @CheckRegistry.register(
             code="VC950",
@@ -121,8 +114,9 @@ class TestNoqaIntegration:
         assert len(results) == 0
 
     def test_disable_noqa_keeps_result(self, _clean_registry, minimal_connector):
-        src_file = minimal_connector / "src" / "target.py"
-        src_file.write_text("x = 1  # noqa: VC950\n", encoding="utf-8")
+        (minimal_connector / "src" / "target.py").write_text(
+            "x = 1  # noqa: VC950\n", encoding="utf-8"
+        )
 
         @CheckRegistry.register(
             code="VC950",
@@ -145,8 +139,9 @@ class TestNoqaIntegration:
         assert results[0].severity == Severity.ERROR
 
     def test_bare_noqa_suppresses_all(self, _clean_registry, minimal_connector):
-        src_file = minimal_connector / "src" / "target.py"
-        src_file.write_text("x = 1  # noqa\n", encoding="utf-8")
+        (minimal_connector / "src" / "target.py").write_text(
+            "x = 1  # noqa\n", encoding="utf-8"
+        )
 
         @CheckRegistry.register(
             code="VC951",
@@ -168,8 +163,9 @@ class TestNoqaIntegration:
         assert len(results) == 0
 
     def test_noqa_wrong_code_no_suppress(self, _clean_registry, minimal_connector):
-        src_file = minimal_connector / "src" / "target.py"
-        src_file.write_text("x = 1  # noqa: VC999\n", encoding="utf-8")
+        (minimal_connector / "src" / "target.py").write_text(
+            "x = 1  # noqa: VC999\n", encoding="utf-8"
+        )
 
         @CheckRegistry.register(
             code="VC952",


### PR DESCRIPTION
### Proposed changes

* Add VC4xx Docker validation checks (3 files, ~218 lines)
* Add VC5xx deprecation detection checks (7 files, ~768 lines)

> **Part 4 of 4** — Stacked on `feat/connector-linter-3-code-checks`. Review only the top commit.

### Related issues

* Part of #5989

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Stacked PR series:
1. **#6293:** Foundation — scaffold + core engine + README
2. **#6292:** VC1xx config + VC2xx metadata checks
3. **#6291:** VC3xx code checks
4. **#6294 (this):** VC4xx docker + VC5xx deprecation checks

Once #6293 is merged, PRs #6292, #6291, #6294 will auto-update their base branches.