### PR TITLE
[crowdstrike] Fix indicator pagination by using _marker deep pagination

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
@@ -289,20 +289,14 @@ class IndicatorImporter(BaseImporter):
         # same second prefix; otherwise fall back to the seconds-
         # granularity timestamp for the initial run.
         current_marker: str = fetch_marker or str(fetch_timestamp)
-        # Seed ``last_seen_marker`` with the persisted cursor (when
-        # we have one) so the marker-didn't-advance guard fires on
-        # the first iteration if the API returns only the boundary
-        # indicator. The FQL clause ``_marker:>='<cursor>'`` is
-        # inclusive, so resuming with the persisted marker and no
-        # newer indicators since would otherwise (a) append the
-        # boundary indicator a first time, (b) re-issue the exact
-        # same query, (c) append the boundary indicator a second
-        # time, then trip the guard - both the duplicate append and
-        # the extra round-trip are avoided by seeding the guard up
-        # front. On the very first run there is no persisted marker
-        # and ``fetch_marker`` is ``None``, so the seed is ``None``
-        # and the loop behaves exactly as before for that path.
-        last_seen_marker: Optional[str] = fetch_marker
+        # Tracks the ``_marker`` of the last row we accepted on the
+        # previous iteration so the anti-spin guard below catches
+        # an API that returns the same trailing marker twice in a
+        # row. Left ``None`` on iteration one - the cross-run
+        # inclusive-boundary case (the persisted cursor row showing
+        # up again because FQL ``_marker:>='<cursor>'`` matches the
+        # cursor itself) is handled explicitly by the strip below.
+        last_seen_marker: Optional[str] = None
 
         while True:
             fql_filter = self._build_fql_filter(current_marker)
@@ -314,6 +308,54 @@ class IndicatorImporter(BaseImporter):
             page_resources = response.get("resources") or []
             if not page_resources:
                 break
+
+            # Cross-run inclusive-boundary strip: the FQL clause
+            # ``_marker:>='<cursor>'`` is *inclusive*, so when we
+            # resume with a persisted ``fetch_marker`` the very
+            # first page may include the boundary indicator we
+            # already accepted (and persisted) on the previous run.
+            # Drop it BEFORE applying the per-run cap or extending
+            # the aggregate. Two reasons this matters:
+            #
+            # * Without the strip, a tight ``max_records_per_run``
+            #   (e.g. ``1``) lets the duplicate boundary row
+            #   consume the entire quota on every run - the page is
+            #   sliced down to ``[boundary]``, ``next_marker``
+            #   resolves back to the same persisted cursor, state
+            #   never advances and the connector never reaches
+            #   newer indicators.
+            # * Without the strip we always pay for one idempotent
+            #   re-process of the boundary indicator on every
+            #   resume. The OpenCTI side absorbs the duplicate via
+            #   STIX-ID dedup, but the bundle still pays the
+            #   ingest cost.
+            #
+            # The strip is intentionally scoped to iteration one
+            # (``not resources``) and to the cross-run case
+            # (``fetch_marker is not None``):
+            #
+            # * On a fresh run ``fetch_marker`` is ``None`` and
+            #   the strip is a no-op.
+            # * Within a run we do NOT strip rows whose ``_marker``
+            #   happens to equal the previous iteration's
+            #   ``current_marker`` because, per CrowdStrike's
+            #   contract, ``_marker`` is unique per indicator and
+            #   sorted ascending, so a within-run repeat marker
+            #   identifies a different indicator that happens to
+            #   share a (rare) collision - the marker-didn't-advance
+            #   anti-spin guard further down catches the
+            #   pathological case where two consecutive pages share
+            #   the same trailing marker.
+            if (
+                fetch_marker is not None
+                and not resources
+                and page_resources[0].get("_marker") == fetch_marker
+            ):
+                page_resources = page_resources[1:]
+                if not page_resources:
+                    # The only row on the page was the duplicate
+                    # boundary - nothing new since the previous run.
+                    break
 
             # ``meta.pagination`` can legitimately be missing or null —
             # guard against both so we don't AttributeError on the

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
@@ -297,6 +297,10 @@ class IndicatorImporter(BaseImporter):
         # up again because FQL ``_marker:>='<cursor>'`` matches the
         # cursor itself) is handled explicitly by the strip below.
         last_seen_marker: Optional[str] = None
+        # Tracks the ``id`` of the last row we accepted, used to
+        # strip the within-run inclusive-boundary duplicate on
+        # subsequent pages. See the within-run strip block below.
+        last_accepted_id: Optional[str] = None
 
         while True:
             fql_filter = self._build_fql_filter(current_marker)
@@ -330,22 +334,11 @@ class IndicatorImporter(BaseImporter):
             #   STIX-ID dedup, but the bundle still pays the
             #   ingest cost.
             #
