### PR TITLE
[Recorded Future] Fix alerts module not using rf_initial_lookback on first run (#6329)

### DIFF
--- a/external-import/recorded-future/src/main.py
+++ b/external-import/recorded-future/src/main.py
@@ -137,6 +137,7 @@ class RFConnector:
                     self.RF.rf_alerts_api,
                     self.RF.opencti_default_severity,
                     self.RF.tlp,
+                    self.RF.rf_initial_lookback,
                 )
                 self.alerts.start()
                 threads.append(self.alerts)

--- a/external-import/recorded-future/src/rflib/rf_alerts.py
+++ b/external-import/recorded-future/src/rflib/rf_alerts.py
@@ -1,6 +1,6 @@
 import base64
 import threading
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from re import search
 
 import pycti
@@ -30,9 +30,11 @@ class RecordedFutureAlertConnector(threading.Thread):
         rf_alerts_api: RecordedFutureApiClient,
         opencti_default_severity: str,
         tlp: str,
+        rf_initial_lookback: int,
     ):
         threading.Thread.__init__(self)
         self.helper = helper
+        self.rf_initial_lookback = rf_initial_lookback
 
         self.helper.connector_logger.info(
             "Starting Recorded Future Alert connector module initialization"
@@ -202,13 +204,19 @@ class RecordedFutureAlertConnector(threading.Thread):
                 "last_processed_alert_date"
             )
             if state_last_processed_alert_date is None:
-                last_processed_alert_date = None
+                last_processed_alert_date = now - timedelta(
+                    hours=self.rf_initial_lookback
+                )
+                self.helper.connector_logger.info(
+                    "[ALERTS] First run, looking back",
+                    {"initial_lookback_hours": self.rf_initial_lookback},
+                )
             else:
                 last_processed_alert_date = datetime.fromisoformat(
                     state_last_processed_alert_date
                 ).replace(tzinfo=timezone.utc)
 
-            alerts = self.collect_alerts(since=last_processed_alert_date or now)
+            alerts = self.collect_alerts(since=last_processed_alert_date)
             alerts.sort(key=lambda a: a.alert_date or "")
             for alert in alerts:
                 try:

--- a/external-import/recorded-future/tests/tests_connector/test_rf_alerts.py
+++ b/external-import/recorded-future/tests/tests_connector/test_rf_alerts.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, call, patch
 
 from rflib.pyrf import Alert, PrioritiedRule, RecordedFutureApiClient
@@ -24,7 +24,7 @@ def _make_alert(alert_id, alert_date="2025-01-01T00:00:00Z"):
     )
 
 
-def _build_connector(helper):
+def _build_connector(helper, rf_initial_lookback=48):
     """Build a connector instance with mocked internals."""
     rf_api = MagicMock()
     with patch.object(
@@ -39,6 +39,7 @@ def _build_connector(helper):
         connector.author = MagicMock()
         connector.update_rules = MagicMock()
         connector.alert_to_incident = MagicMock()
+        connector.rf_initial_lookback = rf_initial_lookback
     return connector
 
 
@@ -217,3 +218,27 @@ def test_raw_get_alerts_sends_sort_params():
         params = mock_get.call_args.kwargs["params"]
         assert params["orderby"] == "triggered"
         assert params["direction"] == "asc"
+
+
+def test_first_run_uses_initial_lookback():
+    """On first run (no state), collect_alerts must use now - rf_initial_lookback hours."""
+    # Given: no prior state and a specific lookback
+    helper = MagicMock()
+    helper.get_state.return_value = {}
+    helper.connect_name = "RecordedFuture"
+    helper.connector_id = "connector-1"
+
+    lookback_hours = 72
+    connector = _build_connector(helper, rf_initial_lookback=lookback_hours)
+    connector.collect_alerts = MagicMock(return_value=[])
+
+    # When: the connector runs
+    before = datetime.now(tz=timezone.utc)
+    connector.run()
+    after = datetime.now(tz=timezone.utc)
+
+    # Then: collect_alerts was called with a 'since' approximately now - lookback
+    since_arg = connector.collect_alerts.call_args.kwargs["since"]
+    expected_earliest = before - timedelta(hours=lookback_hours)
+    expected_latest = after - timedelta(hours=lookback_hours)
+    assert expected_earliest <= since_arg <= expected_latest


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  Fix first-run lookback, align with analyst notes module, add test  

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/6329

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
