### PR TITLE
[connectors-sdk] Rename config to settings for external import connector

### DIFF
--- a/connectors-sdk/connectors_sdk/connectors/external_import/base_data_processor.py
+++ b/connectors-sdk/connectors_sdk/connectors/external_import/base_data_processor.py
@@ -65,36 +65,36 @@ class BaseDataProcessor(ABC):
             Changing ``work_name`` between calls to ``send()`` (or between iterations
             in a generator-based ``transform()``) will close the current work and
             open a new one with the updated name.
-        config: The connector settings, injected via ``inject_dependencies()``.
+        settings: The connector settings, injected via ``inject_dependencies()``.
         work_manager: The ``WorkManager`` instance, created in ``inject_dependencies()``.
         logger: The ``ConnectorLogger`` instance, injected via ``inject_dependencies()``.
         state: The ``ExternalImportConnectorState`` instance, injected via ``inject_dependencies()``.
     """
 
     work_name: str
-    config: BaseConnectorSettings
+    settings: BaseConnectorSettings
     work_manager: WorkManager
     logger: ConnectorLogger
     state: ExternalImportConnectorState
 
     def inject_dependencies(
         self,
-        config: BaseConnectorSettings,
+        settings: BaseConnectorSettings,
         helper: OpenCTIConnectorHelper,
         state: ExternalImportConnectorState,
     ) -> None:
         """Inject dependencies from the base connector and create the WorkManager.
 
         Called by ``ExternalImportConnector`` after helper initialization.
-        Sets ``config``, ``logger`` and ``state``, and creates the ``WorkManager``
+        Sets ``settings``, ``logger`` and ``state``, and creates the ``WorkManager``
         for this processor.
 
         Args:
-            config: The connector configuration settings.
+            settings: The connector configuration settings.
             helper: The ``OpenCTIConnectorHelper`` instance.
             state: The ``ExternalImportConnectorState`` instance.
         """
-        self.config = config
+        self.settings = settings
         self.work_manager = WorkManager(helper)
         self.logger = ConnectorLogger(helper)
         self.state = state
@@ -103,7 +103,7 @@ class BaseDataProcessor(ABC):
         """Hook called after ``inject_dependencies()`` wires up dependencies.
 
         Override this method to perform initialization that requires
-        the injected dependencies (logger, state, config, etc.).
+        the injected dependencies (logger, state, settings, etc.).
         Called by ``ExternalImportConnector._init_dependencies()``.
 
         By default, does nothing.

--- a/connectors-sdk/connectors_sdk/connectors/external_import/external_import_connector.py
+++ b/connectors-sdk/connectors_sdk/connectors/external_import/external_import_connector.py
@@ -44,7 +44,7 @@ class ExternalImportConnector:
     (e.g. one for indicators, one for reports, one for vulnerabilities).
 
     Attributes:
-        config: The connector configuration (subclass of ``BaseConnectorSettings``).
+        settings: The connector configuration (subclass of ``BaseConnectorSettings``).
         logger: The ``ConnectorLogger`` for logging without direct pycti dependency.
         state: The ``ExternalImportConnectorState`` for persisting connector state.
         data_processors: The list of ``BaseDataProcessor`` instances.
@@ -60,7 +60,7 @@ class ExternalImportConnector:
         ...
         >>> settings = MyConnectorSettings()
         >>> connector = ExternalImportConnector(
-        ...     config=settings,
+        ...     settings=settings,
         ...     data_processors=[IndicatorProcessor()],
         ... )
         >>> connector.start()
@@ -68,7 +68,7 @@ class ExternalImportConnector:
 
     def __init__(
         self,
-        config: BaseConnectorSettings,
+        settings: BaseConnectorSettings,
         data_processors: list[BaseDataProcessor],
         state: ExternalImportConnectorState | None = None,
     ) -> None:
@@ -78,14 +78,14 @@ class ExternalImportConnector:
         created when ``start()`` is called (via ``_init_dependencies()``).
 
         Args:
-            config: The connector configuration settings.
+            settings: The connector configuration settings.
             data_processors: The list of ``BaseDataProcessor`` instances to run.
             state: Optional custom state instance. If ``None``, a default
                 ``ExternalImportConnectorState`` is created in ``_init_dependencies()``.
         """
         if not data_processors:
             raise ValueError("At least one BaseDataProcessor must be provided.")
-        self.config = config
+        self.settings = settings
         self.data_processors = data_processors
         self.state = state if state is not None else ExternalImportConnectorState()
 
@@ -98,12 +98,12 @@ class ExternalImportConnector:
         3. Initializes the state and injects dependencies
         4. Calls ``inject_dependencies()`` on each data processor
         """
