### PR TITLE
[intel471-darknet] Use rstrip to avoid double slash in url

### DIFF
--- a/external-import/intel471-darknet/src/main.py
+++ b/external-import/intel471-darknet/src/main.py
@@ -128,7 +128,7 @@ class Intel471AlertsConnector(ExternalImportConnector):
             ["intel471", "api_url"],
             config,
             default="https://api.intel471.com/v1",
-        )
+        ).rstrip("/")
         self.intel471_api_username = get_config_variable(
             "INTEL471_API_USERNAME",
             ["intel471", "api_username"],


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix url

### Related issues

* Closes: #6443 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