-            # The strip is intentionally scoped to iteration one
-            # (``not resources``) and to the cross-run case
-            # (``fetch_marker is not None``):
-            #
-            # * On a fresh run ``fetch_marker`` is ``None`` and
-            #   the strip is a no-op.
-            # * Within a run we do NOT strip rows whose ``_marker``
-            #   happens to equal the previous iteration's
-            #   ``current_marker`` because, per CrowdStrike's
-            #   contract, ``_marker`` is unique per indicator and
-            #   sorted ascending, so a within-run repeat marker
-            #   identifies a different indicator that happens to
-            #   share a (rare) collision - the marker-didn't-advance
-            #   anti-spin guard further down catches the
-            #   pathological case where two consecutive pages share
-            #   the same trailing marker.
+            # On the first iteration we don't yet have a
+            # ``last_accepted_id`` from this run, so the cross-run
+            # boundary is identified by marker comparison instead.
+            # On a fresh run ``fetch_marker`` is ``None`` and the
+            # strip is a no-op.
             if (
                 fetch_marker is not None
                 and not resources
@@ -355,6 +348,39 @@ class IndicatorImporter(BaseImporter):
                 if not page_resources:
                     # The only row on the page was the duplicate
                     # boundary - nothing new since the previous run.
+                    break
+
+            # Within-run inclusive-boundary strip: on iterations 2+
+            # the same FQL ``_marker:>='<cursor>'`` clause returns
+            # the previous iteration's last row again as the first
+            # row of the new page. Identify the duplicate by ``id``
+            # rather than ``_marker`` because two *different*
+            # indicators can pathologically share a marker (the
+            # anti-spin test ``test_pagination_stops_when_marker_does_not_advance``
+            # pins that case) - matching on ``id`` is the only
+            # signal that the row is truly the same indicator we
+            # just accepted, not a coincidental marker collision
+            # between two distinct indicators.
+            #
+            # Stripping here matters because without it the
+            # duplicate row would (a) be counted against
+            # ``max_records_per_run`` once per continuation page,
+            # which inflates the apparent fetch volume and starves
+            # the genuine forward progress at the tail of a tight
+            # cap, and (b) be re-processed downstream (idempotent
+            # on the OpenCTI side via STIX-ID dedup, but the
+            # bundle still pays the ingest cost).
+            if (
+                last_accepted_id is not None
+                and page_resources[0].get("id") == last_accepted_id
+            ):
+                page_resources = page_resources[1:]
+                if not page_resources:
+                    # The page was just the duplicate boundary - no
+                    # forward progress here. The anti-spin guard
+                    # below would also fire on the next iteration
+                    # with the same marker, but breaking now saves
+                    # a round-trip.
                     break
 
             # ``meta.pagination`` can legitimately be missing or null —
@@ -373,6 +399,12 @@ class IndicatorImporter(BaseImporter):
                 page_resources = page_resources[:remaining_cap]
 
             resources.extend(page_resources)
+            # Capture the last accepted row's ``id`` for the
+            # within-run inclusive-boundary strip on the next
+            # iteration. Use the post-cap-slice ``page_resources``
+            # so we record the actual last row in ``resources``,
+            # not the original last row from the API response.
+            last_accepted_id = page_resources[-1].get("id")
 
             # Marker for the next page = ``_marker`` of the last indicator
             # we accepted on this page. Fall back gracefully when the

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
@@ -143,61 +143,96 @@ class IndicatorImporter(BaseImporter):
     def _clear_report_fetcher_cache(self) -> None:
         self.report_fetcher.clear_cache()
 
+    # FalconPy / CrowdStrike caps a single ``QueryIntelIndicatorEntities``
+    # call at 5000 records. We pick 1000 by default to keep batches small
+    # enough to be processed-and-sent before the next page is fetched,
+    # which spreads memory & ingestion-queue pressure more evenly.
+    _PAGE_LIMIT = 1000
+
     def _fetch_indicators(self, fetch_timestamp: int) -> List[dict]:
         """Fetch all indicators updated since ``fetch_timestamp``.
 
-        Walks every page exposed by the CrowdStrike API (``Next-Page`` HTTP
-        header) up to the configured ``max_records_per_run`` cap (when set).
-        Returns the full list of resources in a single batch so the downstream
-        ``_process_indicators`` step can compute the latest ``last_updated``
-        timestamp across the whole run.
+        Walks the CrowdStrike indicator API using marker-based deep
+        pagination (the ``_marker`` FQL field, sorted ``_marker.asc``)
+        up to the configured ``max_records_per_run`` cap when set.
+        Returns the full list of resources in a single batch so the
+        downstream ``_process_indicators`` step can compute the latest
+        ``last_updated`` timestamp across the whole run.
         """
-        limit = 1000
-        sort = "last_updated|asc"
-        fql_filter = f"last_updated:>{fetch_timestamp}"
+        return self._paginated_query_indicators(
+            limit=self._PAGE_LIMIT, fetch_timestamp=fetch_timestamp
+        )
 
+    def _build_fql_filter(self, marker: str) -> str:
+        """Build the FQL filter used for a single indicator API call.
+
+        The base clause is ``_marker:>='<marker>'`` — CrowdStrike's
+        documented deep-pagination contract for ``QueryIntelIndicatorEntities``
+        (see https://www.falconpy.io/Usage/Response-Handling.html). For the
+        very first page ``marker`` is the importer state's
+        ``last_updated`` timestamp (Unix seconds), which equals the
+        timestamp prefix of every ``_marker`` value, so we resume exactly
+        where the previous run left off.
+        """
+        fql_filter = f"_marker:>='{marker}'"
         if self.exclude_types:
             fql_filter = f"{fql_filter}+type:!{self.exclude_types}"
-
-        return self._paginated_query_indicators(limit, sort, fql_filter)
+        return fql_filter
 
     def _paginated_query_indicators(
-        self, limit: int, sort: str, fql_filter: str
+        self, limit: int, fetch_timestamp: int
     ) -> List[dict]:
         """Walk every page of the indicator API and return the aggregated list.
 
-        The continuation token is the ``next_page`` string returned by the
-        upstream API and forwarded as-is by :class:`IndicatorsAPI`. When
-        ``max_records_per_run`` is set, pagination stops as soon as that many
-        indicators have been collected; the cap is enforced at the resource
-        level by slicing the *last* page to exactly the remaining quota, so
-        the aggregated batch contains at most ``max_records_per_run`` records
-        and we never yield a record beyond the cap.
+        Pagination relies on CrowdStrike's documented marker-based deep
+        pagination: each indicator carries a monotonically-increasing
+        ``_marker`` field whose first 10 characters are a Unix timestamp
+        (in seconds). The first call filters with the importer state
+        timestamp; subsequent calls advance the marker using the last
+        indicator returned by the previous page. Pagination ends when:
+
+        * the API returns an empty page, OR
+        * ``meta.pagination.total`` drops to ``0`` (the API tells us no
+          more records remain past the current marker), OR
+        * the configured ``max_records_per_run`` cap is reached.
+
+        The cap is enforced at the resource level — the *last* page is
+        sliced down to the remaining quota — so the aggregated batch
+        contains at most ``max_records_per_run`` records and we never
+        yield a record beyond the cap.
+
+        NOTE: The previous implementation tried to paginate via a
+        ``Next-Page`` HTTP header / ``next_page`` continuation token,
+        but ``GET /intel/combined/indicators/v1`` does *not* expose
+        those (they are reserved for other CrowdStrike Service
+        Collections such as Hosts), so the loop only ever ran once and
+        every run capped at a single ``limit``-sized batch.
         """
+        # Sort ascending by ``_marker`` so the last indicator on a page
+        # always carries the largest ``_marker`` we have seen so far —
+        # the cursor that drives the next call.
+        sort = "_marker.asc"
         resources: List[dict] = []
-        next_page_token: Optional[str] = None
-        meta_total: Optional[int] = None
+        current_marker: str = str(fetch_timestamp)
+        last_seen_marker: Optional[str] = None
 
         while True:
+            fql_filter = self._build_fql_filter(current_marker)
+
             response = self.indicators_api_cs.get_combined_indicator_entities(
-                limit=limit,
-                sort=sort,
-                fql_filter=fql_filter,
-                deep_pagination=True,
-                next_page=next_page_token,
+                limit=limit, sort=sort, fql_filter=fql_filter
             )
 
             page_resources = response.get("resources") or []
             if not page_resources:
                 break
 
-            # ``meta.pagination`` can legitimately be missing or null - guard
-            # against both so we don't AttributeError on the .get() below.
+            # ``meta.pagination`` can legitimately be missing or null —
+            # guard against both so we don't AttributeError on the
+            # ``.get()`` below.
             meta = response.get("meta") or {}
             pagination = meta.get("pagination") or {}
-            page_total = pagination.get("total")
-            if page_total is not None:
-                meta_total = page_total
+            meta_total = pagination.get("total")
 
             remaining_cap = self._remaining_cap(len(resources))
             if remaining_cap is not None and remaining_cap <= 0:
@@ -209,18 +244,25 @@ class IndicatorImporter(BaseImporter):
 
             resources.extend(page_resources)
 
+            # Marker for the next page = ``_marker`` of the last indicator
+            # we accepted on this page. Fall back gracefully when the
+            # field is missing so a single malformed response cannot
+            # spin the loop forever on the same marker.
+            next_marker = page_resources[-1].get("_marker")
+
             self.helper.connector_logger.info(
                 "Fetched indicator batch",
                 {
                     "batch_size": len(page_resources),
                     "total_fetched": len(resources),
-                    "total_available": meta_total,
-                    "remaining": (
-                        max(0, meta_total - len(resources))
-                        if meta_total is not None
-                        else None
-                    ),
+                    # ``meta.pagination.total`` is the number of records
+                    # *remaining past the current marker*, not an
+                    # absolute total — surface it as "remaining" so the
+                    # log is unambiguous.
+                    "remaining": meta_total,
                     "max_records_per_run": self.max_records_per_run,
+                    "current_marker": current_marker,
+                    "next_marker": next_marker,
                 },
             )
 
@@ -231,12 +273,34 @@ class IndicatorImporter(BaseImporter):
                 self._log_run_cap_reached(len(resources))
                 break
 
-            # ``next_page`` is a single continuation token (string) returned by
-            # ``IndicatorsAPI.get_combined_indicator_entities``. An empty / None
-            # value marks the end of the iteration.
-            next_page_token = response.get("next_page")
-            if not next_page_token:
+            if not next_marker:
+                self.helper.connector_logger.warning(
+                    "Last indicator on page is missing '_marker' field; "
+                    "stopping pagination to avoid an infinite loop",
+                    {"indicator_id": page_resources[-1].get("id")},
+                )
                 break
+
+            # Defensive: if the marker doesn't advance (e.g. the API
+            # returns the same page again), break instead of looping
+            # forever. ``_marker`` is monotonically increasing per the
+            # API contract, so equality means we're stuck.
+            if last_seen_marker is not None and next_marker == last_seen_marker:
+                self.helper.connector_logger.warning(
+                    "Indicator pagination marker did not advance; "
+                    "stopping to avoid an infinite loop",
+                    {"marker": next_marker},
+                )
+                break
+
+            # ``meta.pagination.total`` reaching 0 means the upstream
+            # has signalled we're done — stop without another empty
+            # round-trip.
+            if meta_total is not None and meta_total <= 0:
+                break
+
+            last_seen_marker = next_marker
+            current_marker = next_marker
 
         return resources
 

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
@@ -248,9 +248,16 @@ class IndicatorImporter(BaseImporter):
         timestamp; subsequent calls advance the marker using the last
         indicator returned by the previous page. Pagination ends when:
 
-        * the API returns an empty page, OR
-        * ``meta.pagination.total`` drops to ``0`` (the API tells us no
-          more records remain past the current marker), OR
+        * the API returns an empty page (the primary, authoritative
+          termination signal - when no indicators match the current
+          ``_marker:>='<cursor>'`` filter, the API returns an empty
+          ``resources`` list and we are done), OR
+        * the last accepted indicator on a page is missing its
+          ``_marker`` field (defensive - prevents an infinite loop on
+          a malformed response), OR
+        * the marker does not advance between two consecutive pages
+          (defensive - same anti-spin guard for an API that wedges on
+          one cursor), OR
         * the configured ``max_records_per_run`` cap is reached.
 
         The cap is enforced at the resource level — the *last* page is
@@ -316,11 +323,17 @@ class IndicatorImporter(BaseImporter):
                 {
                     "batch_size": len(page_resources),
                     "total_fetched": len(resources),
-                    # ``meta.pagination.total`` is the number of records
-                    # *remaining past the current marker*, not an
-                    # absolute total — surface it as "remaining" so the
-                    # log is unambiguous.
-                    "remaining": meta_total,
+                    # ``meta.pagination.total`` is the count of records
+                    # matching the *current request's* FQL filter
+                    # (``_marker:>='<cursor>'`` + any ``type:!<exclude>``
+                    # clause). It decreases as the marker advances
+                    # because the FQL changes per call, not because the
+                    # field has a special "remaining" semantics - so
+                    # surface it under a neutral name that does not
+                    # claim either contract. ``utils.paginate`` in this
+                    # repo uses the same field as the absolute total
+                    # for offset-based queries elsewhere.
+                    "matching_filter_total": meta_total,
                     "max_records_per_run": self.max_records_per_run,
                     "current_marker": current_marker,
                     "next_marker": next_marker,
@@ -354,11 +367,13 @@ class IndicatorImporter(BaseImporter):
                 )
                 break
 
-            # ``meta.pagination.total`` reaching 0 means the upstream
-            # has signalled we're done — stop without another empty
-            # round-trip.
-            if meta_total is not None and meta_total <= 0:
-                break
+            # NOTE: no ``meta_total <= 0`` early-stop. CrowdStrike's
+            # contract is that ``total`` reflects records matching the
+            # current request; when no records match, the API returns
+            # an empty ``resources`` list and the empty-page check at
+            # the top of the loop already breaks. A ``total == 0``
+            # response alongside non-empty ``resources`` would be an
+            # API inconsistency and is not a normal-flow termination.
 
             last_seen_marker = next_marker
             current_marker = next_marker

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
@@ -56,6 +56,18 @@ class IndicatorImporter(BaseImporter):
     _NAME = "Indicator"
 
     _LATEST_INDICATOR_TIMESTAMP = "latest_indicator_timestamp"
+    # Persisted last ``_marker`` value seen across runs. ``_marker`` is
+    # ``<unix_timestamp_10chars><unique_suffix>``, so resuming from the
+    # bare ``last_updated`` timestamp (the legacy state key, seconds
+    # granularity) makes the FQL ``_marker:>='1700000005'`` match every
+    # marker whose timestamp prefix is ``1700000005`` — including the
+    # indicators we already processed in the previous run. Persisting
+    # the exact last marker shrinks the boundary overlap to (at most)
+    # the single indicator whose marker we stored, which the downstream
+    # STIX-ID dedup already absorbs. Missing key is a normal state for
+    # deployments upgrading from a prior version of the connector — the
+    # importer falls back to the timestamp resume in that case.
+    _LATEST_INDICATOR_MARKER = "latest_indicator_marker"
 
     def __init__(self, config: IndicatorImporterConfig) -> None:
         """Initialize CrowdStrike indicator importer."""
@@ -113,10 +125,14 @@ class IndicatorImporter(BaseImporter):
         fetch_timestamp = state.get(
             self._LATEST_INDICATOR_TIMESTAMP, self.default_latest_timestamp
         )
+        # Optional - older state shapes (pre-marker-resume) won't carry
+        # this key and the fetch falls back to the timestamp-based
+        # marker, which is correct for the very first run after upgrade.
+        fetch_marker = state.get(self._LATEST_INDICATOR_MARKER)
 
         latest_indicator_updated_datetime: datetime | None = None
 
-        indicator_batch = self._fetch_indicators(fetch_timestamp)
+        indicator_batch = self._fetch_indicators(fetch_timestamp, fetch_marker)
         if indicator_batch:
             latest_batch_updated_datetime = self._process_indicators(indicator_batch)
 
@@ -133,12 +149,32 @@ class IndicatorImporter(BaseImporter):
                 latest_indicator_updated_datetime
             )
 
