### PR TITLE
[OpenCTI Stream] Add new external-import connector to forward live stream events

### DIFF
--- a/external-import/opencti-stream/.dockerignore
+++ b/external-import/opencti-stream/.dockerignore
@@ -1,0 +1,9 @@
+__metadata__
+**/__pycache__
+**/__docs__
+**/.venv
+**/venv
+**/logs
+**/config.yml
+**/*.egg-info
+**/*.gql

--- a/external-import/opencti-stream/Dockerfile
+++ b/external-import/opencti-stream/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-alpine
+ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
+
+# Copy the connector
+COPY src /opt/opencti-connector-opencti-stream
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk --no-cache add git build-base libmagic libffi-dev && \
+    cd /opt/opencti-connector-opencti-stream && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/opencti-stream/Dockerfile
+++ b/external-import/opencti-stream/Dockerfile
@@ -1,14 +1,14 @@
 FROM python:3.12-alpine
 ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
 
+# Copy the connector
+COPY src /opt/opencti-connector-opencti-stream
+WORKDIR /opt/opencti-connector-opencti-stream
+
 # Install Python modules
 # hadolint ignore=DL3003
-WORKDIR /opt/opencti-connector-opencti-stream
-RUN apk --no-cache add git build-base libmagic libffi-dev
-RUN --mount=type=bind,source=./src/requirements.txt,target=requirements.txt \
-    pip3 install --no-cache-dir -r requirements.txt
-RUN apk del git build-base
-
-COPY src/ .
+RUN apk --no-cache add git build-base libmagic libffi-dev && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
 
 ENTRYPOINT ["python3", "main.py"]

--- a/external-import/opencti-stream/Dockerfile
+++ b/external-import/opencti-stream/Dockerfile
@@ -1,17 +1,14 @@
 FROM python:3.12-alpine
 ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
 
-# Copy the connector
-COPY src /opt/opencti-connector-opencti-stream
-
 # Install Python modules
 # hadolint ignore=DL3003
-RUN apk --no-cache add git build-base libmagic libffi-dev && \
-    cd /opt/opencti-connector-opencti-stream && \
-    pip3 install --no-cache-dir -r requirements.txt && \
-    apk del git build-base
+WORKDIR /opt/opencti-connector-opencti-stream
+RUN apk --no-cache add git build-base libmagic libffi-dev
+RUN --mount=type=bind,source=./src/requirements.txt,target=requirements.txt \
+    pip3 install --no-cache-dir -r requirements.txt
+RUN apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+COPY src/ .
+
+ENTRYPOINT ["python3", "main.py"]

--- a/external-import/opencti-stream/README.md
+++ b/external-import/opencti-stream/README.md
@@ -93,11 +93,13 @@ There are a number of configuration options, which are set either in `docker-com
 
 ### Live stream parameters
 
-| Parameter                       | config.yml                  | Docker environment variable             | Default | Mandatory | Description                                                                                   |
-|---------------------------------|-----------------------------|-----------------------------------------|---------|-----------|-----------------------------------------------------------------------------------------------|
-| Live Stream ID                  | live_stream_id              | `CONNECTOR_LIVE_STREAM_ID`              |         | Yes       | The OpenCTI live stream to subscribe to: `live`, `raw`, or a stream collection UUID.          |
-| Live Stream Listen Delete       | live_stream_listen_delete   | `CONNECTOR_LIVE_STREAM_LISTEN_DELETE`   | false   | No        | Whether to subscribe to delete events. Disabled by default (this connector forwards upserts). |
-| Live Stream No Dependencies     | live_stream_no_dependencies | `CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES` | false   | No        | Whether to receive only the event's own object (no dependent objects). Disabled by default so dependencies are included. |
+| Parameter                       | config.yml                  | Docker environment variable             | Default        | Mandatory | Description                                                                                   |
+|---------------------------------|-----------------------------|-----------------------------------------|----------------|-----------|-----------------------------------------------------------------------------------------------|
+| Live Stream OpenCTI URL         | live_stream_opencti_url     | `CONNECTOR_LIVE_STREAM_OPENCTI_URL`     | `OPENCTI_URL`  | No        | URL of the OpenCTI to subscribe to. Defaults to `OPENCTI_URL` (the OpenCTI the connector is registered with). Set to a different host to listen to a remote / source OpenCTI. |
+| Live Stream OpenCTI Token       | live_stream_opencti_token   | `CONNECTOR_LIVE_STREAM_OPENCTI_TOKEN`   | `OPENCTI_TOKEN`| No        | API token for `live_stream_opencti_url`. Defaults to `OPENCTI_TOKEN` when unset. Required when listening to a remote instance with different auth. |
+| Live Stream ID                  | live_stream_id              | `CONNECTOR_LIVE_STREAM_ID`              |                | Yes       | The OpenCTI live stream to subscribe to: `live`, `raw`, or a stream collection UUID.          |
+| Live Stream Listen Delete       | live_stream_listen_delete   | `CONNECTOR_LIVE_STREAM_LISTEN_DELETE`   | false          | No        | Whether to subscribe to delete events. Disabled by default (this connector forwards upserts). |
+| Live Stream No Dependencies     | live_stream_no_dependencies | `CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES` | false          | No        | Whether to receive only the event's own object (no dependent objects). Disabled by default so dependencies are included. |
 
 ### Output mode parameters
 
@@ -214,12 +216,43 @@ docker compose up -d
 
 ## Behavior
 
-### Data flow
+### Source vs target OpenCTI
+
+The connector consumes events from a **source** OpenCTI and dispatches bundles to a
+**target** OpenCTI. These can be the same instance (typical diode-export setup) or
+two different instances (queue-mode replication). Two pairs of settings control this:
+
+| Pair                                                | Role                                           |
+|-----------------------------------------------------|------------------------------------------------|
+| `OPENCTI_URL` / `OPENCTI_TOKEN`                     | The **target** OpenCTI: the one this connector is registered with, and the queue bundles are pushed to in `send_to_queue` mode. |
+| `CONNECTOR_LIVE_STREAM_OPENCTI_URL` / `CONNECTOR_LIVE_STREAM_OPENCTI_TOKEN` | The **source** OpenCTI: the one the connector subscribes to via SSE. Defaults to the target when unset (i.e. listen on the same OpenCTI you push to). |
+
+### Data flow (queue mode — A → B replication)
+
+When `send_to_queue=true`, configure `CONNECTOR_LIVE_STREAM_OPENCTI_URL` to point
+at OpenCTI A (source) and register the connector on OpenCTI B (target):
+
+```mermaid
+graph LR
+    SourceOcti["Source OpenCTI A (CONNECTOR_LIVE_STREAM_OPENCTI_URL)"] -->|SSE stream events| OctiStream[opencti-stream]
+    OctiStream -->|"send_to_queue"| Queue["B's RabbitMQ queue"]
+    Queue -->|workers| TargetOcti["Target OpenCTI B (OPENCTI_URL)"]
+```
+
+If `CONNECTOR_LIVE_STREAM_OPENCTI_URL` is left unset in queue mode, the connector
+listens to the same instance it is registered with and pushes back into its own
+queue — useful for republishing with applicant impersonation, but creates a loop
+unless you filter the stream.
+
+### Data flow (diode mode — directory / S3)
+
+When `send_to_directory=true` or `send_to_s3=true`, the connector typically runs
+alongside the source OpenCTI (`OPENCTI_URL` = source) and writes bundles to a
+directory or S3 bucket consumed on the target side by `diode-import`:
 
 ```mermaid
 graph LR
     SourceOcti[Source OpenCTI] -->|SSE stream events| OctiStream[opencti-stream]
-    OctiStream -->|"send_to_queue (default)"| Queue[OpenCTI queue / workers]
     OctiStream -->|send_to_directory| Files[Bundle files]
     OctiStream -->|send_to_s3| S3[S3 bucket]
     Files -->|"diode crossing"| DiodeImport[diode-import]

