### PR TITLE
[RansomwareLive] Add HTTP retry on rate limit

### DIFF
--- a/external-import/ransomwarelive/src/models/configs/config_loader.py
+++ b/external-import/ransomwarelive/src/models/configs/config_loader.py
@@ -1,3 +1,4 @@
+import datetime
 import warnings
 from datetime import timedelta
 from pathlib import Path
@@ -9,7 +10,7 @@ from models.configs.connector_configs import (
     _ConfigLoaderConnector,
     _ConfigLoaderOCTI,
 )
-from pydantic import Field, model_validator
+from pydantic import Field, TypeAdapter, model_validator
 from pydantic_settings import (
     BaseSettings,
     DotEnvSettingsSource,
@@ -121,6 +122,11 @@ class ConfigLoader(ConfigBaseSettings):
                 )
             else:
                 raise ValueError(f"Invalid value for CONNECTOR_RUN_EVERY: {run_every}")
+
+        timedelta_adapter = TypeAdapter(datetime.timedelta)
+        td = timedelta_adapter.validate_python(connector_data["duration_period"])
+        if td < timedelta(minutes=1):
+            raise ValueError("CONNECTOR_DURATION_PERIOD must be greater than 1 minute")
 
         return data
 

--- a/external-import/ransomwarelive/src/models/configs/config_loader.py
+++ b/external-import/ransomwarelive/src/models/configs/config_loader.py
@@ -123,10 +123,14 @@ class ConfigLoader(ConfigBaseSettings):
             else:
                 raise ValueError(f"Invalid value for CONNECTOR_RUN_EVERY: {run_every}")
 
+        duration_period = connector_data.get("duration_period")
+        if duration_period is None:
+            return data
+
         timedelta_adapter = TypeAdapter(datetime.timedelta)
-        td = timedelta_adapter.validate_python(connector_data["duration_period"])
+        td = timedelta_adapter.validate_python(duration_period)
         if td < timedelta(minutes=1):
-            raise ValueError("CONNECTOR_DURATION_PERIOD must be greater than 1 minute")
+            raise ValueError("CONNECTOR_DURATION_PERIOD must at least 1 minute")
 
         return data
 

--- a/external-import/ransomwarelive/src/ransomwarelive/api_client.py
+++ b/external-import/ransomwarelive/src/ransomwarelive/api_client.py
@@ -13,6 +13,7 @@ _RETRY_BACKOFF_FACTOR = 60  # seconds — matches the API's "1 per 1 minute" rat
 _RETRY_BACKOFF_JITTER = (
     30  # seconds of random jitter to spread retries across instances
 )
+_REQUEST_TIMEOUT_SECONDS = 30
 
 API_BASE_URL = "https://api.ransomware.live/v2/"
 
@@ -50,6 +51,7 @@ class RansomwareAPIClient:
             response = self._session.get(
                 url,
                 headers={"accept": "application/json", "User-Agent": "OpenCTI"},
+                timeout=_REQUEST_TIMEOUT_SECONDS,
             )
             response.raise_for_status()
 
