### PR TITLE
[mitre] Fix kill chain phases order for ATT&CK v19 Stealth & Defense Impairment tactics

### DIFF
--- a/external-import/mitre/src/__main__.py
+++ b/external-import/mitre/src/__main__.py
@@ -10,7 +10,8 @@ from pycti import OpenCTIConnectorHelper
 from src import ConfigLoader
 
 from .constants import (
-    ENTERPRISE_ATTACK_KILL_CHAIN_PHASES,
+    ENTERPRISE_ATTACK_KILL_CHAIN_PHASES_V18,
+    ENTERPRISE_ATTACK_KILL_CHAIN_PHASES_V19,
     ICS_ATTACK_KILL_CHAIN_PHASES,
     MOBILE_ATTACK_KILL_CHAIN_PHASES,
     STATEMENT_MARKINGS,
@@ -176,17 +177,58 @@ class Mitre:
         return None
 
     @staticmethod
-    def _build_kill_chain_order_mapping() -> dict:
+    def _build_kill_chain_order_mapping(
+        collection_version: Optional[str] = None,
+    ) -> dict:
         """
         Build a mapping from (kill_chain_name, phase_name) to x_opencti_order.
+
+        The Enterprise variant is selected from ``collection_version``
+        because MITRE ATT&CK v19 (April 2026) split the legacy
+        ``defense-evasion`` tactic into ``stealth`` /
+        ``defense-impairment`` and shifted every subsequent tactic's
+        order up by one. Pre-v19 bundles (operators pinning
+        ``MITRE_ENTERPRISE_FILE_URL`` to an older release) carry
+        ``defense-evasion``; v19+ bundles carry the two new tactic
+        names. Selecting the right variant at build time keeps the
+        order mapping aligned with whichever schema the inbound bundle
+        actually uses — without this guard, a v18 bundle would lose
+        ``x_opencti_order`` on every Defense Evasion attack-pattern
+        (and OpenCTI would silently default the order to 0 in the
+        UI).
+
+        Mobile and ICS mappings are unchanged across v18 / v19 (the
+        Defense Evasion split is Enterprise-only per the official
+        ATT&CK v19 release notes), so they share a single static
+        mapping regardless of the collection version.
+
+        Parameters
+        ----------
+        collection_version : Optional[str]
+            The major version of the bundle's ``x-mitre-collection``
+            object (e.g. ``"18"``, ``"19"``). When ``None`` or
+            unparseable (synthetic bundles, partial fixtures, etc.),
+            falls back to the v19+ shape — the canonical
+            ``enterprise-attack/enterprise-attack.json`` on MITRE's
+            CTI repo currently ships v19, so the unknown-version path
+            mirrors the most likely real-world input.
 
         Returns
         -------
         dict
             A dictionary mapping (kill_chain_name, phase_name) tuples to order values.
         """
+        try:
+            major = int(collection_version) if collection_version else None
+        except (TypeError, ValueError):
+            major = None
+        enterprise_phases = (
+            ENTERPRISE_ATTACK_KILL_CHAIN_PHASES_V18
+            if major is not None and major < 19
+            else ENTERPRISE_ATTACK_KILL_CHAIN_PHASES_V19
+        )
         mapping = {}
-        for phase in ENTERPRISE_ATTACK_KILL_CHAIN_PHASES:
+        for phase in enterprise_phases:
             mapping[("mitre-attack", phase["name"])] = phase["order"]
         for phase in MOBILE_ATTACK_KILL_CHAIN_PHASES:
             mapping[("mitre-mobile-attack", phase["name"])] = phase["order"]
@@ -208,9 +250,6 @@ class Mitre:
         url : str
             The URL from which the bundle was retrieved (used to check if CAPEC).
         """
-        # Build the order mapping
-        order_mapping = self._build_kill_chain_order_mapping()
-
         # Check if this is CAPEC
         is_capec = "capec" in url.lower()
 
@@ -227,6 +266,25 @@ class Mitre:
                     "Could not find x-mitre-collection version in bundle, skipping versioned kill chain phases"
                 )
 
+        # Build the order mapping. ``collection_version`` selects the
+        # Enterprise variant (v18 vs v19+) so a bundle pinned to a
+        # pre-v19 release still maps ``defense-evasion`` correctly —
+        # see :meth:`_build_kill_chain_order_mapping` for the full
+        # rationale.
+        order_mapping = self._build_kill_chain_order_mapping(collection_version)
+
+        # Track per-cycle missing-phase pairs so the warning logs once
+        # per unique ``(kill_chain_name, phase_name)`` rather than once
+        # per attack-pattern. The previous shape fired the warning
+        # inside the per-phase loop, which on a missing tactic with N
+        # techniques produced N identical warnings per cycle — for a
+        # MITRE-scale bundle (Enterprise carries ~600 techniques across
+        # 14 tactics) that could turn a single mapping miss into
+        # hundreds of duplicate log lines per cycle. Deduping at the
+        # cycle level keeps the operator-visible signal sharp without
+        # losing it on the first appearance of an unmapped phase.
+        missing_phases: set[tuple[str, str]] = set()
+
         # Process all attack patterns
         for obj in stix_bundle["objects"]:
             if obj.get("type") == "attack-pattern" and "kill_chain_phases" in obj:
@@ -238,21 +296,21 @@ class Mitre:
                     # Look up the order for this phase
                     order = order_mapping.get((kill_chain_name, phase_name))
 
-                    # Warn if no mapping found for ATT&CK phases (CAPEC phases are expected to be unmapped)
+                    # Record the miss for the deduped per-cycle summary
+                    # (CAPEC phases are expected to be unmapped — no
+                    # ``x_opencti_order`` is required for them — so
+                    # only track ATT&CK matrices).
                     if (
                         order is None
                         and not is_capec
                         and kill_chain_name
-                        in [
+                        in (
                             "mitre-attack",
                             "mitre-mobile-attack",
                             "mitre-ics-attack",
-                        ]
-                    ):
-                        self.helper.log_warning(
-                            f"No order mapping found for kill chain phase: "
-                            f"'{kill_chain_name}' / '{phase_name}' — x_opencti_order will default to 0"
                         )
+                    ):
+                        missing_phases.add((kill_chain_name, phase_name))
 
                     # Build enriched phase with x_opencti_order
                     enriched_phase = {
@@ -265,11 +323,11 @@ class Mitre:
                     enriched_phases.append(enriched_phase)
 
                     # Add versioned kill chain phase for ATT&CK matrices
-                    if collection_version and kill_chain_name in [
+                    if collection_version and kill_chain_name in (
                         "mitre-attack",
                         "mitre-mobile-attack",
                         "mitre-ics-attack",
-                    ]:
+                    ):
                         versioned_phase = {
                             "kill_chain_name": f"{kill_chain_name}-v{collection_version}",
                             "phase_name": phase_name,
@@ -280,6 +338,25 @@ class Mitre:
 
                 # Replace with enriched phases
                 obj["kill_chain_phases"] = enriched_phases
+
+        # Emit one structured warning per unique missing phase so a
+        # future MITRE tactic addition surfaces as a clear actionable
+        # signal in the operator's logs rather than getting silently
+        # defaulted to ``x_opencti_order=0`` in the UI. Using
+        # ``connector_logger.warning`` (the structured-logger API) so
+        # the ``kill_chain_name`` / ``phase_name`` ride as proper
+        # metadata fields — the older ``helper.log_warning`` would
+        # collapse them into the message body.
+        for kill_chain_name, phase_name in sorted(missing_phases):
+            self.helper.connector_logger.warning(
+                "No order mapping found for kill chain phase; "
+                "x_opencti_order will default to 0 in the UI",
+                meta={
+                    "kill_chain_name": kill_chain_name,
+                    "phase_name": phase_name,
+                    "collection_version": collection_version,
+                },
+            )
 
     def process_data(self):
         unixtime_now = get_unixtime_now()

--- a/external-import/mitre/src/__main__.py
+++ b/external-import/mitre/src/__main__.py
@@ -104,8 +104,10 @@ class Mitre:
             # First find all revoked ids
             revoked_objects = list(
                 filter(
-                    lambda stix: stix.get("revoked", False) is True
-                    or stix.get("x_capec_status", "") == "Deprecated",
+                    lambda stix: (
+                        stix.get("revoked", False) is True
+                        or stix.get("x_capec_status", "") == "Deprecated"
+                    ),
                     stix_objects,
                 )
             )
@@ -235,6 +237,22 @@ class Mitre:
 
                     # Look up the order for this phase
                     order = order_mapping.get((kill_chain_name, phase_name))
+
+                    # Warn if no mapping found for ATT&CK phases (CAPEC phases are expected to be unmapped)
+                    if (
+                        order is None
+                        and not is_capec
+                        and kill_chain_name
+                        in [
+                            "mitre-attack",
+                            "mitre-mobile-attack",
+                            "mitre-ics-attack",
+                        ]
+                    ):
+                        self.helper.log_warning(
+                            f"No order mapping found for kill chain phase: "
+                            f"'{kill_chain_name}' / '{phase_name}' — x_opencti_order will default to 0"
+                        )
 
                     # Build enriched phase with x_opencti_order
                     enriched_phase = {

--- a/external-import/mitre/src/constants.py
+++ b/external-import/mitre/src/constants.py
@@ -10,14 +10,15 @@ ENTERPRISE_ATTACK_KILL_CHAIN_PHASES = [
     {"name": "execution", "order": 3},
     {"name": "persistence", "order": 4},
     {"name": "privilege-escalation", "order": 5},
-    {"name": "defense-evasion", "order": 6},
-    {"name": "credential-access", "order": 7},
-    {"name": "discovery", "order": 8},
-    {"name": "lateral-movement", "order": 9},
-    {"name": "collection", "order": 10},
-    {"name": "command-and-control", "order": 11},
-    {"name": "exfiltration", "order": 12},
-    {"name": "impact", "order": 13},
+    {"name": "stealth", "order": 6},
+    {"name": "defense-impairment", "order": 7},
+    {"name": "credential-access", "order": 8},
+    {"name": "discovery", "order": 9},
+    {"name": "lateral-movement", "order": 10},
+    {"name": "collection", "order": 11},
+    {"name": "command-and-control", "order": 12},
+    {"name": "exfiltration", "order": 13},
+    {"name": "impact", "order": 14},
 ]
 
 MOBILE_ATTACK_KILL_CHAIN_PHASES = [

--- a/external-import/mitre/src/constants.py
+++ b/external-import/mitre/src/constants.py
@@ -3,7 +3,43 @@ STATEMENT_MARKINGS = [
     "marking-definition--17d82bb2-eeeb-4898-bda5-3ddbcd2b799d",
 ]
 
-ENTERPRISE_ATTACK_KILL_CHAIN_PHASES = [
+# v18 and earlier Enterprise mapping. Kept as a first-class constant
+# (rather than collapsed into ``ENTERPRISE_ATTACK_KILL_CHAIN_PHASES``)
+# so an operator who pins ``MITRE_ENTERPRISE_FILE_URL`` to a pre-v19
+# release still gets the correct ``x_opencti_order`` for the legacy
+# ``defense-evasion`` tactic. The MITRE ATT&CK v19 release (April
+# 2026) split this tactic into ``stealth`` and ``defense-impairment``
+# (see :data:`ENTERPRISE_ATTACK_KILL_CHAIN_PHASES_V19` below) — older
+# bundles do NOT carry either of those names, so without this
+# variant ``enrich_kill_chain_phases`` would default the order to 0
+# in the UI for every Defense Evasion attack-pattern across older
+# bundles.
+ENTERPRISE_ATTACK_KILL_CHAIN_PHASES_V18 = [
+    {"name": "reconnaissance", "order": 0},
+    {"name": "resource-development", "order": 1},
+    {"name": "initial-access", "order": 2},
+    {"name": "execution", "order": 3},
+    {"name": "persistence", "order": 4},
+    {"name": "privilege-escalation", "order": 5},
+    {"name": "defense-evasion", "order": 6},
+    {"name": "credential-access", "order": 7},
+    {"name": "discovery", "order": 8},
+    {"name": "lateral-movement", "order": 9},
+    {"name": "collection", "order": 10},
+    {"name": "command-and-control", "order": 11},
+    {"name": "exfiltration", "order": 12},
+    {"name": "impact", "order": 13},
+]
+
+# v19+ Enterprise mapping. The April 2026 ATT&CK v19 release split the
+# legacy ``defense-evasion`` tactic into ``stealth`` (techniques where
+# adversaries hide malicious activity within legitimate behaviour) and
+# ``defense-impairment`` (techniques where adversaries actively
+# disable / degrade / compromise security controls), and shifted every
+# subsequent tactic's order up by one. ``stealth`` inherits the
+# original ``TA0005`` id while ``defense-impairment`` is a new
+# ``TA0112``.
+ENTERPRISE_ATTACK_KILL_CHAIN_PHASES_V19 = [
     {"name": "reconnaissance", "order": 0},
     {"name": "resource-development", "order": 1},
     {"name": "initial-access", "order": 2},
@@ -20,6 +56,16 @@ ENTERPRISE_ATTACK_KILL_CHAIN_PHASES = [
     {"name": "exfiltration", "order": 13},
     {"name": "impact", "order": 14},
 ]
+
+# Default Enterprise mapping used when the bundle does not advertise
+# an ``x-mitre-collection`` version (synthetic bundles, partial test
+# fixtures, etc.). Default to the v19 shape because that is what the
+# canonical ``enterprise-attack/enterprise-attack.json`` from MITRE's
+# CTI repo currently ships; the version-aware selector in
+# ``__main__.py::_build_kill_chain_order_mapping`` swaps to the v18
+# variant when the bundle's ``x-mitre-collection`` major version is
+# ``< 19``.
+ENTERPRISE_ATTACK_KILL_CHAIN_PHASES = ENTERPRISE_ATTACK_KILL_CHAIN_PHASES_V19
 
 MOBILE_ATTACK_KILL_CHAIN_PHASES = [
     {"name": "initial-access", "order": 0},


### PR DESCRIPTION
### Proposed changes

* Added `stealth` (order 6) and `defense-impairment` (order 7) to `ENTERPRISE_ATTACK_KILL_CHAIN_PHASES` in `constants.py` to fix incorrect `x_opencti_order` values after ingesting MITRE ATT&CK v19 data.
* Removed `defense-evasion` from `ENTERPRISE_ATTACK_KILL_CHAIN_PHASES` as it no longer exists as a tactic in Enterprise ATT&CK v19.
* Left `MOBILE_ATTACK_KILL_CHAIN_PHASES` and `ICS_ATTACK_KILL_CHAIN_PHASES` unchanged ΓÇö the Defense Evasion split is Enterprise-only in v19 (Mobile keeps `defense-evasion`, ICS keeps `evasion`).
* Added a log warning in `enrich_kill_chain_phases()` for any ATT&CK phase that has no order mapping, to make future tactic additions visible instead of silently defaulting to `x_opencti_order=0` in the UI.

### Background

MITRE ATT&CK v19 (April 2026) [officially split the Enterprise "Defense Evasion" tactic](https://attack.mitre.org/resources/updates/updates-april-2026/) into:

* **Stealth** ΓÇö inherits the tactic id `TA0005`, covers techniques where adversaries hide malicious activity within legitimate behaviour.
* **Defense Impairment** ΓÇö new tactic id `TA0112`, covers techniques where adversaries actively disable, degrade or compromise security controls.

`ENTERPRISE_ATTACK_KILL_CHAIN_PHASES` did not carry either new tactic name, so `enrich_kill_chain_phases()` was returning `None` for their order and omitting `x_opencti_order`, which caused OpenCTI to default the ordering to `0` in the UI.

### Follow-up Copilot review fixes (`c8fa3ab`)

Three Copilot review threads on `044876f` were addressed in a single signed follow-up commit:

* **Version-aware Enterprise kill chain mapping (`constants.py` + `__main__.py`)** — the previous shape removed `defense-evasion` from `ENTERPRISE_ATTACK_KILL_CHAIN_PHASES`, which silently broke any operator pinning `MITRE_ENTERPRISE_FILE_URL` to a pre-v19 release: their Defense Evasion attack-patterns lost `x_opencti_order` and OpenCTI defaulted the ordering to 0 in the UI. The versioned `mitre-attack-v18` kill chain inherited the same bug because the versioned-phase generator reused the unversioned order mapping. Constants are now split into `ENTERPRISE_ATTACK_KILL_CHAIN_PHASES_V18` (the legacy schema with `defense-evasion=6`) and `ENTERPRISE_ATTACK_KILL_CHAIN_PHASES_V19` (the new schema with `stealth=6` / `defense-impairment=7` and every subsequent order shifted up by one), and `_build_kill_chain_order_mapping(collection_version)` picks the right variant from the `x-mitre-collection` major version already extracted upstream — pre-v19 bundles map cleanly, v19+ bundles map cleanly, and an unknown / unparseable version falls through to v19 (the current canonical shape MITRE ships on the CTI repo). Mobile / ICS mappings are unchanged per the official ATT&CK v19 release notes — the Defense Evasion split is Enterprise-only.
* **Deduped missing-phase warning (`__main__.py`)** — the previous shape fired the warning inside the per-attack-pattern per-phase loop, which on a future tactic addition (or any other mapping miss) would emit one warning per technique using that phase. For a MITRE-scale Enterprise bundle (~600 techniques across 14 tactics) a single mapping miss could produce hundreds of duplicate log lines per cycle and drown out the surrounding info-level run summary. The warnings are now collected into a per-cycle `set[tuple[str, str]]` and emitted once per unique `(kill_chain_name, phase_name)` after the bundle walk completes, preserving the operator-visible signal on the first miss without flooding the logs.
* **Switched to `connector_logger.warning` with structured metadata (`__main__.py`)** — the per-cycle missing-phase summary now uses the structured-logger API used elsewhere in the repo (rather than the legacy `helper.log_warning`) and rides the `kill_chain_name` / `phase_name` / `collection_version` as proper `meta={...}` fields instead of collapsing them into the message body, so log aggregators can filter / group on them.

### Related issues

* Closes #6321

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The fix is minimal and targeted ΓÇö only `constants.py` and `__main__.py` are touched. The root cause was that `stealth` and `defense-impairment` were not present in the kill chain order mapping, so `enrich_kill_chain_phases()` was returning `None` for their order and omitting `x_opencti_order`, causing OpenCTI to default it to 0 in the UI. Mobile and ICS were intentionally left unchanged as confirmed by the official ATT&CK v19 release notes ΓÇö the tactic split only applies to Enterprise.

#### Testing

Validated the fix by running unit tests covering:

* `stealth` and `defense-impairment` are present in the Enterprise mapping with correct order values (6 and 7).
* `defense-evasion` is absent from the Enterprise mapping.
* `defense-evasion` is still present in the Mobile mapping.
* No duplicate order values exist across Enterprise, Mobile, and ICS phase lists.
* A scratch script was run against the live v19 Enterprise ATT&CK STIX bundle from GitHub to verify all phases in the real data are covered by the mapping with no `MISSING` entries.

Scratch script output against live v19 bundle:

```
Phases in bundle vs mapping:
  mitre-attack / collection ΓåÆ order: 11
  mitre-attack / command-and-control ΓåÆ order: 12
  mitre-attack / credential-access ΓåÆ order: 8
  mitre-attack / defense-impairment ΓåÆ order: 7
  mitre-attack / discovery ΓåÆ order: 9
  mitre-attack / execution ΓåÆ order: 3
  mitre-attack / exfiltration ΓåÆ order: 13
  mitre-attack / impact ΓåÆ order: 14
  mitre-attack / initial-access ΓåÆ order: 2
  mitre-attack / lateral-movement ΓåÆ order: 10
  mitre-attack / persistence ΓåÆ order: 4
  mitre-attack / privilege-escalation ΓåÆ order: 5
  mitre-attack / reconnaissance ΓåÆ order: 0
  mitre-attack / resource-development ΓåÆ order: 1
  mitre-attack / stealth ΓåÆ order: 6
```

#### Maintainer follow-up pass (`044876f`)

The original commit (`a7dcdf8`, authored by @Aditi-24-05) was unverified, which the repo's `Check signed commits in PR` workflow now rejects. Squashed into a single GPG-signed maintainer commit with the original authorship preserved via the `Co-authored-by:` trailer; rebased onto current `origin/master` so the branch picks up the modern GitHub-Actions CI pipeline (the legacy CircleCI `test` job that was failing on the original branch is no longer part of the matrix on master ΓÇö see #6417). No code changes ΓÇö the diff against master is byte-for-byte identical to the original commit.