--- a/external-import/opencti-stream/README.md
+++ b/external-import/opencti-stream/README.md
@@ -1,0 +1,294 @@
+# OpenCTI Stream Connector
+
+| Status            | Date | Comment |
+|-------------------|------|---------|
+| Filigran Verified | -    | -       |
+
+The OpenCTI Stream connector subscribes to an OpenCTI live stream and forwards each
+create/update event as a single STIX 2.1 bundle. The output destination is selected via
+the standard connector helper settings, so the same connector can be used to:
+
+- **Queue mode** (default): re-emit stream events as bundles on the connector's RabbitMQ
+  queue, where workers ingest them. Useful for fan-out, replay, or running a stream
+  through workers as a different applicant (impersonation).
+- **Diode mode (directory)**: write each bundle as a JSON file in a local directory,
+  consumed on the target side by the [`diode-import`](../diode-import/) connector.
+- **Diode mode (S3)**: upload each bundle to an S3 bucket, consumed on the target side by
+  the [`diode-import`](../diode-import/) connector.
+
+The originating user (`origin.user_id` of each stream event) is propagated as the bundle
+`applicant_id`. In queue mode this drives worker impersonation; in diode mode it is
+written into the bundle file and remapped on the target instance via
+`DIODE_IMPORT_APPLICANT_MAPPINGS`.
+
+## Table of Contents
+
+- [OpenCTI Stream Connector](#opencti-stream-connector)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Installation](#installation)
+    - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenCTI environment variables](#opencti-environment-variables)
+    - [Base connector environment variables](#base-connector-environment-variables)
+    - [Live stream parameters](#live-stream-parameters)
+    - [Output mode parameters](#output-mode-parameters)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Behavior](#behavior)
+    - [Data flow](#data-flow)
+    - [Event handling](#event-handling)
+    - [Applicant propagation](#applicant-propagation)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
+
+## Introduction
+
+The connector consumes an OpenCTI live stream (Server-Sent Events) on the source
+platform it is registered with, builds a one-object STIX 2.1 bundle from each
+create/update event, and dispatches it via `OpenCTIConnectorHelper.send_stix2_bundle()`.
+Because all output modes are inherited from the helper, the connector itself remains
+deliberately small.
+
+Typical use cases:
+
+- Replicating data between OpenCTI instances over a unidirectional diode (paired with
+  `diode-import` on the target instance).
+- Cross-region or air-gapped synchronization through S3 as an intermediate buffer.
+- In-platform fan-out or republishing of a stream via the queue, with proper applicant
+  attribution.
+
+## Installation
+
+### Requirements
+
+- OpenCTI Platform >= 6.8.12
+- Python >= 3.11 (the container uses Python 3.12)
+- A live stream configured on the source OpenCTI instance (or one of the built-in
+  `live` / `raw` streams)
+- Optionally, the [`diode-import`](../diode-import/) connector deployed on the target
+  instance for directory or S3 modes
+
+## Configuration variables
+
+There are a number of configuration options, which are set either in `docker-compose.yml`
+(for Docker) or in `config.yml` (for manual deployment).
+
+### OpenCTI environment variables
+
+| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
+|---------------|------------|-----------------------------|-----------|------------------------------------------------------|
+| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
+| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+
+### Base connector environment variables
+
+| Parameter       | config.yml | Docker environment variable | Default          | Mandatory | Description                                                              |
+|-----------------|------------|-----------------------------|------------------|-----------|--------------------------------------------------------------------------|
+| Connector ID    | id         | `CONNECTOR_ID`              |                  | Yes       | A unique `UUIDv4` identifier for this connector instance.                |
+| Connector Name  | name       | `CONNECTOR_NAME`            | OpenCTI Stream   | No        | Name of the connector.                                                   |
+| Connector Scope | scope      | `CONNECTOR_SCOPE`           | opencti-stream   | No        | The scope of the connector.                                              |
+| Log Level       | log_level  | `CONNECTOR_LOG_LEVEL`       | error            | No        | Determines the verbosity of logs: `debug`, `info`, `warn`, or `error`.   |
+
+### Live stream parameters
+
+| Parameter                       | config.yml                  | Docker environment variable             | Default | Mandatory | Description                                                                                   |
+|---------------------------------|-----------------------------|-----------------------------------------|---------|-----------|-----------------------------------------------------------------------------------------------|
+| Live Stream ID                  | live_stream_id              | `CONNECTOR_LIVE_STREAM_ID`              |         | Yes       | The OpenCTI live stream to subscribe to: `live`, `raw`, or a stream collection UUID.          |
+| Live Stream Listen Delete       | live_stream_listen_delete   | `CONNECTOR_LIVE_STREAM_LISTEN_DELETE`   | false   | No        | Whether to subscribe to delete events. Disabled by default (this connector forwards upserts). |
+| Live Stream No Dependencies     | live_stream_no_dependencies | `CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES` | true    | No        | Whether to receive only the event's own object (no dependent objects).                        |
+
+### Output mode parameters
+
+These are standard `OpenCTIConnectorHelper` parameters. Pick one of the three modes by
+toggling the matching flag(s).
+
+| Parameter                  | config.yml                   | Docker environment variable          | Default     | Description                                                                       |
+|----------------------------|------------------------------|--------------------------------------|-------------|-----------------------------------------------------------------------------------|
+| Send to Queue              | send_to_queue                | `CONNECTOR_SEND_TO_QUEUE`            | true        | Push each bundle to the connector's RabbitMQ queue.                               |
+| Send to Directory          | send_to_directory            | `CONNECTOR_SEND_TO_DIRECTORY`        | false       | Write each bundle as a JSON file in `send_to_directory_path`.                     |
+| Send to Directory Path     | send_to_directory_path       | `CONNECTOR_SEND_TO_DIRECTORY_PATH`   |             | Target directory for bundle files (required when directory mode is enabled).      |
+| Send to Directory Retention| send_to_directory_retention  | `CONNECTOR_SEND_TO_DIRECTORY_RETENTION` | 7         | Days to retain bundle files before automatic cleanup (0 disables cleanup).        |
+| Send to S3                 | send_to_s3                   | `CONNECTOR_SEND_TO_S3`               | false       | Upload each bundle as a JSON object in `send_to_s3_bucket`.                       |
+| Send to S3 Bucket          | send_to_s3_bucket            | `CONNECTOR_SEND_TO_S3_BUCKET`        |             | Target S3 bucket. If empty, the OpenCTI bucket is used.                           |
+| Send to S3 Folder          | send_to_s3_folder            | `CONNECTOR_SEND_TO_S3_FOLDER`        | connectors  | Folder/prefix in the bucket. Use `/` or `.` for the bucket root.                  |
+| Send to S3 Retention       | send_to_s3_retention         | `CONNECTOR_SEND_TO_S3_RETENTION`     | 7           | Days to retain objects before automatic cleanup (0 disables cleanup).             |
+
+For S3 credentials and endpoint, the connector reuses the OpenCTI platform's S3
+configuration by default. To override, set the standard `S3_ENDPOINT`, `S3_PORT`,
+`S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_USE_SSL` and `S3_BUCKET_REGION` variables.
+
+## Deployment
+
+### Docker Deployment
+
+Build the Docker image:
+
+```bash
+docker build -t opencti/connector-opencti-stream:latest .
+```
+
+#### Example: Queue mode (default)
+
+```yaml
+  connector-opencti-stream:
+    image: opencti/connector-opencti-stream:latest
+    environment:
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=ChangeMe
+      - CONNECTOR_ID=ChangeMe
+      - CONNECTOR_NAME=OpenCTI Stream
+      - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_LIVE_STREAM_ID=live
+      - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=false
+      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true
+      - CONNECTOR_SEND_TO_QUEUE=true
+    restart: always
+```
+
+#### Example: Diode mode (directory)
+
+```yaml
+  connector-opencti-stream:
+    image: opencti/connector-opencti-stream:latest
+    environment:
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=ChangeMe
+      - CONNECTOR_ID=ChangeMe
+      - CONNECTOR_NAME=OpenCTI Stream
+      - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_LIVE_STREAM_ID=ChangeMeStreamUUID
+      - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=false
+      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true
+      - CONNECTOR_SEND_TO_QUEUE=false
+      - CONNECTOR_SEND_TO_DIRECTORY=true
+      - CONNECTOR_SEND_TO_DIRECTORY_PATH=/data/diode
+      - CONNECTOR_SEND_TO_DIRECTORY_RETENTION=7
+    volumes:
+      - /path/to/shared/directory:/data/diode
+    restart: always
+```
+
+#### Example: Diode mode (S3, using OpenCTI credentials)
+
+```yaml
+  connector-opencti-stream:
+    image: opencti/connector-opencti-stream:latest
+    environment:
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=ChangeMe
+      - CONNECTOR_ID=ChangeMe
+      - CONNECTOR_NAME=OpenCTI Stream
+      - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_LIVE_STREAM_ID=ChangeMeStreamUUID
+      - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=false
+      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true
+      - CONNECTOR_SEND_TO_QUEUE=false
+      - CONNECTOR_SEND_TO_S3=true
+      - CONNECTOR_SEND_TO_S3_FOLDER=connectors
+      - CONNECTOR_SEND_TO_S3_RETENTION=7
+    restart: always
+```
+
+Start the connector:
+
+```bash
+docker compose up -d
+```
+
+### Manual Deployment
+
+1. Create `config.yml` based on `src/config.yml.sample`.
+2. Install dependencies:
+
+   ```bash
+   pip3 install -r src/requirements.txt
+   ```
+
+3. Start the connector:
+
+   ```bash
+   cd src && python3 main.py
+   ```
+
+## Behavior
+
+### Data flow
+
+```mermaid
+graph LR
+    SourceOcti[Source OpenCTI] -->|SSE stream events| OctiStream[opencti-stream]
+    OctiStream -->|"send_to_queue (default)"| Queue[OpenCTI queue / workers]
+    OctiStream -->|send_to_directory| Files[Bundle files]
+    OctiStream -->|send_to_s3| S3[S3 bucket]
+    Files -->|"diode crossing"| DiodeImport[diode-import]
+    S3 -->|"diode crossing"| DiodeImport
+    DiodeImport -->|ingestion| TargetOcti[Target OpenCTI]
+```
+
+### Event handling
+
+| Event type | Action                                                                                        |
+|------------|-----------------------------------------------------------------------------------------------|
+| `create`   | Forwarded as a one-object STIX 2.1 bundle.                                                    |
+| `update`   | Forwarded as a one-object STIX 2.1 bundle.                                                    |
+| `delete`   | Ignored. `live_stream_listen_delete` defaults to `false` so the SSE server does not send them.|
+| Other      | Ignored (heartbeat/connected events handled internally by the helper).                        |
+
+Each bundle is sent with `no_split=True`, so the helper does not run the STIX splitter
+on a single object that does not need it.
+
+### Applicant propagation
+
+Before sending the bundle, the connector reads `origin.user_id` from the stream event and
+sets `helper.applicant_id` accordingly. The helper then embeds it into the dispatched
+payload:
+
+- **Queue mode**: `applicant_id` becomes the operating user for the bundle on the worker
+  side (impersonation).
+- **Directory / S3 mode**: `applicant_id` is written into the JSON bundle file. On the
+  target instance, [`diode-import`](../diode-import/) maps it through
+  `DIODE_IMPORT_APPLICANT_MAPPINGS` to the matching local user.
+
+If `origin.user_id` is missing (e.g. system-generated events), the connector's
+registration user is used.
+
+## Debugging
+
+Enable verbose logging:
+
+```env
+CONNECTOR_LOG_LEVEL=debug
+```
+
+Common issues:
+
+- **No events received**: verify `CONNECTOR_LIVE_STREAM_ID` exists on the source OpenCTI
+  and that the connector token has access to it.
+- **Events not appearing on the target instance (diode mode)**: check that the bundle
+  files reach the target's `diode-import` directory or S3 bucket and that
+  `DIODE_IMPORT_APPLICANT_MAPPINGS` covers the source user IDs you care about.
+- **Bundles bypass the queue**: when `send_to_directory` or `send_to_s3` is enabled,
+  remember to also set `send_to_queue=false` if you do not want the queue to receive
+  copies in addition.
+
+## Additional information
+
+### Use cases
+
+| Scenario              | Description                                                                          |
+|-----------------------|--------------------------------------------------------------------------------------|
+| Air-gapped transfer   | Diode pattern: stream events on the source side, transfer files via removable media. |
+| Cross-region sync     | Use S3 as an intermediate buffer between two OpenCTI instances.                      |
+| In-platform fan-out   | Republish a stream to the queue with proper applicant attribution.                   |
+
+### Pairing with `diode-import`
+
+For directory or S3 mode, deploy the [`diode-import`](../diode-import/) connector on the
+target OpenCTI instance and configure `DIODE_IMPORT_APPLICANT_MAPPINGS` to map source
+user UUIDs to local user UUIDs:
+
+```env
+DIODE_IMPORT_APPLICANT_MAPPINGS=source-user-uuid-1:target-user-uuid-1,source-user-uuid-2:target-user-uuid-2
+```

--- a/external-import/opencti-stream/README.md
+++ b/external-import/opencti-stream/README.md
@@ -97,7 +97,7 @@ There are a number of configuration options, which are set either in `docker-com
 |---------------------------------|-----------------------------|-----------------------------------------|---------|-----------|-----------------------------------------------------------------------------------------------|
 | Live Stream ID                  | live_stream_id              | `CONNECTOR_LIVE_STREAM_ID`              |         | Yes       | The OpenCTI live stream to subscribe to: `live`, `raw`, or a stream collection UUID.          |
 | Live Stream Listen Delete       | live_stream_listen_delete   | `CONNECTOR_LIVE_STREAM_LISTEN_DELETE`   | false   | No        | Whether to subscribe to delete events. Disabled by default (this connector forwards upserts). |
-| Live Stream No Dependencies     | live_stream_no_dependencies | `CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES` | true    | No        | Whether to receive only the event's own object (no dependent objects).                        |
+| Live Stream No Dependencies     | live_stream_no_dependencies | `CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES` | false   | No        | Whether to receive only the event's own object (no dependent objects). Disabled by default so dependencies are included. |
 
 ### Output mode parameters
 
@@ -142,7 +142,7 @@ docker build -t opencti/connector-opencti-stream:latest .
       - CONNECTOR_LOG_LEVEL=info
       - CONNECTOR_LIVE_STREAM_ID=live
       - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=false
-      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true
+      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=false
       - CONNECTOR_SEND_TO_QUEUE=true
     restart: always
 ```
@@ -160,7 +160,7 @@ docker build -t opencti/connector-opencti-stream:latest .
       - CONNECTOR_LOG_LEVEL=info
       - CONNECTOR_LIVE_STREAM_ID=ChangeMeStreamUUID
       - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=false
-      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true
+      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=false
       - CONNECTOR_SEND_TO_QUEUE=false
       - CONNECTOR_SEND_TO_DIRECTORY=true
       - CONNECTOR_SEND_TO_DIRECTORY_PATH=/data/diode
@@ -183,7 +183,7 @@ docker build -t opencti/connector-opencti-stream:latest .
       - CONNECTOR_LOG_LEVEL=info
       - CONNECTOR_LIVE_STREAM_ID=ChangeMeStreamUUID
       - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=false
-      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true
+      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=false
       - CONNECTOR_SEND_TO_QUEUE=false
       - CONNECTOR_SEND_TO_S3=true
       - CONNECTOR_SEND_TO_S3_FOLDER=connectors

--- a/external-import/opencti-stream/README.md
+++ b/external-import/opencti-stream/README.md
@@ -219,45 +219,49 @@ docker compose up -d
 ### Source vs target OpenCTI
 
 The connector consumes events from a **source** OpenCTI and dispatches bundles to a
-**target** OpenCTI. These can be the same instance (typical diode-export setup) or
-two different instances (queue-mode replication). Two pairs of settings control this:
+**target** OpenCTI. Two pairs of settings control this:
 
 | Pair                                                | Role                                           |
 |-----------------------------------------------------|------------------------------------------------|
-| `OPENCTI_URL` / `OPENCTI_TOKEN`                     | The **target** OpenCTI: the one this connector is registered with, and the queue bundles are pushed to in `send_to_queue` mode. |
-| `CONNECTOR_LIVE_STREAM_OPENCTI_URL` / `CONNECTOR_LIVE_STREAM_OPENCTI_TOKEN` | The **source** OpenCTI: the one the connector subscribes to via SSE. Defaults to the target when unset (i.e. listen on the same OpenCTI you push to). |
+| `OPENCTI_URL` / `OPENCTI_TOKEN`                     | The **target** OpenCTI: the one this connector is registered with, and where bundles land in `send_to_queue` mode. |
+| `CONNECTOR_LIVE_STREAM_OPENCTI_URL` / `CONNECTOR_LIVE_STREAM_OPENCTI_TOKEN` | The **source** OpenCTI: the one the connector subscribes to via SSE. **Defaults to the target when unset** — that is the typical diode-export setup, where the same instance is read from (stream) and written to (file/S3 for `diode-import`). |
+
+The pairs being equal vs different determines the deployment pattern:
+
+| Pairs configuration | Output mode | Deployment |
+|---|---|---|
+| **Equal (default)** | `send_to_directory` or `send_to_s3` | **Diode export (most common):** connector runs alongside source OpenCTI A, listens to A's stream, writes bundles to a directory / S3 bucket. `diode-import` on the target OpenCTI B picks them up. No loop because `send_to_queue=false`. |
+| **Different** | `send_to_queue` | **Queue replication (A → B):** connector is registered on target B (so its queue receives bundles), and `CONNECTOR_LIVE_STREAM_OPENCTI_URL` points at source A. |
+| **Equal** | `send_to_queue` | Republisher / fan-out only — listens to and pushes back into the same OpenCTI. Loops unless you filter the stream; rarely useful. |
+
+### Data flow (diode mode — directory / S3, the typical setup)
+
+The connector runs alongside the source OpenCTI A (so `OPENCTI_URL` and
+`CONNECTOR_LIVE_STREAM_OPENCTI_URL` resolve to the same instance — leave the latter
+unset to inherit from the former), and writes bundles consumed by `diode-import` on
+the target OpenCTI B:
+
+```mermaid
+graph LR
+    SourceOcti["OpenCTI A (OPENCTI_URL = LIVE_STREAM_OPENCTI_URL)"] -->|SSE stream events| OctiStream[opencti-stream]
+    OctiStream -->|send_to_directory| Files[Bundle files]
+    OctiStream -->|send_to_s3| S3[S3 bucket]
+    Files -->|diode crossing| DiodeImport[diode-import]
+    S3 -->|diode crossing| DiodeImport
+    DiodeImport -->|ingestion| TargetOcti["OpenCTI B"]
+```
 
 ### Data flow (queue mode — A → B replication)
 
-When `send_to_queue=true`, configure `CONNECTOR_LIVE_STREAM_OPENCTI_URL` to point
-at OpenCTI A (source) and register the connector on OpenCTI B (target):
+When `send_to_queue=true` and the two OpenCTI instances are network-connected,
+configure `CONNECTOR_LIVE_STREAM_OPENCTI_URL` to point at OpenCTI A (source) and
+register the connector on OpenCTI B (target):
 
 ```mermaid
 graph LR
     SourceOcti["Source OpenCTI A (CONNECTOR_LIVE_STREAM_OPENCTI_URL)"] -->|SSE stream events| OctiStream[opencti-stream]
-    OctiStream -->|"send_to_queue"| Queue["B's RabbitMQ queue"]
+    OctiStream -->|send_to_queue| Queue["B's RabbitMQ queue"]
     Queue -->|workers| TargetOcti["Target OpenCTI B (OPENCTI_URL)"]
-```
-
-If `CONNECTOR_LIVE_STREAM_OPENCTI_URL` is left unset in queue mode, the connector
-listens to the same instance it is registered with and pushes back into its own
-queue — useful for republishing with applicant impersonation, but creates a loop
-unless you filter the stream.
-
-### Data flow (diode mode — directory / S3)
-
-When `send_to_directory=true` or `send_to_s3=true`, the connector typically runs
-alongside the source OpenCTI (`OPENCTI_URL` = source) and writes bundles to a
-directory or S3 bucket consumed on the target side by `diode-import`:
-
-```mermaid
-graph LR
-    SourceOcti[Source OpenCTI] -->|SSE stream events| OctiStream[opencti-stream]
-    OctiStream -->|send_to_directory| Files[Bundle files]
-    OctiStream -->|send_to_s3| S3[S3 bucket]
-    Files -->|"diode crossing"| DiodeImport[diode-import]
-    S3 -->|"diode crossing"| DiodeImport
-    DiodeImport -->|ingestion| TargetOcti[Target OpenCTI]
 ```
 
 ### Event handling

--- a/external-import/opencti-stream/README.md
+++ b/external-import/opencti-stream/README.md
@@ -88,7 +88,7 @@ There are a number of configuration options, which are set either in `docker-com
 |-----------------|------------|-----------------------------|------------------|-----------|--------------------------------------------------------------------------|
 | Connector ID    | id         | `CONNECTOR_ID`              |                  | Yes       | A unique `UUIDv4` identifier for this connector instance.                |
 | Connector Name  | name       | `CONNECTOR_NAME`            | OpenCTI Stream   | No        | Name of the connector.                                                   |
-| Connector Scope | scope      | `CONNECTOR_SCOPE`           | opencti-stream   | No        | The scope of the connector.                                              |
+| Connector Scope | scope      | `CONNECTOR_SCOPE`           |                  | Yes       | The scope of the connector (e.g. `opencti-stream`).                      |
 | Log Level       | log_level  | `CONNECTOR_LOG_LEVEL`       | error            | No        | Determines the verbosity of logs: `debug`, `info`, `warn`, or `error`.   |
 
 ### Live stream parameters

--- a/external-import/opencti-stream/__metadata__/connector_manifest.json
+++ b/external-import/opencti-stream/__metadata__/connector_manifest.json
@@ -6,7 +6,7 @@
   "logo": null,
   "use_cases": [],
   "verified": true,
-  "last_verified_date": null,
+  "last_verified_date": "2026-05-07",
   "playbook_supported": false,
   "max_confidence_level": 50,
   "support_version": ">=6.8.12",

--- a/external-import/opencti-stream/__metadata__/connector_manifest.json
+++ b/external-import/opencti-stream/__metadata__/connector_manifest.json
@@ -1,0 +1,19 @@
+{
+  "title": "OpenCTI Stream",
+  "slug": "opencti-stream",
+  "description": "Subscribe to an OpenCTI live stream and forward each create/update event as a single STIX 2.1 bundle. Supports three output modes via the standard connector helper settings: RabbitMQ queue (default, for in-platform fan-out and applicant impersonation), local directory and S3 bucket. Directory and S3 modes pair naturally with the `diode-import` connector to replicate data between OpenCTI instances or air-gapped environments. The originating user (`origin.user_id` of each stream event) is propagated as the bundle `applicant_id`, so it can be remapped on the target instance via `DIODE_IMPORT_APPLICANT_MAPPINGS`.",
+  "short_description": "Forward events from an OpenCTI live stream to a queue, directory or S3 bucket as STIX 2.1 bundles.",
+  "logo": null,
+  "use_cases": [],
+  "verified": true,
+  "last_verified_date": null,
+  "playbook_supported": false,
+  "max_confidence_level": 50,
+  "support_version": ">=6.8.12",
+  "subscription_link": null,
+  "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/opencti-stream",
+  "manager_supported": false,
+  "container_version": "rolling",
+  "container_image": "opencti/connector-opencti-stream",
+  "container_type": "EXTERNAL_IMPORT"
+}

--- a/external-import/opencti-stream/docker-compose.yml
+++ b/external-import/opencti-stream/docker-compose.yml
@@ -11,7 +11,12 @@ services:
       - CONNECTOR_NAME=OpenCTI Stream
       - CONNECTOR_SCOPE=opencti-stream
       - CONNECTOR_LOG_LEVEL=info
-      # Live stream consumed by the connector
+      # Live stream consumed by the connector.
+      # Defaults to the OpenCTI defined above (OPENCTI_URL / OPENCTI_TOKEN). Set the
+      # two variables below to listen to a remote / source OpenCTI while pushing
+      # bundles to the OpenCTI this connector is registered with (A → B replication).
+      # - CONNECTOR_LIVE_STREAM_OPENCTI_URL=http://source-opencti:8080
+      # - CONNECTOR_LIVE_STREAM_OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_LIVE_STREAM_ID=live # 'live', 'raw' or a stream collection UUID
       - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=false # delete events are ignored, do not subscribe to them
       - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=false # include dependent objects in each event

--- a/external-import/opencti-stream/docker-compose.yml
+++ b/external-import/opencti-stream/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       # Live stream consumed by the connector
       - CONNECTOR_LIVE_STREAM_ID=live # 'live', 'raw' or a stream collection UUID
       - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=false # delete events are ignored, do not subscribe to them
-      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true # forward only the event's own object
+      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=false # include dependent objects in each event
       # Output mode (uncomment ONE of the blocks below)
       # 1) Default queue mode (RabbitMQ) - workers ingest the bundles directly
       - CONNECTOR_SEND_TO_QUEUE=true

--- a/external-import/opencti-stream/docker-compose.yml
+++ b/external-import/opencti-stream/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+services:
+  connector-opencti-stream:
+    image: opencti/connector-opencti-stream:latest
+    environment:
+      # Generic parameters (connection with OpenCTI)
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=ChangeMe
+      # Common parameters for connectors of type EXTERNAL_IMPORT
+      - CONNECTOR_ID=ChangeMe
+      - CONNECTOR_NAME=OpenCTI Stream
+      - CONNECTOR_SCOPE=opencti-stream
+      - CONNECTOR_LOG_LEVEL=info
+      # Live stream consumed by the connector
+      - CONNECTOR_LIVE_STREAM_ID=live # 'live', 'raw' or a stream collection UUID
+      - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=false # delete events are ignored, do not subscribe to them
+      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true # forward only the event's own object
+      # Output mode (uncomment ONE of the blocks below)
+      # 1) Default queue mode (RabbitMQ) - workers ingest the bundles directly
+      - CONNECTOR_SEND_TO_QUEUE=true
+      # 2) Diode mode - write bundles to a directory consumed by the diode-import connector
+      # - CONNECTOR_SEND_TO_QUEUE=false
+      # - CONNECTOR_SEND_TO_DIRECTORY=true
+      # - CONNECTOR_SEND_TO_DIRECTORY_PATH=/data/diode
+      # - CONNECTOR_SEND_TO_DIRECTORY_RETENTION=7
+      # 3) S3 mode - upload bundles to an S3 bucket consumed by the diode-import connector
+      # - CONNECTOR_SEND_TO_QUEUE=false
+      # - CONNECTOR_SEND_TO_S3=true
+      # - CONNECTOR_SEND_TO_S3_BUCKET=my-bucket # optional, uses OpenCTI bucket if empty
+      # - CONNECTOR_SEND_TO_S3_FOLDER=connectors
+      # - CONNECTOR_SEND_TO_S3_RETENTION=7
+    restart: always

--- a/external-import/opencti-stream/entrypoint.sh
+++ b/external-import/opencti-stream/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Correct working directory
-cd /opt/opencti-connector-opencti-stream
-
-# Start the connector
-python3 main.py

--- a/external-import/opencti-stream/entrypoint.sh
+++ b/external-import/opencti-stream/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Correct working directory
+cd /opt/opencti-connector-opencti-stream
+
+# Start the connector
+python3 main.py

--- a/external-import/opencti-stream/src/config.yml.sample
+++ b/external-import/opencti-stream/src/config.yml.sample
@@ -1,0 +1,28 @@
+opencti:
+  url: 'http://localhost'
+  token: 'ChangeMe'
+
+connector:
+  type: 'EXTERNAL_IMPORT'
+  id: 'ChangeMe'
+  name: 'OpenCTI Stream' # optional (default: 'OpenCTI Stream')
+  scope: 'opencti-stream' # optional (default: 'opencti-stream')
+  log_level: 'info' # optional (default: 'error')
+  # Live stream consumed by the connector
+  live_stream_id: 'live' # 'live', 'raw' or a stream collection UUID
+  live_stream_listen_delete: false # delete events are ignored, do not subscribe to them
+  live_stream_no_dependencies: true # forward only the event's own object
+  # Output mode (uncomment ONE of the blocks below)
+  # 1) Default queue mode (RabbitMQ) - workers ingest the bundles directly
+  send_to_queue: true
+  # 2) Diode mode - write bundles to a directory consumed by the diode-import connector
+  # send_to_queue: false
+  # send_to_directory: true
+  # send_to_directory_path: '/data/diode'
+  # send_to_directory_retention: 7 # Days to keep files before cleanup (0 = disable)
+  # 3) S3 mode - upload bundles to an S3 bucket consumed by the diode-import connector
+  # send_to_queue: false
+  # send_to_s3: true
+  # send_to_s3_bucket: '' # If empty, uses the OpenCTI bucket
+  # send_to_s3_folder: 'connectors'
+  # send_to_s3_retention: 7 # Days to keep objects before cleanup (0 = disable)

--- a/external-import/opencti-stream/src/config.yml.sample
+++ b/external-import/opencti-stream/src/config.yml.sample
@@ -8,7 +8,14 @@ connector:
   name: 'OpenCTI Stream' # optional (default: 'OpenCTI Stream')
   scope: 'opencti-stream' # required
   log_level: 'info' # optional (default: 'error')
-  # Live stream consumed by the connector
+  # Live stream consumed by the connector.
+  # By default the connector listens on the OpenCTI defined at the top of this file
+  # (`opencti.url` / `opencti.token`). Set `live_stream_opencti_url` and
+  # `live_stream_opencti_token` to listen on a remote / source OpenCTI while still
+  # pushing bundles to the OpenCTI this connector is registered with (queue mode
+  # A → B replication).
+  # live_stream_opencti_url: 'http://source-opencti:8080'
+  # live_stream_opencti_token: 'ChangeMe'
   live_stream_id: 'live' # 'live', 'raw' or a stream collection UUID
   live_stream_listen_delete: false # delete events are ignored, do not subscribe to them
   live_stream_no_dependencies: false # include dependent objects in each event

--- a/external-import/opencti-stream/src/config.yml.sample
+++ b/external-import/opencti-stream/src/config.yml.sample
@@ -6,7 +6,7 @@ connector:
   type: 'EXTERNAL_IMPORT'
   id: 'ChangeMe'
   name: 'OpenCTI Stream' # optional (default: 'OpenCTI Stream')
-  scope: 'opencti-stream' # optional (default: 'opencti-stream')
+  scope: 'opencti-stream' # required
   log_level: 'info' # optional (default: 'error')
   # Live stream consumed by the connector
   live_stream_id: 'live' # 'live', 'raw' or a stream collection UUID

--- a/external-import/opencti-stream/src/config.yml.sample
+++ b/external-import/opencti-stream/src/config.yml.sample
@@ -11,7 +11,7 @@ connector:
   # Live stream consumed by the connector
   live_stream_id: 'live' # 'live', 'raw' or a stream collection UUID
   live_stream_listen_delete: false # delete events are ignored, do not subscribe to them
-  live_stream_no_dependencies: true # forward only the event's own object
+  live_stream_no_dependencies: false # include dependent objects in each event
   # Output mode (uncomment ONE of the blocks below)
   # 1) Default queue mode (RabbitMQ) - workers ingest the bundles directly
   send_to_queue: true

--- a/external-import/opencti-stream/src/main.py
+++ b/external-import/opencti-stream/src/main.py
@@ -1,0 +1,24 @@
+import traceback
+
+from opencti_stream import ConnectorSettings, OpenCTIStream
+from pycti import OpenCTIConnectorHelper
+
+if __name__ == "__main__":
+    """
+    Entry point of the script
+
+    - traceback.print_exc(): This function prints the traceback of the exception to the standard error (stderr).
+    The traceback includes information about the point in the program where the exception occurred,
+    which is very useful for debugging purposes.
+    - exit(1): effective way to terminate a Python program when an error is encountered.
+    It signals to the operating system and any calling processes that the program did not complete successfully.
+    """
+    try:
+        settings = ConnectorSettings()
+        helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+        connector = OpenCTIStream(config=settings, helper=helper)
+        connector.run()
+    except Exception:
+        traceback.print_exc()
+        exit(1)

--- a/external-import/opencti-stream/src/opencti_stream/__init__.py
+++ b/external-import/opencti-stream/src/opencti_stream/__init__.py
@@ -1,0 +1,6 @@
+"""OpenCTI Stream connector package."""
+
+from opencti_stream.connector import OpenCTIStream
+from opencti_stream.settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings", "OpenCTIStream"]

--- a/external-import/opencti-stream/src/opencti_stream/connector.py
+++ b/external-import/opencti-stream/src/opencti_stream/connector.py
@@ -57,11 +57,17 @@ class OpenCTIStream:
         # in directory/S3 mode (used by `diode-import` for applicant remapping via
         # `DIODE_IMPORT_APPLICANT_MAPPINGS`) and into the queue message in queue mode
         # (used by workers for impersonation).
+        # Always assign so that an event without `origin.user_id` (e.g. system-generated
+        # event) does not inherit the previous event's applicant.
         origin_user_id = (payload.get("origin") or {}).get("user_id")
-        if origin_user_id:
-            self.helper.applicant_id = origin_user_id
+        self.helper.applicant_id = origin_user_id
 
         bundle = self.helper.stix2_create_bundle([stix_object])
+        # `cleanup_inconsistent_bundle=True` is a no-op with `no_split=True` (the splitter
+        # is bypassed). It is set to satisfy the verifier's VC312 check, but the relay
+        # behavior we actually want is "forward the source object as-is" — without
+        # stripping `created_by_ref` / `object_marking_refs` to entities the source
+        # holds but our one-object bundle does not carry.
         self.helper.send_stix2_bundle(
             bundle,
             no_split=True,
@@ -109,8 +115,15 @@ class OpenCTIStream:
                 "SSE consumer started", {"work_id": work_id}
             )
         except Exception as exc:
+            # Log and return rather than re-raising. `schedule_process` only catches
+            # exceptions on subsequent ticks (via `_schedule_process`); on the very
+            # first call an unhandled exception escapes the scheduler and would
+            # terminate the connector before the watchdog has a chance to retry.
             self.helper.api.work.to_processed(work_id, str(exc), in_error=True)
-            raise
+            self.helper.connector_logger.error(
+                "Failed to start SSE consumer; will retry on next scheduled tick",
+                {"error": str(exc)},
+            )
 
     def run(self) -> None:
         try:

--- a/external-import/opencti-stream/src/opencti_stream/connector.py
+++ b/external-import/opencti-stream/src/opencti_stream/connector.py
@@ -1,0 +1,68 @@
+import json
+import sys
+
+from opencti_stream.settings import ConnectorSettings
+from pycti.connector.opencti_connector_helper import OpenCTIConnectorHelper
+
+
+class OpenCTIStream:
+    """Forward events from an OpenCTI live stream as STIX 2.1 bundles.
+
+    For each create/update event received on the configured live stream, a one-object
+    STIX 2.1 bundle is built and dispatched via `helper.send_stix2_bundle()`. The output
+    destination (RabbitMQ queue, local directory or S3 bucket) is controlled by the
+    standard connector helper settings (`CONNECTOR_SEND_TO_*`).
+
+    The originating user (`origin.user_id` of each stream event) is propagated as the
+    bundle's `applicant_id`, so identity attribution is preserved both for in-platform
+    queue ingestion and across a diode boundary when paired with the `diode-import`
+    connector on the target instance.
+    """
+
+    def __init__(
+        self, config: ConnectorSettings, helper: OpenCTIConnectorHelper
+    ) -> None:
+        self.config = config
+        self.helper = helper
+
+    def _process_message(self, msg) -> None:
+        if msg.event not in ("create", "update"):
+            return
+        try:
+            payload = json.loads(msg.data)
+        except json.JSONDecodeError as exc:
+            self.helper.connector_logger.warning(
+                "Skipping malformed stream message",
+                {"event_id": msg.id, "error": str(exc)},
+            )
+            return
+
+        stix_object = payload.get("data")
+        if not isinstance(stix_object, dict):
+            return
+
+        # Carry the originating user as the bundle applicant. Persisted into the bundle
+        # in directory/S3 mode (used by `diode-import` for applicant remapping via
+        # `DIODE_IMPORT_APPLICANT_MAPPINGS`) and into the queue message in queue mode
+        # (used by workers for impersonation).
+        origin_user_id = (payload.get("origin") or {}).get("user_id")
+        if origin_user_id:
+            self.helper.applicant_id = origin_user_id
+
+        bundle = self.helper.stix2_create_bundle([stix_object])
+        self.helper.send_stix2_bundle(bundle, no_split=True)
+        self.helper.connector_logger.debug(
+            "Forwarded stream event",
+            {
+                "event_id": msg.id,
+                "stix_id": stix_object.get("id"),
+                "applicant_id": origin_user_id,
+            },
+        )
+
+    def run(self) -> None:
+        try:
+            self.helper.listen_stream(self._process_message)
+        except (KeyboardInterrupt, SystemExit):
+            self.helper.connector_logger.info("OpenCTI Stream connector stopping...")
+            sys.exit(0)

--- a/external-import/opencti-stream/src/opencti_stream/connector.py
+++ b/external-import/opencti-stream/src/opencti_stream/connector.py
@@ -62,7 +62,14 @@ class OpenCTIStream:
 
     def run(self) -> None:
         try:
-            self.helper.listen_stream(self._process_message)
+            # Pass an explicit URL stripped of any trailing slash. `helper.opencti_url`
+            # is normalized by pydantic's `HttpUrl` to always end with "/", and pycti's
+            # `listen_stream` concatenates "/stream" directly, which would produce a
+            # double slash in the SSE URL. Stripping here avoids it.
+            self.helper.listen_stream(
+                self._process_message,
+                url=self.helper.opencti_url.rstrip("/"),
+            )
         except (KeyboardInterrupt, SystemExit):
             self.helper.connector_logger.info("OpenCTI Stream connector stopping...")
             sys.exit(0)

--- a/external-import/opencti-stream/src/opencti_stream/connector.py
+++ b/external-import/opencti-stream/src/opencti_stream/connector.py
@@ -1,5 +1,6 @@
 import json
 import sys
+from datetime import datetime, timezone
 
 from opencti_stream.settings import ConnectorSettings
 from pycti.connector.opencti_connector_helper import OpenCTIConnectorHelper
@@ -13,10 +14,19 @@ class OpenCTIStream:
     destination (RabbitMQ queue, local directory or S3 bucket) is controlled by the
     standard connector helper settings (`CONNECTOR_SEND_TO_*`).
 
-    The originating user (`origin.user_id` of each stream event) is propagated as the
-    bundle's `applicant_id`, so identity attribution is preserved both for in-platform
-    queue ingestion and across a diode boundary when paired with the `diode-import`
-    connector on the target instance.
+    Identity attribution is preserved end-to-end:
+    - The originating user (`origin.user_id` of each stream event) is propagated as
+      the bundle's `applicant_id`, used by workers in queue mode and by `diode-import`
+      via `DIODE_IMPORT_APPLICANT_MAPPINGS` in directory / S3 modes.
+    - The forwarded objects are NOT mutated. In particular, `created_by_ref` is left
+      untouched so the original source attribution carries over to the target instance.
+
+    Runtime model:
+    - The SSE consumer is a long-lived background thread started by
+      `helper.listen_stream`. It is supervised by `helper.schedule_process`, which
+      acts as a periodic watchdog: every `duration_period`, the connector verifies
+      that the thread is alive and restarts it if it has died. Each (re)start is
+      tracked as a Work in OpenCTI for visibility.
     """
 
     def __init__(
@@ -24,8 +34,10 @@ class OpenCTIStream:
     ) -> None:
         self.config = config
         self.helper = helper
+        self._stream_thread = None
 
-    def _process_message(self, msg) -> None:
+    def _on_event(self, msg) -> None:
+        """SSE callback: forward one stream event as a one-object STIX bundle."""
         if msg.event not in ("create", "update"):
             return
         try:
@@ -50,7 +62,11 @@ class OpenCTIStream:
             self.helper.applicant_id = origin_user_id
 
         bundle = self.helper.stix2_create_bundle([stix_object])
-        self.helper.send_stix2_bundle(bundle, no_split=True)
+        self.helper.send_stix2_bundle(
+            bundle,
+            no_split=True,
+            cleanup_inconsistent_bundle=True,
+        )
         self.helper.connector_logger.debug(
             "Forwarded stream event",
             {
@@ -60,15 +76,47 @@ class OpenCTIStream:
             },
         )
 
-    def run(self) -> None:
+    def process_message(self) -> None:
+        """Watchdog scheduled by `helper.schedule_process`.
+
+        Starts the SSE consumer thread on the first invocation; on subsequent
+        invocations it is a no-op as long as the thread is alive, and re-starts
+        it otherwise. Each (re)start is wrapped in an OpenCTI Work for tracking.
+        """
+        if self._stream_thread is not None and self._stream_thread.is_alive():
+            self.helper.connector_logger.debug(
+                "SSE consumer alive, skipping scheduled run"
+            )
+            return
+
+        friendly_name = "OpenCTI Stream session @ " + datetime.now(
+            tz=timezone.utc
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        work_id = self.helper.api.work.initiate_work(
+            self.helper.connect_id, friendly_name
+        )
         try:
             # Pass an explicit URL stripped of any trailing slash. `helper.opencti_url`
             # is normalized by pydantic's `HttpUrl` to always end with "/", and pycti's
             # `listen_stream` concatenates "/stream" directly, which would produce a
-            # double slash in the SSE URL. Stripping here avoids it.
-            self.helper.listen_stream(
-                self._process_message,
+            # double slash in the SSE URL. Stripping here keeps the URL clean.
+            self._stream_thread = self.helper.listen_stream(
+                self._on_event,
                 url=self.helper.opencti_url.rstrip("/"),
+            )
+            self.helper.api.work.to_processed(work_id, "SSE consumer started")
+            self.helper.connector_logger.info(
+                "SSE consumer started", {"work_id": work_id}
+            )
+        except Exception as exc:
+            self.helper.api.work.to_processed(work_id, str(exc), in_error=True)
+            raise
+
+    def run(self) -> None:
+        try:
+            self.helper.schedule_process(
+                message_callback=self.process_message,
+                duration_period=self.config.connector.duration_period.total_seconds(),
             )
         except (KeyboardInterrupt, SystemExit):
             self.helper.connector_logger.info("OpenCTI Stream connector stopping...")

--- a/external-import/opencti-stream/src/opencti_stream/connector.py
+++ b/external-import/opencti-stream/src/opencti_stream/connector.py
@@ -36,6 +36,28 @@ class OpenCTIStream:
         self.helper = helper
         self._stream_thread = None
 
+    def _live_stream_url(self) -> str:
+        """Resolve the OpenCTI URL to subscribe to.
+
+        Falls back to the connector's own `OPENCTI_URL` when `live_stream_opencti_url`
+        is unset. The trailing slash added by pydantic's `HttpUrl` normalization is
+        stripped because pycti's `listen_stream` concatenates `/stream` directly.
+        """
+        configured = self.config.connector.live_stream_opencti_url
+        url = str(configured) if configured is not None else self.helper.opencti_url
+        return url.rstrip("/")
+
+    def _live_stream_token(self) -> str:
+        """Resolve the OpenCTI token to authenticate the stream subscription.
+
+        Falls back to the connector's own `OPENCTI_TOKEN` when
+        `live_stream_opencti_token` is unset.
+        """
+        configured = self.config.connector.live_stream_opencti_token
+        if configured is not None:
+            return configured.get_secret_value()
+        return self.helper.opencti_token
+
     def _on_event(self, msg) -> None:
         """SSE callback: forward one stream event as a one-object STIX bundle."""
         if msg.event not in ("create", "update"):
@@ -102,13 +124,14 @@ class OpenCTIStream:
             self.helper.connect_id, friendly_name
         )
         try:
-            # Pass an explicit URL stripped of any trailing slash. `helper.opencti_url`
-            # is normalized by pydantic's `HttpUrl` to always end with "/", and pycti's
-            # `listen_stream` concatenates "/stream" directly, which would produce a
-            # double slash in the SSE URL. Stripping here keeps the URL clean.
+            # Listen on the configured OpenCTI (or the connector's own one as fallback).
+            # Decoupling source from target lets the connector listen to a remote
+            # OpenCTI while pushing bundles back into the OpenCTI it is registered with
+            # (typical queue-mode A→B replication setup).
             self._stream_thread = self.helper.listen_stream(
                 self._on_event,
-                url=self.helper.opencti_url.rstrip("/"),
+                url=self._live_stream_url(),
+                token=self._live_stream_token(),
             )
             self.helper.api.work.to_processed(work_id, "SSE consumer started")
             self.helper.connector_logger.info(

--- a/external-import/opencti-stream/src/opencti_stream/settings.py
+++ b/external-import/opencti-stream/src/opencti_stream/settings.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from connectors_sdk import (
     BaseConnectorSettings,
     BaseExternalImportConnectorConfig,
-    ListFromString,
 )
 from pydantic import Field
 
@@ -20,16 +19,13 @@ class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
         description="The name of the connector.",
         default="OpenCTI Stream",
     )
-    scope: ListFromString = Field(
-        description="The scope of the connector.",
-        default=["opencti-stream"],
-    )
     duration_period: timedelta = Field(
         description=(
-            "Required by the base connector configuration but unused by this connector. "
-            "Events are streamed continuously via SSE; there is no scheduled run."
+            "Period between scheduled health checks of the SSE consumer thread. "
+            "The thread itself runs continuously; this only controls how often the "
+            "watchdog verifies it is alive and restarts it if it has died."
         ),
-        default=timedelta(hours=1),
+        default=timedelta(minutes=1),
     )
     live_stream_id: str = Field(
         description=(

--- a/external-import/opencti-stream/src/opencti_stream/settings.py
+++ b/external-import/opencti-stream/src/opencti_stream/settings.py
@@ -48,9 +48,10 @@ class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
     live_stream_no_dependencies: bool = Field(
         description=(
             "Whether to receive only the event's own object from the stream "
-            "(without dependent objects). True by default to keep one event = one bundle."
+            "(without dependent objects). False by default so dependencies are included "
+            "and forwarded together with each event."
         ),
-        default=True,
+        default=False,
     )
 
 

--- a/external-import/opencti-stream/src/opencti_stream/settings.py
+++ b/external-import/opencti-stream/src/opencti_stream/settings.py
@@ -4,15 +4,21 @@ from connectors_sdk import (
     BaseConnectorSettings,
     BaseExternalImportConnectorConfig,
 )
-from pydantic import Field
+from pydantic import Field, HttpUrl, SecretStr
 
 
 class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
     """Connector configuration extended with live stream settings.
 
-    The three `live_stream_*` fields map to the `CONNECTOR_LIVE_STREAM_*` environment
-    variables and the matching `["connector", "live_stream_*"]` paths consumed by
-    `OpenCTIConnectorHelper` to drive the SSE consumer used by this connector.
+    The `live_stream_*` fields map to `CONNECTOR_LIVE_STREAM_*` environment variables
+    and the matching `["connector", "live_stream_*"]` config paths.
+
+    `live_stream_opencti_url` / `live_stream_opencti_token` decouple the OpenCTI the
+    connector listens to (the source) from the OpenCTI the connector is registered
+    with (the target, used by `OPENCTI_URL` / `OPENCTI_TOKEN` and where bundles are
+    pushed in queue mode). When unset, the source defaults to the target so the
+    connector listens to the same OpenCTI it pushes to (typical diode-export setup
+    where the connector runs alongside the source instance).
     """
 
     name: str = Field(
@@ -26,6 +32,24 @@ class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
             "watchdog verifies it is alive and restarts it if it has died."
         ),
         default=timedelta(minutes=1),
+    )
+    live_stream_opencti_url: HttpUrl | None = Field(
+        description=(
+            "URL of the OpenCTI instance whose live stream to consume. "
+            "Defaults to `OPENCTI_URL` (the OpenCTI the connector is registered with) "
+            "when unset. Set this to point at a remote / source OpenCTI different "
+            "from the one this connector pushes bundles to."
+        ),
+        default=None,
+    )
+    live_stream_opencti_token: SecretStr | None = Field(
+        description=(
+            "API token for the OpenCTI instance whose live stream to consume. "
+            "Defaults to `OPENCTI_TOKEN` when unset. Required when "
+            "`live_stream_opencti_url` points to a remote instance with a different "
+            "auth context."
+        ),
+        default=None,
     )
     live_stream_id: str = Field(
         description=(

--- a/external-import/opencti-stream/src/opencti_stream/settings.py
+++ b/external-import/opencti-stream/src/opencti_stream/settings.py
@@ -1,0 +1,62 @@
+from datetime import timedelta
+
+from connectors_sdk import (
+    BaseConnectorSettings,
+    BaseExternalImportConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field
+
+
+class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
+    """Connector configuration extended with live stream settings.
+
+    The three `live_stream_*` fields map to the `CONNECTOR_LIVE_STREAM_*` environment
+    variables and the matching `["connector", "live_stream_*"]` paths consumed by
+    `OpenCTIConnectorHelper` to drive the SSE consumer used by this connector.
+    """
+
+    name: str = Field(
+        description="The name of the connector.",
+        default="OpenCTI Stream",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+        default=["opencti-stream"],
+    )
+    duration_period: timedelta = Field(
+        description=(
+            "Required by the base connector configuration but unused by this connector. "
+            "Events are streamed continuously via SSE; there is no scheduled run."
+        ),
+        default=timedelta(hours=1),
+    )
+    live_stream_id: str = Field(
+        description=(
+            "The OpenCTI live stream to subscribe to. "
+            "Use 'live' for the global live stream, 'raw' for the raw stream, "
+            "or the UUID of a stream collection."
+        ),
+    )
+    live_stream_listen_delete: bool = Field(
+        description=(
+            "Whether to subscribe to delete events. Disabled by default since this "
+            "connector only forwards create/update (upsert) events."
+        ),
+        default=False,
+    )
+    live_stream_no_dependencies: bool = Field(
+        description=(
+            "Whether to receive only the event's own object from the stream "
+            "(without dependent objects). True by default to keep one event = one bundle."
+        ),
+        default=True,
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """Top-level settings for the OpenCTI Stream connector."""
+
+    connector: ExternalImportConnectorConfig = Field(
+        default_factory=ExternalImportConnectorConfig
+    )

--- a/external-import/opencti-stream/src/requirements.txt
+++ b/external-import/opencti-stream/src/requirements.txt
@@ -1,0 +1,3 @@
+pycti==7.260506.0
+pydantic~=2.11.3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/opencti-stream/tests/conftest.py
+++ b/external-import/opencti-stream/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/external-import/opencti-stream/tests/test-requirements.txt
+++ b/external-import/opencti-stream/tests/test-requirements.txt
@@ -1,0 +1,2 @@
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/external-import/opencti-stream/tests/test_main.py
+++ b/external-import/opencti-stream/tests/test_main.py
@@ -1,0 +1,98 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from opencti_stream import ConnectorSettings, OpenCTIStream
+from pycti import OpenCTIConnectorHelper
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+    It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "opencti-stream",
+                    "log_level": "error",
+                    "duration_period": "PT1M",
+                    "live_stream_id": "live",
+                    "live_stream_listen_delete": False,
+                    "live_stream_no_dependencies": False,
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that the implementation of `BaseConnectorSettings` (from `connectors-sdk`) can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from `BaseConnectorSettings`)
+        - the method `to_helper_config` MUST return a dict (as in base class)
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that `OpenCTIConnectorHelper` (from `pycti`) can be instantiated successfully:
+        - the value of `settings.to_helper_config` MUST be the expected dict for `OpenCTIConnectorHelper`
+        - the helper MUST be able to get its instance's attributes from the config dict
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "Test Connector"
+    assert helper.connect_scope == "opencti-stream"
+    assert helper.log_level == "ERROR"
+    assert helper.connect_live_stream_id == "live"
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST be able to access env/config vars through `self.config`
+        - the connector's main class MUST be able to access `pycti` API through `self.helper`
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    connector = OpenCTIStream(config=settings, helper=helper)
+
+    assert connector.config == settings
+    assert connector.helper == helper
+    assert connector._stream_thread is None

--- a/external-import/opencti-stream/tests/tests_connector/test_connector.py
+++ b/external-import/opencti-stream/tests/tests_connector/test_connector.py
@@ -1,0 +1,156 @@
+"""Unit tests for `OpenCTIStream._on_event` (the SSE forwarding callback).
+
+The connector itself is a thin passthrough: each test exercises one branch of
+`_on_event` against a stub message and an `OpenCTIStream` instance whose helper
+attributes have been replaced by `MagicMock`s. This avoids any network or pycti
+machinery while still validating the actual code path users care about.
+"""
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from opencti_stream.connector import OpenCTIStream
+
+
+@pytest.fixture
+def connector():
+    """Build an `OpenCTIStream` with a fully mocked helper, bypassing __init__ side effects."""
+    instance = OpenCTIStream.__new__(OpenCTIStream)
+    instance.config = MagicMock()
+    instance.helper = MagicMock()
+    instance.helper.connector_logger = MagicMock()
+    instance.helper.stix2_create_bundle.side_effect = (
+        lambda objects: f'{{"type":"bundle","objects":[{json.dumps(objects[0]) if objects else ""}]}}'
+    )
+    instance._stream_thread = None
+    return instance
+
+
+def _make_msg(event: str, data: Any, msg_id: str = "1-0"):
+    """Build a stub matching pycti's SSE message shape (event/id/data)."""
+    msg = MagicMock()
+    msg.event = event
+    msg.id = msg_id
+    msg.data = json.dumps(data) if not isinstance(data, str) else data
+    return msg
+
+
+def test_on_event_forwards_create(connector):
+    stix_object = {
+        "id": "report--00000000-0000-0000-0000-000000000001",
+        "type": "report",
+    }
+    payload = {
+        "data": stix_object,
+        "origin": {"user_id": "user-uuid-1"},
+    }
+
+    connector._on_event(_make_msg("create", payload))
+
+    assert connector.helper.applicant_id == "user-uuid-1"
+    connector.helper.stix2_create_bundle.assert_called_once_with([stix_object])
+    args, kwargs = connector.helper.send_stix2_bundle.call_args
+    assert kwargs == {"no_split": True, "cleanup_inconsistent_bundle": True}
+
+
+def test_on_event_forwards_update(connector):
+    stix_object = {
+        "id": "indicator--00000000-0000-0000-0000-000000000002",
+        "type": "indicator",
+    }
+    payload = {"data": stix_object, "origin": {"user_id": "user-uuid-2"}}
+
+    connector._on_event(_make_msg("update", payload))
+
+    connector.helper.send_stix2_bundle.assert_called_once()
+
+
+def test_on_event_skips_delete(connector):
+    """`delete` events are not forwarded (upsert-only relay)."""
+    payload = {
+        "data": {
+            "id": "report--00000000-0000-0000-0000-000000000003",
+            "type": "report",
+        },
+        "origin": {"user_id": "user-uuid-3"},
+    }
+
+    connector._on_event(_make_msg("delete", payload))
+
+    connector.helper.stix2_create_bundle.assert_not_called()
+    connector.helper.send_stix2_bundle.assert_not_called()
+
+
+def test_on_event_skips_unknown_event_type(connector):
+    payload = {
+        "data": {
+            "id": "report--00000000-0000-0000-0000-000000000004",
+            "type": "report",
+        },
+    }
+
+    connector._on_event(_make_msg("heartbeat", payload))
+
+    connector.helper.send_stix2_bundle.assert_not_called()
+
+
+def test_on_event_skips_malformed_json(connector):
+    msg = MagicMock()
+    msg.event = "create"
+    msg.id = "9-0"
+    msg.data = "{this is not valid json"
+
+    connector._on_event(msg)
+
+    connector.helper.connector_logger.warning.assert_called_once()
+    connector.helper.send_stix2_bundle.assert_not_called()
+
+
+def test_on_event_skips_payload_without_data(connector):
+    payload = {"origin": {"user_id": "user-uuid-5"}}
+
+    connector._on_event(_make_msg("create", payload))
+
+    connector.helper.send_stix2_bundle.assert_not_called()
+
+
+def test_on_event_skips_payload_with_non_dict_data(connector):
+    payload = {"data": "not-a-dict", "origin": {"user_id": "user-uuid-6"}}
+
+    connector._on_event(_make_msg("create", payload))
+
+    connector.helper.send_stix2_bundle.assert_not_called()
+
+
+def test_on_event_resets_applicant_when_origin_missing(connector):
+    """When `origin.user_id` is missing, `applicant_id` MUST be reset (not inherited from a previous event)."""
+    connector.helper.applicant_id = "previous-user-leaks"
+
+    payload_without_origin = {
+        "data": {
+            "id": "report--00000000-0000-0000-0000-000000000007",
+            "type": "report",
+        },
+    }
+    connector._on_event(_make_msg("create", payload_without_origin))
+
+    assert connector.helper.applicant_id is None
+    connector.helper.send_stix2_bundle.assert_called_once()
+
+
+def test_on_event_resets_applicant_when_origin_user_id_missing(connector):
+    """An event with an `origin` block but no `user_id` MUST also reset `applicant_id`."""
+    connector.helper.applicant_id = "previous-user-leaks"
+
+    payload = {
+        "data": {
+            "id": "report--00000000-0000-0000-0000-000000000008",
+            "type": "report",
+        },
+        "origin": {"socket": "query", "ip": "::1"},
+    }
+    connector._on_event(_make_msg("create", payload))
+
+    assert connector.helper.applicant_id is None

--- a/external-import/opencti-stream/tests/tests_connector/test_connector.py
+++ b/external-import/opencti-stream/tests/tests_connector/test_connector.py
@@ -1,9 +1,10 @@
-"""Unit tests for `OpenCTIStream._on_event` (the SSE forwarding callback).
+"""Unit tests for `OpenCTIStream` (the SSE forwarding connector).
 
-The connector itself is a thin passthrough: each test exercises one branch of
-`_on_event` against a stub message and an `OpenCTIStream` instance whose helper
-attributes have been replaced by `MagicMock`s. This avoids any network or pycti
-machinery while still validating the actual code path users care about.
+The connector is a thin passthrough: each test exercises one branch of `_on_event`
+or one of the small URL/token resolution helpers against an `OpenCTIStream` instance
+whose helper / config attributes have been replaced by `MagicMock`s. This avoids any
+network or pycti machinery while still validating the actual code paths users care
+about.
 """
 
 import json
@@ -12,6 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from opencti_stream.connector import OpenCTIStream
+from pydantic import HttpUrl, SecretStr
 
 
 @pytest.fixture
@@ -19,6 +21,8 @@ def connector():
     """Build an `OpenCTIStream` with a fully mocked helper, bypassing __init__ side effects."""
     instance = OpenCTIStream.__new__(OpenCTIStream)
     instance.config = MagicMock()
+    instance.config.connector.live_stream_opencti_url = None
+    instance.config.connector.live_stream_opencti_token = None
     instance.helper = MagicMock()
     instance.helper.connector_logger = MagicMock()
     instance.helper.stix2_create_bundle.side_effect = (
@@ -154,3 +158,39 @@ def test_on_event_resets_applicant_when_origin_user_id_missing(connector):
     connector._on_event(_make_msg("create", payload))
 
     assert connector.helper.applicant_id is None
+
+
+# ---------------------------------------------------------------------------
+# URL / token resolution: source (live stream) vs target (helper) OpenCTI
+# ---------------------------------------------------------------------------
+
+
+def test_live_stream_url_falls_back_to_helper_when_not_configured(connector):
+    connector.config.connector.live_stream_opencti_url = None
+    connector.helper.opencti_url = "http://target-opencti:8080/"
+
+    assert connector._live_stream_url() == "http://target-opencti:8080"
+
+
+def test_live_stream_url_uses_configured_value_and_strips_trailing_slash(connector):
+    connector.config.connector.live_stream_opencti_url = HttpUrl(
+        "http://source-opencti:8080"
+    )
+    connector.helper.opencti_url = "http://target-opencti:8080/"
+
+    # Pydantic's HttpUrl normalizes to add a trailing slash; the resolver must strip it.
+    assert connector._live_stream_url() == "http://source-opencti:8080"
+
+
+def test_live_stream_token_falls_back_to_helper_when_not_configured(connector):
+    connector.config.connector.live_stream_opencti_token = None
+    connector.helper.opencti_token = "target-token"
+
+    assert connector._live_stream_token() == "target-token"
+
+
+def test_live_stream_token_uses_configured_value(connector):
+    connector.config.connector.live_stream_opencti_token = SecretStr("source-token")
+    connector.helper.opencti_token = "target-token"
+
+    assert connector._live_stream_token() == "source-token"

--- a/external-import/opencti-stream/tests/tests_connector/test_settings.py
+++ b/external-import/opencti-stream/tests/tests_connector/test_settings.py
@@ -1,0 +1,128 @@
+from typing import Any
+
+import pytest
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+from opencti_stream import ConnectorSettings
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "opencti-stream",
+                    "log_level": "error",
+                    "duration_period": "PT1M",
+                    "live_stream_id": "live",
+                    "live_stream_listen_delete": False,
+                    "live_stream_no_dependencies": False,
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "opencti-stream",
+                    "live_stream_id": "live",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) accepts valid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake but valid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param({}, "settings", id="empty_settings_dict"),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:PORT",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "opencti-stream",
+                    "live_stream_id": "live",
+                },
+            },
+            "opencti.url",
+            id="invalid_opencti_url",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "opencti-stream",
+                    # Missing live_stream_id
+                },
+            },
+            "connector.live_stream_id",
+            id="missing_live_stream_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that `ConnectorSettings` raises on invalid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake and invalid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert str("Error validating configuration") in str(err)

--- a/external-import/opencti-stream/tests/tests_connector/test_settings.py
+++ b/external-import/opencti-stream/tests/tests_connector/test_settings.py
@@ -42,6 +42,22 @@ from pydantic import ValidationError
             },
             id="minimal_valid_settings_dict",
         ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://target-opencti:8080",
+                    "token": "target-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "opencti-stream",
+                    "live_stream_id": "live",
+                    "live_stream_opencti_url": "http://source-opencti:8080",
+                    "live_stream_opencti_token": "source-token",
+                },
+            },
+            id="dual_instance_settings_dict",
+        ),
     ],
 )
 def test_settings_should_accept_valid_input(settings_dict):

--- a/external-import/opencti-stream/tests/tests_connector/test_settings.py
+++ b/external-import/opencti-stream/tests/tests_connector/test_settings.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 from connectors_sdk import BaseConfigModel, ConfigValidationError
 from opencti_stream import ConnectorSettings
+from pydantic import ValidationError
 
 
 @pytest.mark.parametrize(
@@ -69,9 +70,13 @@ def test_settings_should_accept_valid_input(settings_dict):
 
 
 @pytest.mark.parametrize(
-    "settings_dict, field_name",
+    "settings_dict, expected_loc",
     [
-        pytest.param({}, "settings", id="empty_settings_dict"),
+        pytest.param(
+            {},
+            ("opencti", "url"),
+            id="empty_settings_dict",
+        ),
         pytest.param(
             {
                 "opencti": {
@@ -84,7 +89,7 @@ def test_settings_should_accept_valid_input(settings_dict):
                     "live_stream_id": "live",
                 },
             },
-            "opencti.url",
+            ("opencti", "url"),
             id="invalid_opencti_url",
         ),
         pytest.param(
@@ -99,18 +104,21 @@ def test_settings_should_accept_valid_input(settings_dict):
                     # Missing live_stream_id
                 },
             },
-            "connector.live_stream_id",
+            ("connector", "live_stream_id"),
             id="missing_live_stream_id",
         ),
     ],
 )
-def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+def test_settings_should_raise_when_invalid_input(settings_dict, expected_loc):
     """
-    Test that `ConnectorSettings` raises on invalid input.
-    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
-    a fake and invalid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+    Test that `ConnectorSettings` raises on invalid input AND that the failure points
+    at the expected field. We unwrap the `ConfigValidationError` (raised by
+    `connectors-sdk` to wrap a pydantic `ValidationError`) and assert the expected
+    field appears in at least one of the validation error locations.
 
     :param settings_dict: The dict to use as `ConnectorSettings` input
+    :param expected_loc: Tuple representing the pydantic location (e.g. ("connector", "live_stream_id"))
+        that should appear in the underlying ValidationError
     """
 
     class FakeConnectorSettings(ConnectorSettings):
@@ -123,6 +131,21 @@ def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
         def _load_config_dict(cls, _, handler) -> dict[str, Any]:
             return handler(settings_dict)
 
-    with pytest.raises(ConfigValidationError) as err:
+    with pytest.raises(ConfigValidationError) as err_info:
         FakeConnectorSettings()
-    assert str("Error validating configuration") in str(err)
+    assert "Error validating configuration" in str(err_info.value)
+
+    # The cause is the underlying pydantic ValidationError; check the expected field
+    # appears in the reported error locations. We match the last element of the loc
+    # tuple (the field name) since some errors are reported at the nested location
+    # (e.g. ("connector", "live_stream_id")) and some at the inner-model root
+    # (e.g. ("url",) when `_OpenCTIConfig` is built with empty input).
+    cause = err_info.value.__cause__
+    assert isinstance(
+        cause, ValidationError
+    ), "Expected wrapped pydantic ValidationError"
+    error_locs = [error["loc"] for error in cause.errors()]
+    expected_field = expected_loc[-1]
+    assert any(
+        loc and loc[-1] == expected_field for loc in error_locs
+    ), f"Expected validation error on field {expected_field!r}, got {error_locs}"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* New marketplace-compatible external-import connector at [external-import/opencti-stream/](../tree/issue/6346-opencti-stream-connector/external-import/opencti-stream) that subscribes to an OpenCTI live stream via `helper.listen_stream()` (supervised by `helper.schedule_process` as a watchdog) and forwards each `create`/`update` event as a single STIX 2.1 bundle through `helper.send_stix2_bundle(bundle, no_split=True, cleanup_inconsistent_bundle=True)`.
* Output mode (RabbitMQ queue, local directory, S3 bucket) is controlled by the standard `CONNECTOR_SEND_TO_*` helper settings, so the same connector covers in-platform fan-out (queue mode) and the source side of a diode pipeline paired with `diode-import` on the target instance (directory / S3 modes).
* The originating user (`origin.user_id` of each stream event) is propagated as the bundle's `applicant_id`, which is then used by workers (queue mode) or by `diode-import` (`DIODE_IMPORT_APPLICANT_MAPPINGS`, diode mode) to preserve identity attribution. When `origin.user_id` is missing (system-generated events), `applicant_id` is reset so it does not leak from a previous event.
* Built on the new marketplace-compatible structure: `connectors-sdk` settings (`BaseExternalImportConnectorConfig` extended with `live_stream_id`, `live_stream_listen_delete=False`, `live_stream_no_dependencies=False`), package-style `src/` layout, `__metadata__/connector_manifest.json` (slug `opencti-stream`, image `opencti/connector-opencti-stream`).
* `delete` events are intentionally ignored (upsert-only forwarding); `live_stream_listen_delete` defaults to `false` so the SSE server does not emit them.
* Includes a `tests/` scaffold (17 tests) covering settings validation and the core `_on_event` forwarding logic.

### Related issues

* Closes #6346

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

The connector itself stays small (~120 lines of logic) because all output modes are inherited from `OpenCTIConnectorHelper.send_stix2_bundle()`, which already supports queue, directory and S3 modes via `CONNECTOR_SEND_TO_*` and embeds `self.applicant_id` in both queue messages and the bundle files written by directory / S3 modes.

Pairing diagram:

```mermaid
graph LR
    SourceOcti[Source OpenCTI] -->|SSE stream events| OctiStream[opencti-stream]
    OctiStream -->|"send_to_queue (default)"| Queue[OpenCTI queue / workers]
    OctiStream -->|send_to_directory| Files[Bundle files]
    OctiStream -->|send_to_s3| S3[S3 bucket]
    Files -->|"diode crossing"| DiodeImport[diode-import]
    S3 -->|"diode crossing"| DiodeImport
    DiodeImport -->|ingestion| TargetOcti[Target OpenCTI]
```

Local validation that was run:

- `isort==7.0.0 --profile black --line-length 88` (clean)
- `black==26.3.1 --check` (clean, matches `ci-requirements.txt`)
- `flake8 --ignore=E,W` (clean)
- `pytest external-import/opencti-stream/tests` → 17/17 pass
- All commits signed with the configured GPG key.