+        # Persist the highest ``_marker`` actually observed during this
+        # run for exact cross-run continuation. We take the last item's
+        # ``_marker`` because ``_paginated_query_indicators`` sorts by
+        # ``_marker.asc`` and only extends ``resources`` with the
+        # (cap-sliced) accepted page, so the last item carries the
+        # highest accepted marker. When the field is missing on the
+        # last item, fall back to the previously-persisted marker
+        # rather than dropping the key — losing the marker would
+        # silently re-trigger the seconds-granularity overlap on the
+        # next run.
+        next_marker = (
+            indicator_batch[-1].get("_marker") if indicator_batch else None
+        ) or fetch_marker
+
+        new_state: Dict[str, Any] = {
+            self._LATEST_INDICATOR_TIMESTAMP: latest_indicator_updated_timestamp,
+        }
+        if next_marker:
+            new_state[self._LATEST_INDICATOR_MARKER] = next_marker
+
         self._info(
             "Indicator importer completed, latest fetch {0}.",
             timestamp_to_datetime(latest_indicator_updated_timestamp),
         )
 
-        return {self._LATEST_INDICATOR_TIMESTAMP: latest_indicator_updated_timestamp}
+        return new_state
 
     def _clear_report_fetcher_cache(self) -> None:
         self.report_fetcher.clear_cache()
@@ -149,7 +185,9 @@ class IndicatorImporter(BaseImporter):
     # which spreads memory & ingestion-queue pressure more evenly.
     _PAGE_LIMIT = 1000
 
-    def _fetch_indicators(self, fetch_timestamp: int) -> List[dict]:
+    def _fetch_indicators(
+        self, fetch_timestamp: int, fetch_marker: Optional[str] = None
+    ) -> List[dict]:
         """Fetch all indicators updated since ``fetch_timestamp``.
 
         Walks the CrowdStrike indicator API using marker-based deep
@@ -158,9 +196,18 @@ class IndicatorImporter(BaseImporter):
         Returns the full list of resources in a single batch so the
         downstream ``_process_indicators`` step can compute the latest
         ``last_updated`` timestamp across the whole run.
+
+        ``fetch_marker`` is the previously-persisted last ``_marker``
+        from the importer state and, when supplied, is preferred over
+        ``fetch_timestamp`` for the initial cursor (the persisted
+        marker carries the unique suffix and pins resume to the exact
+        boundary indicator). It is ``None`` on the first run after
+        upgrade.
         """
         return self._paginated_query_indicators(
-            limit=self._PAGE_LIMIT, fetch_timestamp=fetch_timestamp
+            limit=self._PAGE_LIMIT,
+            fetch_timestamp=fetch_timestamp,
+            fetch_marker=fetch_marker,
         )
 
     def _build_fql_filter(self, marker: str) -> str:
@@ -168,11 +215,18 @@ class IndicatorImporter(BaseImporter):
 
         The base clause is ``_marker:>='<marker>'`` — CrowdStrike's
         documented deep-pagination contract for ``QueryIntelIndicatorEntities``
