### PR TITLE
[connectors-sdk] Add Tool entity model

### DIFF
--- a/connectors-sdk/connectors_sdk/models/__init__.py
+++ b/connectors-sdk/connectors_sdk/models/__init__.py
@@ -43,6 +43,7 @@ from connectors_sdk.models.software import Software
 from connectors_sdk.models.text import Text
 from connectors_sdk.models.threat_actor_group import ThreatActorGroup
 from connectors_sdk.models.tlp_marking import TLPMarking
+from connectors_sdk.models.tool import Tool
 from connectors_sdk.models.url import URL
 from connectors_sdk.models.user_account import UserAccount
 from connectors_sdk.models.vulnerability import Vulnerability
@@ -93,6 +94,7 @@ __all__ = [
     "Software",
     "Text",
     "ThreatActorGroup",
+    "Tool",
     "TLPMarking",
     "URL",
     "UserAccount",

--- a/connectors-sdk/connectors_sdk/models/enums.py
+++ b/connectors-sdk/connectors_sdk/models/enums.py
@@ -585,3 +585,19 @@ class TLPLevel(StrEnum):
     AMBER = "amber"
     AMBER_STRICT = "amber+strict"
     RED = "red"
+
+
+class ToolType(_PermissiveEnum):
+    """Tool Type Open Vocabulary Enum.
+
+    See https://docs.oasis-open.org/cti/stix/v2.1/csprd01/stix-v2.1-csprd01.html#_Toc16070818
+    """
+
+    DENIAL_OF_SERVICE = "denial-of-service"
+    EXPLOITATION = "exploitation"
+    INFORMATION_GATHERING = "information-gathering"
+    NETWORK_CAPTURE = "network-capture"
+    CREDENTIAL_EXPLOITATION = "credential-exploitation"
+    REMOTE_ACCESS = "remote-access"
+    VULNERABILITY_SCANNING = "vulnerability-scanning"
+    UNKNOWN = "unknown"

--- a/connectors-sdk/connectors_sdk/models/enums.py
+++ b/connectors-sdk/connectors_sdk/models/enums.py
@@ -32,6 +32,7 @@ __all__ = [
     "ThreatActorSophistication",
     "ThreatActorTypes",
     "TLPLevel",
+    "ToolType",
 ]
 
 

--- a/connectors-sdk/connectors_sdk/models/tool.py
+++ b/connectors-sdk/connectors_sdk/models/tool.py
@@ -1,0 +1,56 @@
+"""Tool entity model."""
+
+from connectors_sdk.models.base_identified_entity import BaseIdentifiedEntity
+from connectors_sdk.models.enums import ToolType
+from connectors_sdk.models.kill_chain_phase import KillChainPhase
+from pycti import Tool as PyctiTool
+from pydantic import Field
+from stix2.v21 import Tool as Stix2Tool
+
+
+class Tool(BaseIdentifiedEntity):
+    """Represent a tool entity.
+
+    STIX2.1 Tool: https://docs.oasis-open.org/cti/stix/v2.1/csprd01/stix-v2.1-csprd01.html#_Toc16070666
+    """
+
+    name: str = Field(
+        description="Name of the tool.",
+        min_length=1,
+    )
+    description: str | None = Field(
+        default=None,
+        description="Description of the tool.",
+    )
+    tool_types: list[ToolType] = Field(
+        description="Kind of tool(s) being described, values SHOULD come from "
+        "the tool-type-ov vocabulary",
+    )
+    aliases: list[str] | None = Field(
+        default=None,
+        description="Alternative names used to identify this Tool.",
+    )
+    kill_chain_phases: list[KillChainPhase] | None = Field(
+        default=None,
+        description="List of kill chain phases for which this Tool can be used.",
+    )
+    tool_version: str | None = Field(
+        default=None,
+        description="Version identifier associated with the Tool.",
+    )
+
+    def to_stix2_object(self) -> Stix2Tool:
+        """Make stix object."""
+        return Stix2Tool(
+            id=PyctiTool.generate_id(name=self.name),
+            name=self.name,
+            description=self.description,
+            tool_types=self.tool_types,
+            aliases=self.aliases,
+            kill_chain_phases=[
+                kill_chain_phase.to_stix2_object()
+                for kill_chain_phase in self.kill_chain_phases or []
+            ],
+            tool_version=self.tool_version,
+            **self._common_stix2_properties(),
+        )

--- a/connectors-sdk/tests/test_models/test_api.py
+++ b/connectors-sdk/tests/test_models/test_api.py
@@ -102,6 +102,7 @@ def test_public_models_are_present():
         "Software",
         "Text",
         "ThreatActorGroup",
+        "Tool",
         "TLPMarking",
         "URL",
         "UserAccount",

--- a/connectors-sdk/tests/test_models/test_enums.py
+++ b/connectors-sdk/tests/test_models/test_enums.py
@@ -30,8 +30,9 @@ ENUMS = OCTI_ENUMS | {
     "ChannelType",
     "IncidentSeverity",
     "IncidentType",
-    "RelationshipType",
     "InfrastructureType",
+    "RelationshipType",
+    "ToolType",
 }
 
 

--- a/connectors-sdk/tests/test_models/test_tool.py
+++ b/connectors-sdk/tests/test_models/test_tool.py
@@ -1,0 +1,71 @@
+import pytest
+from connectors_sdk.models.base_identified_entity import BaseIdentifiedEntity
+from connectors_sdk.models.enums import ToolType
+from connectors_sdk.models.tool import Tool
+from pydantic import ValidationError
+from stix2.v21 import Tool as Stix2Tool
+
+
+def test_tool_is_a_base_identified_entity():
+    """Test that Tool is a BaseIdentifiedEntity."""
+    # Given the Tool class
+    # When checking its type
+    # Then it should be a subclass of BaseIdentifiedEntity
+    assert issubclass(Tool, BaseIdentifiedEntity)
+
+
+def test_tool_class_should_not_accept_invalid_input():
+    """Test that Tool class should not accept invalid input."""
+    # Given: An invalid input data for Tool
+    input_data = {
+        "name": "Test Tool",
+        "tool_types": ["remote-access"],
+        "invalid_key": "invalid_value",
+    }
+    # When validating the tool
+    # Then: It should raise a ValidationError with the expected error field
+    with pytest.raises(ValidationError) as error:
+        Tool.model_validate(input_data)
+        assert error.value.errors()[0]["loc"] == ("invalid_key",)
+
+
+def test_tool_to_stix2_object_returns_valid_stix_object(
+    fake_valid_organization_author,
+    fake_valid_external_references,
+    fake_valid_tlp_markings,
+):
+    """Test that Tool to_stix2_object method returns a valid STIX2.1 Tool."""
+    # Given: A valid Tool instance
+    tool = Tool(
+        name="Test Tool",
+        description="Test description",
+        tool_types=[ToolType.REMOTE_ACCESS],
+        aliases=["alias_1", "alias_2"],
+        kill_chain_phases=[{"chain_name": "test", "phase_name": "pre-attack"}],
+        tool_version="1.0.0",
+        author=fake_valid_organization_author,
+        markings=fake_valid_tlp_markings,
+        external_references=fake_valid_external_references,
+    )
+    # When: calling to_stix2_object method
+    stix2_obj = tool.to_stix2_object()
+    # Then: A valid STIX2.1 Tool is returned
+    assert isinstance(stix2_obj, Stix2Tool)
+
+
+def test_tool_to_stix2_object_with_minimal_fields(
+    fake_valid_organization_author,
+    fake_valid_tlp_markings,
+):
+    """Test that Tool to_stix2_object works with only required fields."""
+    # Given: A Tool instance with only required fields
+    tool = Tool(
+        name="Minimal Tool",
+        tool_types=[ToolType.EXPLOITATION],
+        author=fake_valid_organization_author,
+        markings=fake_valid_tlp_markings,
+    )
+    # When: calling to_stix2_object method
+    stix2_obj = tool.to_stix2_object()
+    # Then: A valid STIX2.1 Tool is returned
+    assert isinstance(stix2_obj, Stix2Tool)


### PR DESCRIPTION
### Proposed changes

* Add `Tool` entity model (`connectors_sdk/models/tool.py`) implementing the STIX 2.1 Tool SDO with fields: `name`, `description`, `tool_types`, `aliases`, `kill_chain_phases`, and `tool_version`
* Add `ToolTypeOV` open vocabulary enum in `enums.py` covering all standard tool types (denial-of-service, exploitation, information-gathering, etc.) per the STIX 2.1 specification
* Export `Tool` from the models package `__init__.py` and add it to `__all__`

### Related issues

* Closes #6457

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This adds the STIX 2.1 Tool SDO to the connectors-sdk, following the same pattern as existing entity models (Malware, ThreatActorGroup, Software, etc.). The model extends `BaseIdentifiedEntity`, uses `ToolTypeOV` as a permissive enum for the `tool_types` field, and generates deterministic STIX IDs via `pycti.Tool.generate_id()`. The `to_stix2_object()` method produces a valid `stix2.v21.Tool` instance with common STIX properties.