### PR TITLE
[vulncheck] Stream STIX bundles and add Reports for advisory sources

### DIFF
--- a/external-import/vulncheck/README.md
+++ b/external-import/vulncheck/README.md
@@ -89,7 +89,7 @@ Below are the parameters you'll need to set for running the connector:
 | Connector ID              | `id`              | `CONNECTOR_ID`                       | /                                                                                                                           | Yes         | A unique `UUIDv4` identifier for this connector.                              |
 | Connector Type            | `type`            | `CONNECTOR_TYPE`                     | EXTERNAL_IMPORT                                                                                                             | No          | Specifies the type of connector. Should always be set to `EXTERNAL_IMPORT`.   |
 | Connector Name            | `name`            | `CONNECTOR_NAME`                     | VulnCheck Connector                                                                                                         | No          | The name of the connector as it will appear in OpenCTI.                       |
-| Connector Scope           | `scope`           | `CONNECTOR_SCOPE`                    | vulnerability,malware,threat-actor,infrastructure,location,ip-addr,indicator,external-reference,software,attack-pattern,course-of-action,x-mitre-data-source     | No          | The scope of data to import, a list of Stix Objects.                          |
+| Connector Scope           | `scope`           | `CONNECTOR_SCOPE`                    | vulnerability,malware,threat-actor,infrastructure,location,ip-addr,indicator,external-reference,software,attack-pattern,course-of-action,x-mitre-data-source,report     | No          | The scope of data to import, a list of Stix Objects.                          |
 | Connector Duration period | `duration_period` | `CONNECTOR_DURATION_PERIOD`          | PT1H                                                                                                                        | No          | The time period for which to fetch data. Default is 24 hours.                 |
 | Log Level                 | `log_level`       | `CONNECTOR_LOG_LEVEL`                | info                                                                                                                        | No          | Sets the verbosity of logs. Options: `debug`, `info`, `warn`, `error`.        |
 | API Base URL              | `api_base_url`    | `CONNECTOR_VULNCHECK_API_BASE_URL`   | <https://api.vulncheck.com/v3>                                                                                                | No          | The base URL for the VulnCheck API (e.g., `https://api.vulncheck.com/v3`).    |
@@ -184,11 +184,14 @@ Malware objects in OpenCTI.
 percentiles, helping prioritize remediation efforts based on exploit
 probability.
 - **Ransomware**: Creates Malware objects for ransomware families, linking them
-to associated vulnerabilities.
+to associated vulnerabilities. When `report` is in scope, each ransomware family
+is wrapped in a STIX Report for browsability in OpenCTI's Reports view.
 - **Threat Actors**: Adds Threat Actor objects with external references,
-relationships to targeted vulnerabilities, and descriptive metadata.
+relationships to targeted vulnerabilities, and descriptive metadata. When `report`
+is in scope, each threat actor entry is wrapped in a STIX Report.
 - **Botnets**: Ingests infrastructure data associated with botnet activities
-and links them to targeted vulnerabilities.
+and links them to targeted vulnerabilities. When `report` is in scope, each
+botnet entry is wrapped in a STIX Report.
 - **Initial Access Indicators**: Maps CPEs and vulnerabilities leveraged for
 initial access tactics.
 - **IP Intelligence**: Adds infrastructure and IP-related intelligence,
@@ -217,7 +220,7 @@ One way to separate these large data sources when `software` is in scope, is to 
 
 - Primary Connector:
   - Sources: `botnets,epss,exploits,ipintel,ransomware,snort,suricata,threat-actors,vulncheck-kev`
-  - Scope: `vulnerability,malware,threat-actor,infrastructure,location,ip-addr,indicator,external-reference`
+  - Scope: `vulnerability,malware,threat-actor,infrastructure,location,ip-addr,indicator,external-reference,report`
   - This connector will handle the main threat intelligence data without
   `software`, ensuring timely ingestion.
 - Secondary Connector:

--- a/external-import/vulncheck/src/vclib/config_variables.py
+++ b/external-import/vulncheck/src/vclib/config_variables.py
@@ -89,7 +89,15 @@ class ConfigConnector:
             ["connector", "scope"],
             self.load_yml,
             required=False,
-            default="vulnerability,malware,threat-actor,infrastructure,location,ip-addr,indicator,external-reference,software",
+            # Includes ``report`` so the STIX Reports produced for
+            # advisory sources (threat actors, ransomware, botnets)
+            # are generated out of the box on a fresh deployment
+            # with no ``CONNECTOR_SCOPE`` override. Operators who
+            # set ``CONNECTOR_SCOPE`` explicitly are unaffected
+            # because env-var precedence applies in
+            # ``get_config_variable``. Matches the documented
+            # default in the connector README.
+            default="vulnerability,malware,threat-actor,infrastructure,location,ip-addr,indicator,external-reference,software,report",
         )
 
         self.log_level = get_config_variable(

--- a/external-import/vulncheck/src/vclib/connector.py
+++ b/external-import/vulncheck/src/vclib/connector.py
@@ -104,12 +104,17 @@ class ConnectorVulnCheck:
             stix2.TLP_WHITE,
             self.converter_to_stix.author,
         ]
+        works.send_bundle(
+            helper=self.helper,
+            logger=self.helper.connector_logger,
+            stix_objects=stix_objects,
+            work_id=work_id,
+        )
         works.finish_work(
-            self.helper,
-            self.helper.connector_logger,
-            stix_objects,
-            work_id,
-            work_name,
+            helper=self.helper,
+            logger=self.helper.connector_logger,
+            work_id=work_id,
+            work_name=work_name,
         )
 
     def process_message(self) -> None:

--- a/external-import/vulncheck/src/vclib/connector_client.py
+++ b/external-import/vulncheck/src/vclib/connector_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List
+from typing import Any, Callable, Generator, List
 
 import requests
 import vulncheck_sdk
@@ -30,87 +30,78 @@ class ConnectorClient:
 
         self.vc_config = vc_config
 