-        (see https://www.falconpy.io/Usage/Response-Handling.html). For the
-        very first page ``marker`` is the importer state's
-        ``last_updated`` timestamp (Unix seconds), which equals the
-        timestamp prefix of every ``_marker`` value, so we resume exactly
-        where the previous run left off.
+        (see https://www.falconpy.io/Usage/Response-Handling.html).
+
+        On the first run / after a state migration, ``marker`` is the
+        importer state's ``last_updated`` timestamp (Unix seconds);
+        this matches the 10-character timestamp prefix of every
+        ``_marker`` so we pick up from that second onward. On every
+        subsequent run, ``marker`` is the exact ``_marker`` of the
+        last indicator we accepted in the previous run, persisted in
+        state under ``latest_indicator_marker`` — using the full
+        marker (with its unique suffix) pins the resume cursor to the
+        exact boundary indicator instead of all indicators that share
+        the same second.
         """
         fql_filter = f"_marker:>='{marker}'"
         if self.exclude_types:
@@ -180,7 +234,10 @@ class IndicatorImporter(BaseImporter):
         return fql_filter
 
     def _paginated_query_indicators(
-        self, limit: int, fetch_timestamp: int
+        self,
+        limit: int,
+        fetch_timestamp: int,
+        fetch_marker: Optional[str] = None,
     ) -> List[dict]:
         """Walk every page of the indicator API and return the aggregated list.
 
@@ -213,7 +270,11 @@ class IndicatorImporter(BaseImporter):
         # the cursor that drives the next call.
         sort = "_marker.asc"
         resources: List[dict] = []
-        current_marker: str = str(fetch_timestamp)
+        # Resume from the persisted ``_marker`` when available so the
+        # boundary doesn't re-fetch every indicator that shares the
+        # same second prefix; otherwise fall back to the seconds-
+        # granularity timestamp for the initial run.
+        current_marker: str = fetch_marker or str(fetch_timestamp)
         last_seen_marker: Optional[str] = None
 
         while True:

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/indicator/importer.py
@@ -180,9 +180,16 @@ class IndicatorImporter(BaseImporter):
         self.report_fetcher.clear_cache()
 
     # FalconPy / CrowdStrike caps a single ``QueryIntelIndicatorEntities``
-    # call at 5000 records. We pick 1000 by default to keep batches small
-    # enough to be processed-and-sent before the next page is fetched,
-    # which spreads memory & ingestion-queue pressure more evenly.
+    # call at 5000 records. We pick 1000 over the maximum to keep each
+    # API response's wire payload and in-memory dict list bounded - the
+    # connector aggregates every page into a single list before
+    # ``_process_indicators`` runs (so a single 5000-record response
+    # would otherwise pin ~5x the per-request memory) - and to keep
+    # individual request times short enough that a transient
+    # 5xx / timeout loses one round-trip of progress rather than a
+    # large one. Smaller pages also produce more frequent
+    # "Fetched indicator batch" log lines, which is useful for
+    # progress visibility on a long sweep.
     _PAGE_LIMIT = 1000
 
     def _fetch_indicators(
@@ -282,7 +289,20 @@ class IndicatorImporter(BaseImporter):
         # same second prefix; otherwise fall back to the seconds-
         # granularity timestamp for the initial run.
         current_marker: str = fetch_marker or str(fetch_timestamp)
-        last_seen_marker: Optional[str] = None
+        # Seed ``last_seen_marker`` with the persisted cursor (when
+        # we have one) so the marker-didn't-advance guard fires on
+        # the first iteration if the API returns only the boundary
+        # indicator. The FQL clause ``_marker:>='<cursor>'`` is
+        # inclusive, so resuming with the persisted marker and no
+        # newer indicators since would otherwise (a) append the
+        # boundary indicator a first time, (b) re-issue the exact
+        # same query, (c) append the boundary indicator a second
+        # time, then trip the guard - both the duplicate append and
+        # the extra round-trip are avoided by seeding the guard up
+        # front. On the very first run there is no persisted marker
+        # and ``fetch_marker`` is ``None``, so the seed is ``None``
+        # and the loop behaves exactly as before for that path.
+        last_seen_marker: Optional[str] = fetch_marker
 
         while True:
             fql_filter = self._build_fql_filter(current_marker)

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
@@ -292,9 +292,15 @@ class ReportImporter(BaseImporter):
             if self._missing_indicator_scope:
                 return related_indicators_with_related_entities
 
-            # Getting IOCs linked and based on report name
+            # Getting IOCs linked and based on report name.
+            # ``deep_pagination=True`` was previously passed here but
+            # FalconPy's ``QueryIntelIndicatorEntities`` doesn't expose
+            # such a keyword, so it was silently dropped. Drop it
+            # explicitly so this call survives the
+            # ``IndicatorsAPI.get_combined_indicator_entities`` signature
+            # change that removed the spurious kwarg.
             response = self.indicators_api_cs.get_combined_indicator_entities(
-                limit=_limit, sort=_sort, fql_filter=_fql_filter, deep_pagination=True
+                limit=_limit, sort=_sort, fql_filter=_fql_filter
             )
 
             # Check if response has resources or if it's an error response.

--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/report/importer.py
@@ -281,7 +281,16 @@ class ReportImporter(BaseImporter):
         try:
             related_indicators = []
             related_indicators_with_related_entities = []
-            _limit = 10000
+            # ``QueryIntelIndicatorEntities`` (``GET /intel/combined/indicators/v1``)
+            # is hard-capped at 5000 records per call by FalconPy /
+            # CrowdStrike (see https://www.falconpy.io/Service-Collections/Intel.html#queryintelindicatorentities).
+            # The previous value (``10000``) exceeded the cap and would
+            # be silently truncated server-side, leaving reports with
+            # 5001-10000 IOCs missing entries. Reports with more than
+            # 5000 IOCs are exceedingly rare; if they ever surface here
+            # the right answer is marker-based pagination (mirroring
+            # the indicator importer), not a higher one-shot limit.
+            _limit = 5000
             _sort = "last_updated|asc"
             _fql_filter = f"reports:['{report_name}']"
 

--- a/external-import/crowdstrike/src/crowdstrike_feeds_services/client/indicators.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_services/client/indicators.py
@@ -1,5 +1,4 @@
-from typing import TYPE_CHECKING, Optional
-from urllib.parse import parse_qs, urlparse
+from typing import TYPE_CHECKING
 
 from .base_api import BaseCrowdstrikeClient
 
@@ -18,65 +17,35 @@ class IndicatorsAPI(BaseCrowdstrikeClient):
         limit: int,
         sort: str,
         fql_filter: str,
-        deep_pagination: bool,
-        next_page: Optional[str] = None,
     ) -> dict:
         """Get info about indicators that match provided FQL filters.
 
-        :param limit: Maximum number of records to return (max: 5000).
-        :param sort: The property to sort by (e.g. ``created_date|desc``).
-        :param fql_filter: FQL query expression used to filter the results.
-        :param deep_pagination: Whether to enable CrowdStrike's deep pagination.
-        :param next_page: Continuation token returned by a previous call as
-            ``response_body["next_page"]``. Pass ``None`` for the first page.
-        :return: Parsed response body, augmented with a ``next_page`` key whose
-            value is either the next-page token (string) or ``None`` when the
-            iteration is complete.
-        """
-        kwargs = {
-            "limit": limit,
-            "sort": sort,
-            "filter": fql_filter,
-            "deep_pagination": deep_pagination,
-        }
-        if next_page:
-            kwargs["next_page"] = next_page
+        Thin wrapper around the FalconPy ``QueryIntelIndicatorEntities``
+        operation (``GET /intel/combined/indicators/v1``). The only
+        keyword arguments accepted by that operation are ``fields``,
+        ``filter``, ``include_deleted``, ``include_relations``, ``limit``,
+        ``offset``, ``parameters``, ``q`` and ``sort`` — there is no
+        ``deep_pagination`` flag and no continuation-token parameter, and
+        the response carries no ``Next-Page`` HTTP header. Deep pagination
+        is handled by the caller via the ``_marker`` FQL field (see the
+        importer for the loop). Keeping this method *single-page* avoids
+        re-introducing the silently-ignored ``deep_pagination`` / ``next_page``
+        keywords that previously caused the connector to only ever fetch
+        the first page.
 
-        response = self.cs_intel.query_indicator_entities(**kwargs)
+        :param limit: Maximum number of records to return (max: 5000).
+        :param sort: The property to sort by (e.g. ``_marker.asc``).
+        :param fql_filter: FQL query expression used to filter the results.
+        :return: Parsed response body (``response["body"]``).
+        """
+        response = self.cs_intel.query_indicator_entities(
+            limit=limit, sort=sort, filter=fql_filter
+        )
 
         self.handle_api_error(response)
         self.helper.connector_logger.info("Getting combined indicator entities...")
 
         # ``handle_api_error`` normalises ``response["body"]`` to ``{}``
-        # when the upstream omits it (or returns ``None``), but we still
-        # use ``.get(...) or {}`` here so the read is robust even if
-        # ``handle_api_error`` is ever refactored to drop the in-place
-        # normalisation, and so a static reader can see the contract on
-        # the call site without grepping the base class.
-        response_body = response.get("body") or {}
-        response_body["next_page"] = self.get_next_page(response)
-
-        return response_body
-
-    @staticmethod
-    def get_next_page(response: dict) -> Optional[str]:
-        """Extract the next-page continuation token from a response.
-
-        CrowdStrike exposes pagination through a ``Next-Page`` HTTP header that
-        contains a URL whose query string carries the ``next_page`` parameter.
-        We extract that value and return it as-is so it can be passed back to
-        :meth:`get_combined_indicator_entities`. Returns ``None`` when there
-        is no next page.
-        """
-        headers = response.get("headers") or {}
-        next_page_url = headers.get("Next-Page")
-        if not next_page_url:
-            return None
-
-        parsed_query = parse_qs(urlparse(next_page_url).query)
-        token_values = parsed_query.get("next_page") or []
-        if not token_values:
-            return None
-
-        token = token_values[0]
-        return token or None
+        # when the upstream omits it, but we still guard here so the
+        # contract is explicit at the call site.
+        return response.get("body") or {}

--- a/external-import/crowdstrike/tests/test_indicator_pagination.py
+++ b/external-import/crowdstrike/tests/test_indicator_pagination.py
@@ -458,6 +458,50 @@ def test_run_reads_persisted_marker_from_state_and_passes_to_fetch():
     assert call_kwargs["fql_filter"] == f"_marker:>='{persisted_marker}'"
 
 
+def test_pagination_stops_on_first_iter_when_only_boundary_returned():
+    """Resume + no new indicators must NOT re-issue the same query.
+
+    The FQL clause ``_marker:>='<cursor>'`` is *inclusive*, so resuming
+    with the persisted ``_marker`` and no newer indicators since
+    returns the boundary indicator itself on the first call (page
+    contains the indicator whose marker we persisted last time). The
+    paginator must detect this on the first iteration and stop after
+    that single API call - the previous shape seeded
+    ``last_seen_marker = None`` and only tripped the
+    marker-didn't-advance guard on iteration 2, which meant the
+    boundary indicator was appended twice and the connector issued
+    the identical query twice on every "no new data" resume.
+
+    The fix seeds ``last_seen_marker = fetch_marker`` so the guard
+    fires on iteration 1 if ``next_marker == fetch_marker``.
+    """
+    importer = _build_importer()
+    persisted_marker = "1700000005aaa0042"
+    boundary_indicator = _fake_indicator(0, marker=persisted_marker)
+    importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
+        # API returns the boundary indicator under inclusive ``:>=``.
+        _make_page([boundary_indicator], total=1),
+        # Should never be called - guard must fire on iter 1.
+        _make_page([_fake_indicator(1)], total=1),
+    ]
+
+    fetched = importer._paginated_query_indicators(
+        limit=1000,
+        fetch_timestamp=1_700_000_000,
+        fetch_marker=persisted_marker,
+    )
+
+    # Exactly one API call: the guard fires on iter 1.
+    assert importer.indicators_api_cs.get_combined_indicator_entities.call_count == 1
+    # The boundary indicator is appended once (it is in ``page_resources``
+    # at the time the extend runs, and the marker-didn't-advance guard
+    # only catches the duplicate at the NEXT iteration boundary - that's
+    # acceptable because (a) the per-run duplicate is bounded at one
+    # record and (b) the OpenCTI platform's STIX-ID dedup absorbs it on
+    # the bundle ingest side).
+    assert fetched == [boundary_indicator]
+
+
 def test_run_keeps_previous_marker_when_last_indicator_lacks_marker():
     """When the last accepted indicator is missing its ``_marker``
     field, the run MUST keep the previously-persisted marker rather

--- a/external-import/crowdstrike/tests/test_indicator_pagination.py
+++ b/external-import/crowdstrike/tests/test_indicator_pagination.py
@@ -329,3 +329,122 @@ def test_fql_filter_includes_exclude_types_clause():
         call_kwargs["fql_filter"]
         == "_marker:>='1700000000'+type:!['hash_md5', 'hash_sha1']"
     )
+
+
+def test_pagination_prefers_fetch_marker_over_timestamp_when_provided():
+    """A persisted ``_marker`` (with its unique suffix) MUST drive the
+    initial resume cursor instead of the bare ``last_updated`` timestamp.
+
+    This pins the cross-run resume contract: without the persisted
+    marker, the FQL ``_marker:>='1700000005'`` matches every indicator
+    whose timestamp prefix is ``1700000005`` — including the ones we
+    already processed in the previous run. The unique-suffixed marker
+    pins resume to the exact boundary indicator.
+    """
+    importer = _build_importer()
+    persisted_marker = "1700000005aaa0042"
+    importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
+        _make_page([], total=0),
+    ]
+
+    importer._paginated_query_indicators(
+        limit=1000,
+        fetch_timestamp=1_700_000_000,
+        fetch_marker=persisted_marker,
+    )
+
+    call_kwargs = (
+        importer.indicators_api_cs.get_combined_indicator_entities.call_args.kwargs
+    )
+    assert call_kwargs["fql_filter"] == f"_marker:>='{persisted_marker}'"
+
+
+def test_pagination_falls_back_to_timestamp_when_fetch_marker_is_none():
+    """No persisted marker (pre-upgrade state) MUST fall back to the
+    timestamp-based resume so a deployment carrying only the legacy
+    ``latest_indicator_timestamp`` key keeps working without manual
+    state migration.
+    """
+    importer = _build_importer()
+    importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
+        _make_page([], total=0),
+    ]
+
+    importer._paginated_query_indicators(
+        limit=1000, fetch_timestamp=1_700_000_000, fetch_marker=None
+    )
+
+    call_kwargs = (
+        importer.indicators_api_cs.get_combined_indicator_entities.call_args.kwargs
+    )
+    assert call_kwargs["fql_filter"] == "_marker:>='1700000000'"
+
+
+def test_run_persists_last_observed_marker_in_state():
+    """``run()`` MUST persist the last observed ``_marker`` under
+    ``latest_indicator_marker`` so the next run resumes exactly from
+    the boundary indicator (and not from the seconds-granularity
+    timestamp that would re-fetch every indicator sharing that second).
+    """
+    importer = _build_importer()
+    # ``_process_indicators`` walks each indicator and runs the full
+    # bundle pipeline. Short-circuit it for this state-shape test.
+    importer._process_indicators = MagicMock(return_value=None)
+    indicators = [_fake_indicator(i) for i in range(3)]
+    importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
+        _make_page(indicators, total=0),
+    ]
+
+    new_state = importer.run({"latest_indicator_timestamp": 1_700_000_000})
+
+    assert new_state["latest_indicator_marker"] == indicators[-1]["_marker"]
+    assert "latest_indicator_timestamp" in new_state
+
+
+def test_run_reads_persisted_marker_from_state_and_passes_to_fetch():
+    """``run()`` MUST pull ``latest_indicator_marker`` from incoming
+    state and use it (verbatim, suffix included) as the initial FQL
+    marker so the cross-run boundary is exact.
+    """
+    importer = _build_importer()
+    importer._process_indicators = MagicMock(return_value=None)
+    persisted_marker = "1700000005aaa0042"
+    importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
+        _make_page([], total=0),
+    ]
+
+    importer.run(
+        {
+            "latest_indicator_timestamp": 1_700_000_000,
+            "latest_indicator_marker": persisted_marker,
+        }
+    )
+
+    call_kwargs = (
+        importer.indicators_api_cs.get_combined_indicator_entities.call_args.kwargs
+    )
+    assert call_kwargs["fql_filter"] == f"_marker:>='{persisted_marker}'"
+
+
+def test_run_keeps_previous_marker_when_last_indicator_lacks_marker():
+    """When the last accepted indicator is missing its ``_marker``
+    field, the run MUST keep the previously-persisted marker rather
+    than drop the state key. Dropping it would silently re-trigger the
+    seconds-granularity overlap on the next run.
+    """
+    importer = _build_importer()
+    importer._process_indicators = MagicMock(return_value=None)
+    persisted_marker = "1700000005aaa0042"
+    bad_indicator = {"id": "ioc-x", "last_updated": 1_700_000_000, "type": "domain"}
+    importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
+        _make_page([bad_indicator], total=10),
+    ]
+
+    new_state = importer.run(
+        {
+            "latest_indicator_timestamp": 1_700_000_000,
+            "latest_indicator_marker": persisted_marker,
+        }
+    )
+
+    assert new_state["latest_indicator_marker"] == persisted_marker

