### PR TITLE
[google-ti-feeds] Do not update state on 429 HTTP errors

### DIFF
--- a/external-import/google-ti-feeds/connector/src/custom/client_api/client_api_base.py
+++ b/external-import/google-ti-feeds/connector/src/custom/client_api/client_api_base.py
@@ -394,6 +394,7 @@ class BaseClientAPI:
                     "error": str(e),
                 },
             )
+            raise
         finally:
             self.logger.debug(
                 "Finished fetching",

--- a/external-import/google-ti-feeds/connector/src/custom/client_api/client_api_base.py
+++ b/external-import/google-ti-feeds/connector/src/custom/client_api/client_api_base.py
@@ -386,17 +386,23 @@ class BaseClientAPI:
                     break
 
         except Exception as e:
+            # Use the child class's LOG_PREFIX if available, otherwise use base LOG_PREFIX
+            prefix = getattr(self.__class__, "LOG_PREFIX", LOG_PREFIX)
+
             self.logger.error(
                 "Failed to fetch page",
                 {
-                    "prefix": LOG_PREFIX,
+                    "prefix": prefix,
                     "entity_description": entity_description,
                     "error": str(e),
                 },
             )
             raise
         finally:
+            # Use the child class's LOG_PREFIX if available, otherwise use base LOG_PREFIX
+            prefix = getattr(self.__class__, "LOG_PREFIX", LOG_PREFIX)
+
             self.logger.debug(
                 "Finished fetching",
-                {"prefix": LOG_PREFIX, "entity_description": entity_description},
+                {"prefix": prefix, "entity_description": entity_description},
             )

--- a/external-import/google-ti-feeds/connector/src/custom/configs/campaign/batch_processor_config_campaign.py
+++ b/external-import/google-ti-feeds/connector/src/custom/configs/campaign/batch_processor_config_campaign.py
@@ -45,5 +45,4 @@ CAMPAIGN_BATCH_PROCESSOR_CONFIG = GenericBatchProcessorConfig(
     date_extraction_function=campaign_extract_stix_date,
     postprocessing_function=log_batch_completion,
     validation_function=validate_stix_object,
-    empty_batch_behavior="update_state",
 )

--- a/external-import/google-ti-feeds/connector/src/custom/configs/malware/batch_processor_config_malware.py
+++ b/external-import/google-ti-feeds/connector/src/custom/configs/malware/batch_processor_config_malware.py
@@ -45,5 +45,4 @@ MALWARE_FAMILY_BATCH_PROCESSOR_CONFIG = GenericBatchProcessorConfig(
     date_extraction_function=malware_family_extract_stix_date,
     postprocessing_function=log_batch_completion,
     validation_function=validate_stix_object,
-    empty_batch_behavior="update_state",
 )

--- a/external-import/google-ti-feeds/connector/src/custom/configs/report/batch_processor_config_report.py
+++ b/external-import/google-ti-feeds/connector/src/custom/configs/report/batch_processor_config_report.py
@@ -45,5 +45,4 @@ REPORT_BATCH_PROCESSOR_CONFIG = GenericBatchProcessorConfig(
     date_extraction_function=report_extract_stix_date,
     postprocessing_function=log_batch_completion,
     validation_function=validate_stix_object,
-    empty_batch_behavior="update_state",
 )

--- a/external-import/google-ti-feeds/connector/src/custom/configs/threat_actor/batch_processor_config_threat_actor.py
+++ b/external-import/google-ti-feeds/connector/src/custom/configs/threat_actor/batch_processor_config_threat_actor.py
@@ -45,5 +45,4 @@ THREAT_ACTOR_BATCH_PROCESSOR_CONFIG = GenericBatchProcessorConfig(
     date_extraction_function=threat_actor_extract_stix_date,
     postprocessing_function=log_batch_completion,
     validation_function=validate_stix_object,
-    empty_batch_behavior="update_state",
 )

--- a/external-import/google-ti-feeds/connector/src/custom/configs/vulnerability/batch_processor_config_vulnerability.py
+++ b/external-import/google-ti-feeds/connector/src/custom/configs/vulnerability/batch_processor_config_vulnerability.py
@@ -45,5 +45,4 @@ VULNERABILITY_BATCH_PROCESSOR_CONFIG = GenericBatchProcessorConfig(
     date_extraction_function=vulnerability_extract_stix_date,
     postprocessing_function=log_batch_completion,
     validation_function=validate_stix_object,
-    empty_batch_behavior="update_state",
 )

--- a/external-import/google-ti-feeds/connector/src/utils/batch_processors/generic_batch_processor.py
+++ b/external-import/google-ti-feeds/connector/src/utils/batch_processors/generic_batch_processor.py
@@ -224,24 +224,10 @@ class GenericBatchProcessor:
                     {"prefix": LOG_PREFIX, "error": str(state_err)},
                 )
         else:
