### PR TITLE
[Recorded Future] Fix unsafe key access in panel evidence summary fields

### DIFF
--- a/external-import/recorded-future/src/rflib/rf_playbook_alerts.py
+++ b/external-import/recorded-future/src/rflib/rf_playbook_alerts.py
@@ -871,31 +871,25 @@ class RecordedFuturePlaybookAlertConnector(threading.Thread):
                 created_by_ref=self.author["id"],
             )
             bundle_objects.append(stix_note)
-        evidence_summary_content = ""
-        if len(playbook_alert["data"]["panel_evidence_summary"]) > 0 and (
-            len(
-                playbook_alert["data"]["panel_evidence_summary"]["resolved_record_list"]
-            )
-            > 0
-            or len(playbook_alert["data"]["panel_evidence_summary"]["screenshots"]) > 0
+
+        panel_evidence_summary = playbook_alert["data"]["panel_evidence_summary"]
+        if len(panel_evidence_summary) > 0 and (
+            len(panel_evidence_summary["resolved_record_list"]) > 0
+            or len(panel_evidence_summary["screenshots"]) > 0
         ):
             evidence_summary_content = "### Resolved records"
-            for record in playbook_alert["data"]["panel_evidence_summary"][
-                "resolved_record_list"
-            ]:
-                evidence_summary_content = (
-                    evidence_summary_content
-                    + "\n"
-                    + make_markdown_table(
-                        [
-                            ["Key", "Value"],
-                            ["entity", str(record["entity"])],
-                            ["risk_score", str(record["risk_score"])],
-                            ["criticality", str(record["criticality"])],
-                            ["record_type", str(record["record_type"])],
-                            ["context_list", str(record["context_list"])],
-                        ]
-                    )
-                )
+            for record in panel_evidence_summary["resolved_record_list"]:
+                markdown_table = [["Key", "Value"]]
+                for key in [
+                    "entity",
+                    "risk_score",
+                    "criticality",
+                    "record_type",
+                    "context_list",
+                ]:
+                    # Set value to N/A if key is not present in the record
+                    markdown_table.append([key, str(record.get(key, "N/A"))])
+                evidence_summary_content += f"\n{make_markdown_table(markdown_table)}"
+
         bundle = stix2.Bundle(objects=bundle_objects, allow_custom=True).serialize()
         self.helper.send_stix2_bundle(bundle, update=True, work_id=self.work_id)


### PR DESCRIPTION
### Proposed changes

* Extract `panel_evidence_summary` into a local variable to eliminate repeated deep-access chains and improve readability.
* Replace direct dictionary key access (`record["key"]`) with `.get(key, "N/A")` for all five evidence record fields (`entity`, `risk_score`, `criticality`, `record_type`, `context_list`), preventing `KeyError` crashes when the Recorded Future API returns records with missing or optional fields.
* Refactor the markdown table construction into a loop over a list of field names, reducing code duplication and making it trivial to add or remove fields in future.
* Use `+=` string concatenation in place of explicit reassignment.

### Related issues

* Closes #6313

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Direct key access (`record["risk_score"]`) raises an unhandled `KeyError` if the Recorded Future API omits any field from a panel evidence record — for example when a record type doesn't carry a `criticality` score. This would silently abort processing of the entire playbook alert bundle. Using `.get(key, "N/A")` makes the connector resilient to partial API responses while still surfacing that a value was absent, rather than hiding the gap entirely.