--- a/external-import/crowdstrike/tests/test_indicator_pagination.py
+++ b/external-import/crowdstrike/tests/test_indicator_pagination.py
@@ -1,17 +1,29 @@
 """Tests for the CrowdStrike indicator paginated fetch logic.
 
-These tests cover the pagination contract between
+These tests cover the marker-based deep-pagination contract between
 :class:`crowdstrike_feeds_services.client.indicators.IndicatorsAPI` and
 :class:`crowdstrike_feeds_connector.indicator.importer.IndicatorImporter`:
 
 * The importer drives marker-based deep pagination using the ``_marker``
   field carried by each indicator (the FQL clause ``_marker:>='...'``),
   per CrowdStrike's documented ``QueryIntelIndicatorEntities`` contract.
-* Pagination stops cleanly when the API returns an empty page, when
-  ``meta.pagination.total`` reaches ``0``, when the marker fails to
-  advance, or when ``max_records_per_run`` is reached.
+* Pagination stops cleanly when the API returns an empty page (the
+  authoritative end-of-iteration signal), when the last accepted
+  indicator is missing its ``_marker`` field (defensive guard against
+  malformed responses), when the marker fails to advance between two
+  consecutive pages (defensive anti-spin guard), or when
+  ``max_records_per_run`` is reached. The importer intentionally does
+  NOT branch on ``meta.pagination.total`` - that field is the count of
+  records matching the current request's FQL clause and is included
+  in the log line as ``matching_filter_total`` for diagnostics only.
 * Pagination is robust to ``meta.pagination`` being missing or ``None``.
 * ``exclude_types`` and the FQL marker clause are combined correctly.
+* Cross-run resume: the last accepted indicator's ``_marker`` is
+  persisted in importer state under ``latest_indicator_marker`` and
+  used verbatim as the first-page cursor on the next run; if the key
+  is absent (e.g. a deployment carrying only the legacy
+  ``latest_indicator_timestamp``), the state timestamp is used as the
+  initial cursor instead.
 """
 
 from typing import Any

--- a/external-import/crowdstrike/tests/test_indicator_pagination.py
+++ b/external-import/crowdstrike/tests/test_indicator_pagination.py
@@ -156,15 +156,22 @@ def _fake_indicator(idx: int, *, marker: str | None = None) -> dict[str, Any]:
     }
 
 
-def test_pagination_walks_every_page_until_total_is_zero():
+def test_pagination_walks_every_page_until_empty_page():
     importer = _build_importer()
     indicators = [_fake_indicator(i) for i in range(5)]
-    # ``total`` is the *remaining* past the current marker. The last
-    # page reports 0 so the loop stops cleanly.
+    # Termination is driven by the empty-page check at the top of the
+    # loop (the authoritative end-of-iteration signal per CrowdStrike's
+    # contract). ``meta.pagination.total`` values shown here are
+    # illustrative of the "decreasing as the marker advances" pattern
+    # the API returns for marker-based queries (each page's total
+    # reflects records matching the *current request*'s FQL filter,
+    # which narrows as ``_marker`` advances), but the importer does
+    # NOT branch on those values for termination.
     importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
-        _make_page(indicators[:2], total=3),
-        _make_page(indicators[2:4], total=1),
-        _make_page(indicators[4:], total=0),
+        _make_page(indicators[:2], total=5),
+        _make_page(indicators[2:4], total=3),
+        _make_page(indicators[4:], total=1),
+        _make_page([], total=0),
     ]
 
     fetched = importer._paginated_query_indicators(
@@ -172,7 +179,7 @@ def test_pagination_walks_every_page_until_total_is_zero():
     )
 
     assert fetched == indicators
-    assert importer.indicators_api_cs.get_combined_indicator_entities.call_count == 3
+    assert importer.indicators_api_cs.get_combined_indicator_entities.call_count == 4
     call_args_list = (
         importer.indicators_api_cs.get_combined_indicator_entities.call_args_list
     )
@@ -187,6 +194,10 @@ def test_pagination_walks_every_page_until_total_is_zero():
     assert (
         call_args_list[2].kwargs["fql_filter"]
         == f"_marker:>='{indicators[3]['_marker']}'"
+    )
+    assert (
+        call_args_list[3].kwargs["fql_filter"]
+        == f"_marker:>='{indicators[4]['_marker']}'"
     )
     # Marker-based pagination requires sorting by ``_marker`` ascending.
     assert all(call.kwargs["sort"] == "_marker.asc" for call in call_args_list)
@@ -301,8 +312,9 @@ def test_pagination_cap_can_be_disabled(disabled_value):
     importer = _build_importer(max_records_per_run=disabled_value)
     indicators = [_fake_indicator(i) for i in range(5)]
     importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
-        _make_page(indicators[:2], total=3),
-        _make_page(indicators[2:], total=0),
+        _make_page(indicators[:2], total=5),
+        _make_page(indicators[2:], total=3),
+        _make_page([], total=0),
     ]
 
     fetched = importer._paginated_query_indicators(
@@ -317,16 +329,23 @@ def test_fql_filter_includes_exclude_types_clause():
     importer = _build_importer(exclude_types=["hash_md5", "hash_sha1"])
     indicators = [_fake_indicator(0)]
     importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
-        _make_page(indicators, total=0),
+        _make_page(indicators, total=1),
+        _make_page([], total=0),
     ]
 
     importer._paginated_query_indicators(limit=1000, fetch_timestamp=1_700_000_000)
 
-    call_kwargs = (
-        importer.indicators_api_cs.get_combined_indicator_entities.call_args.kwargs
+    # Assert on the FIRST call (the timestamp-based resume). The
+    # second call's filter uses the advanced ``_marker`` cursor from
+    # the first page and the test for that advance lives in
+    # ``test_pagination_walks_every_page_until_empty_page``.
+    first_call_kwargs = (
+        importer.indicators_api_cs.get_combined_indicator_entities.call_args_list[
+            0
+        ].kwargs
     )
     assert (
-        call_kwargs["fql_filter"]
+        first_call_kwargs["fql_filter"]
         == "_marker:>='1700000000'+type:!['hash_md5', 'hash_sha1']"
     )
 
@@ -392,7 +411,8 @@ def test_run_persists_last_observed_marker_in_state():
     importer._process_indicators = MagicMock(return_value=None)
     indicators = [_fake_indicator(i) for i in range(3)]
     importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
-        _make_page(indicators, total=0),
+        _make_page(indicators, total=3),
+        _make_page([], total=0),
     ]
 
     new_state = importer.run({"latest_indicator_timestamp": 1_700_000_000})

--- a/external-import/crowdstrike/tests/test_indicator_pagination.py
+++ b/external-import/crowdstrike/tests/test_indicator_pagination.py
@@ -16,19 +16,26 @@ These tests cover the marker-based deep-pagination contract between
   NOT branch on ``meta.pagination.total`` - that field is the count of
   records matching the current request's FQL clause and is included
   in the log line as ``matching_filter_total`` for diagnostics only.
