### PR TITLE
[anyrun] Fix Docker images

### DIFF
--- a/internal-enrichment/anyrun-lookup/docker-compose.yml
+++ b/internal-enrichment/anyrun-lookup/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   connector-anyrun-ti-lookup:
-    image: anyrun/opencti-connector-anyrun-ti-lookup:latest
+    image: opencti/connector-anyrun-lookup:latest
     environment:
       # OpenCTI settings.
       - OPENCTI_URL=http://localhost # The URL of the OpenCTI platform. Note that final `/` should be avoided. Example value: `http://opencti:8080`

--- a/internal-enrichment/anyrun-task/docker-compose.yml
+++ b/internal-enrichment/anyrun-task/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   connector-anyrun-task:
-    image: anyrun/opencti-connector-anyrun-task:latest
+    image: opencti/connector-anyrun-task:latest
     environment:
       # OpenCTI settings.
       - OPENCTI_URL=http://localhost # The URL of the OpenCTI platform. Note that final `/` should be avoided. Example value: `http://opencti:8080`


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!
-->

### Proposed changes

Both ANY.RUN connectors ship a `docker-compose.yml` whose `image:` line points to a Docker Hub repository that does not exist (`anyrun/...`). The OpenCTI build pipeline publishes the connectors under the canonical `opencti/connector-<slug>:<tag>` namespace, which is also what the matching `__metadata__/connector_manifest.json` files declare. This PR aligns the compose files with the canonical image names so `docker compose up -d` actually works out of the box.

* `internal-enrichment/anyrun-lookup/docker-compose.yml`:
  `anyrun/opencti-connector-anyrun-ti-lookup:latest` → `opencti/connector-anyrun-lookup:latest`
* `internal-enrichment/anyrun-task/docker-compose.yml`:
  `anyrun/opencti-connector-anyrun-task:latest` → `opencti/connector-anyrun-task:latest`

### Related issues

Closes #6397

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

No comments.
