### PR TITLE
[tenable-vuln-management] fix: make operating system optional in Asset model (#6324)

### DIFF
--- a/external-import/tenable-vuln-management/src/tenable_vuln_management/converter_to_stix.py
+++ b/external-import/tenable-vuln-management/src/tenable_vuln_management/converter_to_stix.py
@@ -233,6 +233,8 @@ class ConverterToStix:
         )
 
     def make_operating_systems(self, asset: Asset) -> list[OperatingSystem]:
+        if asset.operating_system is None:
+            return []
         return [
             OperatingSystem(
                 author=self.author,

--- a/external-import/tenable-vuln-management/src/tenable_vuln_management/models/tenable.py
+++ b/external-import/tenable-vuln-management/src/tenable_vuln_management/models/tenable.py
@@ -281,8 +281,8 @@ class Asset(FrozenBaseModelWithWarnedExtra):
     netbios_name: Optional[str] = Field(
         None, description="The NetBIOS name of the asset."
     )
-    operating_system: list[str] = Field(
-        ..., description="List of operating systems running on the asset."
+    operating_system: Optional[list[str]] = Field(
+        None, description="List of operating systems running on the asset."
     )
     network_id: str = Field(
         ..., description="The ID of the network the asset belongs to."

--- a/external-import/tenable-vuln-management/tests/test_converter_to_stix.py
+++ b/external-import/tenable-vuln-management/tests/test_converter_to_stix.py
@@ -538,3 +538,45 @@ def test_converter_to_stix_process_vuln_finding(
         has_relationships[0].source_ref == systems[0].id
         and has_relationships[0].target_ref == vulnerabilities[0].id
     )
+
+
+def test_converter_to_stix_make_operating_systems_with_none(
+    mock_helper, mock_config, fake_asset
+):
+    # Given a converter to stix instance
+    converter_to_stix = ConverterToStix(
+        helper=mock_helper, config=mock_config, default_marking="TLP:CLEAR"
+    )
+
+    # And an asset without operating_system (e.g. network device, bare IP host)
+    asset_without_os = fake_asset.model_copy(update={"operating_system": None})
+
+    # When calling make_operating_systems
+    operating_systems = converter_to_stix.make_operating_systems(asset=asset_without_os)
+
+    # Then it should return an empty list
+    assert operating_systems == []
+
+
+def test_converter_to_stix_process_asset_without_operating_system(
+    mock_helper, mock_config, fake_asset
+):
+    # Given a converter to stix instance
+    converter_to_stix = ConverterToStix(
+        helper=mock_helper, config=mock_config, default_marking="TLP:CLEAR"
+    )
+
+    # And an asset without operating_system
+    asset_without_os = fake_asset.model_copy(update={"operating_system": None})
+
+    # When calling process_asset
+    result = converter_to_stix.process_asset(asset=asset_without_os)
+
+    # Then the system object should still be created
+    assert result["system"].name == "sharepoint2016"
+    # Observables should not include operating_system
+    assert (
+        len(result["observables"]) == 5
+    )  # ipv4, hostname, mac, ipv6, domain_name (no operating_system)
+    # Relationships should match observables count
+    assert len(result["relationships"]) == 5

--- a/external-import/tenable-vuln-management/tests/test_models/test_tenable.py
+++ b/external-import/tenable-vuln-management/tests/test_models/test_tenable.py
@@ -92,3 +92,21 @@ def test_vulbearbility_finding_model_should_not_accept_not_to_have_scan_target_a
     vf = VulnerabilityFinding.model_validate(tenable_api_response_1_report)
     # Then no ValidationError is raised
     assert vf.scan.target is None
+
+
+@pytest.mark.parametrize(
+    "tenable_api_response_1_report",
+    [
+        pytest.param(raw_report, id=raw_report["plugin"]["name"])
+        for raw_report in load_responses()
+    ],
+)
+def test_asset_without_operating_system_should_not_raise(
+    tenable_api_response_1_report,
+):
+    # Given a tenable api response without asset.operating_system field
+    del tenable_api_response_1_report["asset"]["operating_system"]
+    # When instantiating a vulnerability_finding
+    vf = VulnerabilityFinding.model_validate(tenable_api_response_1_report)
+    # Then no ValidationError is raised and operating_system is None
+    assert vf.asset.operating_system is None


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

 - Made `Asset.operating_system` optional (`Optional[list[str]] = None`)
 - `make_operating_systems()` returns `[]` when field is `None`
 - Added tests for missing OS scenario

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/6324

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