-        self._helper = OpenCTIConnectorHelper(config=self.config.to_helper_config())
+        self._helper = OpenCTIConnectorHelper(config=self.settings.to_helper_config())
         self.logger = ConnectorLogger(self._helper)
         self.state.inject_dependencies(self._helper)
         for processor in self.data_processors:
             processor.inject_dependencies(
-                config=self.config,
+                settings=self.settings,
                 helper=self._helper,
                 state=self.state,
             )
@@ -120,7 +120,7 @@ class ExternalImportConnector:
 
         Override this method for fully custom processing logic.
         """
-        connector_name = self.config.connector.name
+        connector_name = self.settings.connector.name
         self.logger.info(
             "[CONNECTOR] Starting connector...",
             {"connector_name": connector_name},
@@ -174,11 +174,11 @@ class ExternalImportConnector:
         until the queue is reduced.
 
         Note:
-            The ``config.connector`` must be a ``BaseExternalImportConnectorConfig``
+            The ``settings.connector`` must be a ``BaseExternalImportConnectorConfig``
             (or subclass) with a ``duration_period`` field.
         """
         self._init_dependencies()
         self._helper.schedule_process(
             message_callback=self.callback,
-            duration_period=self.config.connector.duration_period.total_seconds(),  # type: ignore[attr-defined]
+            duration_period=self.settings.connector.duration_period.total_seconds(),  # type: ignore[attr-defined]
         )

--- a/connectors-sdk/tests/test_connectors/conftest.py
+++ b/connectors-sdk/tests/test_connectors/conftest.py
@@ -33,10 +33,10 @@ def mock_logger(mock_helper: MagicMock) -> ConnectorLogger:
 
 
 @pytest.fixture
-def mock_config() -> MagicMock:
+def mock_settings() -> MagicMock:
     """Mock BaseConnectorSettings with required attributes."""
-    config = MagicMock()
-    config.connector.name = "Test Connector"
-    config.connector.duration_period = timedelta(hours=1)
-    config.to_helper_config.return_value = {}
-    return config
+    settings = MagicMock()
+    settings.connector.name = "Test Connector"
+    settings.connector.duration_period = timedelta(hours=1)
+    settings.to_helper_config.return_value = {}
+    return settings

--- a/connectors-sdk/tests/test_connectors/test_data_processor.py
+++ b/connectors-sdk/tests/test_connectors/test_data_processor.py
@@ -71,7 +71,7 @@ class TestBaseDataProcessor:
         mock_logger: ConnectorLogger,
     ) -> None:
         processor.inject_dependencies(
-            config=MagicMock(),
+            settings=MagicMock(),
             helper=mock_helper,
             state=MagicMock(),
         )

--- a/connectors-sdk/tests/test_connectors/test_external_import_connector.py
+++ b/connectors-sdk/tests/test_connectors/test_external_import_connector.py
@@ -57,43 +57,47 @@ def _make_state_mock() -> MagicMock:
 
 
 class TestExternalImportConnector:
-    def test_init(self, mock_config: MagicMock):
+    def test_init(self, mock_settings: MagicMock):
         proc = DummyProcessor()
-        connector = ExternalImportConnector(config=mock_config, data_processors=[proc])
-        assert connector.config is mock_config
+        connector = ExternalImportConnector(
+            settings=mock_settings, data_processors=[proc]
+        )
+        assert connector.settings is mock_settings
         assert connector.data_processors == [proc]
 
-    def test_init_empty_processors_raises(self, mock_config: MagicMock):
+    def test_init_empty_processors_raises(self, mock_settings: MagicMock):
         with pytest.raises(ValueError, match="At least one BaseDataProcessor"):
-            ExternalImportConnector(config=mock_config, data_processors=[])
+            ExternalImportConnector(settings=mock_settings, data_processors=[])
 
     @patch(PATCH_HELPER)
     def test_init_dependencies_wires_up_components(
-        self, mock_helper_cls: MagicMock, mock_config: MagicMock
+        self, mock_helper_cls: MagicMock, mock_settings: MagicMock
     ):
         mock_helper_cls.return_value = _make_helper_mock()
 
         proc = DummyProcessor()
-        connector = ExternalImportConnector(config=mock_config, data_processors=[proc])
+        connector = ExternalImportConnector(
+            settings=mock_settings, data_processors=[proc]
+        )
         connector._init_dependencies()
 
         assert connector.logger is not None
         assert connector.state is not None
