### PR TITLE
[crowdstrike] Add filter to not import old reports

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
@@ -133,6 +133,10 @@ class ReportImporter(BaseImporter):
 
         fql_filter = f"last_modified_date:>{start_timestamp}"
 
+        # Also filter by created_date to avoid importing very old reports
+        # that were recently modified (e.g., tag updates by CrowdStrike).
+        fql_filter = f"{fql_filter}+created_date:>{self.default_latest_timestamp}"
+
         if self.include_types:
             fql_filter = f"{fql_filter}+type:{self.include_types}"
 

--- a/external-import/crowdstrike/tests/test_report_created_date_filter.py
+++ b/external-import/crowdstrike/tests/test_report_created_date_filter.py
@@ -1,0 +1,126 @@
+"""Tests for report importer created_date FQL filter."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from crowdstrike_feeds_connector.report.importer import ReportImporter
+
+
+@pytest.fixture
+def report_importer():
+    """Create a ReportImporter with mocked dependencies."""
+    mock_config = MagicMock()
+    mock_helper = MagicMock()
+    mock_author = MagicMock()
+    mock_tlp = MagicMock()
+
+    # Set a known default_latest_timestamp (e.g., 2025-01-01 00:00:00 UTC)
+    default_ts = int(datetime(2025, 1, 1, tzinfo=timezone.utc).timestamp())
+
+    with patch("crowdstrike_feeds_connector.report.importer.ReportsAPI"), patch(
+        "crowdstrike_feeds_connector.report.importer.IndicatorsAPI"
+    ):
+        importer = ReportImporter(
+            config=mock_config,
+            helper=mock_helper,
+            author=mock_author,
+            default_latest_timestamp=default_ts,
+            tlp_marking=mock_tlp,
+            include_types=[],
+            target_industries=[],
+            report_status=0,
+            report_type="threat-report",
+            guess_malware=False,
+            report_guess_relations=False,
+            indicator_config={},
+            no_file_trigger_import=True,
+            scopes=set(),
+        )
+    return importer
+
+
+def test_fetch_reports_includes_created_date_filter(report_importer):
+    """The FQL filter must include created_date to exclude old reports."""
+    start_timestamp = int(datetime(2025, 4, 1, tzinfo=timezone.utc).timestamp())
+
+    with patch("crowdstrike_feeds_connector.report.importer.paginate") as mock_paginate:
+        mock_paginated_fn = MagicMock(return_value=iter([]))
+        mock_paginate.return_value = mock_paginated_fn
+
+        # Exhaust the generator
+        list(report_importer._fetch_reports(start_timestamp))
+
+        mock_paginated_fn.assert_called_once()
+        call_kwargs = mock_paginated_fn.call_args[1]
+        fql_filter = call_kwargs["fql_filter"]
+
+        # Must filter by last_modified_date (pagination cursor)
+        assert f"last_modified_date:>{start_timestamp}" in fql_filter
+        # Must also filter by created_date using the configured start timestamp
+        assert f"created_date:>{report_importer.default_latest_timestamp}" in fql_filter
+
+
+def test_fetch_reports_created_date_filter_uses_configured_timestamp(report_importer):
+    """created_date filter should use default_latest_timestamp, not the advancing cursor."""
+    # Simulate the cursor having advanced well past the configured timestamp
+    advancing_cursor = int(datetime(2025, 5, 1, tzinfo=timezone.utc).timestamp())
+
+    with patch("crowdstrike_feeds_connector.report.importer.paginate") as mock_paginate:
+        mock_paginated_fn = MagicMock(return_value=iter([]))
+        mock_paginate.return_value = mock_paginated_fn
+
+        list(report_importer._fetch_reports(advancing_cursor))
+
+        call_kwargs = mock_paginated_fn.call_args[1]
+        fql_filter = call_kwargs["fql_filter"]
+
+        # The created_date filter must use the original configured timestamp,
+        # not the advancing pagination cursor.
+        assert f"created_date:>{report_importer.default_latest_timestamp}" in fql_filter
+        # The last_modified_date filter uses the advancing cursor
+        assert f"last_modified_date:>{advancing_cursor}" in fql_filter
+
+
+def test_fetch_reports_includes_type_and_industry_filters():
+    """FQL filter should combine created_date with type and target_industries."""
+    mock_config = MagicMock()
+    mock_helper = MagicMock()
+
+    default_ts = int(datetime(2025, 1, 1, tzinfo=timezone.utc).timestamp())
+
+    with patch("crowdstrike_feeds_connector.report.importer.ReportsAPI"), patch(
+        "crowdstrike_feeds_connector.report.importer.IndicatorsAPI"
+    ):
+        importer = ReportImporter(
+            config=mock_config,
+            helper=mock_helper,
+            author=MagicMock(),
+            default_latest_timestamp=default_ts,
+            tlp_marking=MagicMock(),
+            include_types=["notice", "tipper"],
+            target_industries=["technology"],
+            report_status=0,
+            report_type="threat-report",
+            guess_malware=False,
+            report_guess_relations=False,
+            indicator_config={},
+            no_file_trigger_import=True,
+            scopes=set(),
+        )
+
+    start_ts = int(datetime(2025, 3, 1, tzinfo=timezone.utc).timestamp())
+
+    with patch("crowdstrike_feeds_connector.report.importer.paginate") as mock_paginate:
+        mock_paginated_fn = MagicMock(return_value=iter([]))
+        mock_paginate.return_value = mock_paginated_fn
+
+        list(importer._fetch_reports(start_ts))
+
+        call_kwargs = mock_paginated_fn.call_args[1]
+        fql_filter = call_kwargs["fql_filter"]
+
+        assert f"last_modified_date:>{start_ts}" in fql_filter
+        assert f"created_date:>{default_ts}" in fql_filter
+        assert "type:['notice', 'tipper']" in fql_filter
+        assert "target_industries:['technology']" in fql_filter


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add filter to not import old reports

### Related issues

* Closes: #5714 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