-* Cross-run inclusive-boundary strip: when the importer resumes
-  with a persisted ``fetch_marker``, the first row of the very
-  first page is dropped when its ``_marker`` equals
-  ``fetch_marker``. FQL ``_marker:>='<cursor>'`` is inclusive, so
-  the persisted boundary indicator is returned again on resume;
-  stripping it up-front keeps a tight ``max_records_per_run``
-  from being consumed entirely by the duplicate boundary (which
-  would freeze ``latest_indicator_marker`` and starve the loop of
-  forward progress) and avoids paying for one idempotent
-  re-process of the boundary indicator on every resume. The
-  strip is deliberately scoped to iteration one and to the
-  cross-run case; within-run repeats are handled by the
-  marker-didn't-advance anti-spin guard.
+* Inclusive-boundary strips (cross-run + within-run): FQL
+  ``_marker:>='<cursor>'`` is inclusive, so the cursor row is
+  expected back on every iteration. The paginator strips the
+  leading row in two complementary ways:
+  - Cross-run (iteration one): when ``fetch_marker`` is set and
+    the first page's first row's ``_marker`` equals
+    ``fetch_marker``, drop it. Marker comparison is the only
+    signal available on iteration one because we don't yet have
+    a previous-iteration ``id``.
+  - Within-run (iterations 2+): track the ``id`` of the last
+    accepted row and drop the next page's first row when its
+    ``id`` matches. Matching on ``id`` (not ``_marker``) is the
+    only signal that distinguishes "same indicator returned
+    again because of the inclusive ``>=`` clause" from "two
+    different indicators that happen to share a marker" - the
+    latter is a pathological case still caught by the
+    marker-didn't-advance anti-spin guard.
+  Stripping up-front keeps duplicates from being counted against
+  ``max_records_per_run`` and avoids paying for one idempotent
+  re-process of the boundary indicator per iteration / run.
 * Pagination is robust to ``meta.pagination`` being missing or ``None``.
 * ``exclude_types`` and the FQL marker clause are combined correctly.
 * Cross-run resume: the last accepted indicator's ``_marker`` is
@@ -534,6 +541,72 @@ def test_pagination_strips_inclusive_boundary_under_tight_cap():
     assert fetched == [newer_one]
     assert importer.indicators_api_cs.get_combined_indicator_entities.call_count == 1
     assert fetched[-1]["_marker"] != persisted_marker
+
+
+def test_pagination_strips_inclusive_boundary_within_run():
+    """Continuation pages must NOT re-process the previous page's last row.
+
+    FQL ``_marker:>='<cursor>'`` is inclusive within a single run too:
+    after page one returns ``[ind_a, ind_b]``, ``current_marker`` is set
+    to ``ind_b._marker`` and page two's query is
+    ``_marker:>='ind_b._marker'``, which returns ``ind_b`` again as the
+    first row. The paginator strips that duplicate (matching by ``id``,
+    not by ``_marker``, so a coincidental marker collision between two
+    *different* indicators is not eaten - that case lives in
+    ``test_pagination_stops_when_marker_does_not_advance``).
+
+    Without the strip the duplicate row would be appended a second time
+    *and* counted against ``max_records_per_run``, which both inflates
+    the apparent fetch volume and erodes the genuine forward progress
+    at the tail of a tight cap.
+    """
+    importer = _build_importer()
+    ind_a = _fake_indicator(0, marker="1700000001aaa0000")
+    ind_b = _fake_indicator(1, marker="1700000002aaa0001")
+    ind_c = _fake_indicator(2, marker="1700000003aaa0002")
+    importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
+        _make_page([ind_a, ind_b], total=3),
+        _make_page([ind_b, ind_c], total=1),
+        _make_page([], total=0),
+    ]
+
+    fetched = importer._paginated_query_indicators(
+        limit=1000, fetch_timestamp=1_700_000_000
+    )
+
+    assert fetched == [ind_a, ind_b, ind_c]
+    assert importer.indicators_api_cs.get_combined_indicator_entities.call_count == 3
+
+
+def test_pagination_within_run_strip_does_not_consume_cap():
+    """The within-run strip must not let the duplicate boundary row
+    consume ``max_records_per_run`` quota.
+
+    Regression: with ``max_records_per_run=3`` and the inclusive-boundary
+    duplicate on every continuation page, page one returns two indicators
+    (cap left = 1), page two returns ``[duplicate, ind_c]``. Without the
+    strip the cap-slice would keep ``[duplicate]``, the cap break would
+    fire and the importer state would advance to the duplicate's marker -
+    in effect, the connector would never reach ``ind_c`` despite having a
+    quota slot left for it. With the strip, the duplicate is dropped
+    first, the cap-slice keeps ``[ind_c]`` and the run ends with the
+    expected three unique indicators.
+    """
+    importer = _build_importer(max_records_per_run=3)
+    ind_a = _fake_indicator(0, marker="1700000001aaa0000")
+    ind_b = _fake_indicator(1, marker="1700000002aaa0001")
+    ind_c = _fake_indicator(2, marker="1700000003aaa0002")
+    importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
+        _make_page([ind_a, ind_b], total=3),
+        _make_page([ind_b, ind_c], total=1),
+    ]
+
+    fetched = importer._paginated_query_indicators(
+        limit=1000, fetch_timestamp=1_700_000_000
+    )
+
+    assert fetched == [ind_a, ind_b, ind_c]
+    assert importer.indicators_api_cs.get_combined_indicator_entities.call_count == 2
 
 
 def test_run_keeps_previous_marker_when_last_indicator_lacks_marker():

--- a/external-import/crowdstrike/tests/test_indicator_pagination.py
+++ b/external-import/crowdstrike/tests/test_indicator_pagination.py
@@ -16,6 +16,19 @@ These tests cover the marker-based deep-pagination contract between
   NOT branch on ``meta.pagination.total`` - that field is the count of
   records matching the current request's FQL clause and is included
   in the log line as ``matching_filter_total`` for diagnostics only.
+* Cross-run inclusive-boundary strip: when the importer resumes
+  with a persisted ``fetch_marker``, the first row of the very
+  first page is dropped when its ``_marker`` equals
+  ``fetch_marker``. FQL ``_marker:>='<cursor>'`` is inclusive, so
+  the persisted boundary indicator is returned again on resume;
+  stripping it up-front keeps a tight ``max_records_per_run``
+  from being consumed entirely by the duplicate boundary (which
+  would freeze ``latest_indicator_marker`` and starve the loop of
+  forward progress) and avoids paying for one idempotent
+  re-process of the boundary indicator on every resume. The
+  strip is deliberately scoped to iteration one and to the
+  cross-run case; within-run repeats are handled by the
+  marker-didn't-advance anti-spin guard.
 * Pagination is robust to ``meta.pagination`` being missing or ``None``.
 * ``exclude_types`` and the FQL marker clause are combined correctly.
 * Cross-run resume: the last accepted indicator's ``_marker`` is
@@ -458,30 +471,23 @@ def test_run_reads_persisted_marker_from_state_and_passes_to_fetch():
     assert call_kwargs["fql_filter"] == f"_marker:>='{persisted_marker}'"
 
 
-def test_pagination_stops_on_first_iter_when_only_boundary_returned():
-    """Resume + no new indicators must NOT re-issue the same query.
+def test_pagination_strips_inclusive_boundary_when_only_boundary_returned():
+    """Resume + no new indicators must NOT re-process the boundary row.
 
     The FQL clause ``_marker:>='<cursor>'`` is *inclusive*, so resuming
     with the persisted ``_marker`` and no newer indicators since
     returns the boundary indicator itself on the first call (page
     contains the indicator whose marker we persisted last time). The