-    def get_data(
+    def iter_data(
         self, index_func: Callable[..., Any], source_name: str, **kwargs
-    ) -> List[Any]:
+    ) -> Generator[List[Any], None, None]:
         self.helper.connector_logger.info(
             f"[API] Getting {source_name} data from VulnCheck API"
         )
 
-        result = []
         with vulncheck_sdk.ApiClient(self.vc_config) as api_client:
             session = vulncheck_sdk.IndicesApi(api_client)
 
-            limit = 2000
             api_response = index_func(
-                session, start_cursor="true", limit=limit, **kwargs
+                session, start_cursor="true", limit=2000, **kwargs
             )
-            total = api_response.meta.total_documents
-            if api_response.data is not None:
-                result = api_response.data
-
-            self.helper.connector_logger.info(f"[API] Total items: {total}")
+            self.helper.connector_logger.info(
+                f"[API] Total items: {api_response.meta.total_documents}"
+            )
+            if api_response.data:
+                yield api_response.data
 
             while api_response.meta.next_cursor is not None:
                 api_response = index_func(
-                    session, cursor=api_response.meta.next_cursor, limit=limit, **kwargs
+                    session, cursor=api_response.meta.next_cursor, limit=2000, **kwargs
                 )
-                if api_response.data is not None:
-                    result.extend(api_response.data)
-                self.helper.connector_logger.debug(
-                    f"[API] Items Processed: {len(result)}/{total}"
-                )
+                if api_response.data:
+                    yield api_response.data
 
