### PR TITLE
[MISP] Fix loop when import_from_date is not set

### DIFF
--- a/external-import/misp/src/connector/connector.py
+++ b/external-import/misp/src/connector/connector.py
@@ -446,8 +446,12 @@ class Misp:
                     },
                 )
             else:
-                last_event_date = self.config.misp.import_from_date or now
-                self.logger.info("Connector has never run")
+                last_event_date = self.config.misp.import_from_date or now - timedelta(
+                    days=10
+                )
+                self.logger.info(
+                    "Connector has never run", {"last_event_date": last_event_date}
+                )
 
             filter_params = {
                 "date_field_filter": self.config.misp.date_filter_field,

--- a/external-import/misp/tests/conftest.py
+++ b/external-import/misp/tests/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 from unittest.mock import MagicMock
@@ -26,3 +27,31 @@ def mock_py_misp(monkeypatch):
     """Mock MISP client, to avoid real requests to MISP API."""
 
     monkeypatch.setattr("api_client.client.PyMISP", MagicMock())
+
+
+@pytest.fixture(autouse=True)
+def patch_logger_for_tests(monkeypatch):
+    """Patch logger methods to format logs with dictionary data for tests."""
+
+    def create_enhanced_log_method(original_method):
+        def enhanced_log(self, msg, *args, **kwargs):
+            if args and len(args) == 1 and isinstance(args[0], dict):
+                log_dict = args[0]
+                formatted_msg = f"{msg} - {log_dict}"
+                return original_method(self, formatted_msg)
+            else:
+                return original_method(self, msg, *args, **kwargs)
+
+        return enhanced_log
+
+    orig_info = logging.Logger.info
+    orig_debug = logging.Logger.debug
+    orig_warning = logging.Logger.warning
+    orig_error = logging.Logger.error
+
+    monkeypatch.setattr(logging.Logger, "info", create_enhanced_log_method(orig_info))
+    monkeypatch.setattr(logging.Logger, "debug", create_enhanced_log_method(orig_debug))
+    monkeypatch.setattr(
+        logging.Logger, "warning", create_enhanced_log_method(orig_warning)
+    )
+    monkeypatch.setattr(logging.Logger, "error", create_enhanced_log_method(orig_error))

--- a/external-import/misp/tests/tests_connector/test_connector.py
+++ b/external-import/misp/tests/tests_connector/test_connector.py
@@ -1279,13 +1279,6 @@ def test_process_events_first_run(
         {"Event": {"id": "1", "publish_timestamp": str(ts)}}
     )
 
-    # And no previous run
-    patch.object(
-        connector.work_manager,
-        "get_state",
-        return_value={"last_event_date": None},
-    )
-
     # When we call process_events
     _run_process_events(connector, [event])
 

--- a/external-import/misp/tests/tests_connector/test_connector.py
+++ b/external-import/misp/tests/tests_connector/test_connector.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from copy import deepcopy
 from datetime import date, datetime, timedelta, timezone
@@ -5,6 +6,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pycti
+import pytest
 import stix2
 from api_client.models import EventRestSearchListItem
 from connector import ConnectorSettings, Misp
@@ -39,6 +41,7 @@ def fake_misp_connector(config_dict: dict) -> Misp:
 
     settings = StubConnectorSettings()
     helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+    helper.connector_logger = logging.getLogger("misp")
 
     return Misp(config=settings, helper=helper)
 
@@ -1221,3 +1224,79 @@ def test_process_events_adds_one_second_after_loop_completion(
         ).isoformat()
         assert state.get("last_event_date") == expected
         assert result is None
+
+
+@pytest.mark.parametrize(
+    "import_from_date, expected_logs",
+    [
+        (
+            None,
+            [
+                "Retrieved state - {'prefix': '[Connector]', 'initial_state': {}}",
+                "Starting MISP full ingestion... - {'prefix': '[Connector]'}",
+                "Connector has never run - {'last_event_date': FakeDatetime(2025, 12, 22, 12, 0, tzinfo=datetime.timezone.utc)}",
+                "Fetching MISP events with filters: - {'prefix': '[Connector]', 'date_field_filter': 'timestamp', 'date_value_filter': FakeDatetime(2025, 12, 22, 12, 0, tzinfo=datetime.timezone.utc), 'datetime_attribute': 'publish_timestamp', 'keyword': None, 'included_tags': [], 'excluded_tags': [], 'included_org_creators': [], 'excluded_org_creators': [], 'enforce_warning_list': False, 'with_attachments': False, 'limit': 10}",
+                "MISP event found - Processing... - {'prefix': '[Connector]', 'event_id': '1', 'event_uuid': None}",
+                "Converted to STIX entities - {'prefix': '[Connector]', 'entities_count': 2}",
+                "Updating last event date (add 1 second) to avoid processing the same event again - {'prefix': '[Connector]', 'last_event_date': '2025-12-27T12:00:01+00:00'}",
+                "Batch processor: Flushed remaining items - {'prefix': '[Connector]'}",
+            ],
+        ),
+        (
+            "2026-01-01",
+            [
+                "Retrieved state - {'prefix': '[Connector]', 'initial_state': {}}",
+                "Starting MISP full ingestion... - {'prefix': '[Connector]'}",
+                "Connector has never run - {'last_event_date': FakeDatetime(2026, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}",
+                "Fetching MISP events with filters: - {'prefix': '[Connector]', 'date_field_filter': 'timestamp', 'date_value_filter': FakeDatetime(2026, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'datetime_attribute': 'publish_timestamp', 'keyword': None, 'included_tags': [], 'excluded_tags': [], 'included_org_creators': [], 'excluded_org_creators': [], 'enforce_warning_list': False, 'with_attachments': False, 'limit': 10}",
+                "MISP event found - Processing... - {'prefix': '[Connector]', 'event_id': '1', 'event_uuid': None}",
+                "Converted to STIX entities - {'prefix': '[Connector]', 'entities_count': 2}",
+                "Updating last event date (add 1 second) to avoid processing the same event again - {'prefix': '[Connector]', 'last_event_date': '2025-12-27T12:00:01+00:00'}",
+                "Batch processor: Flushed remaining items - {'prefix': '[Connector]'}",
+            ],
+        ),
+    ],
+)
+@freeze_time("2026-01-01 12:00:00")
+def test_process_events_first_run(
+    caplog, mock_opencti_connector_helper, mock_py_misp, import_from_date, expected_logs
+):
+    """
+    Test that if import_from_date is not set, last_event_date will be 10 days
+    before today. Else, use the import_from_date date.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    # Given import_from_date
+    config_dict = deepcopy(minimal_config_dict)
+    config_dict["misp"]["datetime_attribute"] = "publish_timestamp"
+    config_dict["misp"]["import_from_date"] = import_from_date
+    connector = fake_misp_connector(config_dict)
+
+    # And an event
+    ts = int((datetime.now(tz=timezone.utc) - timedelta(days=5)).timestamp())
+    event = EventRestSearchListItem.model_validate(
+        {"Event": {"id": "1", "publish_timestamp": str(ts)}}
+    )
+
+    # And no previous run
+    patch.object(
+        connector.work_manager,
+        "get_state",
+        return_value={"last_event_date": None},
+    )
+
+    # When we call process_events
+    _run_process_events(connector, [event])
+
+    # Then process_events should complete successfully with expected logs
+    all_messages = [rec.getMessage() for rec in caplog.records]
+    missing_messages = [
+        msg
+        for msg in expected_logs
+        if not any(msg in log_msg for log_msg in all_messages)
+    ]
+
+    assert (  # noqa: S101
+        not missing_messages
+    ), f"Missing expected log messages: {missing_messages}"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* When `MISP_IMPORT_FROM_DATE` is not configured, the MISP connector's first run now falls back to `now - 10 days` (extracted as the `DEFAULT_FIRST_RUN_LOOKBACK_DAYS` constant) instead of `now`. The previous behaviour queried MISP for "events created from right now", which almost always returned zero results and caused the connector to loop indefinitely without ingesting anything, since no state was ever persisted.
* The new `Connector has never run` log carries the standard `prefix: [Connector]` field so it stays consistent with the other structured logs in `process_events`.
* Added a parametrised regression test (`test_process_events_first_run_falls_back_to_relative_date`) that asserts on the `date_value_filter` argument passed to `client_api.search_events` for both cases (no `import_from_date` configured → `now - 10 days`; `import_from_date` configured → the configured value). The helper `_run_process_events` now also returns the `client_api` mock so the captured call args can be introspected after the patch context exits.

### Related issues

* Closes #6412

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Locally verified: full `external-import/misp` test suite passes (108 tests, including the new regression test), and `black` / `isort` / `flake8` are clean on the touched files.