@@ -101,5 +103,19 @@ class RansomwareAPIClient:
         """
         url = f"{API_BASE_URL}{path}"
         data = self._send_request(url)
+
+        if data is None:
+            return []
+
+        if not isinstance(data, list):
+            raise RansomwareAPIError(
+                "Unexpected Ransomware API response type for feed",
+                {"url": f"GET {url}", "response_type": type(data).__name__},
+            )
+        if not all(isinstance(item, dict) for item in data):
+            raise RansomwareAPIError(
+                "Unexpected Ransomware API feed item type",
+                {"url": f"GET {url}", "response_type": "list"},
+            )
 
         return data

--- a/external-import/ransomwarelive/src/ransomwarelive/api_client.py
+++ b/external-import/ransomwarelive/src/ransomwarelive/api_client.py
@@ -1,33 +1,71 @@
 import requests
+from pycti import OpenCTIConnectorHelper
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 
 class RansomwareAPIError(Exception):
     """Custom wrapper for exceptions raised in RansomwareAPIClient"""
 
 
+_MAX_RETRIES = 5
+_RETRY_BACKOFF_FACTOR = 60  # seconds — matches the API's "1 per 1 minute" rate limit
+_RETRY_BACKOFF_JITTER = (
+    30  # seconds of random jitter to spread retries across instances
+)
+
+API_BASE_URL = "https://api.ransomware.live/v2/"
+
+
 class RansomwareAPIClient:
-    def __init__(
-        self,
-    ):
+    def __init__(self, helper: OpenCTIConnectorHelper):
         """
         Initialize the client with necessary configurations
         """
-        self.api_base_url = "https://api.ransomware.live/v2/"
+        self.helper = helper
+        self._session = self._build_session()
+
+    @staticmethod
+    def _build_session() -> requests.Session:
+        retry = Retry(
+            total=_MAX_RETRIES,
+            status_forcelist=[429],
+            backoff_factor=_RETRY_BACKOFF_FACTOR,
+            backoff_jitter=_RETRY_BACKOFF_JITTER,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session = requests.Session()
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        return session
 
     def _send_request(self, url: str):
         """
         Send a request to Ransomware API.
+        Retries up to _MAX_RETRIES times on HTTP 429 with exponential backoff and jitter.
         :param url: request URL in string
         :return: response data returned by the API
         """
         try:
-            response = requests.get(
-                url, headers={"accept": "application/json", "User-Agent": "OpenCTI"}
+            response = self._session.get(
+                url,
+                headers={"accept": "application/json", "User-Agent": "OpenCTI"},
             )
             response.raise_for_status()
 
             if response.content:
                 return response.json()
+            return None
+
+        except requests.exceptions.RetryError as err:
+            self.helper.connector_logger.error(
+                "Exceeded maximum retries for Ransomware API due to rate limiting",
+                {"url": f"GET {url}", "status_code": 429, "retries": _MAX_RETRIES},
+            )
+            raise RansomwareAPIError(
+                f"Error while fetching Ransomware API: HTTP 429 after {_MAX_RETRIES} retries",
+                {"url": f"GET {url}", "status_code": 429},
+            ) from err
 
         except requests.exceptions.HTTPError as err:
             status = err.response.status_code
@@ -36,16 +74,20 @@ class RansomwareAPIClient:
             if status == 500 and "No victims found" in text:
                 return []
 
+            self.helper.connector_logger.error(
+                "HTTP error while fetching Ransomware API",
+                {"url": f"GET {url}", "status_code": status, "response_body": text},
+            )
             raise RansomwareAPIError(
                 f"Error while fetching Ransomware API: HTTP {status}",
-                {
-                    "url": f"GET {url}",
-                    "status_code": status,
-                    "response_body": text,
-                },
+                {"url": f"GET {url}", "status_code": status, "response_body": text},
             ) from err
 
         except requests.RequestException as err:
+            self.helper.connector_logger.error(
+                "Request error while fetching Ransomware API",
+                {"url": f"GET {url}", "error": str(err)},
+            )
             raise RansomwareAPIError(
                 f"Error while fetching Ransomware API: {err}",
                 {"url": f"GET {url}", "error": err},
@@ -57,7 +99,7 @@ class RansomwareAPIClient:
         :param path: path to get feed from.
         :return: data's feed items
         """
-        url = f"{self.api_base_url}{path}"
+        url = f"{API_BASE_URL}{path}"
         data = self._send_request(url)
 
         return data

--- a/external-import/ransomwarelive/src/ransomwarelive/ransom_conn.py
+++ b/external-import/ransomwarelive/src/ransomwarelive/ransom_conn.py
@@ -29,7 +29,7 @@ class RansomwareAPIConnector:
         self.last_run_datetime_with_ingested_data = None
         self.converter_to_stix = ConverterToStix()
         self.author = self.converter_to_stix.author