-        assert proc.config is mock_config
+        assert proc.settings is mock_settings
         assert proc.logger is not None
         assert proc.state is connector.state
         assert proc.work_manager is not None
 
     @patch(PATCH_HELPER)
     def test_init_dependencies_custom_state(
-        self, mock_helper_cls: MagicMock, mock_config: MagicMock
+        self, mock_helper_cls: MagicMock, mock_settings: MagicMock
     ):
         mock_helper_cls.return_value = _make_helper_mock()
 
         custom_state = MagicMock()
         proc = DummyProcessor()
         connector = ExternalImportConnector(
-            config=mock_config, data_processors=[proc], state=custom_state
+            settings=mock_settings, data_processors=[proc], state=custom_state
         )
         connector._init_dependencies()
 
@@ -101,14 +105,16 @@ class TestExternalImportConnector:
         assert proc.state is custom_state
 
     @patch(PATCH_HELPER)
-    def test_callback_success(self, mock_helper_cls: MagicMock, mock_config: MagicMock):
+    def test_callback_success(
+        self, mock_helper_cls: MagicMock, mock_settings: MagicMock
+    ):
         helper = _make_helper_mock()
         mock_helper_cls.return_value = helper
         state = _make_state_mock()
 
         proc = DummyProcessor()
         connector = ExternalImportConnector(
-            config=mock_config, data_processors=[proc], state=state
+            settings=mock_settings, data_processors=[proc], state=state
         )
         connector._init_dependencies()
         connector.callback()
@@ -119,7 +125,7 @@ class TestExternalImportConnector:
 
     @patch(PATCH_HELPER)
     def test_callback_with_last_run(
-        self, mock_helper_cls: MagicMock, mock_config: MagicMock
+        self, mock_helper_cls: MagicMock, mock_settings: MagicMock
     ):
         helper = _make_helper_mock()
         mock_helper_cls.return_value = helper
@@ -128,7 +134,7 @@ class TestExternalImportConnector:
 
         proc = DummyProcessor()
         connector = ExternalImportConnector(
-            config=mock_config, data_processors=[proc], state=state
+            settings=mock_settings, data_processors=[proc], state=state
         )
         connector._init_dependencies()
         connector.callback()
@@ -137,7 +143,7 @@ class TestExternalImportConnector:
 
     @patch(PATCH_HELPER)
     def test_callback_exception_is_logged(
-        self, mock_helper_cls: MagicMock, mock_config: MagicMock
+        self, mock_helper_cls: MagicMock, mock_settings: MagicMock
     ):
         helper = _make_helper_mock()
         mock_helper_cls.return_value = helper
@@ -145,7 +151,7 @@ class TestExternalImportConnector:
 
         proc = FailingProcessor()
         connector = ExternalImportConnector(
-            config=mock_config, data_processors=[proc], state=state
+            settings=mock_settings, data_processors=[proc], state=state
         )
         connector._init_dependencies()
         connector.callback()
@@ -154,7 +160,7 @@ class TestExternalImportConnector:
 
     @patch(PATCH_HELPER)
     def test_callback_keyboard_interrupt(
-        self, mock_helper_cls: MagicMock, mock_config: MagicMock
+        self, mock_helper_cls: MagicMock, mock_settings: MagicMock
     ):
         helper = _make_helper_mock()
         mock_helper_cls.return_value = helper
@@ -163,7 +169,7 @@ class TestExternalImportConnector:
 
         proc = DummyProcessor()
         connector = ExternalImportConnector(
-            config=mock_config, data_processors=[proc], state=state
+            settings=mock_settings, data_processors=[proc], state=state
         )
         connector._init_dependencies()
 
@@ -172,7 +178,7 @@ class TestExternalImportConnector:
 
     @patch(PATCH_HELPER)
     def test_callback_system_exit(
-        self, mock_helper_cls: MagicMock, mock_config: MagicMock
+        self, mock_helper_cls: MagicMock, mock_settings: MagicMock
     ):
         helper = _make_helper_mock()
         mock_helper_cls.return_value = helper
@@ -181,7 +187,7 @@ class TestExternalImportConnector:
 
         proc = DummyProcessor()
         connector = ExternalImportConnector(
-            config=mock_config, data_processors=[proc], state=state
+            settings=mock_settings, data_processors=[proc], state=state
         )
         connector._init_dependencies()
 
@@ -189,12 +195,14 @@ class TestExternalImportConnector:
             connector.callback()
 
     @patch(PATCH_HELPER)
-    def test_start(self, mock_helper_cls: MagicMock, mock_config: MagicMock):
+    def test_start(self, mock_helper_cls: MagicMock, mock_settings: MagicMock):
         helper = _make_helper_mock()
         mock_helper_cls.return_value = helper
 
         proc = DummyProcessor()
-        connector = ExternalImportConnector(config=mock_config, data_processors=[proc])
+        connector = ExternalImportConnector(
+            settings=mock_settings, data_processors=[proc]
+        )
         connector.start()
 
         helper.schedule_process.assert_called_once_with(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Rename config to settings

### Related issues

* Related to: #6209 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