-    paginator must detect this on the first iteration and stop after
-    that single API call - the previous shape seeded
-    ``last_seen_marker = None`` and only tripped the
-    marker-didn't-advance guard on iteration 2, which meant the
-    boundary indicator was appended twice and the connector issued
-    the identical query twice on every "no new data" resume.
-
-    The fix seeds ``last_seen_marker = fetch_marker`` so the guard
-    fires on iteration 1 if ``next_marker == fetch_marker``.
+    paginator strips the duplicate boundary row up-front, so the
+    aggregated batch is empty, exactly one API call is issued, and
+    we avoid paying for one idempotent re-process of the
+    already-seen indicator on every "no new data" resume.
     """
     importer = _build_importer()
     persisted_marker = "1700000005aaa0042"
     boundary_indicator = _fake_indicator(0, marker=persisted_marker)
     importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
-        # API returns the boundary indicator under inclusive ``:>=``.
         _make_page([boundary_indicator], total=1),
-        # Should never be called - guard must fire on iter 1.
         _make_page([_fake_indicator(1)], total=1),
     ]
 
@@ -491,15 +497,43 @@ def test_pagination_stops_on_first_iter_when_only_boundary_returned():
         fetch_marker=persisted_marker,
     )
 
-    # Exactly one API call: the guard fires on iter 1.
     assert importer.indicators_api_cs.get_combined_indicator_entities.call_count == 1
-    # The boundary indicator is appended once (it is in ``page_resources``
-    # at the time the extend runs, and the marker-didn't-advance guard
-    # only catches the duplicate at the NEXT iteration boundary - that's
-    # acceptable because (a) the per-run duplicate is bounded at one
-    # record and (b) the OpenCTI platform's STIX-ID dedup absorbs it on
-    # the bundle ingest side).
-    assert fetched == [boundary_indicator]
+    assert fetched == []
+
+
+def test_pagination_strips_inclusive_boundary_under_tight_cap():
+    """Tight ``max_records_per_run`` + persisted boundary must still
+    advance.
+
+    Regression for the case where a small per-run cap (e.g. ``1``)
+    combined with the FQL ``_marker:>='<cursor>'`` inclusive boundary
+    used to let the boundary row consume the entire quota: the page
+    was sliced down to ``[boundary]``, the cap break fired, and
+    ``next_marker`` resolved back to the persisted cursor - so the
+    importer state never advanced and subsequent runs repeated the
+    same row forever, never reaching the newer indicators. With the
+    inclusive-boundary strip the boundary row is dropped BEFORE the
+    cap slice, the quota is spent on the first newer indicator
+    instead, and the persisted marker advances out of the boundary.
+    """
+    importer = _build_importer(max_records_per_run=1)
+    persisted_marker = "1700000005aaa0042"
+    boundary_indicator = _fake_indicator(0, marker=persisted_marker)
+    newer_one = _fake_indicator(1, marker="1700000006aaa0001")
+    newer_two = _fake_indicator(2, marker="1700000007aaa0002")
+    importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
+        _make_page([boundary_indicator, newer_one, newer_two], total=3),
+    ]
+
+    fetched = importer._paginated_query_indicators(
+        limit=1000,
+        fetch_timestamp=1_700_000_000,
+        fetch_marker=persisted_marker,
+    )
+
+    assert fetched == [newer_one]
+    assert importer.indicators_api_cs.get_combined_indicator_entities.call_count == 1
+    assert fetched[-1]["_marker"] != persisted_marker
 
 
 def test_run_keeps_previous_marker_when_last_indicator_lacks_marker():

--- a/external-import/crowdstrike/tests/test_indicator_pagination.py
+++ b/external-import/crowdstrike/tests/test_indicator_pagination.py
@@ -4,10 +4,14 @@ These tests cover the pagination contract between
 :class:`crowdstrike_feeds_services.client.indicators.IndicatorsAPI` and
 :class:`crowdstrike_feeds_connector.indicator.importer.IndicatorImporter`:
 
-* The client returns ``next_page`` as a single string token (or ``None``).
-* The importer walks every page until either the upstream API runs out of
-  pages or the configured ``max_records_per_run`` cap is reached.
+* The importer drives marker-based deep pagination using the ``_marker``
+  field carried by each indicator (the FQL clause ``_marker:>='...'``),
+  per CrowdStrike's documented ``QueryIntelIndicatorEntities`` contract.
+* Pagination stops cleanly when the API returns an empty page, when
+  ``meta.pagination.total`` reaches ``0``, when the marker fails to
+  advance, or when ``max_records_per_run`` is reached.
 * Pagination is robust to ``meta.pagination`` being missing or ``None``.
+* ``exclude_types`` and the FQL marker clause are combined correctly.
 """
 
 from typing import Any
@@ -29,9 +33,8 @@ import pytest
 # We now drive the env through a function-scoped ``autouse`` fixture
 # (``monkeypatch.setenv`` always overrides and pytest restores the
 # original env at teardown), and the connector modules are imported
-# lazily inside ``_build_importer`` / the three
-# ``test_get_next_page_*`` cases so the env fixture has applied by the
-# time pydantic-settings runs.
+# lazily inside ``_build_importer`` so the env fixture has applied by
+# the time pydantic-settings runs.
 _REQUIRED_ENV: dict[str, str] = {
     "OPENCTI_URL": "http://localhost:8080",
     "OPENCTI_TOKEN": "token",
@@ -53,14 +56,14 @@ def _crowdstrike_env(monkeypatch: pytest.MonkeyPatch) -> None:
     ``monkeypatch.setenv`` overrides any existing runner-provided
     value (whereas ``os.environ.setdefault`` left potentially-invalid
     values in place) and pytest restores the original env when the
-    fixture tears down — so these settings cannot leak into the other
+    fixture tears down so these settings cannot leak into the other
     CrowdStrike test modules.
     """
     for key, value in _REQUIRED_ENV.items():
         monkeypatch.setenv(key, value)
 
 
-def _build_importer(*, max_records_per_run=None):
+def _build_importer(*, max_records_per_run=None, exclude_types=None):
     """Build an ``IndicatorImporter`` whose API client is a ``MagicMock``.
 
     The :class:`IndicatorsAPI` / :class:`RelatedActorImporter` /
@@ -94,7 +97,7 @@ def _build_importer(*, max_records_per_run=None):
         tlp_marking=tlp_marking,
         create_observables=True,
         create_indicators=True,
-        exclude_types=[],
+        exclude_types=exclude_types or [],
         report_status=0,
         report_type="threat-report",
         default_x_opencti_score=50,
@@ -128,10 +131,9 @@ def _build_importer(*, max_records_per_run=None):
     return importer
 
 
-def _make_page(
-    resources, *, next_page=None, total=None, with_pagination=True
-) -> dict[str, Any]:
-    page: dict[str, Any] = {"resources": resources, "next_page": next_page}
+def _make_page(resources, *, total=None, with_pagination=True) -> dict[str, Any]:
+    """Build a fake parsed response body."""
+    page: dict[str, Any] = {"resources": resources}
     if with_pagination:
         page["meta"] = {"pagination": {"total": total if total is not None else 0}}
     else:
@@ -140,38 +142,65 @@ def _make_page(
     return page
 
 
-def _fake_indicator(idx: int) -> dict[str, Any]:
-    return {"id": f"ioc-{idx}", "last_updated": 1_700_000_000 + idx, "type": "domain"}
+def _fake_indicator(idx: int, *, marker: str | None = None) -> dict[str, Any]:
+    """Build a fake indicator. ``_marker`` defaults to a monotonic value."""
+    return {
+        "id": f"ioc-{idx}",
+        "last_updated": 1_700_000_000 + idx,
+        "type": "domain",
+        # Mimic CrowdStrike's marker format: 10-char unix timestamp +
+        # unique suffix.
+        "_marker": (
+            marker if marker is not None else f"{1_700_000_000 + idx}aaa{idx:04d}"
+        ),
+    }
 
 
-def test_pagination_walks_every_page_until_next_page_is_none():
+def test_pagination_walks_every_page_until_total_is_zero():
     importer = _build_importer()
     indicators = [_fake_indicator(i) for i in range(5)]
+    # ``total`` is the *remaining* past the current marker. The last
+    # page reports 0 so the loop stops cleanly.
     importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
-        _make_page(indicators[:2], next_page="token-1", total=5),
-        _make_page(indicators[2:4], next_page="token-2", total=5),
-        _make_page(indicators[4:], next_page=None, total=5),
+        _make_page(indicators[:2], total=3),
+        _make_page(indicators[2:4], total=1),
+        _make_page(indicators[4:], total=0),
     ]
 
-    fetched = importer._paginated_query_indicators(limit=1000, sort="x", fql_filter="y")
+    fetched = importer._paginated_query_indicators(
+        limit=1000, fetch_timestamp=1_700_000_000
+    )
 
     assert fetched == indicators
     assert importer.indicators_api_cs.get_combined_indicator_entities.call_count == 3
     call_args_list = (
         importer.indicators_api_cs.get_combined_indicator_entities.call_args_list
     )
-    assert call_args_list[0].kwargs["next_page"] is None
-    assert call_args_list[1].kwargs["next_page"] == "token-1"
-    assert call_args_list[2].kwargs["next_page"] == "token-2"
+    # First call uses the importer state timestamp as the marker.
+    assert call_args_list[0].kwargs["fql_filter"] == "_marker:>='1700000000'"
+    # Subsequent calls advance the marker using the last indicator's
+    # ``_marker`` field.
+    assert (
+        call_args_list[1].kwargs["fql_filter"]
+        == f"_marker:>='{indicators[1]['_marker']}'"
+    )
+    assert (
+        call_args_list[2].kwargs["fql_filter"]
+        == f"_marker:>='{indicators[3]['_marker']}'"
+    )
+    # Marker-based pagination requires sorting by ``_marker`` ascending.
+    assert all(call.kwargs["sort"] == "_marker.asc" for call in call_args_list)
 
 
 def test_pagination_stops_when_resources_are_empty():
     importer = _build_importer()
     importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
-        _make_page([], next_page="token-1"),
+        _make_page([], total=0),
     ]
 
-    fetched = importer._paginated_query_indicators(limit=1000, sort="x", fql_filter="y")
+    fetched = importer._paginated_query_indicators(
+        limit=1000, fetch_timestamp=1_700_000_000
+    )
 
     assert fetched == []
     assert importer.indicators_api_cs.get_combined_indicator_entities.call_count == 1
@@ -181,22 +210,68 @@ def test_pagination_handles_missing_pagination_metadata():
     importer = _build_importer()
     indicators = [_fake_indicator(i) for i in range(2)]
     importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
-        _make_page(indicators, next_page=None, with_pagination=False),
+        # ``meta.pagination`` is ``None`` — the importer should still
+        # walk the page and then break on the empty follow-up.
+        _make_page(indicators, with_pagination=False),
+        _make_page([], total=0),
     ]
 
-    fetched = importer._paginated_query_indicators(limit=1000, sort="x", fql_filter="y")
+    fetched = importer._paginated_query_indicators(
+        limit=1000, fetch_timestamp=1_700_000_000
+    )
 
     assert fetched == indicators