-            current_time = self.config.get_current_timestamp()
             self._logger.info(
-                "State update: Setting to current time",
-                {
-                    "prefix": LOG_PREFIX,
-                    "state_key": self.config.state_key,
-                    "current_time": current_time,
-                },
+                "State update skipped: no successfully ingested entity date tracked",
+                {"prefix": LOG_PREFIX, "state_key": self.config.state_key},
             )
-            try:
-                self._work_manager.update_state(
-                    state_key=self.config.state_key, date_str=current_time
-                )
-            except Exception as state_err:
-                self._logger.error(
-                    "Failed to update final state with current time",
-                    {"prefix": LOG_PREFIX, "error": str(state_err)},
-                )
 
     def get_statistics(self) -> dict[str, Any]:
         """Get processing statistics.

--- a/external-import/google-ti-feeds/connector/src/utils/batch_processors/generic_batch_processor.py
+++ b/external-import/google-ti-feeds/connector/src/utils/batch_processors/generic_batch_processor.py
@@ -161,9 +161,6 @@ class GenericBatchProcessor:
             Configured exception class: If batch processing fails
 
         """
-        if not self._current_batch:
-            return self._handle_empty_batch()
-
         batch_items = self._current_batch.copy()
         self._current_batch.clear()
 
@@ -277,42 +274,6 @@ class GenericBatchProcessor:
         """
         if date_str and (not self._latest_date or date_str > self._latest_date):
             self._latest_date = date_str
-
-    def _handle_empty_batch(self) -> str | None:
-        """Handle processing of empty batches based on configuration.
-
-        Returns:
-            None (empty batches don't create work)
-
-        Raises:
-            Configured exception class: If empty_batch_behavior is 'error'
-
-        """
-        if self.config.empty_batch_behavior == "error":
-            raise self.config.create_exception("Cannot process empty batch")
-
-        if self.config.empty_batch_behavior == "update_state":
-            current_time = self.config.get_current_timestamp()
-            self._logger.debug(
-                "Updating state with current time for empty batch",
-                {"prefix": LOG_PREFIX, "current_time": current_time},
-            )
-            try:
-                self._work_manager.update_state(
-                    state_key=self.config.state_key, date_str=current_time
-                )
-                self._latest_date = current_time
-            except Exception as state_err:
-                self._logger.warning(
-                    "Failed to update state for empty batch",
-                    {"prefix": LOG_PREFIX, "error": str(state_err)},
-                )
-
-        self._logger.info(
-            "No items in batch to process",
-            {"prefix": LOG_PREFIX, "display_name": self.config.display_name},
-        )
-        return None
 
     def _process_batch_with_retries(
         self, batch_items: list[Any], batch_num: int

--- a/external-import/google-ti-feeds/connector/src/utils/batch_processors/generic_batch_processor_config.py
+++ b/external-import/google-ti-feeds/connector/src/utils/batch_processors/generic_batch_processor_config.py
@@ -51,8 +51,6 @@ class GenericBatchProcessorConfig:
 
     validation_function: Callable[[Any], bool] | None = None
     """Function to validate individual items before adding to batch"""
-    empty_batch_behavior: str = "update_state"
-    """Behavior when processing empty batches: 'skip', 'update_state', or 'error'"""
 
     max_retries: int = 0
     """Maximum number of retries for failed batch processing"""
@@ -73,11 +71,6 @@ class GenericBatchProcessorConfig:
                 self.display_name_singular = self.display_name[:-1]
             else:
                 self.display_name_singular = self.display_name
-
-        if self.empty_batch_behavior not in ("skip", "update_state", "error"):
-            raise ValueError(
-                "empty_batch_behavior must be 'skip', 'update_state', or 'error'"
-            )
 
     def format_work_name(self, batch_num: int, **kwargs: Any) -> str:
         """Format the work name with batch number and optional parameters.

--- a/external-import/google-ti-feeds/tests/custom/client_api/test_client_api_base.py
+++ b/external-import/google-ti-feeds/tests/custom/client_api/test_client_api_base.py
@@ -1,0 +1,131 @@
+"""Test module for BaseClientAPI pagination behavior."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from connector.src.custom.client_api.client_api_base import BaseClientAPI
+
+# =====================
+# Fixtures
+# =====================
+
+
+@pytest.fixture
+def base_client() -> BaseClientAPI:
+    """Fixture for BaseClientAPI with mocked dependencies."""
+    return BaseClientAPI(
+        config=SimpleNamespace(),
+        logger=MagicMock(),
+        api_client=MagicMock(),
+        fetcher_factory=MagicMock(),
+    )
+
+
+# =====================
+# Scenario: Pagination behavior
+# =====================
+
+
+@pytest.mark.asyncio
+async def test_paginate_with_cursor_reraises_fetch_errors(
+    base_client: BaseClientAPI,
+) -> None:
+    """Test that pagination errors are propagated to callers."""
+    # Given: A fetcher that fails with a quota error
+    fetcher = MagicMock()
+    fetcher.config = SimpleNamespace(
+        endpoint="/collections",
+    )
+    fetcher.fetch_single = AsyncMock(side_effect=RuntimeError("Quota exceeded"))
+
+    # When: Pagination is executed
+    results, exception = await _when_paginate_called(
+        client=base_client,
+        fetcher=fetcher,
+        initial_params={"limit": 40},
+        entity_description="reports",
+    )
+
+    # Then: The quota error is re-raised and no results are yielded
+    _then_pagination_failed_with_error(exception)
+    _then_results_are(results, [])
+
+
+@pytest.mark.asyncio
+async def test_paginate_with_cursor_yields_data_on_success(
+    base_client: BaseClientAPI,
+) -> None:
+    """Test that normal pagination flow yields API data."""
+    # Given: A fetcher returning two successful pages
+    fetcher = MagicMock()
+    fetcher.config = SimpleNamespace(
+        endpoint="/collections",
+    )
+    fetcher.fetch_single = AsyncMock(
+        side_effect=[
+            {
+                "data": [{"id": "item-1"}],
+                "meta": {"cursor": "next-page", "count": 2},
+            },
+            {
+                "data": [{"id": "item-2"}],
+                "meta": {"count": 2},
+            },
+        ]
+    )
+
+    # When: Pagination is executed
+    results, exception = await _when_paginate_called(
+        client=base_client,
+        fetcher=fetcher,
+        initial_params={"limit": 40},
+        entity_description="reports",
+    )
+
+    # Then: Results from both pages are returned in order
+    _then_pagination_succeeded(exception)
+    _then_results_are(results, [{"id": "item-1"}, {"id": "item-2"}])
+
+
+# =====================
+# GWT Helper Functions
+# =====================
+
+
+async def _when_paginate_called(
+    client: BaseClientAPI,
+    fetcher: Any,
+    initial_params: dict[str, Any],
+    entity_description: str,
+) -> tuple[list[Any], Exception | None]:
+    """Execute pagination and capture yielded results and exceptions."""
+    results: list[Any] = []
+    try:
+        async for page_data in client._paginate_with_cursor(
+            fetcher=fetcher,
+            initial_params=initial_params,
+            entity_description=entity_description,
+        ):
+            results.extend(page_data)
+        return results, None
+    except Exception as exc:
+        return results, exc
+
+
+def _then_pagination_failed_with_error(exception: Exception | None) -> None:
+    """Assert that pagination failed with the expected error."""
+    assert exception is not None  # noqa: S101
+    assert isinstance(exception, RuntimeError)  # noqa: S101
+    assert len(str(exception)) > 0  # noqa: S101
+
+
+def _then_pagination_succeeded(exception: Exception | None) -> None:
+    """Assert that pagination completed without errors."""
+    assert exception is None  # noqa: S101
+
+
+def _then_results_are(results: list[Any], expected_results: list[Any]) -> None:
+    """Assert that pagination results match expected values."""
+    assert results == expected_results  # noqa: S101

--- a/external-import/google-ti-feeds/tests/utils/batch_processors/test_generic_batch_processor.py
+++ b/external-import/google-ti-feeds/tests/utils/batch_processors/test_generic_batch_processor.py
@@ -441,17 +441,6 @@ def test_process_current_batch_success(
     _then_current_batch_is_empty(basic_processor)
 
 
-def test_process_current_batch_empty(basic_processor: GenericBatchProcessor) -> None:
-    """Test processing empty batch."""
-    # Given: A basic processor with empty batch
-
-    # When: The empty batch is processed
-    work_id, exception = _when_current_batch_processed(basic_processor)
-
-    # Then: Processing should handle empty batch gracefully
-    _then_empty_batch_processed(work_id, exception)
-
-
 def test_process_current_batch_with_preprocessing(
     preprocessing_config: GenericBatchProcessorConfig,
     mock_work_manager: Any,
@@ -1039,14 +1028,6 @@ def _then_batch_processed_successfully(
     assert work_id.startswith("work-")  # noqa: S101
 
 
-def _then_empty_batch_processed(
-    work_id: str | None, exception: Exception | None
-) -> None:
-    """Assert that empty batch was processed (returns None)."""
-    assert exception is None  # noqa: S101
-    assert work_id is None  # noqa: S101
-
-
 def _then_batch_processing_failed_after_retries(
     work_id: str | None, exception: Exception | None
 ) -> None:
@@ -1100,14 +1081,6 @@ def _then_state_updated_with_date(
     mock_work_manager.update_state.assert_called_with(
         state_key="dated_cursor", date_str=expected_date
     )
-
-
-def _then_state_updated_with_current_time(mock_work_manager: MockWorkManager) -> None:
-    """Assert that state was updated with current time."""
-    mock_work_manager.update_state.assert_called()
-    call_args = mock_work_manager.update_state.call_args
-    assert call_args[1]["state_key"] == "test_cursor"  # noqa: S101
-    assert "T" in call_args[1]["date_str"]  # noqa: S101
 
 
 def _then_state_not_updated(mock_work_manager: MockWorkManager) -> None:

--- a/external-import/google-ti-feeds/tests/utils/batch_processors/test_generic_batch_processor.py
+++ b/external-import/google-ti-feeds/tests/utils/batch_processors/test_generic_batch_processor.py
@@ -604,8 +604,8 @@ def test_update_final_state_without_tracked_date(
     # When: Final state is updated
     _when_final_state_updated(basic_processor)
 
-    # Then: State should be updated with current time
-    _then_state_updated_with_current_time(mock_work_manager)
+    # Then: State should not be updated
+    _then_state_not_updated(mock_work_manager)
 
 
 def test_set_latest_date_manually(basic_processor: GenericBatchProcessor) -> None:
@@ -1108,6 +1108,11 @@ def _then_state_updated_with_current_time(mock_work_manager: MockWorkManager) ->
     call_args = mock_work_manager.update_state.call_args
     assert call_args[1]["state_key"] == "test_cursor"  # noqa: S101
     assert "T" in call_args[1]["date_str"]  # noqa: S101
+
+
+def _then_state_not_updated(mock_work_manager: MockWorkManager) -> None:
+    """Assert that state was not updated."""
+    mock_work_manager.update_state.assert_not_called()
 
 
 def _then_statistics_are_initial(stats: dict[str, Any]) -> None:

--- a/external-import/google-ti-feeds/tests/utils/batch_processors/test_generic_batch_processor_config.py
+++ b/external-import/google-ti-feeds/tests/utils/batch_processors/test_generic_batch_processor_config.py
@@ -106,7 +106,6 @@ def full_config() -> GenericBatchProcessorConfig:
         preprocessing_function=sample_preprocessor,
         postprocessing_function=sample_postprocessor,
         validation_function=sample_validator,
-        empty_batch_behavior="skip",
         max_retries=3,
         retry_delay=2.0,
         work_timeout=120.0,
@@ -183,24 +182,6 @@ def test_basic_config_validation_on_creation() -> None:
             display_name="test",
         )
     assert "batch_size must be greater than 0" in str(excinfo.value)  # noqa: S101
-
-
-def test_basic_config_validation_empty_batch_behavior() -> None:
-    """Test validation of empty_batch_behavior parameter."""
-    # Given: Invalid empty_batch_behavior value
-
-    # When: Configuration is created with invalid empty_batch_behavior
-    # Then: ValueError should be raised
-    with pytest.raises(ValueError) as excinfo:
-        GenericBatchProcessorConfig(
-            batch_size=10,
-            work_name_template="Test",
-            state_key="test",
-            entity_type="test",
-            display_name="test",
-            empty_batch_behavior="invalid_value",
-        )
-    assert "empty_batch_behavior must be" in str(excinfo.value)  # noqa: S101
 
 
 # Scenario: Creating full configuration with all parameters
@@ -773,7 +754,6 @@ def _then_config_has_default_values(config: GenericBatchProcessorConfig) -> None
     assert config.preprocessing_function is None  # noqa: S101
     assert config.postprocessing_function is None  # noqa: S101
     assert config.validation_function is None  # noqa: S101
-    assert config.empty_batch_behavior == "update_state"  # noqa: S101
     assert config.max_retries == 0  # noqa: S101
     assert config.retry_delay == 1.0  # noqa: S101
     assert config.work_timeout is None  # noqa: S101
@@ -795,7 +775,6 @@ def _then_config_has_full_properties(config: GenericBatchProcessorConfig) -> Non
     assert config.preprocessing_function == sample_preprocessor  # noqa: S101
     assert config.postprocessing_function == sample_postprocessor  # noqa: S101
     assert config.validation_function == sample_validator  # noqa: S101
-    assert config.empty_batch_behavior == "skip"  # noqa: S101
     assert config.max_retries == 3  # noqa: S101
     assert config.retry_delay == 2.0  # noqa: S101
     assert config.work_timeout == 120.0  # noqa: S101


### PR DESCRIPTION
### Proposed changes

* do not update state when `latest_date` is None
* stop pagination on HTTP errors to avoid data loss

### Related issues

* close #6380 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

