### PR TITLE
[Github Instructions]: add guideline for Note.generate_id

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -44,3 +44,11 @@ function isValidEmail(email) {
 }
 
 submitButton.enabled = isValidEmail(user.email);
+
+Neither use a datetime for Note.generate_id(). This will prevent the generation of duplicate notes which can lead to the saturation of the RabbitMQ queue. For example:
+
+// Instead of:
+Note.generate_id(created=datetime.now(), content="the content")
+
+// Consider:
+Note.generate_id(created=None, content="the content")


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add guideline to discourage to use datetime.now() as note.generate_id() argument to .github/instructions instead (need for deterministic IDs)

### Related issues

* Close #5823

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
