### PR TITLE
[Google TI Feeds] fetch relationship entities directly from collections API

### DIFF
--- a/external-import/google-ti-feeds/CONTRIBUTING.md
+++ b/external-import/google-ti-feeds/CONTRIBUTING.md
@@ -292,7 +292,7 @@ CONVERTER_CONFIGS["{entity_type}"] = GTI_{ENTITY_TYPE}_CONVERTER_CONFIG
 
 ```python
 # File: src/custom/client_api.py
-# Add to fetch_subentities_ids method
+# Add to fetch_subentities method
 subentity_types = [
     "malware_families",
     "threat_actors",

--- a/external-import/google-ti-feeds/connector/src/custom/client_api/client_api.py
+++ b/external-import/google-ti-feeds/connector/src/custom/client_api/client_api.py
@@ -175,10 +175,10 @@ class ClientAPI:
         async for campaign_data in self.campaign_client.fetch_campaigns(initial_state):
             yield campaign_data
 
-    async def fetch_subentities_ids(
+    async def fetch_subentities(
         self, entity_name: str, entity_id: str, subentity_types: list[str]
-    ) -> dict[str, list[str]]:
-        """Fetch subentities IDs from the API.
+    ) -> dict[str, list[Any]]:
+        """Fetch related subentities with full payloads from the API.
 
         Args:
             entity_name (str): The name of the entity.
@@ -186,26 +186,12 @@ class ClientAPI:
             subentity_types (list[str]): The type of subentities to fetch.
 
         Returns:
-            dict[str, list[str]]: The fetched subentities IDs.
+            dict[str, list[Any]]: The fetched related subentities.
 
         """
-        return await self.shared_client.fetch_subentities_ids(
+        return await self.shared_client.fetch_subentities(
             entity_name, entity_id, subentity_types
         )
-
-    async def fetch_subentity_details(
-        self, subentity_ids: dict[str, list[str]]
-    ) -> dict[str, list[Any]]:
-        """Fetch subentity details in parallel for multiple IDs.
-
-        Args:
-            subentity_ids: dictionary mapping entity types to lists of IDs
-
-        Returns:
-            dictionary mapping entity types to lists of fetched entities
-
-        """
-        return await self.shared_client.fetch_subentity_details(subentity_ids)
 
     def _create_fetcher_factory(self) -> GenericFetcherFactory:
         """Create and configure the fetcher factory with all configurations."""

--- a/external-import/google-ti-feeds/connector/src/custom/client_api/client_api_shared.py
+++ b/external-import/google-ti-feeds/connector/src/custom/client_api/client_api_shared.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any
 
 from connector.src.custom.client_api.client_api_base import BaseClientAPI
-from connector.src.utils.api_engine.exceptions.api_http_error import ApiHttpError
 
 LOG_PREFIX = "[FetcherShared]"
 
@@ -22,10 +21,10 @@ class ClientAPIShared(BaseClientAPI):
         """Initialize Shared Client API."""
         super().__init__(config, logger, api_client, fetcher_factory)
 
-    async def fetch_subentities_ids(
+    async def fetch_subentities(
         self, entity_name: str, entity_id: str, subentity_types: list[str]
-    ) -> dict[str, list[str]]:
-        """Fetch subentities IDs from the API.
+    ) -> dict[str, list[Any]]:
+        """Fetch related subentities with full payloads from the API.
 
         Args:
             entity_name (str): The name of the entity.
@@ -33,17 +32,18 @@ class ClientAPIShared(BaseClientAPI):
             subentity_types (list[str]): The type of subentities to fetch.
 
         Returns:
-            dict[str, list[str]]: The fetched subentities IDs.
+            dict[str, list[Any]]: Related subentities grouped by type.
 
         """
-        subentities_ids = {}
+        subentities: dict[str, list[Any]] = {}
+        total_collection_calls = 0
 
         relationships_fetcher = self.fetcher_factory.create_fetcher_by_name(
             "relationships", base_url=self.config.api_url.unicode_string()
         )
         try:
             for subentity_type in subentity_types:
-                all_ids = []
+                all_entities: list[Any] = []
 
                 params = {
                     entity_name: entity_id,
@@ -55,24 +55,17 @@ class ClientAPIShared(BaseClientAPI):
                     async for page_data in self._paginate_with_cursor(
                         relationships_fetcher, params, f"{subentity_type} relationships"
                     ):
+                        total_collection_calls += 1
                         if isinstance(page_data, list):
-                            all_ids.extend(
-                                [
-                                    item["id"]
-                                    for item in page_data
-                                    if isinstance(item, dict) and item.get("id")
-                                ]
-                            )
+                            all_entities.extend(page_data)
                         elif isinstance(page_data, dict) and "data" in page_data:
                             data = page_data["data"]
                             if isinstance(data, list):
-                                all_ids.extend(
-                                    [
-                                        item["id"]
-                                        for item in data
-                                        if isinstance(item, dict) and item.get("id")
-                                    ]
-                                )
+                                all_entities.extend(data)
+                            elif isinstance(data, dict):
+                                all_entities.append(data)
+                        elif isinstance(page_data, dict):
+                            all_entities.append(page_data)
 
                 except Exception as e:
                     self.logger.debug(
@@ -84,21 +77,24 @@ class ClientAPIShared(BaseClientAPI):
                         },
                     )
 
-                if all_ids:
+                if all_entities:
+                    typed_entities = self._deserialize_subentities(
+                        subentity_type, all_entities
+                    )
                     self.logger.info(
-                        "Retrieved relationship IDs",
+                        "Retrieved related entities",
                         {
                             "prefix": LOG_PREFIX,
-                            "count": len(all_ids),
+                            "count": len(typed_entities),
                             "subentity_type": subentity_type,
                             "entity_name": entity_name,
                             "entity_id": entity_id,
                         },
                     )
-                    subentities_ids[subentity_type] = all_ids
+                    subentities[subentity_type] = typed_entities
                 else:
                     self.logger.debug(
-                        "No relationship IDs found",
+                        "No related entities found",
                         {
                             "prefix": LOG_PREFIX,
                             "subentity_type": subentity_type,
@@ -107,7 +103,6 @@ class ClientAPIShared(BaseClientAPI):
                         },
                     )
 
-            return subentities_ids
         except Exception as e:
             self.logger.error(
                 "Failed to gather relationships",
@@ -119,7 +114,7 @@ class ClientAPIShared(BaseClientAPI):
                 },
             )
             return {entity_type: [] for entity_type in subentity_types}
-        finally:
+        else:
             self.logger.info(
                 "Finished gathering relationships",
                 {
@@ -128,85 +123,43 @@ class ClientAPIShared(BaseClientAPI):
                     "entity_id": entity_id,
                 },
             )
+            return subentities
 
-    async def fetch_subentity_details(
-        self, subentity_ids: dict[str, list[str]]
-    ) -> dict[str, list[Any]]:
-        """Fetch subentity details in parallel for multiple IDs.
-
-        Args:
-            subentity_ids: dictionary mapping entity types to lists of IDs
-
-        Returns:
-            dictionary mapping entity types to lists of fetched entities
-
-        """
-        subentities: dict[str, list[Any]] = {}
-        total_to_fetch = sum(len(ids) for ids in subentity_ids.values())
-
-        if total_to_fetch > 0:
-            self.logger.info(
-                "Fetching details for subentities",
-                {"prefix": LOG_PREFIX, "total_to_fetch": total_to_fetch},
+    def _deserialize_subentities(
+        self, subentity_type: str, entities: list[Any]
+    ) -> list[Any]:
+        """Deserialize related entities to their configured model when available."""
+        try:
+            fetcher = self.fetcher_factory.create_fetcher_by_name(
+                subentity_type, base_url=self.config.api_url.unicode_string()
             )
+            response_model = fetcher.config.response_model
+        except Exception as e:
+            self.logger.debug(
+                "Could not create typed fetcher for related entities",
+                {
+                    "prefix": LOG_PREFIX,
+                    "subentity_type": subentity_type,
+                    "error": str(e),
+                },
+            )
+            response_model = None
 
-        for entity_type, ids in subentity_ids.items():
-            if not ids:
-                subentities[entity_type] = []
-                continue
-
-            try:
-                fetcher = self.fetcher_factory.create_fetcher_by_name(
-                    entity_type, base_url=self.config.api_url.unicode_string()
-                )
-                entities = await fetcher.fetch_multiple(ids)
-                subentities[entity_type] = entities
-                self.logger.debug(
-                    "Fetched entities",
-                    {
-                        "prefix": LOG_PREFIX,
-                        "count": len(entities),
-                        "entity_type": entity_type,
-                    },
-                )
-
-            except ApiHttpError as e:
-                if e.status_code == 404 and entity_type == "files":
-                    self.logger.info(
-                        "404 errors expected for files (files may no longer exist in VirusTotal). Treating as normal behavior.",
-                        {"prefix": LOG_PREFIX},
-                    )
-                    subentities[entity_type] = []
-                else:
-                    self.logger.error(
-                        "HTTP error fetching details",
+        deserialized_entities: list[Any] = []
+        for entity in entities:
+            if response_model and isinstance(entity, dict):
+                try:
+                    deserialized_entities.append(response_model.model_validate(entity))
+                    continue
+                except Exception as e:
+                    self.logger.debug(
+                        "Failed to deserialize related entity, keeping raw payload",
                         {
                             "prefix": LOG_PREFIX,
-                            "status_code": e.status_code,
-                            "entity_type": entity_type,
+                            "subentity_type": subentity_type,
                             "error": str(e),
                         },
                     )
-                    subentities[entity_type] = []
-            except Exception as e:
-                self.logger.error(
-                    "Failed to fetch details",
-                    {
-                        "prefix": LOG_PREFIX,
-                        "entity_type": entity_type,
-                        "error": str(e),
-                    },
-                )
-                subentities[entity_type] = []
+            deserialized_entities.append(entity)
 
-        if total_to_fetch > 0:
-            fetched_summary = ", ".join(
-                [f"{k}: {len(v)}" for k, v in subentities.items() if len(v) > 0]
-            )
-            if fetched_summary:
-                self.logger.info(
-                    "Fetched details",
-                    {"prefix": LOG_PREFIX, "summary": fetched_summary},
-                )
-
-        return subentities
+        return deserialized_entities

--- a/external-import/google-ti-feeds/connector/src/custom/configs/fetcher_config_common.py
+++ b/external-import/google-ti-feeds/connector/src/custom/configs/fetcher_config_common.py
@@ -43,7 +43,7 @@ GTI_ATTACK_TECHNIQUE_FETCHER_CONFIG = GenericFetcherConfig(
 
 GTI_RELATIONSHIP_FETCHER_CONFIG = GenericFetcherConfig(
     entity_type="relationships",
-    endpoint="/collections/{entity_id}/relationships/{entity_type}",
+    endpoint="/collections/{entity_id}/{entity_type}",
     display_name="relationships",
     exception_class=GTIRelationshipFetchError,
     response_model=None,

--- a/external-import/google-ti-feeds/connector/src/custom/orchestrators/campaign/orchestrator_campaign.py
+++ b/external-import/google-ti-feeds/connector/src/custom/orchestrators/campaign/orchestrator_campaign.py
@@ -97,14 +97,14 @@ class OrchestratorCampaign(BaseOrchestrator):
                     campaign_entities = self.converter.convert_campaign_to_stix(
                         campaign
                     )
-                    subentities_ids = await self.client_api.fetch_subentities_ids(
+                    subentities = await self.client_api.fetch_subentities(
                         entity_name="entity_id",
                         entity_id=campaign.id,
                         subentity_types=subentity_types,
                     )
 
                     rel_summary = ", ".join(
-                        [f"{k}: {len(v)}" for k, v in subentities_ids.items()]
+                        [f"{k}: {len(v)}" for k, v in subentities.items()]
                     )
                     if len(rel_summary) > 0:
                         self.logger.info(
@@ -117,13 +117,12 @@ class OrchestratorCampaign(BaseOrchestrator):
                             },
                         )
 
-                    # Skip fetch_subentity_details for attack_techniques (quota optimization)
-                    attack_technique_ids = subentities_ids.get("attack_techniques", [])
-                    filtered_subentities_ids = {
-                        k: v
-                        for k, v in subentities_ids.items()
-                        if k != "attack_techniques"
-                    }
+                    attack_technique_entities = subentities.pop("attack_techniques", [])
+                    attack_technique_ids = [
+                        attack_technique.id
+                        for attack_technique in attack_technique_entities
+                        if getattr(attack_technique, "id", None)
+                    ]
 
                     if attack_technique_ids:
                         self.logger.info(
@@ -134,11 +133,7 @@ class OrchestratorCampaign(BaseOrchestrator):
                             },
                         )
 
-                    subentities_detailed = (
-                        await self.client_api.fetch_subentity_details(
-                            filtered_subentities_ids
-                        )
-                    )
+                    subentities_detailed = subentities
 
                     # Convert attack technique IDs to proper model format for conversion
                     if attack_technique_ids:

--- a/external-import/google-ti-feeds/connector/src/custom/orchestrators/malware/orchestrator_malware.py
+++ b/external-import/google-ti-feeds/connector/src/custom/orchestrators/malware/orchestrator_malware.py
@@ -94,14 +94,14 @@ class OrchestratorMalware(BaseOrchestrator):
                     malware_family_entities = (
                         self.converter.convert_malware_family_to_stix(malware_family)
                     )
-                    subentities_ids = await self.client_api.fetch_subentities_ids(
+                    subentities = await self.client_api.fetch_subentities(
                         entity_name="entity_id",
                         entity_id=malware_family.id,
                         subentity_types=subentity_types,
                     )
 
                     rel_summary = ", ".join(
-                        [f"{k}: {len(v)}" for k, v in subentities_ids.items()]
+                        [f"{k}: {len(v)}" for k, v in subentities.items()]
                     )
                     if len(rel_summary) > 0:
                         self.logger.info(
@@ -114,13 +114,12 @@ class OrchestratorMalware(BaseOrchestrator):
                             },
                         )
 
-                    # Skip fetch_subentity_details for attack_techniques (quota optimization)
-                    attack_technique_ids = subentities_ids.get("attack_techniques", [])
-                    filtered_subentities_ids = {
-                        k: v
-                        for k, v in subentities_ids.items()
-                        if k != "attack_techniques"
-                    }
+                    attack_technique_entities = subentities.pop("attack_techniques", [])
+                    attack_technique_ids = [
+                        attack_technique.id
+                        for attack_technique in attack_technique_entities
+                        if getattr(attack_technique, "id", None)
+                    ]
 
                     if attack_technique_ids:
                         self.logger.info(
@@ -131,11 +130,7 @@ class OrchestratorMalware(BaseOrchestrator):
                             },
                         )
 
-                    subentities_detailed = (
-                        await self.client_api.fetch_subentity_details(
-                            filtered_subentities_ids
-                        )
-                    )
+                    subentities_detailed = subentities
 
                     # Convert attack technique IDs to proper model format for conversion
                     if attack_technique_ids:

--- a/external-import/google-ti-feeds/connector/src/custom/orchestrators/report/orchestrator_report.py
+++ b/external-import/google-ti-feeds/connector/src/custom/orchestrators/report/orchestrator_report.py
@@ -92,14 +92,14 @@ class OrchestratorReport(BaseOrchestrator):
                 for report_idx, report in enumerate(gti_reports):
                     self._update_index_inplace()
                     report_entities = self.converter.convert_report_to_stix(report)
-                    subentities_ids = await self.client_api.fetch_subentities_ids(
+                    subentities = await self.client_api.fetch_subentities(
                         entity_name="entity_id",
                         entity_id=report.id,
                         subentity_types=subentity_types,
                     )
 
                     rel_summary = ", ".join(
-                        [f"{k}: {len(v)}" for k, v in subentities_ids.items()]
+                        [f"{k}: {len(v)}" for k, v in subentities.items()]
                     )
                     if len(rel_summary) > 0:
                         self.logger.info(
@@ -112,13 +112,12 @@ class OrchestratorReport(BaseOrchestrator):
                             },
                         )
 
-                    # Skip fetch_subentity_details for attack_techniques (quota optimization)
-                    attack_technique_ids = subentities_ids.get("attack_techniques", [])
-                    filtered_subentities_ids = {
-                        k: v
-                        for k, v in subentities_ids.items()
-                        if k != "attack_techniques"
-                    }
+                    attack_technique_entities = subentities.pop("attack_techniques", [])
+                    attack_technique_ids = [
+                        attack_technique.id
+                        for attack_technique in attack_technique_entities
+                        if getattr(attack_technique, "id", None)
+                    ]
 
                     if attack_technique_ids:
                         self.logger.info(
@@ -129,11 +128,7 @@ class OrchestratorReport(BaseOrchestrator):
                             },
                         )
 
-                    subentities_detailed = (
-                        await self.client_api.fetch_subentity_details(
-                            filtered_subentities_ids
-                        )
-                    )
+                    subentities_detailed = subentities
 
                     # Convert attack technique IDs to proper model format for conversion
                     if attack_technique_ids:

--- a/external-import/google-ti-feeds/connector/src/custom/orchestrators/threat_actor/orchestrator_threat_actor.py
+++ b/external-import/google-ti-feeds/connector/src/custom/orchestrators/threat_actor/orchestrator_threat_actor.py
@@ -99,14 +99,14 @@ class OrchestratorThreatActor(BaseOrchestrator):
                     threat_actor_entities = self.converter.convert_threat_actor_to_stix(
                         threat_actor
                     )
-                    subentities_ids = await self.client_api.fetch_subentities_ids(
+                    subentities = await self.client_api.fetch_subentities(
                         entity_name="entity_id",
                         entity_id=threat_actor.id,
                         subentity_types=subentity_types,
                     )
 
                     rel_summary = ", ".join(
-                        [f"{k}: {len(v)}" for k, v in subentities_ids.items()]
+                        [f"{k}: {len(v)}" for k, v in subentities.items()]
                     )
                     if len(rel_summary) > 0:
                         self.logger.info(
@@ -119,13 +119,12 @@ class OrchestratorThreatActor(BaseOrchestrator):
                             },
                         )
 
-                    # Skip fetch_subentity_details for attack_techniques (quota optimization)
-                    attack_technique_ids = subentities_ids.get("attack_techniques", [])
-                    filtered_subentities_ids = {
-                        k: v
-                        for k, v in subentities_ids.items()
-                        if k != "attack_techniques"
-                    }
+                    attack_technique_entities = subentities.pop("attack_techniques", [])
+                    attack_technique_ids = [
+                        attack_technique.id
+                        for attack_technique in attack_technique_entities
+                        if getattr(attack_technique, "id", None)
+                    ]
 
                     if attack_technique_ids:
                         self.logger.info(
@@ -136,11 +135,7 @@ class OrchestratorThreatActor(BaseOrchestrator):
                             },
                         )
 
-                    subentities_detailed = (
-                        await self.client_api.fetch_subentity_details(
-                            filtered_subentities_ids
-                        )
-                    )
+                    subentities_detailed = subentities
 
                     # Convert attack technique IDs to proper model format for conversion
                     if attack_technique_ids:

--- a/external-import/google-ti-feeds/connector/src/custom/orchestrators/vulnerability/orchestrator_vulnerability.py
+++ b/external-import/google-ti-feeds/connector/src/custom/orchestrators/vulnerability/orchestrator_vulnerability.py
@@ -99,14 +99,14 @@ class OrchestratorVulnerability(BaseOrchestrator):
                     vulnerability_entities = (
                         self.converter.convert_vulnerability_to_stix(vulnerability)
                     )
-                    subentities_ids = await self.client_api.fetch_subentities_ids(
+                    subentities = await self.client_api.fetch_subentities(
                         entity_name="entity_id",
                         entity_id=vulnerability.id,
                         subentity_types=subentity_types,
                     )
 
                     rel_summary = ", ".join(
-                        [f"{k}: {len(v)}" for k, v in subentities_ids.items()]
+                        [f"{k}: {len(v)}" for k, v in subentities.items()]
                     )
                     if len(rel_summary) > 0:
                         self.logger.info(
@@ -119,13 +119,12 @@ class OrchestratorVulnerability(BaseOrchestrator):
                             },
                         )
 
-                    # Skip fetch_subentity_details for attack_techniques (quota optimization)
-                    attack_technique_ids = subentities_ids.get("attack_techniques", [])
-                    filtered_subentities_ids = {
-                        k: v
-                        for k, v in subentities_ids.items()
-                        if k != "attack_techniques"
-                    }
+                    attack_technique_entities = subentities.pop("attack_techniques", [])
+                    attack_technique_ids = [
+                        attack_technique.id
+                        for attack_technique in attack_technique_entities
+                        if getattr(attack_technique, "id", None)
+                    ]
 
                     if attack_technique_ids:
                         self.logger.info(
@@ -136,11 +135,7 @@ class OrchestratorVulnerability(BaseOrchestrator):
                             },
                         )
 
-                    subentities_detailed = (
-                        await self.client_api.fetch_subentity_details(
-                            filtered_subentities_ids
-                        )
-                    )
+                    subentities_detailed = subentities
 
                     # Convert attack technique IDs to proper model format for conversion
                     if attack_technique_ids:

--- a/external-import/google-ti-feeds/connector/src/utils/fetchers/generic_fetcher.py
+++ b/external-import/google-ti-feeds/connector/src/utils/fetchers/generic_fetcher.py
@@ -13,8 +13,15 @@ from typing import Any
 from connector.src.utils.api_engine.api_client import ApiClient
 from connector.src.utils.api_engine.exceptions.api_network_error import ApiNetworkError
 from connector.src.utils.fetchers.generic_fetcher_config import GenericFetcherConfig
+from prometheus_client import Counter
 
 LOG_PREFIX = "[GenericFetcher]"
+
+_ENDPOINT_CALL_COUNTER = Counter(
+    "google_ti_feeds_api_endpoint_calls",
+    "Count of API calls made by GenericFetcher for each Google TI Feeds API endpoint",
+    ["endpoint"],
+)
 
 
 class GenericFetcher:
@@ -42,6 +49,8 @@ class GenericFetcher:
         self.api_client = api_client
         self.base_url = base_url
         self.logger = logger or logging.getLogger(__name__)
+
+        self._endpoint_counter: dict[str, Counter] = {}
 
         self.headers = {}
         if base_headers:
@@ -405,6 +414,14 @@ class GenericFetcher:
                     "query_params": query_params,
                 },
             )
+
+            if self.config.endpoint not in self._endpoint_counter:
+                # Initialize a Prometheus counter for this endpoint if it doesn't exist
+                self._endpoint_counter[self.config.endpoint] = (
+                    _ENDPOINT_CALL_COUNTER.labels(endpoint=self.config.endpoint)
+                )
+
+            self._endpoint_counter[self.config.endpoint].inc()
 
             response = await self.api_client.call_api(
                 url=endpoint,

--- a/external-import/google-ti-feeds/tests/custom/test_orchestrator.py
+++ b/external-import/google-ti-feeds/tests/custom/test_orchestrator.py
@@ -128,23 +128,40 @@ def patch_perform_single_attempt(monkeypatch: Any) -> Any:
             "GTICampaignData": "campaigns",
         }
 
-        if "relationship" in self.api_req.url:
-            response_key = "relationships"
-        elif (
-            "/collections" in self.api_req.url
-            and hasattr(self.api_req, "model")
-            and self.api_req.model
-        ):
-            # Check if this is a main collection fetch or a specific collection entity fetch
-            url_parts = self.api_req.url.split("/")
-            if len(url_parts) > 4 and url_parts[4]:  # /collections/specific-id
-                # This is a specific collection entity fetch (subentity)
+        related_collection_keys = {
+            "malware_families",
+            "threat_actors",
+            "attack_techniques",
+            "vulnerabilities",
+            "campaigns",
+            "domains",
+            "files",
+            "urls",
+            "ip_addresses",
+        }
+
+        if "/collections/" in self.api_req.url:
+            url_parts = [part for part in self.api_req.url.split("/") if part]
+            endpoint_tail = url_parts[-1].split("?")[0] if url_parts else ""
+
+            if endpoint_tail in related_collection_keys:
+                response_key = endpoint_tail
+            elif (
+                hasattr(self.api_req, "model")
+                and self.api_req.model
+                and endpoint_tail != "collections"
+            ):
+                # This is a specific collection entity fetch (legacy subentity route)
                 model_name = self.api_req.model.__name__
                 response_key = model_mapping.get(model_name, "reports")
-            else:
+            elif hasattr(self.api_req, "model") and self.api_req.model:
                 # This is a main collection fetch
                 model_name = self.api_req.model.__name__
                 response_key = model_mapping.get(model_name, "main_reports")
+            else:
+                response_key = "reports"
+        elif "relationship" in self.api_req.url:
+            response_key = "relationships"
         else:
             # Other subentity fetches
             model_name = (
@@ -203,16 +220,6 @@ def expected_report_log_messages() -> list[str]:
         "Fetched 1 ip_addresses relationships from API - {'prefix': '[BaseFetcher]'}",
         "Found relationships - {'prefix': '[OrchestratorReport]', 'current': 1, 'total': 1, 'relationships': 'malware_families: 1, threat_actors: 1, attack_techniques: 1, vulnerabilities: 1, campaigns: 1, domains: 1, files: 1, urls: 1, ip_addresses: 1'}",
         "Using ID-only approach for attack techniques (quota optimization) - {'prefix': '[OrchestratorReport]', 'attack_technique_count': 1}",
-        "Fetching details for subentities - {'prefix': '[FetcherShared]', 'total_to_fetch': 8}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'malware families'}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'threat actors'}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'vulnerabilities'}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'campaigns'}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'domains'}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'files'}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'URLs'}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'IP addresses'}",
-        "Fetched details - {'prefix': '[FetcherShared]', 'summary': 'malware_families: 1, threat_actors: 1, vulnerabilities: 1, campaigns: 1, domains: 1, files: 1, urls: 1, ip_addresses: 1'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 33, 'entity_type': 'malware families'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 53, 'entity_type': 'threat actors'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 52, 'entity_type': 'vulnerabilities'}",
@@ -244,10 +251,6 @@ def expected_threat_actor_log_messages() -> list[str]:
         "Fetched 1 vulnerabilities relationships from API - {'prefix': '[BaseFetcher]'}",
         "Found relationships - {'prefix': '[OrchestratorThreatActor]', 'current': 1, 'total': 1, 'relationships': 'malware_families: 1, attack_techniques: 1, vulnerabilities: 1'}",
         "Using ID-only approach for attack techniques (quota optimization) - {'prefix': '[OrchestratorThreatActor]', 'attack_technique_count': 1}",
-        "Fetching details for subentities - {'prefix': '[FetcherShared]', 'total_to_fetch': 2}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'malware families'}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'vulnerabilities'}",
-        "Fetched details - {'prefix': '[FetcherShared]', 'summary': 'malware_families: 1, vulnerabilities: 1'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 34, 'entity_type': 'malware families'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 53, 'entity_type': 'vulnerabilities'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 2, 'entity_type': 'attack techniques'}",
@@ -273,10 +276,6 @@ def expected_malware_family_log_messages() -> list[str]:
         "Fetched 1 vulnerabilities relationships from API - {'prefix': '[BaseFetcher]'}",
         "Found relationships - {'prefix': '[OrchestratorMalware]', 'current': 1, 'total': 1, 'relationships': 'threat_actors: 1, attack_techniques: 1, vulnerabilities: 1'}",
         "Using ID-only approach for attack techniques (quota optimization) - {'prefix': '[OrchestratorMalware]', 'attack_technique_count': 1}",
-        "Fetching details for subentities - {'prefix': '[FetcherShared]', 'total_to_fetch': 2}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'threat actors'}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'vulnerabilities'}",
-        "Fetched details - {'prefix': '[FetcherShared]', 'summary': 'threat_actors: 1, vulnerabilities: 1'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 54, 'entity_type': 'threat actors'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 53, 'entity_type': 'vulnerabilities'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 2, 'entity_type': 'attack techniques'}",
@@ -302,10 +301,6 @@ def expected_vulnerability_log_messages_no_software() -> list[str]:
         "Fetched 1 threat_actors relationships from API - {'prefix': '[BaseFetcher]'}",
         "Found relationships - {'prefix': '[OrchestratorVulnerability]', 'current': 1, 'total': 1, 'relationships': 'malware_families: 1, attack_techniques: 1, threat_actors: 1'}",
         "Using ID-only approach for attack techniques (quota optimization) - {'prefix': '[OrchestratorVulnerability]', 'attack_technique_count': 1}",
-        "Fetching details for subentities - {'prefix': '[FetcherShared]', 'total_to_fetch': 2}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'malware families'}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'threat actors'}",
-        "Fetched details - {'prefix': '[FetcherShared]', 'summary': 'malware_families: 1, threat_actors: 1'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 34, 'entity_type': 'malware families'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 54, 'entity_type': 'threat actors'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 2, 'entity_type': 'attack techniques'}",
@@ -331,10 +326,6 @@ def expected_vulnerability_log_messages() -> list[str]:
         "Fetched 1 threat_actors relationships from API - {'prefix': '[BaseFetcher]'}",
         "Found relationships - {'prefix': '[OrchestratorVulnerability]', 'current': 1, 'total': 1, 'relationships': 'malware_families: 1, attack_techniques: 1, threat_actors: 1'}",
         "Using ID-only approach for attack techniques (quota optimization) - {'prefix': '[OrchestratorVulnerability]', 'attack_technique_count': 1}",
-        "Fetching details for subentities - {'prefix': '[FetcherShared]', 'total_to_fetch': 2}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'malware families'}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'threat actors'}",
-        "Fetched details - {'prefix': '[FetcherShared]', 'summary': 'malware_families: 1, threat_actors: 1'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 34, 'entity_type': 'malware families'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 54, 'entity_type': 'threat actors'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 2, 'entity_type': 'attack techniques'}",
@@ -361,11 +352,6 @@ def expected_campaign_log_messages() -> list[str]:
         "Fetched 1 threat_actors relationships from API - {'prefix': '[BaseFetcher]'}",
         "Found relationships - {'prefix': '[OrchestratorCampaign]', 'current': 1, 'total': 1, 'relationships': 'malware_families: 1, attack_techniques: 1, vulnerabilities: 1, threat_actors: 1'}",
         "Using ID-only approach for attack techniques (quota optimization) - {'prefix': '[OrchestratorCampaign]', 'attack_technique_count': 1}",
-        "Fetching details for subentities - {'prefix': '[FetcherShared]', 'total_to_fetch': 3}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'malware families'}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'vulnerabilities'}",
-        "Fetched entities - {'prefix': '[GenericFetcher]', 'count': 1, 'entity_type': 'threat actors'}",
-        "Fetched details - {'prefix': '[FetcherShared]', 'summary': 'malware_families: 1, vulnerabilities: 1, threat_actors: 1'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 34, 'entity_type': 'malware families'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 53, 'entity_type': 'vulnerabilities'}",
         "Converted entities to STIX format - {'prefix': '[GenericConverter]', 'count': 54, 'entity_type': 'threat actors'}",
@@ -653,7 +639,9 @@ def _load_debug_responses(debug_folder: Path) -> dict[str, Any]:
         files = sorted(debug_folder.glob(f"{response_type}_*.json"))
         assert (  # noqa: S101
             len(files) == 1
-        ), f"Expected exactly one {response_type}_*.json under {debug_folder}, got {len(files)}"
+        ), (
+            f"Expected exactly one {response_type}_*.json under {debug_folder}, got {len(files)}"
+        )
 
         data = json.loads(files[0].read_text(encoding="utf-8"))
         response_data[response_type] = data.get("response", data)

--- a/external-import/google-ti-feeds/tests/custom/test_orchestrator.py
+++ b/external-import/google-ti-feeds/tests/custom/test_orchestrator.py
@@ -639,9 +639,7 @@ def _load_debug_responses(debug_folder: Path) -> dict[str, Any]:
         files = sorted(debug_folder.glob(f"{response_type}_*.json"))
         assert (  # noqa: S101
             len(files) == 1
-        ), (
-            f"Expected exactly one {response_type}_*.json under {debug_folder}, got {len(files)}"
-        )
+        ), f"Expected exactly one {response_type}_*.json under {debug_folder}, got {len(files)}"
 
         data = json.loads(files[0].read_text(encoding="utf-8"))
         response_data[response_type] = data.get("response", data)

--- a/external-import/google-ti-feeds/tests/octi/configs/test_connector_config.py
+++ b/external-import/google-ti-feeds/tests/octi/configs/test_connector_config.py
@@ -278,33 +278,34 @@ def _when_connector_created() -> tuple[Any, Any]:
 # Then the connector should be created successfully
 def _then_connector_created_successfully(capfd, mock_env, connector, data) -> None:  # type: ignore
     """Check if the connector was created successfully."""
-    assert connector is not None  # noqa: S101
+    try:
+        assert connector is not None  # noqa: S101
 
-    for key, value in data.items():
-        if key.startswith("OPENCTI_"):
-            config_key = key[len("OPENCTI_") :].lower()
-            attr = getattr(connector._config.octi_config, config_key)
-            if isinstance(attr, HttpUrl):
-                assert attr.encoded_string() == value  # noqa: S101
-            else:
-                assert attr == value  # noqa: S101
-        elif key.startswith("CONNECTOR_"):
-            config_key = key[len("CONNECTOR_") :].lower()
-            attr = getattr(connector._config.connector_config, config_key)
-            if config_key == "duration_period":
-                assert attr == isodate.parse_duration(value)  # noqa: S101
-            else:
+        for key, value in data.items():
+            if key.startswith("OPENCTI_"):
+                config_key = key[len("OPENCTI_") :].lower()
+                attr = getattr(connector._config.octi_config, config_key)
                 if isinstance(attr, HttpUrl):
                     assert attr.encoded_string() == value  # noqa: S101
                 else:
-                    assert str(attr) == value  # noqa: S101
+                    assert attr == value  # noqa: S101
+            elif key.startswith("CONNECTOR_"):
+                config_key = key[len("CONNECTOR_") :].lower()
+                attr = getattr(connector._config.connector_config, config_key)
+                if config_key == "duration_period":
+                    assert attr == isodate.parse_duration(value)  # noqa: S101
+                else:
+                    if isinstance(attr, HttpUrl):
+                        assert attr.encoded_string() == value  # noqa: S101
+                    else:
+                        assert str(attr) == value  # noqa: S101
 
-    log_records = capfd.readouterr()
-    if connector._config.connector_config.log_level in ["info", "debug"]:
-        registered_message = f'"name": "{connector._config.connector_config.name}", "message": "Connector registered with ID", "attributes": {{"id": "{connector._config.connector_config.id}"}}'
-        assert registered_message in log_records.err  # noqa: S101
-
-    mock_env.stop()
+        log_records = capfd.readouterr()
+        if connector._config.connector_config.log_level in ["info", "debug"]:
+            assert "Connector registered with ID" in log_records.err  # noqa: S101
+            assert f'"id": "{connector._config.connector_config.id}"' in log_records.err  # noqa: S101
+    finally:
+        mock_env.stop()
 
 
 # Then the connector config should raise a custom ConfigurationException
@@ -312,7 +313,8 @@ def _then_connector_configuration_exception(  # type: ignore
     mock_env, connector, config_ex
 ) -> None:
     """Check if the connector config raises a custom ConfigurationException."""
-    assert connector is None  # noqa: S101
-    assert isinstance(config_ex, ConfigurationError)  # noqa: S101
-
-    mock_env.stop()
+    try:
+        assert connector is None  # noqa: S101
+        assert isinstance(config_ex, ConfigurationError)  # noqa: S101
+    finally:
+        mock_env.stop()

--- a/external-import/google-ti-feeds/tests/octi/configs/test_connector_config.py
+++ b/external-import/google-ti-feeds/tests/octi/configs/test_connector_config.py
@@ -303,7 +303,9 @@ def _then_connector_created_successfully(capfd, mock_env, connector, data) -> No
         log_records = capfd.readouterr()
         if connector._config.connector_config.log_level in ["info", "debug"]:
             assert "Connector registered with ID" in log_records.err  # noqa: S101
-            assert f'"id": "{connector._config.connector_config.id}"' in log_records.err  # noqa: S101
+            assert (
+                f'"id": "{connector._config.connector_config.id}"' in log_records.err
+            )  # noqa: S101
     finally:
         mock_env.stop()
 


### PR DESCRIPTION
### Proposed changes

* Refactored relationship retrieval to use direct collections endpoints (`/collections/{entity_id}/{entity_type}`) and return related entities directly instead of re-fetching details, reducing extra API calls and simplifying data flow.
* Updated orchestrators (`campaign`, `malware`, `report`, `threat_actor`, `vulnerability`) to consume direct related-entity payloads while preserving attack-technique ID-only optimization.
* Added Prometheus endpoint-call instrumentation in `GenericFetcher` via `google_ti_feeds_api_endpoint_calls{endpoint="..."}` for API usage observability.
* Updated fixtures and assertions in orchestrator/config tests to match direct relationship payload behavior and improve stability.
* Updated `CONTRIBUTING.md` to reference the renamed API method (`fetch_subentities`).
* Added a follow-up style commit normalizing test file line endings to satisfy `black` in pre-commit.

### Related issues

* Closes #6236

### Checklist

- [x] I consider the submitted work as finished
- [z] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
