### PR TITLE
[all] Fix url to avoid double slash

### DIFF
--- a/external-import/cape/src/cape/telemetry.py
+++ b/external-import/cape/src/cape/telemetry.py
@@ -60,7 +60,9 @@ class openCTIInterface:
         self.report = report
         self.labels = labels
         self.update = update
-        self.cuckoo_url = CuckooURL
+        self.cuckoo_url = (
+            CuckooURL.rstrip("/") if isinstance(CuckooURL, str) else CuckooURL
+        )
         self.EnableNetTraffic = EnableNetTraffic
         self.EnableRegKeys = EnableRegKeys
         self.ReportScore = ReportScore

--- a/external-import/citalid/src/citalid_api.py
+++ b/external-import/citalid/src/citalid_api.py
@@ -16,10 +16,9 @@ class Client:
     def __init__(self, customer_sub_domain_url, language="en"):
         self.client_id = "0RcQ2BmuJRRsZKvY1Xf1gdjiwYRZhQKBNOxY9KOI"
         self.customer_sub_domain_url = self._parse_url(customer_sub_domain_url)
-        self.connection_service_base_url = f"{customer_sub_domain_url}/auth"
-        self.api_base_url = (
-            f"{customer_sub_domain_url}/facade/risk-intelligence-center/api/v1"
-        )
+        _base = self.customer_sub_domain_url.rstrip("/")
+        self.connection_service_base_url = f"{_base}/auth"
+        self.api_base_url = f"{_base}/facade/risk-intelligence-center/api/v1"
         self.headers = {}
         self.set_language(language)
 

--- a/external-import/cluster25/src/cluster25/core.py
+++ b/external-import/cluster25/src/cluster25/core.py
@@ -45,6 +45,8 @@ class Cluster25:
 
         # Cluster25 connector configuration
         self.base_url = self._get_configuration(config, self._CONFIG_BASE_URL)
+        if isinstance(self.base_url, str):
+            self.base_url = self.base_url.rstrip("/")
         self.client_id = self._get_configuration(config, self._CONFIG_CLIENT_ID)
         self.client_secret = self._get_configuration(config, self._CONFIG_CLIENT_SECRET)
 

--- a/external-import/criminalip-c2-daily-feed/src/main.py
+++ b/external-import/criminalip-c2-daily-feed/src/main.py
@@ -36,6 +36,8 @@ class CriminalIPC2DailyFeedConnector:
         self.csv_url = get_config_variable(
             "CRIMINALIP_CSV_URL", ["criminalipc2dailyfeed", "csv_url"], config
         )
+        if isinstance(self.csv_url, str):
+            self.csv_url = self.csv_url.rstrip("/")
         # Identity for Criminal IP
         self.identity = self.helper.api.identity.create(
             type="Organization",

--- a/external-import/cuckoo/src/cuckoo/telemetry.py
+++ b/external-import/cuckoo/src/cuckoo/telemetry.py
@@ -36,7 +36,9 @@ class openCTIInterface:
         self.report = report
         self.labels = labels
         self.update = update
-        self.cuckoo_url = CuckooURL
+        self.cuckoo_url = (
+            CuckooURL.rstrip("/") if isinstance(CuckooURL, str) else CuckooURL
+        )
         self.EnableNetTraffic = EnableNetTraffic
         self.EnableRegKeys = EnableRegKeys
         self.ReportScore = ReportScore

--- a/external-import/flashpoint/src/flashpoint_client/client_api.py
+++ b/external-import/flashpoint/src/flashpoint_client/client_api.py
@@ -27,7 +27,9 @@ class FlashpointClient:
         """
         Initialize the client with necessary configurations
         """
-        self.api_base_url = api_base_url
+        self.api_base_url = (
+            api_base_url.rstrip("/") if isinstance(api_base_url, str) else api_base_url
+        )
 
         # Define headers in session and update when needed
         headers = {

--- a/external-import/harfanglab-incidents/src/harfanglab_incidents_connector/config_variables.py
+++ b/external-import/harfanglab-incidents/src/harfanglab_incidents_connector/config_variables.py
@@ -51,7 +51,7 @@ class ConfigConnector:
             yaml_path=["harfanglab_incidents", "url"],
             config=self.load,
             required=True,
-        )
+        ).rstrip("/")
         self.harfanglab_ssl_verify = get_config_variable(
             env_var="HARFANGLAB_INCIDENTS_SSL_VERIFY",
             yaml_path=["harfanglab_incidents", "ssl_verify"],

--- a/external-import/luminar/src/luminar_connector/connector.py
+++ b/external-import/luminar/src/luminar_connector/connector.py
@@ -114,7 +114,7 @@ class ConnectorLuminar:
         self.helper = OpenCTIConnectorHelper(self.config.load)
 
         # Extra config
-        self.luminar_base_url = self.config.luminar_base_url
+        self.luminar_base_url = str(self.config.luminar_base_url).rstrip("/")
         self.luminar_account_id = self.config.luminar_account_id
         self.luminar_client_id = self.config.luminar_client_id
         self.luminar_client_secret = self.config.luminar_client_secret

--- a/external-import/misp-feed/src/connector/settings.py
+++ b/external-import/misp-feed/src/connector/settings.py
@@ -83,7 +83,10 @@ class MispFeedConfig(BaseConfigModel):
         description="Source type for the MISP feed (`url` or `s3`).",
         default="url",
     )
-    url: str | None = Field(
+    url: Annotated[
+        str | None,
+        BeforeValidator(lambda v: v.rstrip("/") if isinstance(v, str) else v),
+    ] = Field(
         description="The URL of the MISP feed (required if `source_type` is `url`).",
         default=None,  # required only if `source_type` is `url`
     )

--- a/external-import/misp/src/connector/use_cases/common.py
+++ b/external-import/misp/src/connector/use_cases/common.py
@@ -89,7 +89,11 @@ class ConverterConfig:
     ):
         self.report_type = report_type
         self.report_description_attribute_filters = report_description_attribute_filters
-        self.external_reference_base_url = external_reference_base_url
+        self.external_reference_base_url = (
+            external_reference_base_url.rstrip("/")
+            if isinstance(external_reference_base_url, str)
+            else external_reference_base_url
+        )
         self.convert_event_to_report = convert_event_to_report
         self.convert_attribute_to_associated_file = convert_attribute_to_associated_file
         self.convert_attribute_to_indicator = convert_attribute_to_indicator

--- a/external-import/opencsam/src/opencsam.py
+++ b/external-import/opencsam/src/opencsam.py
@@ -34,6 +34,8 @@ class OpenCSAM:
         self.opencsam_api_url = get_config_variable(
             "OPENCSAM_API_URL", ["opencsam", "api_url"], config
         )