-        self.api_client = RansomwareAPIClient()
+        self.api_client = RansomwareAPIClient(helper=self.helper)
 
     def location_fetcher(self, country: str):
         """
@@ -410,9 +410,10 @@ class RansomwareAPIConnector:
         last_run_datetime = self.last_run_datetime_with_ingested_data or self.last_run
 
         for item in response_json:
-            created = datetime.strptime(
-                item.get("discovered"), "%Y-%m-%d %H:%M:%S.%f"
-            ).replace(tzinfo=timezone.utc)
+            discovered_raw = item.get("discovered")
+            created = datetime.fromisoformat(discovered_raw)
+            if created.tzinfo is None:
+                created = created.replace(tzinfo=timezone.utc)
 
             # We only retrieve the data from the last 24h.
             # If no last_run, just put time_diff to 0.

--- a/external-import/ransomwarelive/src/ransomwarelive/ransom_conn.py
+++ b/external-import/ransomwarelive/src/ransomwarelive/ransom_conn.py
@@ -327,6 +327,11 @@ class RansomwareAPIConnector:
         """Collects historic intelligence from ransomware.live"""
         # fetching group information
         group_data = self.api_client.get_feed("groups")
+        if not group_data:
+            self.helper.connector_logger.info(
+                "No group data retrieved from ransomware.live API"
+            )
+            return
 
         # Checking if the historic year is less than 2020 as there is no data past 2020
         year = (
@@ -345,6 +350,11 @@ class RansomwareAPIConnector:
                 bundles = []
                 path = year_url + "/" + str(month)
                 response_json = self.api_client.get_feed(path)
+                if not response_json:
+                    self.helper.connector_logger.info(
+                        f"No data retrieved from ransomware.live API for {year}/{month}"
+                    )
+                    continue
 
                 for item in response_json:
                     try:
@@ -401,9 +411,19 @@ class RansomwareAPIConnector:
         """Collects intelligence from the last 24 on ransomware.live"""
         # fetching group information
         group_data = self.api_client.get_feed("groups")
+        if not group_data:
+            self.helper.connector_logger.info(
+                "No group data retrieved from ransomware.live API"
+            )
+            return
 
         # fetching recent requests
         response_json = self.api_client.get_feed("recentvictims")
+        if not response_json:
+            self.helper.connector_logger.info(
+                "No recent victim data retrieved from ransomware.live API"
+            )
+            return
 
         nb_stix_objects = 0
         bundles = []
@@ -411,7 +431,7 @@ class RansomwareAPIConnector:
 
         for item in response_json:
             discovered_raw = item.get("discovered")
-            created = datetime.fromisoformat(discovered_raw)
+            created = safe_datetime(discovered_raw)
             if created.tzinfo is None:
                 created = created.replace(tzinfo=timezone.utc)
 


### PR DESCRIPTION
### Proposed changes

* **Add HTTP retry with exponential backoff on HTTP 429**: replaced bare `requests.get` with a persistent `requests.Session` backed by a `urllib3.Retry` adapter. Retries up to 5 times with a 60-second backoff factor and 30 seconds of random jitter. After exhausting retries, raises `RansomwareAPIError` and logs the failure via the OpenCTI helper.
* **Fix timezone-aware datetime parsing for the `discovered` field**: replaced a rigid `strptime` call with `datetime.fromisoformat`, which handles ISO 8601 variants returned by the API. A UTC fallback is applied when the parsed datetime is timezone-naive, preventing `TypeError` crashes during datetime comparisons.
* **Validate `CONNECTOR_DURATION_PERIOD` is at least 1 minute**: added a Pydantic `model_validator` guard that rejects any configured duration shorter than one minute, preventing the connector from hammering the rate-limited API on misconfigured deployments.

### Related issues

* Closes #6339

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Backoff constants match the Ransomware.live API's "1 request per minute" rate limit. `_RETRY_BACKOFF_FACTOR = 60` produces waits of ~60s, ~120s, etc. `_RETRY_BACKOFF_JITTER = 30` spreads retries across concurrent connector instances. Only HTTP 429 is in `status_forcelist`; other errors go through the existing `HTTPError` path and are not retried.