-            self.helper.connector_logger.info(
-                f"[API] Successfully retrieved {len(result)} items from {source_name}"
-            )
-
-        return result
-
-    def get_ipintel(self) -> list[AdvisoryIpIntelRecord]:
-        return self.get_data(
+    def iter_ipintel(self) -> Generator[List[AdvisoryIpIntelRecord], None, None]:
+        yield from self.iter_data(
             lambda session, **kwargs: session.index_ipintel3d_get(id="c2", **kwargs),
             source_name=data_source.IPINTEL,
         )
 
-    def get_vckev(self) -> list[AdvisoryVulnCheckKEV]:
-        return self.get_data(
+    def iter_vckev(self) -> Generator[List[AdvisoryVulnCheckKEV], None, None]:
+        yield from self.iter_data(
             lambda session, **kwargs: session.index_vulncheck_kev_get(**kwargs),
             source_name=data_source.VULNCHECK_KEV,
         )
 
-    def get_epss(self) -> list[ApiEPSSData]:
-        return self.get_data(
+    def iter_epss(self) -> Generator[List[ApiEPSSData], None, None]:
+        yield from self.iter_data(
             lambda session, **kwargs: session.index_epss_get(**kwargs),
             source_name=data_source.EPSS,
         )
 
-    def get_botnets(self) -> list[AdvisoryBotnet]:
-        return self.get_data(
+    def iter_botnets(self) -> Generator[List[AdvisoryBotnet], None, None]:
+        yield from self.iter_data(
             lambda session, **kwargs: session.index_botnets_get(**kwargs),
             source_name=data_source.BOTNETS,
         )
 
-    def get_ransomware(self) -> list[AdvisoryRansomwareExploit]:
-        return self.get_data(
+    def iter_ransomware(self) -> Generator[List[AdvisoryRansomwareExploit], None, None]:
+        yield from self.iter_data(
             lambda session, **kwargs: session.index_ransomware_get(**kwargs),
             source_name=data_source.RANSOMWARE,
         )
 
-    def get_threat_actors(self) -> list[AdvisoryThreatActorWithExternalObjects]:
-        return self.get_data(
+    def iter_threat_actors(
+        self,
+    ) -> Generator[List[AdvisoryThreatActorWithExternalObjects], None, None]:
+        yield from self.iter_data(
             lambda session, **kwargs: session.index_threat_actors_get(**kwargs),
             source_name=data_source.THREAT_ACTORS,
         )
 
-    def get_exploits(self) -> list[ApiExploitV3Result]:
-        return self.get_data(
+    def iter_exploits(self) -> Generator[List[ApiExploitV3Result], None, None]:
+        yield from self.iter_data(
             lambda session, **kwargs: session.index_exploits_get(**kwargs),
             source_name=data_source.EXPLOITS,
         )
 
-    def get_initial_access(self) -> list[ApiInitialAccess]:
-        return self.get_data(
+    def iter_initial_access(self) -> Generator[List[ApiInitialAccess], None, None]:
+        yield from self.iter_data(
             lambda session, **kwargs: session.index_initial_access_get(**kwargs),
             source_name=data_source.INITIAL_ACCESS,
         )

--- a/external-import/vulncheck/src/vclib/converter_to_stix.py
+++ b/external-import/vulncheck/src/vclib/converter_to_stix.py
@@ -12,6 +12,7 @@ from pycti import (
     Infrastructure,
     Location,
     Malware,
+    Report,
     StixCoreRelationship,
     ThreatActorGroup,
     Vulnerability,
@@ -584,6 +585,29 @@ class ConverterToStix:
             object_marking_refs=[stix2.TLP_AMBER],
         )
         return course_of_action
+
+    def create_report(
+        self,
+        name: str,
+        published: datetime,
+        object_refs: list,
+        description: str = "",
+        labels: list[str] | None = None,
+    ) -> stix2.Report:
+        # ``labels`` defaults to ``None`` rather than ``[]`` to avoid the
+        # mutable-default pitfall: a shared list would accumulate
+        # mutations across calls and leak labels between Reports.
+        return stix2.Report(
+            id=Report.generate_id(name, published.strftime("%Y-%m-%dT%H:%M:%SZ")),
+            name=name,
+            description=description,
+            published=published,
+            report_types=["threat-report"],
+            object_refs=object_refs,
+            created_by_ref=self.author,
+            object_marking_refs=[stix2.TLP_AMBER],
+            labels=labels if labels is not None else [],
+        )
 
     def create_mitre_data_source(
         self,

--- a/external-import/vulncheck/src/vclib/sources/botnets.py
+++ b/external-import/vulncheck/src/vclib/sources/botnets.py
@@ -1,9 +1,12 @@
+from datetime import datetime
+
 import stix2
 import vclib.util.works as works
 from pycti import OpenCTIConnectorHelper
 from stix2.v21.vocab import INFRASTRUCTURE_TYPE_BOTNET
 from vclib.util.config import (
     SCOPE_INFRASTRUCTURE,
+    SCOPE_REPORT,
     SCOPE_VULNERABILITY,
     compare_config_to_target_scope,
 )
@@ -57,13 +60,14 @@ def _extract_stix_from_botnet(
 
     logger.info("[BOTNET] Parsing data into STIX objects")
     for entity in entities:
+        entity_objects = []
         infrastructure = None
 
         if SCOPE_INFRASTRUCTURE in target_scope and entity.botnet_name is not None:
             infrastructure = _create_infra(
                 converter_to_stix=converter_to_stix, entity=entity, logger=logger
             )
-            result.append(infrastructure)
+            entity_objects.append(infrastructure)
 
         if SCOPE_VULNERABILITY in target_scope and entity.cve is not None:
             for cve in entity.cve:
@@ -72,9 +76,9 @@ def _extract_stix_from_botnet(
                     cve=cve,
                     logger=logger,
                 )
-                result.append(vuln)
+                entity_objects.append(vuln)
                 if infrastructure is not None:
-                    result.append(
+                    entity_objects.append(
                         _create_rel_related_to(
                             infrastructure=infrastructure,
                             vulnerability=vuln,
@@ -87,6 +91,40 @@ def _extract_stix_from_botnet(
                             logger=logger,
                         )
                     )
+
+        if (
+            SCOPE_REPORT in target_scope
+            and entity_objects
+            and entity.botnet_name
+            and entity.date_added
+        ):
+            # ``published`` uses ``entity.date_added`` rather than
+            # ``datetime.now(timezone.utc)``: ``Report.generate_id``
+            # hashes ``name + published``, so a wall-clock ``now()``
+            # would mint a brand-new Report id on every connector run
+            # and the platform would accumulate one duplicate Report
+            # per botnet per cycle. ``date_added`` is a stable,
+            # entity-derived ISO-8601 value, so the resulting Report
+            # id is deterministic across runs and updates patch the
+            # same Report in place. Guards on ``botnet_name`` and
+            # ``date_added`` skip Report creation rather than
+            # crashing the run on a partial payload.
+            cve_count = len(entity.cve) if entity.cve else 0
+            description = (
+                f"{entity.botnet_name} is a botnet known to exploit "
+                f"{cve_count} {'vulnerability' if cve_count == 1 else 'vulnerabilities'} "
+                f"as tracked by VulnCheck."
+            )
+            report = converter_to_stix.create_report(
+                name=entity.botnet_name,
+                published=datetime.fromisoformat(entity.date_added),
+                object_refs=[obj["id"] for obj in entity_objects],
+                description=description,
+                labels=[entity.botnet_name],
+            )
+            entity_objects.append(report)
+
+        result.extend(entity_objects)
     return result
 
 
@@ -95,7 +133,7 @@ def collect_botnets(
 ) -> None:
     # Check if data source is in scope for this run
     source_name = "Botnet"
-    target_scope = [SCOPE_INFRASTRUCTURE, SCOPE_VULNERABILITY]
+    target_scope = [SCOPE_INFRASTRUCTURE, SCOPE_VULNERABILITY, SCOPE_REPORT]
     target_scope = compare_config_to_target_scope(
         config=config,
         target_scope=target_scope,
@@ -108,23 +146,21 @@ def collect_botnets(
         return
 
     logger.info("[BOTNET] Starting collection")
-    entities = client.get_botnets()
-
-    # Initiate new work
     work_id = works.start_work(helper=helper, logger=logger, work_name=source_name)
 
-    stix_objects = _extract_stix_from_botnet(
-        converter_to_stix=converter_to_stix,
-        entities=entities,
-        target_scope=target_scope,
-        logger=logger,
-    )
+    for page in client.iter_botnets():
+        stix_objects = _extract_stix_from_botnet(
+            converter_to_stix=converter_to_stix,
+            entities=page,
+            target_scope=target_scope,
+            logger=logger,
+        )
+        if stix_objects:
+            works.send_bundle(
+                helper=helper, logger=logger, stix_objects=stix_objects, work_id=work_id
+            )
 
     works.finish_work(
-        helper=helper,
-        logger=logger,
-        stix_objects=stix_objects,
-        work_id=work_id,
-        work_name=source_name,
+        helper=helper, logger=logger, work_id=work_id, work_name=source_name
     )
     logger.info("[BOTNET] Data Source Completed!")

--- a/external-import/vulncheck/src/vclib/sources/epss.py
+++ b/external-import/vulncheck/src/vclib/sources/epss.py
@@ -46,21 +46,20 @@ def collect_epss(
         return
 
     logger.info("[EPSS] Starting collection")
-    entities = client.get_epss()
-
-    # Initiate new work
     work_id = works.start_work(helper=helper, logger=logger, work_name=source_name)
-    stix_objects = _extract_stix_from_epss(
-        converter_to_stix=converter_to_stix,
-        entities=entities,
-        logger=logger,
-    )
+
+    for page in client.iter_epss():
+        stix_objects = _extract_stix_from_epss(
+            converter_to_stix=converter_to_stix,
+            entities=page,
+            logger=logger,
+        )
+        if stix_objects:
+            works.send_bundle(
+                helper=helper, logger=logger, stix_objects=stix_objects, work_id=work_id
+            )
 
     works.finish_work(
-        helper=helper,
-        logger=logger,
-        stix_objects=stix_objects,
-        work_id=work_id,
-        work_name=source_name,
+        helper=helper, logger=logger, work_id=work_id, work_name=source_name
     )
     logger.info("[EPSS] Data Source Completed!")

--- a/external-import/vulncheck/src/vclib/sources/exploits.py
+++ b/external-import/vulncheck/src/vclib/sources/exploits.py
@@ -88,7 +88,7 @@ def _extract_stix_from_exploits(
             )
             result.append(vuln)
 
-        if SCOPE_MALWARE and entity.exploits is not None:
+        if SCOPE_MALWARE in target_scope and entity.exploits is not None:
             for exploit in entity.exploits:
                 malware = _create_malware(
                     exploit=exploit,
@@ -127,23 +127,21 @@ def collect_exploits(
         return
 
     logger.info("[EXPLOITS] Starting collection")
-    entities = client.get_exploits()
-
-    # Initiate new work
     work_id = works.start_work(helper=helper, logger=logger, work_name=source_name)
 
-    stix_objects = _extract_stix_from_exploits(
-        converter_to_stix=converter_to_stix,
-        entities=entities,
-        target_scope=target_scope,
-        logger=logger,
-    )
+    for page in client.iter_exploits():
+        stix_objects = _extract_stix_from_exploits(
+            converter_to_stix=converter_to_stix,
+            entities=page,
+            target_scope=target_scope,
+            logger=logger,
+        )
+        if stix_objects:
+            works.send_bundle(
+                helper=helper, logger=logger, stix_objects=stix_objects, work_id=work_id
+            )
 
     works.finish_work(
-        helper=helper,
-        logger=logger,
-        stix_objects=stix_objects,
-        work_id=work_id,
-        work_name=source_name,
+        helper=helper, logger=logger, work_id=work_id, work_name=source_name
     )
     logger.info("[EXPLOITS] Data Source Completed!")

--- a/external-import/vulncheck/src/vclib/sources/initial_access.py
+++ b/external-import/vulncheck/src/vclib/sources/initial_access.py
@@ -106,23 +106,21 @@ def collect_initial_access(
         return
 
     logger.info("[INITIAL ACCESS] Starting collection")
-    entities = client.get_initial_access()
-
-    # Initiate new work
     work_id = works.start_work(helper=helper, logger=logger, work_name=source_name)
 
-    stix_objects = _extract_stix_from_initial_access(
-        converter_to_stix=converter_to_stix,
-        entities=entities,
-        target_scope=target_scope,
-        logger=logger,
-    )
+    for page in client.iter_initial_access():
+        stix_objects = _extract_stix_from_initial_access(
+            converter_to_stix=converter_to_stix,
+            entities=page,
+            target_scope=target_scope,
+            logger=logger,
+        )
+        if stix_objects:
+            works.send_bundle(
+                helper=helper, logger=logger, stix_objects=stix_objects, work_id=work_id
+            )
 
     works.finish_work(
-        helper=helper,
-        logger=logger,
-        stix_objects=stix_objects,
-        work_id=work_id,
-        work_name=source_name,
+        helper=helper, logger=logger, work_id=work_id, work_name=source_name
     )
     logger.info("[INITIAL ACCESS] Data Source Completed!")

--- a/external-import/vulncheck/src/vclib/sources/ipintel.py
+++ b/external-import/vulncheck/src/vclib/sources/ipintel.py
@@ -138,23 +138,21 @@ def collect_ipintel(
         return
 
     logger.info("[IP INTEL] Starting collection")
-    entities = client.get_ipintel()
-
-    # Initiate new work
     work_id = works.start_work(helper=helper, logger=logger, work_name=source_name)
 
-    stix_objects = _extract_stix_from_ipintel(
-        converter_to_stix=converter_to_stix,
-        entities=entities,
-        target_scope=target_scope,
-        logger=logger,
-    )
+    for page in client.iter_ipintel():
+        stix_objects = _extract_stix_from_ipintel(
+            converter_to_stix=converter_to_stix,
+            entities=page,
+            target_scope=target_scope,
+            logger=logger,
+        )
+        if stix_objects:
+            works.send_bundle(
+                helper=helper, logger=logger, stix_objects=stix_objects, work_id=work_id
+            )
 
     works.finish_work(
-        helper=helper,
-        logger=logger,
-        stix_objects=stix_objects,
-        work_id=work_id,
-        work_name=source_name,
+        helper=helper, logger=logger, work_id=work_id, work_name=source_name
     )
     logger.info("[IP INTEL] Data Source Completed!")

--- a/external-import/vulncheck/src/vclib/sources/nistnvd2.py
+++ b/external-import/vulncheck/src/vclib/sources/nistnvd2.py
@@ -15,7 +15,7 @@ from vclib.util.config import (
 )
 from vclib.util.cpe import parse_cpe_uri
 from vclib.util.memory_usage import log_memory_usage
-from vclib.util.nvd import check_size_of_stix_objects, check_vuln_description
+from vclib.util.nvd import check_vuln_description
 from vulncheck_sdk.models.advisory_cvssv40 import AdvisoryCVSSV40
 from vulncheck_sdk.models.api_nvd20_cve import ApiNVD20CVE
 from vulncheck_sdk.models.api_nvd20_cvss_data_v2 import ApiNVD20CvssDataV2
@@ -295,17 +295,8 @@ def _collect_nist_nvd2_from_backup(
     logger,
     cleanup=True,
 ) -> None:
-    work_num = 1
     source_name = "NIST NVD-2"
-
-    # Initiate new work
-    work_id = works.start_work(
-        helper=helper,
-        logger=logger,
-        work_name=source_name,
-        work_num=work_num,
-    )
-    stix_objects = []
+    work_id = works.start_work(helper=helper, logger=logger, work_name=source_name)
 
     logger.info("[NIST NVD-2] Parsing data into STIX objects")
 
@@ -314,36 +305,24 @@ def _collect_nist_nvd2_from_backup(
             if file_name.endswith(".gz"):
                 with zip_ref.open(file_name) as gz_file:
                     with gzip.open(gz_file) as json_file:
-                        stix_objects.extend(
-                            _process_nist_nvd2_json(
-                                converter_to_stix=converter_to_stix,
-                                logger=logger,
-                                target_scope=target_scope,
-                                data=json.load(json_file),
-                            )
-                        )
-
-                        stix_objects, work_id, work_num = check_size_of_stix_objects(
-                            helper=helper,
+                        stix_objects = _process_nist_nvd2_json(
+                            converter_to_stix=converter_to_stix,
                             logger=logger,
-                            source_name=source_name,
-                            stix_objects=stix_objects,
-                            work_id=work_id,
-                            work_num=work_num,
+                            target_scope=target_scope,
+                            data=json.load(json_file),
                         )
+                        if stix_objects:
+                            works.send_bundle(
+                                helper=helper,
+                                logger=logger,
+                                stix_objects=stix_objects,
+                                work_id=work_id,
+                            )
 
-    if len(stix_objects) > 0:
-        works.finish_work(
-            helper=helper,
-            logger=logger,
-            stix_objects=stix_objects,
-            work_id=work_id,
-            work_name=source_name,
-            work_num=work_num,
-        )
-    logger.info(
-        "Finished parsing STIX from NIST-NVD2 backup!",
+    works.finish_work(
+        helper=helper, logger=logger, work_id=work_id, work_name=source_name
     )
+    logger.info("Finished parsing STIX from NIST-NVD2 backup!")
     if cleanup:
         os.remove(filepath)
 

--- a/external-import/vulncheck/src/vclib/sources/ransomware.py
+++ b/external-import/vulncheck/src/vclib/sources/ransomware.py
@@ -1,8 +1,11 @@
+from datetime import datetime
+
 import stix2
 import vclib.util.works as works
 from pycti import OpenCTIConnectorHelper
 from vclib.util.config import (
     SCOPE_MALWARE,
+    SCOPE_REPORT,
     SCOPE_VULNERABILITY,
     compare_config_to_target_scope,
 )
@@ -60,22 +63,23 @@ def _extract_stix_from_ransomware(
 
     logger.info("[RANSOMWARE] Parsing data into STIX objects")
     for entity in entities:
+        entity_objects = []
         malware = None
 
         if SCOPE_MALWARE in target_scope:
             malware = _create_malware(converter_to_stix, entity, logger)
-            result.append(malware)
+            entity_objects.append(malware)
 
-        if SCOPE_VULNERABILITY and entity.cve is not None:
+        if SCOPE_VULNERABILITY in target_scope and entity.cve is not None:
             for cve in entity.cve:
                 vuln = _create_vuln(
                     converter_to_stix=converter_to_stix,
                     cve=cve,
                     logger=logger,
                 )
-                result.append(vuln)
+                entity_objects.append(vuln)
                 if malware is not None:
-                    result.append(
+                    entity_objects.append(
                         _create_rel_exploits(
                             malware=malware,
                             vulnerability=vuln,
@@ -88,6 +92,34 @@ def _extract_stix_from_ransomware(
                             logger=logger,
                         )
                     )
+
+        if (
+            SCOPE_REPORT in target_scope
+            and entity_objects
+            and entity.ransomware_family
+            and entity.date_added
+        ):
+            # Guards on ``ransomware_family`` and ``date_added`` keep
+            # ``Report.generate_id`` deterministic across runs (it hashes
+            # ``name + published``) and skip Report creation rather than
+            # crashing the run if either field is missing from a partial
+            # payload.
+            cve_count = len(entity.cve) if entity.cve else 0
+            description = (
+                f"{entity.ransomware_family} is a ransomware family known to exploit "
+                f"{cve_count} {'vulnerability' if cve_count == 1 else 'vulnerabilities'} "
+                f"as tracked by VulnCheck."
+            )
+            report = converter_to_stix.create_report(
+                name=entity.ransomware_family,
+                published=datetime.fromisoformat(entity.date_added),
+                object_refs=[obj["id"] for obj in entity_objects],
+                description=description,
+                labels=[entity.ransomware_family],
+            )
+            entity_objects.append(report)
+
+        result.extend(entity_objects)
     return result
 
 
@@ -100,7 +132,7 @@ def collect_ransomware(
     _: dict,
 ) -> None:
     source_name = "Ransomware"
-    target_scope = [SCOPE_VULNERABILITY, SCOPE_MALWARE]
+    target_scope = [SCOPE_VULNERABILITY, SCOPE_MALWARE, SCOPE_REPORT]
     target_scope = compare_config_to_target_scope(
         config=config,
         target_scope=target_scope,
@@ -113,23 +145,21 @@ def collect_ransomware(
         return
 
     logger.info("[RANSOMWARE] Starting collection")
-    entities = client.get_ransomware()
-
-    # Initiate new work
     work_id = works.start_work(helper=helper, logger=logger, work_name=source_name)
 
-    stix_objects = _extract_stix_from_ransomware(
-        converter_to_stix=converter_to_stix,
-        entities=entities,
-        target_scope=target_scope,
-        logger=logger,
-    )
+    for page in client.iter_ransomware():
+        stix_objects = _extract_stix_from_ransomware(
+            converter_to_stix=converter_to_stix,
+            entities=page,
+            target_scope=target_scope,
+            logger=logger,
+        )
+        if stix_objects:
+            works.send_bundle(
+                helper=helper, logger=logger, stix_objects=stix_objects, work_id=work_id
+            )
 
     works.finish_work(
-        helper=helper,
-        logger=logger,
-        stix_objects=stix_objects,
-        work_id=work_id,
-        work_name=source_name,
+        helper=helper, logger=logger, work_id=work_id, work_name=source_name
     )
     logger.info("[RANSOMWARE] Data Source Completed!")

--- a/external-import/vulncheck/src/vclib/sources/snort.py
+++ b/external-import/vulncheck/src/vclib/sources/snort.py
@@ -54,11 +54,11 @@ def collect_snort(
         logger=logger,
     )
 
+    if stix_objects:
+        works.send_bundle(
+            helper=helper, logger=logger, stix_objects=stix_objects, work_id=work_id
+        )
     works.finish_work(
-        helper=helper,
-        logger=logger,
-        stix_objects=stix_objects,
-        work_id=work_id,
-        work_name=source_name,
+        helper=helper, logger=logger, work_id=work_id, work_name=source_name
     )
     logger.info("[SNORT] Data Source Completed!")

--- a/external-import/vulncheck/src/vclib/sources/suricata.py
+++ b/external-import/vulncheck/src/vclib/sources/suricata.py
@@ -54,11 +54,11 @@ def collect_suricata(
         logger=logger,
     )
 
+    if stix_objects:
+        works.send_bundle(
+            helper=helper, logger=logger, stix_objects=stix_objects, work_id=work_id
+        )
     works.finish_work(
-        helper=helper,
-        logger=logger,
-        stix_objects=stix_objects,
-        work_id=work_id,
-        work_name=source_name,
+        helper=helper, logger=logger, work_id=work_id, work_name=source_name
     )
     logger.info("[SURICATA] Data Source Completed!")

--- a/external-import/vulncheck/src/vclib/sources/threat_actors.py
+++ b/external-import/vulncheck/src/vclib/sources/threat_actors.py
@@ -5,6 +5,7 @@ import vclib.util.works as works
 from pycti import OpenCTIConnectorHelper
 from vclib.util.config import (
     SCOPE_EXTERNAL_REF,
+    SCOPE_REPORT,
     SCOPE_THREAT_ACTOR,
     SCOPE_VULNERABILITY,
     compare_config_to_target_scope,
@@ -151,7 +152,8 @@ def _extract_stix_from_threat_actors(
             logger=logger,
         )
 
-        stix_objects.extend(
+        entity_objects = list(vulnerabilities)
+        entity_objects.extend(
             _extract_threat_actors(
                 entity=entity,
                 external_refs=external_refs,
@@ -161,6 +163,33 @@ def _extract_stix_from_threat_actors(
                 logger=logger,
             )
         )
+
+        if (
+            SCOPE_REPORT in target_scope
+            and entity_objects
+            and entity.threat_actor_name
+            and entity.date_added
+        ):
+            # Guards on ``threat_actor_name`` and ``date_added`` keep
+            # ``Report.generate_id`` deterministic across runs (it
+            # hashes ``name + published``) and skip Report creation
+            # rather than crashing the run if either field is missing
+            # from a partial payload.
+            description = (
+                entity.misp_threat_actor.description
+                if entity.misp_threat_actor and entity.misp_threat_actor.description
+                else ""
+            )
+            report = converter_to_stix.create_report(
+                name=entity.threat_actor_name,
+                published=datetime.fromisoformat(entity.date_added),
+                object_refs=[obj["id"] for obj in entity_objects],
+                description=description,
+                labels=[entity.threat_actor_name],
+            )
+            entity_objects.append(report)
+
+        stix_objects.extend(entity_objects)
     return stix_objects
 
 
@@ -174,7 +203,12 @@ def collect_threat_actors(
 ) -> None:
     # Check if data source is in scope for this run
     source_name = "Threat Actors"
-    target_scope = [SCOPE_THREAT_ACTOR, SCOPE_VULNERABILITY, SCOPE_EXTERNAL_REF]
+    target_scope = [
+        SCOPE_THREAT_ACTOR,
+        SCOPE_VULNERABILITY,
+        SCOPE_EXTERNAL_REF,
+        SCOPE_REPORT,
+    ]
     target_scope = compare_config_to_target_scope(
         config=config,
         target_scope=target_scope,
@@ -187,23 +221,21 @@ def collect_threat_actors(
         return
 
     logger.info("[THREAT ACTORS] Starting collection")
-    entities = client.get_threat_actors()
-
-    # Initiate new work
     work_id = works.start_work(helper=helper, logger=logger, work_name=source_name)
 
-    stix_objects = _extract_stix_from_threat_actors(
-        converter_to_stix=converter_to_stix,
-        entities=entities,
-        target_scope=target_scope,
-        logger=logger,
-    )
+    for page in client.iter_threat_actors():
+        stix_objects = _extract_stix_from_threat_actors(
+            converter_to_stix=converter_to_stix,
+            entities=page,
+            target_scope=target_scope,
+            logger=logger,
+        )
+        if stix_objects:
+            works.send_bundle(
+                helper=helper, logger=logger, stix_objects=stix_objects, work_id=work_id
+            )
 
     works.finish_work(
-        helper=helper,
-        logger=logger,
-        stix_objects=stix_objects,
-        work_id=work_id,
-        work_name=source_name,
+        helper=helper, logger=logger, work_id=work_id, work_name=source_name
     )
     logger.info("[THREAT ACTORS] Data Source Completed!")

--- a/external-import/vulncheck/src/vclib/sources/vckev.py
+++ b/external-import/vulncheck/src/vclib/sources/vckev.py
@@ -50,22 +50,20 @@ def collect_vckev(
         return
 
     logger.info("[VULNCHECK KEV] Starting collection")
-    entities = client.get_vckev()
-
-    # Initiate new work
     work_id = works.start_work(helper=helper, logger=logger, work_name=source_name)
 
-    stix_objects = _extract_stix_from_vckev(
-        converter_to_stix=converter_to_stix,
-        entities=entities,
-        logger=logger,
-    )
+    for page in client.iter_vckev():
+        stix_objects = _extract_stix_from_vckev(
+            converter_to_stix=converter_to_stix,
+            entities=page,
+            logger=logger,
+        )
+        if stix_objects:
+            works.send_bundle(
+                helper=helper, logger=logger, stix_objects=stix_objects, work_id=work_id
+            )
 
     works.finish_work(
-        helper=helper,
-        logger=logger,
-        stix_objects=stix_objects,
-        work_id=work_id,
-        work_name=source_name,
+        helper=helper, logger=logger, work_id=work_id, work_name=source_name
     )
     logger.info("[VULNCHECK KEV] Data Source Completed!")

--- a/external-import/vulncheck/src/vclib/sources/vcnvd2.py
+++ b/external-import/vulncheck/src/vclib/sources/vcnvd2.py
@@ -17,7 +17,7 @@ from vclib.util.config import (
 )
 from vclib.util.cpe import parse_cpe_uri
 from vclib.util.memory_usage import log_memory_usage
-from vclib.util.nvd import check_size_of_stix_objects, check_vuln_description
+from vclib.util.nvd import check_vuln_description
 from vulncheck_sdk.models.advisory_cvssv40 import AdvisoryCVSSV40
 from vulncheck_sdk.models.api_nvd20_cve_extended import ApiNVD20CVEExtended
 from vulncheck_sdk.models.api_nvd20_cvss_data_v2 import ApiNVD20CvssDataV2
@@ -572,16 +572,7 @@ def _collect_vc_nvd2_from_backup(
     source_name: str,
     cleanup=True,
 ) -> None:
-    work_num = 1
-
-    # Initiate new work
-    work_id = works.start_work(
-        helper=helper,
-        logger=logger,
-        work_name=source_name,
-        work_num=work_num,
-    )
-    stix_objects = []
+    work_id = works.start_work(helper=helper, logger=logger, work_name=source_name)
 
     logger.info("[VULNCHECK NVD-2] Parsing data into STIX objects")
 
@@ -589,36 +580,24 @@ def _collect_vc_nvd2_from_backup(
         for file_name in zip_ref.namelist():
             if file_name.endswith(".json"):
                 with zip_ref.open(file_name) as json_file:
-                    stix_objects.extend(
-                        _process_vc_nvd2_json(
-                            converter_to_stix=converter_to_stix,
-                            logger=logger,
-                            target_scope=target_scope,
-                            data=json.load(json_file),
-                        )
-                    )
-
-                    stix_objects, work_id, work_num = check_size_of_stix_objects(
-                        helper=helper,
+                    stix_objects = _process_vc_nvd2_json(
+                        converter_to_stix=converter_to_stix,
                         logger=logger,
-                        source_name=source_name,
-                        stix_objects=stix_objects,
-                        work_id=work_id,
-                        work_num=work_num,
+                        target_scope=target_scope,
+                        data=json.load(json_file),
                     )
+                    if stix_objects:
+                        works.send_bundle(
+                            helper=helper,
+                            logger=logger,
+                            stix_objects=stix_objects,
+                            work_id=work_id,
+                        )
 
-    if len(stix_objects) > 0:
-        works.finish_work(
-            helper=helper,
-            logger=logger,
-            stix_objects=stix_objects,
-            work_id=work_id,
-            work_name=source_name,
-            work_num=work_num,
-        )
-    logger.info(
-        "Finished parsing STIX from VulnCheck-NVD2 backup!",
+    works.finish_work(
+        helper=helper, logger=logger, work_id=work_id, work_name=source_name
     )
+    logger.info("Finished parsing STIX from VulnCheck-NVD2 backup!")
     if cleanup:
         os.remove(filepath)
 

--- a/external-import/vulncheck/src/vclib/util/config.py
+++ b/external-import/vulncheck/src/vclib/util/config.py
@@ -12,6 +12,7 @@ SCOPE_EXTERNAL_REF = "external-reference"
 SCOPE_ATTACK_PATTERN = "attack-pattern"
 SCOPE_COURSE_OF_ACTION = "course-of-action"
 SCOPE_DATA_SOURCE = "x-mitre-data-source"
+SCOPE_REPORT = "report"
 
 
 def compare_config_to_target_scope(

--- a/external-import/vulncheck/src/vclib/util/nvd.py
+++ b/external-import/vulncheck/src/vclib/util/nvd.py
@@ -1,39 +1,5 @@
-from vclib.util import works
-
-MAX_BUNDLE_SIZE = 200_000
-
-
 def check_vuln_description(descriptions: list) -> str:
     for d in descriptions:
         if d.lang == "en":
             return d.value
     return ""
-
-
-def check_size_of_stix_objects(
-    helper,
-    logger,
-    source_name: str,
-    stix_objects: list,
-    work_id: str,
-    work_num: int,
-) -> tuple[list, str, int]:
-    # PERF: We're intentionally bundling things here in groups to avoid OOM
-    if len(stix_objects) > MAX_BUNDLE_SIZE:
-        works.finish_work(
-            helper=helper,
-            logger=logger,
-            stix_objects=stix_objects,
-            work_id=work_id,
-            work_name=source_name,
-            work_num=work_num,
-        )
-        stix_objects = []
-        work_num += 1
-        work_id = works.start_work(
-            helper=helper,
-            logger=logger,
-            work_name=source_name,
-            work_num=work_num,
-        )
-    return stix_objects, work_id, work_num

--- a/external-import/vulncheck/src/vclib/util/works.py
+++ b/external-import/vulncheck/src/vclib/util/works.py
@@ -3,45 +3,24 @@ from datetime import datetime
 from pycti import OpenCTIConnectorHelper
 
 
-def start_work(helper: OpenCTIConnectorHelper, logger, work_name, work_num=None):
+def start_work(helper: OpenCTIConnectorHelper, logger, work_name) -> str:
     logger.info(
         "[WORKS] Starting new work...",
     )
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     message = f"VulnCheck {work_name} run @{now}"
-    if work_num is not None:
-        message = f"VulnCheck {work_name} run {work_num} @{now}"
-    id = helper.api.work.initiate_work(helper.connect_id, message)
-    return id
+    return helper.api.work.initiate_work(helper.connect_id, message)
 
 
-def finish_work(
-    helper: OpenCTIConnectorHelper,
-    logger,
-    stix_objects,
-    work_id,
-    work_name,
-    work_num=None,
-):
-    logger.debug(
-        "[WORKS] Bundling objects",
-    )
-    stix_objects_bundle = helper.stix2_create_bundle(stix_objects)
-    logger.info(
-        "[WORKS] Preparing to send bundle",
-    )
-    if stix_objects_bundle is not None:
-        bundles_sent = helper.send_stix2_bundle(stix_objects_bundle, work_id=work_id)
-        logger.info(
-            "[WORKS] Sending STIX objects to OpenCTI...",
-            {"bundles_sent": {str(len(bundles_sent))}},
-        )
+def send_bundle(helper: OpenCTIConnectorHelper, logger, stix_objects, work_id) -> None:
+    logger.debug("[WORKS] Bundling objects")
+    bundle = helper.stix2_create_bundle(stix_objects)
+    if bundle is not None:
+        bundles_sent = helper.send_stix2_bundle(bundle, work_id=work_id)
+        logger.info("[WORKS] Bundle sent", {"bundles_sent": len(bundles_sent)})
 
-    message = (
-        f"[WORKS] Run {work_name}-{work_num} completed"
-        if work_num is not None
-        else f"[WORKS] Run {work_name} completed"
-    )
 
+def finish_work(helper: OpenCTIConnectorHelper, logger, work_id, work_name) -> None:
+    message = f"[WORKS] Run {work_name} completed"
     helper.api.work.to_processed(work_id, message)
     logger.info(message)


### PR DESCRIPTION
<!--
Supersedes #6143 (authored by @maddawik on a fork with "Allow edits by
maintainers" disabled). All five Copilot review threads on #6143 have been
addressed here, plus one additional senior-reviewer finding. Commit is
signed and co-authored by the original contributor.
-->

### Proposed changes

- **Streaming bundle architecture** — replaces the previous collect-then-send pattern with stream-and-send at natural data boundaries. API-paginated sources now yield one page at a time via `iter_data()` (up to 2,000 items); ZIP-based sources (`vcnvd2`, `nistnvd2`) flush one bundle per file. All bundles flow under a single `work_id` per source. Removes `MAX_BUNDLE_SIZE`, `check_size_of_stix_objects()`, and the `run 1` / `run 2` work numbering.
- **STIX Reports for advisory sources** — threat actors, ransomware families and botnets each produce a `stix2.Report` wrapping their associated STIX objects, making advisory intelligence browsable as a unit in OpenCTI's Reports view. Gated behind a new `SCOPE_REPORT` config key so operators can opt out.

### Related issues

- Closes #6148
- Supersedes #6143 (original PR from @maddawik on `vulncheck-oss/connectors:patch-1` with `maintainer_can_modify: false`; original commits squashed into a single signed commit on the OpenCTI-Platform side so the four Copilot review findings + the additional senior-reviewer fix can land cleanly).

### Further comments

The root cause of the memory issues was `get_data()` eagerly loading all API pages into memory before any conversion ran. For large sources such as NIST NVD-2 (200k+ CVEs) this caused OOM and produced bundles large enough to hit RabbitMQ's `listen_too-large-bundle` queue. `MAX_BUNDLE_SIZE = 200_000` was a workaround that only applied to NVD-2 and left every other source unbounded. The new `iter_data()` is a generator that yields one page at a time — memory usage stays proportional to a single page (~2,000 items) regardless of dataset size. The `_extract_stix_from_X()` functions in each source are unchanged since they already accept a list; a page is just a smaller one.

#### Correctness fixes folded in during review

The four Copilot threads on #6143 plus one related senior-reviewer finding are all addressed in this PR:

- `ConverterToStix.create_report()` — replaced the mutable-default `labels: list[str] = []` with `labels: list[str] | None = None` and materialise an empty list inside the body to avoid the shared-default footgun.
- `sources/ransomware.py` — `if SCOPE_VULNERABILITY in target_scope and entity.cve is not None:` (was `if SCOPE_VULNERABILITY` which is always truthy because the constant is the non-empty string `"vulnerability"`, so vulnerabilities were being created even when `vulnerability` was excluded from `CONNECTOR_SCOPE`).
- `sources/exploits.py` — same shape: `SCOPE_MALWARE in target_scope`. Pre-existing bug surfaced while reading the surrounding code; trivially fixed in the same PR for consistency with every other scope check in the connector.
- `sources/botnets.py` — Report `published` now uses `entity.date_added` rather than `datetime.now(timezone.utc)`. `Report.generate_id` hashes `name + published`, so a wall-clock `now()` was minting a brand-new Report id on every connector run and the platform was accumulating one duplicate Report per botnet per cycle. `date_added` is a stable, entity-derived ISO-8601 value (matches the pattern already used by ransomware and threat-actor sources). Drops the now-unused `timezone` import.
- `sources/botnets.py` / `sources/ransomware.py` / `sources/threat_actors.py` — Report creation now also guards on `entity.<name>` and `entity.date_added` so a partial payload skips Report creation rather than crashing the run.
- `config_variables.py` — default `CONNECTOR_SCOPE` now includes `report` so a fresh deployment with no override produces the new Reports out of the box. Matches the documented default in the connector README. Operators who set `CONNECTOR_SCOPE` explicitly are unaffected because env-var precedence applies in `get_config_variable`.

#### Verification

- `black --check`, `isort --check-only --profile black`, `flake8 --ignore=E,W` on `external-import/vulncheck/src/` — all clean.
- `python -m py_compile` on every touched file — all clean.
- Mutable-default regression: confirmed `create_report(...)` with no `labels` returns an empty list and that mutating the returned list does not leak across calls.
- Stable Report id: `Report.generate_id("Fbot", "2019-02-20T00:00:00Z")` returns the same UUID on every call; the old `datetime.now(timezone.utc)` shape produces two different UUIDs for the same botnet name on calls one second apart.
- Scope-check correctness: the old bare-string `if SCOPE_VULNERABILITY:` evaluates to `True` regardless of scope content; the new `in target_scope` shape returns `True` only when `"vulnerability"` is in scope.

#### Out-of-scope follow-ups (deliberately not in this PR)

- Other mutable-default parameters in `ConverterToStix` (`create_relationship`, `create_infrastructure`, `create_malware`, `create_threat_actor_group`, `create_vulnerability`) carry the same footgun shape but pre-date this PR and are worth a separate cleanup so the diff stays focused on the streaming/Reports work.
- The README documents `attack-pattern,course-of-action,x-mitre-data-source` in the default `CONNECTOR_SCOPE` but the code default still does not include those. That mismatch pre-dates this PR and the three are software-heavy (see the `Data Volume` warning in the README) so adding them to the default deserves its own change.
- The VulnCheck connector currently has no test suite (codecov reports 0% patch coverage on #6143 / this PR). Adding tests would require setting up a mock VulnCheck SDK and is intentionally not in scope here.

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