+        if isinstance(self.opencsam_api_url, str):
+            self.opencsam_api_url = self.opencsam_api_url.rstrip("/")
         self.opencsam_api_key = get_config_variable(
             "OPENCSAM_API_KEY", ["opencsam", "api_key"], config
         )

--- a/external-import/rst-threat-feed/src/rstcloud/FeedFetch.py
+++ b/external-import/rst-threat-feed/src/rstcloud/FeedFetch.py
@@ -6,7 +6,9 @@ import requests
 class Downloader:
     def __init__(self, conf):
         # connection
-        self.api_url = str(conf.get("baseurl", "https://api.rstcloud.net/v1"))
+        self.api_url = conf.get("baseurl", "https://api.rstcloud.net/v1")
+        if isinstance(self.api_url, str):
+            self.api_url = self.api_url.rstrip("/")
         self.api_key = str(conf.get("apikey", "REPLACEME"))
         self.timeout = (
             int(conf.get("contimeout", 30)),

--- a/external-import/sentinelone-threats/src/s1api.py
+++ b/external-import/sentinelone-threats/src/s1api.py
@@ -15,7 +15,7 @@ class SentinelOneApi:
         api_url: str representing the endpoint to call the SentinelOne API, e.g. https://xxxxxxx.sentinelone.net
         api_token: str representing the API token
         """
-        self._api_url = api_url
+        self._api_url = api_url.rstrip("/") if isinstance(api_url, str) else api_url
         # TODO the api token automatically re-generates after 6 months
         self._headers = {"Authorization": f"ApiToken {api_token}"}
 

--- a/external-import/tanium-incidents/src/tanium_incidents_connector/client_api.py
+++ b/external-import/tanium-incidents/src/tanium_incidents_connector/client_api.py
@@ -9,7 +9,11 @@ class ConnectorAPI:
         self.helper = helper
         self.config = config
 
-        self.url = config.tanium_url
+        self.url = (
+            config.tanium_url.rstrip("/")
+            if isinstance(config.tanium_url, str)
+            else config.tanium_url
+        )
         self.token = config.tanium_token
         self.ssl_verify = config.tanium_ssl_verify
 

--- a/external-import/tanium-incidents/src/tanium_incidents_connector/config_variables.py
+++ b/external-import/tanium-incidents/src/tanium_incidents_connector/config_variables.py
@@ -41,11 +41,15 @@ class ConfigConnector:
         self.tanium_url = get_config_variable(
             "TANIUM_INCIDENTS_URL", ["tanium_incidents", "url"], self.load
         )
+        if isinstance(self.tanium_url, str):
+            self.tanium_url = self.tanium_url.rstrip("/")
         self.tanium_url_console = get_config_variable(
             "TANIUM_INCIDENTS_URL_CONSOLE",
             ["tanium_incidents", "url_console"],
             self.load,
         )
+        if isinstance(self.tanium_url_console, str):
+            self.tanium_url_console = self.tanium_url_console.rstrip("/")
         self.tanium_ssl_verify = get_config_variable(
             "TANIUM_INCIDENTS_SSL_VERIFY",
             ["tanium_incidents", "ssl_verify"],

--- a/external-import/tenable-vuln-management/src/tenable_vuln_management/config_variables.py
+++ b/external-import/tenable-vuln-management/src/tenable_vuln_management/config_variables.py
@@ -56,7 +56,7 @@ class ConfigConnector:
             yaml_path=["tenable_vuln_management", "api_base_url"],
             config=self.load,
             required=True,
-        )
+        ).rstrip("/")
         self.tio_api_access_key = get_config_variable(
             env_var="TIO_API_ACCESS_KEY",
             yaml_path=["tenable_vuln_management", "api_access_key"],

--- a/external-import/thehive/src/thehive.py
+++ b/external-import/thehive/src/thehive.py
@@ -51,6 +51,8 @@ class TheHive:
         self.thehive_url = get_config_variable(
             "THEHIVE_URL", ["thehive", "url"], config
         )
+        if isinstance(self.thehive_url, str):
+            self.thehive_url = self.thehive_url.rstrip("/")
         self.thehive_api_key = get_config_variable(
             "THEHIVE_API_KEY", ["thehive", "api_key"], config
         )

--- a/external-import/usta/src/usta_client/api_client.py
+++ b/external-import/usta/src/usta_client/api_client.py
@@ -76,7 +76,7 @@ class UstaClient:
         page_size: int = 100,
     ) -> None:
         self.helper = helper
-        self.base_url = str(base_url).rstrip("/")
+        self.base_url = base_url.rstrip("/") if isinstance(base_url, str) else base_url
         self.api_key = api_key
         self.page_size = page_size
 

--- a/internal-enrichment/anyrun-task/src/anyrun_sandbox.py
+++ b/internal-enrichment/anyrun-task/src/anyrun_sandbox.py
@@ -108,7 +108,9 @@ class AnyRunSandbox:
         :param file: OpenCTI file params
         :return: File data
         """
-        artifact_url = f'{self._helper.opencti_url}/storage/get/{file.get("id")}'
+        artifact_url = (
+            f'{self._helper.opencti_url.rstrip("/")}/storage/get/{file.get("id")}'
+        )
         try:
             return self._helper.api.fetch_opencti_file(
                 artifact_url, binary=True

--- a/internal-enrichment/cape-sandbox/src/cape-sandbox.py
+++ b/internal-enrichment/cape-sandbox/src/cape-sandbox.py
@@ -45,9 +45,13 @@ class CapeSandboxConnector:
         self.octi_api_url = get_config_variable(
             "OPENCTI_URL", ["opencti", "url"], config
         )
+        if isinstance(self.octi_api_url, str):
+            self.octi_api_url = self.octi_api_url.rstrip("/")
         self.cape_api_url = get_config_variable(
             "CAPE_SANDBOX_URL", ["cape_sandbox", "url"], config
         )
+        if isinstance(self.cape_api_url, str):
+            self.cape_api_url = self.cape_api_url.rstrip("/")
         self.token = get_config_variable(
             "CAPE_SANDBOX_TOKEN", ["cape_sandbox", "token"], config
         )

--- a/internal-enrichment/glimps-malware/src/glimps_malware_connector/glimps_malware.py
+++ b/internal-enrichment/glimps-malware/src/glimps_malware_connector/glimps_malware.py
@@ -75,7 +75,7 @@ class GLIMPSMalwareConnector:
         file_id = observable["importFiles"][0]["id"]
         file_name = observable["importFiles"][0]["name"]
 
-        file_uri = f"{self.helper.opencti_url}/storage/get/{file_id}"
+        file_uri = f"{self.helper.opencti_url.rstrip('/')}/storage/get/{file_id}"
         file_content = self.helper.api.fetch_opencti_file(file_uri, True)
 
         file_sha256 = ""

--- a/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
+++ b/internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py
@@ -45,6 +45,8 @@ class HatchingTriageSandboxConnector:
         self.octi_api_url = get_config_variable(
             "OPENCTI_URL", ["opencti", "url"], config
         )
+        if isinstance(self.octi_api_url, str):
+            self.octi_api_url = self.octi_api_url.rstrip("/")
 
         # Get URL and token from config, use to instantiate the Triage Client
         base_url = get_config_variable(

--- a/internal-enrichment/hybrid-analysis-sandbox/src/hybrid-analysis-sandbox.py
+++ b/internal-enrichment/hybrid-analysis-sandbox/src/hybrid-analysis-sandbox.py
@@ -316,7 +316,7 @@ class HybridAnalysis:
         file_name = opencti_entity["importFiles"][0]["name"]
         file_uri = opencti_entity["importFiles"][0]["id"]
         file_content = self.helper.api.fetch_opencti_file(
-            self.helper.opencti_url + "/storage/get/" + file_uri, True
+            self.helper.opencti_url.rstrip("/") + "/storage/get/" + file_uri, True
         )
         # Write the file
         f = open(file_name, "wb")

--- a/internal-enrichment/intezer-sandbox/src/intezer_sandbox.py
+++ b/internal-enrichment/intezer-sandbox/src/intezer_sandbox.py
@@ -30,6 +30,8 @@ class IntezerSandboxConnector:
         self.octi_api_url = get_config_variable(
             "OPENCTI_URL", ["opencti", "url"], config
         )
+        if isinstance(self.octi_api_url, str):
+            self.octi_api_url = self.octi_api_url.rstrip("/")
 
         # Get api key from config, use to instantiate the client
         api_key = get_config_variable(

--- a/internal-enrichment/ipqs/src/ipqs/client.py
+++ b/internal-enrichment/ipqs/src/ipqs/client.py
@@ -14,7 +14,7 @@ class IPQSClient:
     ) -> None:
         """Initialize IPQS client."""
         self.helper = helper
-        self.url = base_url
+        self.url = base_url.rstrip("/") if isinstance(base_url, str) else base_url
         self.headers = {"IPQS-KEY": api_key}
         self.session = session()
         self.ip_enrich_fields = {

--- a/internal-enrichment/joe-sandbox/src/joe-sandbox.py
+++ b/internal-enrichment/joe-sandbox/src/joe-sandbox.py
@@ -33,6 +33,8 @@ class JoeSandboxConnector:
         self.octi_api_url = get_config_variable(
             "OPENCTI_URL", ["opencti", "url"], config
         )
+        if isinstance(self.octi_api_url, str):
+            self.octi_api_url = self.octi_api_url.rstrip("/")
 
         # JoeSandbox class instatiation settings from config
         api_key = get_config_variable(
@@ -48,6 +50,8 @@ class JoeSandboxConnector:
         self._analysis_url = get_config_variable(
             "JOE_SANDBOX_ANALYSIS_URL", ["joe_sandbox", "analysis_url"], config
         )
+        if isinstance(self._analysis_url, str):
+            self._analysis_url = self._analysis_url.rstrip("/")
         accept_tac = get_config_variable(
             "JOE_SANDBOX_ACCEPT_TAC", ["joe_sandbox", "accept_tac"], config
         )

--- a/internal-enrichment/orion-malware/src/main.py
+++ b/internal-enrichment/orion-malware/src/main.py
@@ -39,10 +39,14 @@ class OrionMalwareConnector:
         self.octi_api_url = get_config_variable(
             "OPENCTI_URL", ["opencti", "url"], config
         )
+        if isinstance(self.octi_api_url, str):
+            self.octi_api_url = self.octi_api_url.rstrip("/")
 
         self._api_url = get_config_variable(
             "ORION_MALWARE_URL", ["orion_malware", "url"], config
         )
+        if isinstance(self._api_url, str):
+            self._api_url = self._api_url.rstrip("/")
         self._verify_ssl = get_config_variable(
             "ORION_MALWARE_VERIFY_SSL", ["orion_malware", "verify_ssl"], config
         )

--- a/internal-enrichment/reversinglabs-spectra-analyze/src/main.py
+++ b/internal-enrichment/reversinglabs-spectra-analyze/src/main.py
@@ -171,7 +171,7 @@ class ReversingLabsSpectraAnalyzeConnector:
         if stix_entity["x_opencti_type"] == "Artifact":
             sample_name = self.opencti_entity["importFiles"][0]["name"]
             file_id = self.opencti_entity["importFiles"][0]["id"]
-            file_uri = f"{self.helper.opencti_url}/storage/get/{file_id}"
+            file_uri = f"{self.helper.opencti_url.rstrip('/')}/storage/get/{file_id}"
 
             analysis_response = self._upload_file_to_spectra_analyze(
                 file_uri, sample_name

--- a/internal-enrichment/reversinglabs-spectra-intel-submission/src/main.py
+++ b/internal-enrichment/reversinglabs-spectra-intel-submission/src/main.py
@@ -542,7 +542,7 @@ class ReversingLabsSpectraIntelConnector(InternalEnrichmentConnector):
             sample_name = self.opencti_entity["importFiles"][0]["name"]
             file_id = self.opencti_entity["importFiles"][0]["id"]
             file_mime_type = self.opencti_entity["mime_type"]
-            file_uri = f"{self.helper.opencti_url}/storage/get/{file_id}"
+            file_uri = f"{self.helper.opencti_url.rstrip('/')}/storage/get/{file_id}"
 
             if file_mime_type in ZIP_MIME_TYPES:
                 is_archive = True

--- a/internal-enrichment/rst-ioc-lookup/src/main.py
+++ b/internal-enrichment/rst-ioc-lookup/src/main.py
@@ -23,14 +23,14 @@ class RSTIocLookupConnector:
             else {}
         )
         self.helper = OpenCTIConnectorHelper(config, True)
-        self.base_url = str(
-            get_config_variable(
-                "RST_IOC_LOOKUP_BASE_URL",
-                ["rst-ioc-lookup", "base_url"],
-                config,
-                default="https://api.rstcloud.net/v1",
-            )
+        self.base_url = get_config_variable(
+            "RST_IOC_LOOKUP_BASE_URL",
+            ["rst-ioc-lookup", "base_url"],
+            config,
+            default="https://api.rstcloud.net/v1",
         )
+        if isinstance(self.base_url, str):
+            self.base_url = self.base_url.rstrip("/")
         self.api_key = str(
             get_config_variable(
                 "RST_IOC_LOOKUP_API_KEY", ["rst-ioc-lookup", "api_key"], config

--- a/internal-enrichment/rst-noise-control/src/main.py
+++ b/internal-enrichment/rst-noise-control/src/main.py
@@ -21,12 +21,14 @@ class RSTNoiseControlConnector:
             else {}
         )
         self.helper = OpenCTIConnectorHelper(config, True)
-        self.base_url = get_config_variable(
-            "RST_NOISE_CONTROL_BASE_URL",
-            ["rst-noise-control", "base_url"],
-            config,
-            default="https://api.rstcloud.net/v1",
-        )
+        self.base_url = str(
+            get_config_variable(
+                "RST_NOISE_CONTROL_BASE_URL",
+                ["rst-noise-control", "base_url"],
+                config,
+                default="https://api.rstcloud.net/v1",
+            )
+        ).rstrip("/")
         self.api_key = get_config_variable(
             "RST_NOISE_CONTROL_API_KEY", ["rst-noise-control", "api_key"], config
         )

--- a/internal-enrichment/rst-whois-api/src/main.py
+++ b/internal-enrichment/rst-whois-api/src/main.py
@@ -30,7 +30,7 @@ class RSTWhoisApiConnector:
                 config,
                 default="https://api.rstcloud.net/v1",
             )
-        )
+        ).rstrip("/")
         self.api_key = str(
             get_config_variable(
                 "RST_WHOIS_API_API_KEY", ["rst-whois-api", "api_key"], config

--- a/internal-enrichment/shadowtrackr/src/shadowtrackr_client/api_client.py
+++ b/internal-enrichment/shadowtrackr/src/shadowtrackr_client/api_client.py
@@ -18,7 +18,7 @@ class ShadowTrackrClient:
         self.helper = helper
         self.logger = helper.connector_logger
 
-        self.base_url = base_url
+        self.base_url = base_url.rstrip("/") if isinstance(base_url, str) else base_url
         self.api_key = api_key
         # Define headers in session and update when needed
         self.session = requests.Session()

--- a/internal-enrichment/team-cymru-scout-search/src/scout_search_connector/connector.py
+++ b/internal-enrichment/team-cymru-scout-search/src/scout_search_connector/connector.py
@@ -12,7 +12,7 @@ class ScoutSearchConnectorConfig:
     """Configuration holder for Scout Search Connector connector."""
 
     def __init__(self, config):
-        self.api_base_url = config.pure_signal_scout.api_url
+        self.api_base_url = config.pure_signal_scout.api_url.rstrip("/")
         self.api_key = config.pure_signal_scout.api_token.get_secret_value()
         self.max_tlp = config.pure_signal_scout.max_tlp
         self.search_interval = config.pure_signal_scout.search_interval

--- a/internal-enrichment/team-cymru-scout/src/pure_signal_scout/connector.py
+++ b/internal-enrichment/team-cymru-scout/src/pure_signal_scout/connector.py
@@ -9,7 +9,7 @@ from pycti import OpenCTIConnectorHelper
 
 class PureSignalScoutConnectorConfig:
     def __init__(self, config):
-        self.api_base_url = config.pure_signal_scout.api_url
+        self.api_base_url = config.pure_signal_scout.api_url.rstrip("/")
         self.api_key = config.pure_signal_scout.api_token.get_secret_value()
         self.max_tlp = config.pure_signal_scout.max_tlp
 

--- a/internal-enrichment/unpac-me/src/unpac_me.py
+++ b/internal-enrichment/unpac-me/src/unpac_me.py
@@ -32,6 +32,8 @@ class UnpacMeConnector:
         self.octi_api_url = get_config_variable(
             "OPENCTI_URL", ["opencti", "url"], config
         )
+        if isinstance(self.octi_api_url, str):
+            self.octi_api_url = self.octi_api_url.rstrip("/")
 
         # Get URL and private from config, use to instantiate the client
         user_agent = get_config_variable(

--- a/internal-enrichment/virustotal/src/virustotal/processors/file.py
+++ b/internal-enrichment/virustotal/src/virustotal/processors/file.py
@@ -114,7 +114,9 @@ class FileProcessor(EntityProcessor):
         self.helper.api.work.to_received(self.helper.work_id, message)
         self.helper.log_debug(message)
 
-        artifact_url = f"{self.helper.opencti_url}/storage/get/{file_meta['id']}"
+        artifact_url = (
+            f"{self.helper.opencti_url.rstrip('/')}/storage/get/{file_meta['id']}"
+        )
         try:
             artifact = self.helper.api.fetch_opencti_file(artifact_url, binary=True)
         except Exception as err:

--- a/internal-enrichment/vmray-analyzer/src/vmray-analyzer.py
+++ b/internal-enrichment/vmray-analyzer/src/vmray-analyzer.py
@@ -40,6 +40,8 @@ class VmrayAnalyzerConnector:
         self.octi_api_url = get_config_variable(
             "OPENCTI_URL", ["opencti", "url"], config
         )
+        if isinstance(self.octi_api_url, str):
+            self.octi_api_url = self.octi_api_url.rstrip("/")
 
         # Get Server and API Key from config, use to instantiate the VMRay Rest Client
         server = get_config_variable(

--- a/stream/chronicle/src/chronicle.py
+++ b/stream/chronicle/src/chronicle.py
@@ -20,7 +20,7 @@ BASE_URL = "https://backstory.googleapis.com"
 
 class ChronicleReference:
     def __init__(self, list_name: str, credentials: dict, url: str) -> None:
-        self.url = url
+        self.url = url.rstrip("/") if isinstance(url, str) else url
         self.credentials = credentials
         self.list_name = list_name
 

--- a/stream/harfanglab-intel/src/harfanglab_intel_connector/api_client.py
+++ b/stream/harfanglab-intel/src/harfanglab_intel_connector/api_client.py
@@ -27,7 +27,7 @@ class HarfanglabClient:
         self.session = requests.Session()
         self.session.headers.update(headers)
 
-        self.api_base_url = self.config.harfanglab_url
+        self.api_base_url = str(self.config.harfanglab_url).rstrip("/")
         self._set_source_lists_ids()
 
     def _set_source_lists_ids(self):

--- a/stream/logrhythm/src/logrhythm.py
+++ b/stream/logrhythm/src/logrhythm.py
@@ -26,7 +26,11 @@ class LogrhythmList:
         logrhythm_list_name: str,
         logrhythm_ssl_verify: bool,
     ) -> None:
-        self.logrhythm_url = logrhythm_url
+        self.logrhythm_url = (
+            logrhythm_url.rstrip("/")
+            if isinstance(logrhythm_url, str)
+            else logrhythm_url
+        )
         self.logrhythm_token = logrhythm_token
         self.logrhythm_entity = logrhythm_entity
         self.logrhythm_list_name = logrhythm_list_name

--- a/stream/microsoft-defender-intel-synchronizer/src/microsoft_defender_intel_synchronizer_connector/config_variables.py
+++ b/stream/microsoft-defender-intel-synchronizer/src/microsoft_defender_intel_synchronizer_connector/config_variables.py
@@ -68,7 +68,7 @@ class ConfigConnector:
             ["microsoft_defender_intel_synchronizer", "base_url"],
             self.load,
             default="https://api.securitycenter.microsoft.com",
-        )
+        ).rstrip("/")
         self.resource_path = get_config_variable(
             "MICROSOFT_DEFENDER_INTEL_SYNCHRONIZER_RESOURCE_PATH",
             ["microsoft_defender_intel_synchronizer", "resource_path"],

--- a/stream/microsoft-defender-intel/src/microsoft_defender_intel_connector/api_handler.py
+++ b/stream/microsoft-defender-intel/src/microsoft_defender_intel_connector/api_handler.py
@@ -52,7 +52,7 @@ class DefenderApiHandler:
         self.tenant_id = tenant_id
         self.client_id = client_id
         self.client_secret = client_secret
-        self.base_url = str(base_url)
+        self.base_url = base_url.rstrip("/") if isinstance(base_url, str) else base_url
         self.resource_path = resource_path
         self.action = action
         self.expired_after = expired_after

--- a/stream/pan-cortex-xsoar-intel/src/pan-cortex-xsoar-intel.py
+++ b/stream/pan-cortex-xsoar-intel/src/pan-cortex-xsoar-intel.py
@@ -89,7 +89,9 @@ class XSoarAPI:
         xsoar_key: str,
         xsoar_ssl_verify: bool,
     ) -> None:
-        self.xsoar_url = xsoar_url
+        self.xsoar_url = (
+            xsoar_url.rstrip("/") if isinstance(xsoar_url, str) else xsoar_url
+        )
         self.xsoar_key_id = xsoar_key_id
         self.xsoar_key = xsoar_key
         self.xsoar_ssl_verify = xsoar_ssl_verify

--- a/stream/qradar/src/qradar.py
+++ b/stream/qradar/src/qradar.py
@@ -39,6 +39,8 @@ class QRadarConnector:
         # Configuration
         self.helper = OpenCTIConnectorHelper(config)
         self.qradar_url = get_config_variable("QRADAR_URL", ["qradar", "url"], config)
+        if isinstance(self.qradar_url, str):
+            self.qradar_url = self.qradar_url.rstrip("/")
         self.qradar_ssl_verify = get_config_variable(
             "QRADAR_SSL_VERIFY", ["qradar", "ssl_verify"], config, default=True
         )

--- a/stream/sekoia-intel/src/sekoia_intel_connector/api_client.py
+++ b/stream/sekoia-intel/src/sekoia_intel_connector/api_client.py
@@ -21,7 +21,7 @@ class SekoiaClient:
         }
         self.session = requests.Session()
         self.session.headers.update(headers)
-        self.api_base_url = self.config.sekoia_url
+        self.api_base_url = str(self.config.sekoia_url).rstrip("/")
         self.collection_id = self.config.sekoia_ioc_collection_uuid
 
     def check_ioc_collection_exist(self) -> bool:

--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -44,7 +44,9 @@ class KVStore:
         splunk_kv_store_name: str,
         splunk_ssl_verify: bool,
     ) -> None:
-        self.splunk_url = splunk_url
+        self.splunk_url = (
+            splunk_url.rstrip("/") if isinstance(splunk_url, str) else splunk_url
+        )
         self.splunk_token = splunk_token
         self.splunk_auth_type = splunk_auth_type
         self.splunk_app = splunk_app

--- a/stream/sumologic-intel/src/sumologic_intel_connector/config_loader.py
+++ b/stream/sumologic-intel/src/sumologic_intel_connector/config_loader.py
@@ -43,7 +43,7 @@ class ConfigConnector:
             ["sumologic_intel", "api_base_url"],
             self.load,
             required=True,
-        )
+        ).rstrip("/")
 
         self.access_id = get_config_variable(
             "SUMOLOGIC_INTEL_ACCESS_ID",

--- a/stream/tanium-intel/src/tanium_intel_connector/config_variables.py
+++ b/stream/tanium-intel/src/tanium_intel_connector/config_variables.py
@@ -37,6 +37,8 @@ class ConfigConnector:
         self.tanium_url = get_config_variable(
             "TANIUM_INTEL_URL", ["tanium_intel", "url"], self.load
         )
+        if isinstance(self.tanium_url, str):
+            self.tanium_url = self.tanium_url.rstrip("/")
         self.tanium_url_console = get_config_variable(
             "TANIUM_INTEL_URL_CONSOLE", ["tanium_intel", "url_console"], self.load
         )

--- a/tests/test_url_construction.py
+++ b/tests/test_url_construction.py
@@ -1,0 +1,444 @@
+"""
+Test that connector URL variables are properly stripped to avoid double slashes.
+
+requests >= 2.34.0 no longer normalizes double slashes in URL paths.
+All connectors that build URLs from config variables must call .rstrip("/")
+on the base URL at assignment time.
+
+This test:
+1. Scans all connector source files for URL variable assignments from config
+2. Verifies that .rstrip("/") (or equivalent) is applied
+3. Checks that URL construction patterns won't produce double slashes
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+CONNECTOR_DIRS = [
+    REPO_ROOT / "external-import",
+    REPO_ROOT / "internal-enrichment",
+    REPO_ROOT / "internal-export-file",
+    REPO_ROOT / "internal-import-file",
+    REPO_ROOT / "stream",
+]
+
+# Broad pattern: any self attribute whose name ends with "url" (case-insensitive).
+# This catches self.base_url, self.api_url, self.endpoint_url, self.target_url, etc.
+URL_VAR_PATTERN = re.compile(r"(self\.\w*url)\s*=", re.IGNORECASE)
+
+# Pattern that indicates the URL is protected (rstrip, strip, endswith check, conditional trim)
+PROTECTED_PATTERNS = [
+    r'\.rstrip\s*\(\s*["\']/?["\']\s*\)',
+    r'\.strip\s*\(\s*["\']/?["\']\s*\)',
+    r'\[-1\]\s*==\s*["\']/',
+    r'\.endswith\s*\(\s*["\']/',
+    r"if.*\.endswith.*\"/\"",
+]
+
+
+def find_connector_python_files():
+    """Find all Python source files in connector src/ directories."""
+    files = []
+    for connector_dir in CONNECTOR_DIRS:
+        if not connector_dir.exists():
+            continue
+        for connector in sorted(connector_dir.iterdir()):
+            src_dir = connector / "src"
+            if not src_dir.exists():
+                continue
+            for py_file in src_dir.rglob("*.py"):
+                if "__pycache__" in str(py_file) or "venv" in str(py_file):
+                    continue
+                files.append(py_file)
+    return files
+
+
+def find_connector_file_groups() -> dict[Path, list[Path]]:
+    """Group Python source files by their connector src/ directory."""
+    groups: dict[Path, list[Path]] = {}
+    for connector_dir in CONNECTOR_DIRS:
+        if not connector_dir.exists():
+            continue
+        for connector in sorted(connector_dir.iterdir()):
+            src_dir = connector / "src"
+            if not src_dir.exists():
+                continue
+            py_files = [
+                f
+                for f in src_dir.rglob("*.py")
+                if "__pycache__" not in str(f) and "venv" not in str(f)
+            ]
+            if py_files:
+                groups[src_dir] = py_files
+    return groups
+
+
+def _get_non_docstring_lines(source: str) -> set[int]:
+    """Return the set of line numbers that are NOT inside docstrings (AST-based)."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        # If the file can't be parsed, treat all lines as code (fall back to text scan)
+        return set(range(1, source.count("\n") + 2))
+
+    docstring_lines: set[int] = set()
+
+    for node in ast.walk(tree):
+        # Docstrings are Expr nodes containing a Constant(str) as first body stmt
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+            if isinstance(node.value.value, str):
+                for ln in range(node.value.lineno, node.value.end_lineno + 1):
+                    docstring_lines.add(ln)
+
+    all_lines = set(range(1, source.count("\n") + 2))
+    return all_lines - docstring_lines
+
+
+def get_url_assignments(file_path: Path) -> list[tuple[int, str, str]]:
+    """
+    Find lines where a URL variable is assigned from config/param (not hardcoded).
+
+    Uses AST to exclude docstrings, then regex to find assignments.
+    Returns list of (line_number, variable_name, full_line).
+    """
+    results = []
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return results
+
+    code_lines = _get_non_docstring_lines(content)
+    lines = content.splitlines()
+
+    for i, line in enumerate(lines, start=1):
+        # Skip lines inside docstrings
+        if i not in code_lines:
+            continue
+
+        stripped = line.strip()
+
+        # Skip comments
+        if stripped.startswith("#"):
+            continue
+
+        # Match self.*url = ... patterns (broad, catches any URL-like attribute)
+        match = URL_VAR_PATTERN.search(line)
+        if not match:
+            continue
+
+        var_name = match.group(1)
+
+        # Skip if it's a hardcoded string (no config variable involvement)
+        # Hardcoded = direct string literal like self.url = "https://..."
+        if re.search(r'=\s*["\']https?://', line):
+            continue
+
+        results.append((i, var_name, line))
+
+    return results
+
+
+def is_assignment_protected(file_path: Path, line_num: int, var_name: str) -> bool:
+    """
+    Check if a URL assignment has .rstrip("/") or equivalent protection.
+
+    Handles:
+    - Direct protection: self.url = x.rstrip("/")
+    - Intermediate variable: _base = x.rstrip("/"); self.url = f"{_base}/..."
+    - Post-assignment guard: self.url = x; if isinstance(self.url, str): self.url = self.url.rstrip("/")
+    """
+    try:
+        source = file_path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return True  # can't check, assume ok
+
+    lines = source.splitlines()
+
+    def _has_protection(text: str) -> bool:
+        return any(re.search(p, text) for p in PROTECTED_PATTERNS)
+
+    # Try AST-based extraction: find the assignment node at this line
+    try:
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign) and node.lineno == line_num:
+                stmt_lines = lines[node.lineno - 1 : node.end_lineno]
+                assignment_text = "\n".join(stmt_lines)
+                if _has_protection(assignment_text):
+                    return True
+
+                # Check if the right-hand side of the assignment uses a local
+                # variable that was rstrip'd in the preceding 3 lines
+                # (intermediate variable pattern)
+                start = max(0, node.lineno - 4)
+                context = "\n".join(lines[start : node.lineno - 1])
+                if _has_protection(context):
+                    return True
+
+                # Check following lines for post-assignment isinstance guard
+                # Pattern: if isinstance(self.var, str): self.var = self.var.rstrip("/")
+                end = min(node.end_lineno + 3, len(lines))
+                following = "\n".join(lines[node.end_lineno : end])
+                if _has_protection(following) and var_name in following:
+                    return True
+
+                return False
+    except SyntaxError:
+        pass
+
+    # Fallback: text-based extraction for files that can't be parsed
+    start = line_num - 1
+    end = min(start + 10, len(lines))
+
+    assignment_text = ""
+    base_indent = len(lines[start]) - len(lines[start].lstrip())
+    for i in range(start, end):
+        assignment_text += lines[i] + "\n"
+        if i > start:
+            current_indent = (
+                len(lines[i]) - len(lines[i].lstrip()) if lines[i].strip() else 999
+            )
+            if current_indent <= base_indent and not lines[i].strip().startswith(")"):
+                break
+
+    if _has_protection(assignment_text):
+        return True
+
+    # Check preceding lines for intermediate variable pattern
+    context_start = max(0, start - 3)
+    context = "\n".join(lines[context_start:start])
+    return _has_protection(context)
+
+
+def is_usage_protected(file_path: Path, usage_line_num: int, var_name: str) -> bool:
+    """
+    Check if a URL usage is protected by a conditional check on the variable.
+
+    Handles patterns like:
+    - if self.URL[-1] == "/": URL = f"{self.URL}{EP}" else: URL = f"{self.URL}/{EP}"
+    - target = self.url if self.url.endswith("/") else self.url + "/"
+    """
+    try:
+        source = file_path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return False
+
+    lines = source.splitlines()
+    short_name = var_name.replace("self.", "")
+
+    # Check a window of 5 lines before and after the usage for conditional checks
+    start = max(0, usage_line_num - 6)
+    end = min(len(lines), usage_line_num + 3)
+    context = "\n".join(lines[start:end])
+
+    # Patterns that indicate runtime handling of trailing slash
+    runtime_patterns = [
+        rf"self\.{re.escape(short_name)}\s*\[\s*-1\s*\]\s*==\s*[\"']/",
+        rf"self\.{re.escape(short_name)}\.endswith\s*\(\s*[\"']/",
+        rf"self\.{re.escape(short_name)}\.rstrip\s*\(\s*[\"']/?[\"']\s*\)",
+    ]
+
+    return any(re.search(p, context) for p in runtime_patterns)
+
+
+def get_url_usages_with_slash(file_path: Path, var_name: str) -> list[tuple[int, str]]:
+    """
+    Find lines where the URL variable is used in URL construction with a leading slash,
+    excluding usages that are already protected by conditional checks.
+
+    Returns list of (line_number, line_content).
+    """
+    results = []
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return results
+
+    short_name = var_name.replace("self.", "")
+
+    for i, line in enumerate(content.splitlines(), start=1):
+        matched = False
+        # f-string pattern: f"{self.xxx_url}/..." or f'{self.xxx_url}/...'
+        if re.search(rf'f["\'].*\{{self\.{re.escape(short_name)}\}}/', line):
+            matched = True
+        # Concatenation pattern: self.xxx_url + "/..." or self.xxx_url + '/...'
+        elif re.search(rf"""self\.{re.escape(short_name)}\s*\+\s*['"]\/""", line):
+            matched = True
+
+        if matched and not is_usage_protected(file_path, i, var_name):
+            results.append((i, line.strip()))
+
+    return results
+
+
+def get_cross_file_usages_with_slash(
+    sibling_files: list[Path], var_name: str
+) -> list[tuple[int, str, Path]]:
+    """
+    Find usages of a URL variable across sibling files in the same connector.
+
+    Catches patterns like self.config.xxx_url + "/..." or f"{self.config.xxx_url}/..."
+    where the attribute is accessed via a nested config object.
+
+    Returns list of (line_number, line_content, file_path).
+    """
+    results = []
+    short_name = var_name.replace("self.", "")
+
+    for sibling in sibling_files:
+        try:
+            content = sibling.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+
+        for i, line in enumerate(content.splitlines(), start=1):
+            matched = False
+            # f-string: f"{self.config.xxx_url}/..." or f"{self.xxx.xxx_url}/..."
+            if re.search(
+                rf"""f['"].*\{{self\.\w+\.{re.escape(short_name)}\}}/""", line
+            ):
+                matched = True
+            # Concatenation: self.config.xxx_url + "/..." or + '/...'
+            elif re.search(
+                rf"""self\.\w+\.{re.escape(short_name)}\s*\+\s*['"]\/""", line
+            ):
+                matched = True
+
+            if matched:
+                results.append((i, line.strip(), sibling))
+
+    return results
+
+
+# Collect all unprotected URL assignments across the codebase
+def collect_unprotected_assignments():
+    """Scan all connectors and collect unprotected URL assignments that are used with /."""
+    violations = []
+    connector_groups = find_connector_file_groups()
+
+    for src_dir, py_files in connector_groups.items():
+        for py_file in py_files:
+            assignments = get_url_assignments(py_file)
+            for line_num, var_name, line in assignments:
+                if is_assignment_protected(py_file, line_num, var_name):
+                    continue
+
+                # Check same-file usages
+                usages = get_url_usages_with_slash(py_file, var_name)
+
+                # Check cross-file usages (via self.config.xxx_url or similar)
+                sibling_files = [f for f in py_files if f != py_file]
+                cross_usages = get_cross_file_usages_with_slash(sibling_files, var_name)
+                for ln, code, xfile in cross_usages:
+                    rel_xfile = xfile.relative_to(REPO_ROOT)
+                    usages.append((ln, f"[{rel_xfile}] {code}"))
+
+                if usages:
+                    rel_path = py_file.relative_to(REPO_ROOT)
+                    violations.append(
+                        (str(rel_path), line_num, var_name, line.strip(), usages)
+                    )
+    return violations
+
+
+@pytest.fixture(scope="session")
+def url_violations():
+    """Lazily collect violations at test time, not at import/collection time."""
+    return collect_unprotected_assignments()
+
+
+def test_no_unprotected_url_assignments(url_violations):
+    """
+    Verify that all URL variables assigned from config have .rstrip("/") protection.
+
+    This prevents double slashes in URLs when requests >= 2.34.0 is used,
+    which no longer normalizes // in URL paths.
+    """
+    if not url_violations:
+        return
+
+    messages = []
+    for file_path, line_num, var_name, assignment, usages in url_violations:
+        usage_lines = ", ".join(f"L{ln}" for ln, _ in usages[:3])
+        messages.append(
+            f"  {file_path}:{line_num} - {var_name} assigned without .rstrip('/') "
+            f"(used at {usage_lines})"
+        )
+    violation_report = "\n".join(messages)
+    pytest.fail(
+        f"Found {len(url_violations)} URL variable(s) without .rstrip('/') protection:\n"
+        f"{violation_report}\n\n"
+        f"Fix: Add .rstrip('/') to the assignment, e.g.:\n"
+        f"  self.base_url = str(config.url).rstrip('/')"
+    )
+
+
+def collect_unprotected_helper_url_usages():
+    """
+    Find usages of self.helper.opencti_url (from pycti) in URL construction
+    without inline .rstrip("/") protection.
+
+    pycti does not strip the trailing slash from opencti_url, so connectors
+    must protect at the usage site.
+    """
+    violations = []
+    helper_url_pattern = re.compile(r"self[._]+helper\.opencti_url")
+
+    for py_file in find_connector_python_files():
+        try:
+            content = py_file.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+
+        for i, line in enumerate(content.splitlines(), start=1):
+            if not helper_url_pattern.search(line):
+                continue
+
+            # Check if this line uses the URL with a slash (f-string or concat)
+            has_slash_usage = (
+                re.search(r"self[._]+helper\.opencti_url\}['\"]?\s*/", line)
+                or re.search(r"self[._]+helper\.opencti_url\}\s*/", line)
+                or re.search(r"self[._]+helper\.opencti_url\s*\+\s*['\"]\/", line)
+                or re.search(r"\{self[._]+helper\.opencti_url\}/", line)
+            )
+            if not has_slash_usage:
+                continue
+
+            # Check if .rstrip is applied inline
+            if "rstrip" in line:
+                continue
+
+            rel_path = py_file.relative_to(REPO_ROOT)
+            violations.append((str(rel_path), i, line.strip()))
+
+    return violations
+
+
+@pytest.fixture(scope="session")
+def helper_url_violations():
+    """Collect unprotected self.helper.opencti_url usages."""
+    return collect_unprotected_helper_url_usages()
+
+
+def test_no_unprotected_helper_opencti_url(helper_url_violations):
+    """
+    Verify that self.helper.opencti_url usages in URL construction
+    include .rstrip("/") since pycti does not strip it.
+    """
+    if not helper_url_violations:
+        return
+
+    messages = []
+    for file_path, line_num, code in helper_url_violations:
+        messages.append(f"  {file_path}:{line_num} - {code}")
+    violation_report = "\n".join(messages)
+    pytest.fail(
+        f"Found {len(helper_url_violations)} unprotected self.helper.opencti_url usage(s):\n"
+        f"{violation_report}\n\n"
+        f"Fix: Add .rstrip('/') inline, e.g.:\n"
+        f"  f\"{{self.helper.opencti_url.rstrip('/')}}/storage/get/{{file_id}}\""
+    )


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add test to check url construction to detect possible double slash
* Fix issues detected

### Related issues

* Closes: #6393 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

Results of the test before fix:
```
Failed: Found 43 URL variable(s) without .rstrip('/') protection:
  external-import/cape/src/cape/telemetry.py:63 - self.cuckoo_url assigned without .rstrip('/') (used at L524)
  external-import/citalid/src/citalid_api.py:19 - self.connection_service_base_url assigned without .rstrip('/') (used at L36)
  external-import/citalid/src/citalid_api.py:20 - self.api_base_url assigned without .rstrip('/') (used at L44)
  external-import/cluster25/src/cluster25/core.py:47 - self.base_url assigned without .rstrip('/') (used at L129, L156)
  external-import/criminalip-c2-daily-feed/src/main.py:36 - self.csv_url assigned without .rstrip('/') (used at L50)
  external-import/cuckoo/src/cuckoo/telemetry.py:39 - self.cuckoo_url assigned without .rstrip('/') (used at L384)
  external-import/flashpoint/src/flashpoint_client/client_api.py:30 - self.api_base_url assigned without .rstrip('/') (used at L54, L66, L100)
  external-import/harfanglab-incidents/src/harfanglab_incidents_connector/config_variables.py:49 - self.harfanglab_api_base_url assigned without .rstrip('/') (used at L201, L246, L395)
  external-import/luminar/src/luminar_connector/connector.py:117 - self.luminar_base_url assigned without .rstrip('/') (used at L150, L214, L282)
  external-import/misp/src/connector/use_cases/common.py:92 - self.external_reference_base_url assigned without .rstrip('/') (used at L265)
  external-import/opencsam/src/opencsam.py:34 - self.opencsam_api_url assigned without .rstrip('/') (used at L117)
  external-import/rst-threat-feed/src/rstcloud/FeedFetch.py:9 - self.api_url assigned without .rstrip('/') (used at L30)
  external-import/sentinelone-threats/src/s1api.py:18 - self._api_url assigned without .rstrip('/') (used at L31, L67)
  external-import/tanium-incidents/src/tanium_incidents_connector/client_api.py:12 - self.url assigned without .rstrip('/') (used at L48, L68)
  external-import/tenable-vuln-management/src/tenable_vuln_management/config_variables.py:54 - self.tio_api_base_url assigned without .rstrip('/') (used at L454)
  external-import/thehive/src/thehive.py:51 - self.thehive_url assigned without .rstrip('/') (used at L680)
  internal-enrichment/cape-sandbox/src/cape-sandbox.py:45 - self.octi_api_url assigned without .rstrip('/') (used at L583)
  internal-enrichment/cape-sandbox/src/cape-sandbox.py:48 - self.cape_api_url assigned without .rstrip('/') (used at L143, L153, L163)
  internal-enrichment/hatching-triage-sandbox/src/hatching-triage-sandbox.py:45 - self.octi_api_url assigned without .rstrip('/') (used at L482)
  internal-enrichment/intezer-sandbox/src/intezer_sandbox.py:30 - self.octi_api_url assigned without .rstrip('/') (used at L122)
  internal-enrichment/ipqs/src/ipqs/client.py:17 - self.url assigned without .rstrip('/') (used at L124)
  internal-enrichment/joe-sandbox/src/joe-sandbox.py:33 - self.octi_api_url assigned without .rstrip('/') (used at L360)
  internal-enrichment/joe-sandbox/src/joe-sandbox.py:48 - self._analysis_url assigned without .rstrip('/') (used at L431)
  internal-enrichment/orion-malware/src/main.py:39 - self.octi_api_url assigned without .rstrip('/') (used at L192)
  internal-enrichment/orion-malware/src/main.py:43 - self._api_url assigned without .rstrip('/') (used at L290)
  internal-enrichment/rst-ioc-lookup/src/main.py:26 - self.base_url assigned without .rstrip('/') (used at L422)
  internal-enrichment/rst-noise-control/src/main.py:24 - self.base_url assigned without .rstrip('/') (used at L211)
  internal-enrichment/rst-whois-api/src/main.py:26 - self.base_url assigned without .rstrip('/') (used at L276, L279, L282)
  internal-enrichment/shadowtrackr/src/shadowtrackr_client/api_client.py:21 - self.base_url assigned without .rstrip('/') (used at L56)
  internal-enrichment/team-cymru-scout/src/pure_signal_scout/connector.py:12 - self.api_base_url assigned without .rstrip('/') (used at L99, L113)
  internal-enrichment/team-cymru-scout-search/src/scout_search_connector/connector.py:15 - self.api_base_url assigned without .rstrip('/') (used at L100)
  internal-enrichment/unpac-me/src/unpac_me.py:32 - self.octi_api_url assigned without .rstrip('/') (used at L173)
  internal-enrichment/vmray-analyzer/src/vmray-analyzer.py:40 - self.octi_api_url assigned without .rstrip('/') (used at L109)
  stream/chronicle/src/chronicle.py:23 - self.url assigned without .rstrip('/') (used at L35, L57, L86)
  stream/harfanglab-intel/src/harfanglab_intel_connector/api_client.py:30 - self.api_base_url assigned without .rstrip('/') (used at L87, L108, L126)
  stream/logrhythm/src/logrhythm.py:29 - self.logrhythm_url assigned without .rstrip('/') (used at L95, L99)
  stream/microsoft-defender-intel/src/microsoft_defender_intel_connector/api_handler.py:55 - self.base_url assigned without .rstrip('/') (used at L78)
  stream/microsoft-defender-intel-synchronizer/src/microsoft_defender_intel_synchronizer_connector/config_variables.py:66 - self.base_url assigned without .rstrip('/') (used at L52)
  stream/pan-cortex-xsoar-intel/src/pan-cortex-xsoar-intel.py:92 - self.xsoar_url assigned without .rstrip('/') (used at L99)
  stream/qradar/src/qradar.py:41 - self.qradar_url assigned without .rstrip('/') (used at L55, L57)
  stream/sekoia-intel/src/sekoia_intel_connector/api_client.py:24 - self.api_base_url assigned without .rstrip('/') (used at L32, L50, L70)
  stream/splunk/src/splunk.py:47 - self.splunk_url assigned without .rstrip('/') (used at L57)
  stream/sumologic-intel/src/sumologic_intel_connector/config_loader.py:41 - self.api_base_url assigned without .rstrip('/') (used at L38, L93)

Failed: Found 6 unprotected self.helper.opencti_url usage(s):
  internal-enrichment/anyrun-task/src/anyrun_sandbox.py:111 - artifact_url = f'{self._helper.opencti_url}/storage/get/{file.get("id")}'
  internal-enrichment/glimps-malware/src/glimps_malware_connector/glimps_malware.py:78 - file_uri = f"{self.helper.opencti_url}/storage/get/{file_id}"
  internal-enrichment/hybrid-analysis-sandbox/src/hybrid-analysis-sandbox.py:319 - self.helper.opencti_url + "/storage/get/" + file_uri, True
  internal-enrichment/reversinglabs-spectra-analyze/src/main.py:174 - file_uri = f"{self.helper.opencti_url}/storage/get/{file_id}"
  internal-enrichment/reversinglabs-spectra-intel-submission/src/main.py:545 - file_uri = f"{self.helper.opencti_url}/storage/get/{file_id}"
  internal-enrichment/virustotal/src/virustotal/processors/file.py:117 - artifact_url = f"{self.helper.opencti_url}/storage/get/{file_meta['id']}"

```
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