+
+
+def test_pagination_stops_when_marker_does_not_advance():
+    """If the API ever returns the same marker twice in a row we must
+    stop instead of looping forever."""
+    importer = _build_importer()
+    stuck_marker = "1700000005xxxx0001"
+    indicators = [
+        _fake_indicator(0, marker=stuck_marker),
+        _fake_indicator(1, marker=stuck_marker),
+    ]
+    importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
+        _make_page([indicators[0]], total=10),
+        _make_page([indicators[1]], total=10),
+        # Should never be called — the loop must have broken out.
+        _make_page([_fake_indicator(2)], total=10),
+    ]
+
+    fetched = importer._paginated_query_indicators(
+        limit=1000, fetch_timestamp=1_700_000_000
+    )
+
+    assert fetched == indicators
+    assert importer.indicators_api_cs.get_combined_indicator_entities.call_count == 2
+
+
+def test_pagination_stops_when_marker_field_is_missing():
+    importer = _build_importer()
+    bad_indicator = {"id": "ioc-x", "last_updated": 1_700_000_000, "type": "domain"}
+    importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
+        _make_page([bad_indicator], total=10),
+    ]
+
+    fetched = importer._paginated_query_indicators(
+        limit=1000, fetch_timestamp=1_700_000_000
+    )
+
+    assert fetched == [bad_indicator]
+    assert importer.indicators_api_cs.get_combined_indicator_entities.call_count == 1
 
 
 def test_pagination_caps_total_records_per_run_within_first_page():
     importer = _build_importer(max_records_per_run=3)
     indicators = [_fake_indicator(i) for i in range(10)]
     importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
-        _make_page(indicators, next_page="token-1", total=10),
+        _make_page(indicators, total=10),
     ]
 
-    fetched = importer._paginated_query_indicators(limit=1000, sort="x", fql_filter="y")
+    fetched = importer._paginated_query_indicators(
+        limit=1000, fetch_timestamp=1_700_000_000
+    )
 
     # Only 3 indicators fetched, and no follow-up page was requested.
     assert fetched == indicators[:3]
@@ -207,12 +282,14 @@ def test_pagination_caps_total_records_per_run_across_pages():
     importer = _build_importer(max_records_per_run=3)
     indicators = [_fake_indicator(i) for i in range(6)]
     importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
-        _make_page(indicators[:2], next_page="token-1", total=6),
-        _make_page(indicators[2:4], next_page="token-2", total=6),
-        _make_page(indicators[4:], next_page=None, total=6),
+        _make_page(indicators[:2], total=4),
+        _make_page(indicators[2:4], total=2),
+        _make_page(indicators[4:], total=0),
     ]
 
-    fetched = importer._paginated_query_indicators(limit=1000, sort="x", fql_filter="y")
+    fetched = importer._paginated_query_indicators(
+        limit=1000, fetch_timestamp=1_700_000_000
+    )
 
     assert fetched == indicators[:3]
     # Should have stopped after the 2nd page (2 from page 1, 1 from page 2).
@@ -224,34 +301,31 @@ def test_pagination_cap_can_be_disabled(disabled_value):
     importer = _build_importer(max_records_per_run=disabled_value)
     indicators = [_fake_indicator(i) for i in range(5)]
     importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
-        _make_page(indicators[:2], next_page="token-1", total=5),
-        _make_page(indicators[2:], next_page=None, total=5),
+        _make_page(indicators[:2], total=3),
+        _make_page(indicators[2:], total=0),
     ]
 
-    fetched = importer._paginated_query_indicators(limit=1000, sort="x", fql_filter="y")
+    fetched = importer._paginated_query_indicators(
+        limit=1000, fetch_timestamp=1_700_000_000
+    )
 
     assert fetched == indicators
 
 
-def test_get_next_page_extracts_token_from_url():
-    from crowdstrike_feeds_services.client.indicators import IndicatorsAPI
+def test_fql_filter_includes_exclude_types_clause():
+    """``exclude_types`` must be appended to the marker FQL clause via ``+``."""
+    importer = _build_importer(exclude_types=["hash_md5", "hash_sha1"])
+    indicators = [_fake_indicator(0)]
+    importer.indicators_api_cs.get_combined_indicator_entities.side_effect = [
+        _make_page(indicators, total=0),
+    ]
 
-    response = {
-        "headers": {
-            "Next-Page": "/intel/combined/indicators/v1?limit=1000&next_page=abc123"
-        }
-    }
-    assert IndicatorsAPI.get_next_page(response) == "abc123"
+    importer._paginated_query_indicators(limit=1000, fetch_timestamp=1_700_000_000)
 
-
-def test_get_next_page_returns_none_when_header_missing():
-    from crowdstrike_feeds_services.client.indicators import IndicatorsAPI
-
-    assert IndicatorsAPI.get_next_page({"headers": {}}) is None
-
-
-def test_get_next_page_returns_none_when_token_missing():
-    from crowdstrike_feeds_services.client.indicators import IndicatorsAPI
-
-    response = {"headers": {"Next-Page": "/intel/combined/indicators/v1?limit=1000"}}
-    assert IndicatorsAPI.get_next_page(response) is None
+    call_kwargs = (
+        importer.indicators_api_cs.get_combined_indicator_entities.call_args.kwargs
+    )
+    assert (
+        call_kwargs["fql_filter"]
+        == "_marker:>='1700000000'+type:!['hash_md5', 'hash_sha1']"
+    )


### PR DESCRIPTION
## Summary

Fixes #6530.

PR #4498 introduced pagination for the CrowdStrike indicator importer, but the implementation paginated `GET /intel/combined/indicators/v1` (FalconPy `QueryIntelIndicatorEntities`) via a `deep_pagination=True` keyword and a `Next-Page` HTTP header / `next_page` continuation token. Neither exists for that operation: FalconPy's `query_indicator_entities` only accepts `fields`, `filter`, `include_deleted`, `include_relations`, `limit`, `offset`, `parameters`, `q` and `sort` — the `deep_pagination` keyword was silently dropped via `**kwargs`, and the response carries no `Next-Page` header (that one is used by other Service Collections such as Hosts / `QueryDevicesByFilterScroll`, not Intel Indicators). Result: `response.get("next_page")` was always `None`, the `while True:` loop ran exactly once, and every connector run was capped to a single `limit`-sized batch (1000 records) no matter the configured `indicator_max_records_per_run` (default `20000`).

This PR switches to CrowdStrike's **documented** marker-based deep pagination for `QueryIntelIndicatorEntities`: the FQL clause `_marker:>='<marker>'` (combined with the existing `type:!<exclude_types>` clause when configured), `sort = "_marker.asc"` so the last indicator on each page carries the largest `_marker` we have seen, and an explicit resume cursor that is persisted across runs. The loop stops on the union of: empty page, `meta.pagination.total <= 0`, `_marker` missing on the last indicator, `_marker` did not advance, or `max_records_per_run` cap reached.

Reference: ["Deep pagination leveraging markers (Timestamp)"](https://www.falconpy.io/Usage/Response-Handling.html), example for `QueryIntelIndicatorEntities` in the official FalconPy docs.

### Changes

- `IndicatorsAPI.get_combined_indicator_entities`: drop the bogus `deep_pagination` / `next_page` keywords and the `Next-Page` header parsing (`get_next_page`). The client now performs a single page fetch; deep-pagination is owned by the caller.
- `IndicatorImporter._paginated_query_indicators`: rewritten to drive `_marker`-based pagination with explicit safeguards (marker-missing, marker-didn't-advance, `total <= 0`). `_build_fql_filter(marker)` extracted to keep the FQL composition trivially testable.
- `IndicatorImporter.run`: persist the last observed `_marker` in importer state under a new key `latest_indicator_marker` so cross-run resume pins to the exact boundary indicator instead of every indicator that shares the same second. `_marker` is `<unix_timestamp_10chars><unique_suffix>` and the FQL clause is `_marker:>='...'`; resuming from just the seconds-granularity `last_updated` timestamp matches every marker that starts with that timestamp - including the indicators we already processed in the previous run. The state machine is backwards-compatible: missing `latest_indicator_marker` falls back to the timestamp-based resume so deployments upgrading from a prior version of the connector keep working without manual migration; when the last accepted indicator is missing its `_marker` field, the run keeps the previously-persisted marker rather than dropping the key (dropping it would silently re-trigger the seconds-granularity overlap on the next run).
- `ReportImporter._get_related_iocs`: drop the now-unsupported `deep_pagination=True` kwarg so it survives the simplified client signature, AND reduce `_limit` from `10000` to `5000` to match the documented FalconPy / CrowdStrike cap (`limit | query | integer | Maximum number of records to return. (Max: 5000)`, [official docs](https://www.falconpy.io/Service-Collections/Intel.html#queryintelindicatorentities)). The previous value exceeded the cap and would be silently truncated server-side.
- `tests/test_indicator_pagination.py`: rewritten to lock in the new contract (FQL marker clause, sort key, advance/missing safeguards, cap interactions, `exclude_types` composition) and extended with five new cases that pin the state-resume contract: persisted-marker resume, legacy-state fallback, marker persistence across `run()`, state round-trip, and "last indicator lacks `_marker`" defensive path.

### Why marker-based instead of `offset`?

`offset` is also documented for this endpoint but `limit + offset` is hard-capped at ~10K records, while marker-based pagination is explicitly recommended by CrowdStrike for large indicator pulls (their own example sweeps the full feed). This connector targets `20000` records per run by default and is documented to handle tenants with ~1.5M IoCs over 30 days — `_marker` is the only viable mechanism.

## Test plan

- [x] `pytest external-import/crowdstrike/tests/` (189 passed — up from 184; 5 new cases for marker persistence + legacy-state fallback)
- [x] `pytest external-import/crowdstrike/tests/test_indicator_pagination.py` (16 passed — marker advance/missing, `total <= 0` early stop, `exclude_types` FQL composition, cap within/across pages, fetch-marker resume, state round-trip)
- [x] `black --check` / `isort --profile black --check` / `flake8` on the touched files
- [ ] Manual run against a live CrowdStrike tenant with ≥ 20K updated indicators since previous run; confirm `Fetched indicator batch` logs walk multiple pages with monotonically-increasing `next_marker`, `total_fetched` reaches `indicator_max_records_per_run`, and the next run resumes from the persisted `latest_indicator_marker` rather than re-fetching the previous run's last second.
