### PR TITLE
[misp]: convert threat-actor Attribution attributes to IntrusionSet (TEST CI - DO NOT MERGE)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+comment:
+    # add "condensed_" to "header", "files" and "footer"
+    layout: "diff, files, condensed_footer"
+    hide_project_coverage: true # set to true
+    require_changes: "coverage_drop AND uncovered_patch"
+
+ignore:
+  # Ignore any folder whose name starts with "test" anywhere in the tree
+  - "**/test*/**"
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        informational: true
+    patch:
+      default:
+        target: 80%
+        threshold: 5%

--- a/external-import/misp/src/connector/use_cases/convert_attribute.py
+++ b/external-import/misp/src/connector/use_cases/convert_attribute.py
@@ -181,6 +181,28 @@ class AttributeConverter:
                 custom_properties=custom_properties,
             )
 
+    def create_intrusion_set_from_attribute(
+        self,
+        attribute: ExtendedAttributeItem,
+        labels: list[str],
+        author: stix2.Identity,
+        markings: list[stix2.v21.MarkingDefinition],
+        external_references: list[stix2.ExternalReference],
+    ) -> stix2.IntrusionSet | None:
+        name = attribute.value
+        if not name:
+            return None
+        return stix2.IntrusionSet(
+            id=pycti.IntrusionSet.generate_id(name=name),
+            name=name,
+            labels=labels,
+            description=attribute.comment,
+            created_by_ref=author["id"],
+            object_marking_refs=markings,
+            external_references=external_references,
+            allow_custom=True,
+        )
+
     def create_observables(
         self,
         attribute: ExtendedAttributeItem,
@@ -535,6 +557,21 @@ class AttributeConverter:
                 tag, author=author, markings=attribute_markings
             )
             stix_objects.extend(tag_stix_objects)
+
+        is_threat_actor_attribution = (
+            attribute.type == "threat-actor" and attribute.category == "Attribution"
+        )
+
+        if is_threat_actor_attribution:
+            intrusion_set = self.create_intrusion_set_from_attribute(
+                attribute,
+                labels=attribute_labels,
+                author=author,
+                markings=attribute_markings,
+                external_references=external_references,
+            )
+            if intrusion_set:
+                stix_objects.append(intrusion_set)
 
         observables = []
         if self.config.convert_attribute_to_observable:

--- a/external-import/misp/tests/tests_connector/test_attribute_converter.py
+++ b/external-import/misp/tests/tests_connector/test_attribute_converter.py
@@ -1,0 +1,51 @@
+import stix2
+from api_client.models import AttributeCategory, AttributeType, ExtendedAttributeItem
+from connector.use_cases.common import ConverterConfig
+from connector.use_cases.convert_attribute import AttributeConverter
+
+
+def _make_config() -> ConverterConfig:
+    return ConverterConfig(external_reference_base_url="http://dummy")
+
+
+def _make_author() -> stix2.Identity:
+    import pycti
+
+    return stix2.Identity(
+        id=pycti.Identity.generate_id(
+            name="Test Author", identity_class="organization"
+        ),
+        name="Test Author",
+        identity_class="organization",
+    )
+
+
+class TestThreatActorAttributionConversion:
+    """Tests for MISP 'threat-actor' Attribution attribute → IntrusionSet conversion."""
+
+    def test_threat_actor_attribution_creates_intrusion_set(self):
+        # GIVEN a threat-actor attribute in Attribution category
+        config = _make_config()
+        converter = AttributeConverter(config)
+        author = _make_author()
+        attribute = ExtendedAttributeItem(
+            type=AttributeType.threat_actor,
+            category=AttributeCategory.Attribution,
+            value="APT28",
+            comment="Known threat actor",
+        )
+
+        # WHEN processing the attribute
+        result = converter.process(
+            attribute,
+            labels=[],
+            score=50,
+            author=author,
+            markings=[],
+            external_references=[],
+        )
+
+        # THEN result contains exactly one IntrusionSet
+        intrusion_sets = [obj for obj in result if isinstance(obj, stix2.IntrusionSet)]
+        assert len(intrusion_sets) == 1
+        assert intrusion_sets[0]["name"] == "APT28"


### PR DESCRIPTION
When a MISP attribute has type 'threat-actor' and category 'Attribution', create a deterministic-ID IntrusionSet instead of an observable/indicator. This handles a previously unrecognised attribute type, fixing ingestion of threat-actor attribution data from MISP events.

Fixes #6366 

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
