### PR TITLE
fix(misp): correct Sighting.Organisation list handling (#6351)

### DIFF
--- a/external-import/misp/src/connector/use_cases/convert_attribute.py
+++ b/external-import/misp/src/connector/use_cases/convert_attribute.py
@@ -648,16 +648,34 @@ class AttributeConverter:
         if indicator:
             # ? The for loop below seems to never be reached
             for misp_sighting in getattr(attribute, "Sighting", []):
-                if (
-                    "Organisation" in misp_sighting
-                    and misp_sighting["Organisation"]["name"] != author.name
-                ):
+                # MISP usually returns Sighting.Organisation as a single dict, but
+                # some deployments / aggregated feeds emit it as a list of dicts.
+                # Normalize to a list to handle both shapes; ignore other types.
+                misp_sighting_org = misp_sighting.get("Organisation")
+                if isinstance(misp_sighting_org, dict):
+                    org_entries = [misp_sighting_org]
+                elif isinstance(misp_sighting_org, list):
+                    org_entries = [
+                        org for org in misp_sighting_org if isinstance(org, dict)
+                    ]
+                else:
+                    org_entries = []
+
+                org_name = next(
+                    (
+                        org.get("name")
+                        for org in org_entries
+                        if org.get("name") and org.get("name") != author.name
+                    ),
+                    None,
+                )
+                if org_name:
                     sighted_by = stix2.Identity(
                         id=pycti.Identity.generate_id(
-                            name=misp_sighting["Organisation"]["name"],
+                            name=org_name,
                             identity_class="organization",
                         ),
-                        name=misp_sighting["Organisation"]["name"],
+                        name=org_name,
                         identity_class="organization",
                     )
                     stix_objects.append(sighted_by)

--- a/external-import/misp/tests/tests_connector/test_convert_attribute.py
+++ b/external-import/misp/tests/tests_connector/test_convert_attribute.py
@@ -1,6 +1,6 @@
-"""Unit tests for ``AttributeConverter.create_stix2_ip_address``.
+"""Unit tests for ``AttributeConverter``.
 
-Pins the IPv4 / IPv6 type-tagging contract added in this PR:
+Pins the IPv4 / IPv6 type-tagging contract of ``create_stix2_ip_address``:
 
 * Single-host IPv4 (``1.2.3.4``) → ``stix2.IPv4Address`` (regression
   guard — pre-PR behaviour also handled this correctly).
@@ -21,12 +21,100 @@ Pins the IPv4 / IPv6 type-tagging contract added in this PR:
   anything that does not parse as IPv4 is type-tagged as IPv6 (the
   MISP source of truth gets to decide what is and is not a valid IP;
   the converter only chooses the STIX type).
+
+Also covers ``AttributeConverter.process()`` Sighting handling: the
+``Organisation`` payload may arrive as a dict or a list of dicts, and
+unexpected types are skipped without raising.
 """
 
+import pycti
 import pytest
 import stix2
+from api_client.models import ExtendedAttributeItem
 from connector.use_cases.common import ConverterConfig
 from connector.use_cases.convert_attribute import AttributeConverter
+
+
+def _make_author() -> stix2.Identity:
+    return stix2.Identity(
+        id=pycti.Identity.generate_id(name="Author Org", identity_class="organization"),
+        name="Author Org",
+        identity_class="organization",
+    )
+
+
+def _make_attribute_with_sighting(sighting_organisation):
+    """Build an `ExtendedAttributeItem` carrying a Sighting payload via Pydantic
+    extras (the model has `extra="allow"`)."""
+    return ExtendedAttributeItem.model_validate(
+        {
+            "type": "ip-dst",
+            "category": "Network activity",
+            "value": "1.2.3.4",
+            "to_ids": True,
+            "timestamp": "1700000000",
+            "comment": "test",
+            "Sighting": [
+                {
+                    "date_sighting": "1700000000",
+                    "Organisation": sighting_organisation,
+                }
+            ],
+        }
+    )
+
+
+def _process(attribute):
+    converter = AttributeConverter(
+        ConverterConfig(external_reference_base_url="http://dummy")
+    )
+    author = _make_author()
+    return converter.process(
+        attribute=attribute,
+        labels=[],
+        score=50,
+        author=author,
+        markings=[],
+        external_references=[],
+        include_relationships=True,
+    )
+
+
+def test_sighting_with_organisation_as_dict_creates_sighted_by():
+    # GIVEN MISP returns Organisation as a dict (the canonical shape)
+    attribute = _make_attribute_with_sighting({"name": "External Org"})
+
+    # WHEN processing the attribute
+    stix_objects = _process(attribute)
+
+    # THEN a sighted-by Identity is emitted using the dict's name
+    identities = [o for o in stix_objects if isinstance(o, stix2.Identity)]
+    assert any(i.name == "External Org" for i in identities)
+
+
+def test_sighting_with_organisation_as_list_does_not_raise():
+    # GIVEN MISP returns Organisation as a list of dicts (seen in some
+    # deployments / aggregated feeds; previously crashed with TypeError)
+    attribute = _make_attribute_with_sighting([{"name": "External Org"}])
+
+    # WHEN processing the attribute
+    stix_objects = _process(attribute)
+
+    # THEN processing succeeds and the sighted-by Identity is still emitted
+    identities = [o for o in stix_objects if isinstance(o, stix2.Identity)]
+    assert any(i.name == "External Org" for i in identities)
+
+
+def test_sighting_with_organisation_as_unexpected_type_is_skipped():
+    # GIVEN Organisation has an unexpected shape
+    attribute = _make_attribute_with_sighting("not-a-dict-or-list")
+
+    # WHEN processing the attribute
+    stix_objects = _process(attribute)
+
+    # THEN no sighted-by Identity is emitted, but processing does not raise
+    identities = [o for o in stix_objects if isinstance(o, stix2.Identity)]
+    assert identities == []
 
 
 @pytest.fixture


### PR DESCRIPTION
### Proposed changes

Normalize `Sighting.Organisation` to a list of dict entries in `external-import/misp/src/connector/use_cases/convert_attribute.py` so the loop handles both the canonical dict shape and the list-of-dicts shape some deployments / aggregated feeds emit. Unexpected shapes are skipped instead of crashing, and a dict entry without a `name` no longer raises.

Adds three regression tests covering dict, list, and unexpected payloads in `tests/tests_connector/test_convert_attribute.py`.

### Related issues

Closes #6351

### Further comments

The previous code did `misp_sighting["Organisation"]["name"]` directly, which raised `TypeError: list indices must be integers or slices, not str` on payloads where `Organisation` is a list rather than a dict. The fix keeps the existing dict path unchanged and adds a list path that picks the first non-author org name; both paths share the same `stix2.Identity` construction.

### Maintainer review update (@SamuelHassine)

Reviewed the full changed files - the fix is correct and also avoids a `KeyError` when a dict entry lacks a `name`. Verified locally: the `test_convert_attribute.py` suite passes (21 tests including the 3 new regressions) and black/isort/flake8 are clean.

Review-and-fix pass (round 2): resolved the Copilot docstring thread (the module docstring now documents the `process()` sighting / Organisation coverage). The contributor had pushed that docstring fix as a DCO `Signed-off-by`-only commit, which re-broke the "Check signed commits in PR" check, so I re-squashed the branch into a single GPG-signed commit (contributor credited via `Co-authored-by`) and merged `master` to de-stale (the branch had fallen behind, which also broke the new uv-based Tests Connectors CI on dependency resolution).

All GitHub Actions checks and Codecov patch (100% of diff) / project are green; 0 unresolved review threads; `mergeable: MERGEABLE`.

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
