### PR TITLE
[abuseipdb] handle missing reporterCountryCode in report payload

### DIFF
--- a/internal-enrichment/abuseipdb/src/connector/abuseipdb.py
+++ b/internal-enrichment/abuseipdb/src/connector/abuseipdb.py
@@ -119,7 +119,7 @@ class ConnectorAbuseIPDB:
             found = []
             cl = defaultdict(dict)
             for report in data["reports"]:
-                countryN = report["reporterCountryCode"]
+                countryN = report.get("reporterCountryCode")
                 if countryN in cl:
                     cl[countryN]["count"] += 1
                     cl[countryN]["firstseen"] = report["reportedAt"]


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Read `reporterCountryCode` from each AbuseIPDB report with `.get()` instead of subscript so reports without that field no longer raise `KeyError` at `internal-enrichment/abuseipdb/src/connector/abuseipdb.py:122`.
* The existing `if ckey is None: continue` guard on line 144 already skips entries with a missing country, so the downstream Location/Sighting generation is unchanged.

### Related issues

* Fixes #6343

### Checklist

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The AbuseIPDB v2 `/check` API documents `reporterCountryCode` as optional, and the field is absent when the reporter is anonymous. The crash was deterministic on any IP whose `reports` array contained such an entry.
