### PR TITLE
[opencti] Expose dataset URL fields as plain str so the Manager UI can render them

### DIFF
--- a/external-import/opencti/README.md
+++ b/external-import/opencti/README.md
@@ -69,9 +69,9 @@ There are a number of configuration options, which are set either in `docker-com
 |------------------------|------------------------------|-------------------------------|------------------------------------------------------------------------------------------|-----------|----------------------------------------------------------------------------------------------|
 | Interval               | config.interval              | `CONFIG_INTERVAL`             | 7                                                                                        | No        | Interval in days between connector runs.                                                     |
 | Remove Creator         | config.remove_creator        | `CONFIG_REMOVE_CREATOR`       | false                                                                                    | No        | Remove `created_by_ref` from every imported object before sending the bundle to OpenCTI.     |
-| Sectors File URL       | config.sectors_file_url      | `CONFIG_SECTORS_FILE_URL`     | https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/sectors.json     | No        | URL to sectors dataset (set to `false` to disable).                                          |
-| Geography File URL     | config.geography_file_url    | `CONFIG_GEOGRAPHY_FILE_URL`   | https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/geography.json   | No        | URL to geography dataset (set to `false` to disable).                                        |
-| Companies File URL     | config.companies_file_url    | `CONFIG_COMPANIES_FILE_URL`   | https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/companies.json   | No        | URL to companies dataset (set to `false` to disable).                                        |
+| Sectors File URL       | config.sectors_file_url      | `CONFIG_SECTORS_FILE_URL`     | https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/sectors.json     | No        | URL to sectors dataset (set to `false` or leave empty to disable).                           |
+| Geography File URL     | config.geography_file_url    | `CONFIG_GEOGRAPHY_FILE_URL`   | https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/geography.json   | No        | URL to geography dataset (set to `false` or leave empty to disable).                         |
+| Companies File URL     | config.companies_file_url    | `CONFIG_COMPANIES_FILE_URL`   | https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/companies.json   | No        | URL to companies dataset (set to `false` or leave empty to disable).                         |
 
 ## Deployment
 
@@ -198,7 +198,10 @@ CONNECTOR_LOG_LEVEL=debug
 
 ## Additional information
 
-- **Disabling Datasets**: Set dataset URL to `false` to skip (e.g., `CONFIG_SECTORS_FILE_URL=false`)
+- **Disabling Datasets**: Set the dataset URL to `false` or leave it empty to skip
+  (e.g., `CONFIG_SECTORS_FILE_URL=false`). Both forms are normalised to "disabled"
+  by the connector; the field is exposed as a plain string in the connector
+  config schema so the OpenCTI Manager / XTM Composer UI renders it correctly.
 - **Update Frequency**: Datasets are updated infrequently; weekly polling is sufficient
 - **Foundation Data**: This connector provides reference data used by other connectors
 - **Reference**: [OpenCTI Datasets Repository](https://github.com/OpenCTI-Platform/datasets)

--- a/external-import/opencti/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/opencti/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -13,8 +13,8 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
 | CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"PT1H"` | The period of time to await between two runs of the connector. |
-| CONFIG_SECTORS_FILE_URL | `const` or `string` |  | `False` and/or string | `"https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/sectors.json"` | URL to sectors dataset (set to `false` to disable). |
-| CONFIG_GEOGRAPHY_FILE_URL | `const` or `string` |  | `False` and/or string | `"https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/geography.json"` | URL to geography dataset (set to `false` to disable). |
-| CONFIG_COMPANIES_FILE_URL | `const` or `string` |  | `False` and/or string | `"https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/companies.json"` | URL to companies dataset (set to `false` to disable). |
+| CONFIG_SECTORS_FILE_URL | `string` |  | string | `"https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/sectors.json"` | URL to sectors dataset (set to `false` or leave empty to disable). |
+| CONFIG_GEOGRAPHY_FILE_URL | `string` |  | string | `"https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/geography.json"` | URL to geography dataset (set to `false` or leave empty to disable). |
+| CONFIG_COMPANIES_FILE_URL | `string` |  | string | `"https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/companies.json"` | URL to companies dataset (set to `false` or leave empty to disable). |
 | CONFIG_REMOVE_CREATOR | `boolean` |  | boolean | `false` | Remove creator identity from imported objects. |
 | CONFIG_INTERVAL | `integer` |  | integer | `7` | Interval in days between connector runs. |

--- a/external-import/opencti/__metadata__/connector_config_schema.json
+++ b/external-import/opencti/__metadata__/connector_config_schema.json
@@ -55,43 +55,19 @@
       "type": "string"
     },
     "CONFIG_SECTORS_FILE_URL": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "const": false,
-          "type": "boolean"
-        }
-      ],
       "default": "https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/sectors.json",
-      "description": "URL to sectors dataset (set to `false` to disable)."
+      "description": "URL to sectors dataset (set to `false` or leave empty to disable).",
+      "type": "string"
     },
     "CONFIG_GEOGRAPHY_FILE_URL": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "const": false,
-          "type": "boolean"
-        }
-      ],
       "default": "https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/geography.json",
-      "description": "URL to geography dataset (set to `false` to disable)."
+      "description": "URL to geography dataset (set to `false` or leave empty to disable).",
+      "type": "string"
     },
     "CONFIG_COMPANIES_FILE_URL": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "const": false,
-          "type": "boolean"
-        }
-      ],
       "default": "https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/companies.json",
-      "description": "URL to companies dataset (set to `false` to disable)."
+      "description": "URL to companies dataset (set to `false` or leave empty to disable).",
+      "type": "string"
     },
     "CONFIG_REMOVE_CREATOR": {
       "default": false,

--- a/external-import/opencti/src/connector/connector.py
+++ b/external-import/opencti/src/connector/connector.py
@@ -25,13 +25,15 @@ class OpenCTI:
             self.config.config.geography_file_url,
             self.config.config.companies_file_url,
         ]
-        # Drop disabled-by-config entries (``False`` after the Pydantic
-        # ``BeforeValidator`` coercion in ``settings.py``, which translates
-        # the literal string ``"false"`` to ``False`` so the README's
-        # "set to ``false`` to disable" UX works regardless of whether the
-        # value arrives from ``config.yml`` (real YAML boolean) or an env
-        # var (``"false"`` string).
-        self.urls = [url for url in urls if url is not False]
+        # Drop disabled-by-config entries. Disabled URLs land as the
+        # empty string ``""`` after the Pydantic ``BeforeValidator`` in
+        # ``settings.py`` normalises the documented disable sentinels -
+        # real YAML ``false``, env-var ``"false"`` (any casing), and the
+        # operator-friendly empty value - so a plain truthy filter is
+        # enough here. ``None`` is also tolerated for the same reason
+        # (config-loader edge cases that surface a missing key as
+        # ``None`` rather than the default URL).
+        self.urls = [url for url in urls if url]
         self.interval = days_to_seconds(self.config_interval)
 
     def retrieve_data(self, url: str) -> dict:

--- a/external-import/opencti/src/connector/connector.py
+++ b/external-import/opencti/src/connector/connector.py
@@ -27,12 +27,10 @@ class OpenCTI:
         ]
         # Drop disabled-by-config entries. Disabled URLs land as the
         # empty string ``""`` after the Pydantic ``BeforeValidator`` in
-        # ``settings.py`` normalises the documented disable sentinels -
-        # real YAML ``false``, env-var ``"false"`` (any casing), and the
-        # operator-friendly empty value - so a plain truthy filter is
-        # enough here. ``None`` is also tolerated for the same reason
-        # (config-loader edge cases that surface a missing key as
-        # ``None`` rather than the default URL).
+        # ``settings.py`` normalises every documented disable sentinel
+        # (real YAML ``false``, env-var ``"false"`` in any casing, YAML
+        # ``null`` / a missing key, and any empty / whitespace-only
+        # string), so a plain truthy filter is enough here.
         self.urls = [url for url in urls if url]
         self.interval = days_to_seconds(self.config_interval)
 

--- a/external-import/opencti/src/connector/connector.py
+++ b/external-import/opencti/src/connector/connector.py
@@ -28,9 +28,11 @@ class OpenCTI:
         # Drop disabled-by-config entries. Disabled URLs land as the
         # empty string ``""`` after the Pydantic ``BeforeValidator`` in
         # ``settings.py`` normalises every documented disable sentinel
-        # (real YAML ``false``, env-var ``"false"`` in any casing, YAML
-        # ``null`` / a missing key, and any empty / whitespace-only
-        # string), so a plain truthy filter is enough here.
+        # (real YAML ``false``, env-var ``"false"`` in any casing, an
+        # explicit YAML null value - key present with no value, which
+        # PyYAML surfaces as Python ``None`` - and any empty /
+        # whitespace-only string), so a plain truthy filter is enough
+        # here.
         self.urls = [url for url in urls if url]
         self.interval = days_to_seconds(self.config_interval)
 

--- a/external-import/opencti/src/connector/settings.py
+++ b/external-import/opencti/src/connector/settings.py
@@ -58,16 +58,23 @@ def _normalize_dataset_url(v):
 
 # Plain ``str`` field that accepts the documented "false to disable"
 # sentinels (real bool ``False`` and the case-insensitive string
-# ``"false"``) and normalises them to ``""``. Anything else passes
-# through to Pydantic's standard ``str`` validation; the only boolean
-# that survives that step is ``True``, which is rejected (``True`` is
-# not a string and ``_normalize_dataset_url`` deliberately does not
-# coerce it) - so a bogus ``True`` still fails fast at startup
-# instead of crashing inside ``urllib.request.urlopen`` on the first
-# scheduled run. ``False`` is intentionally NOT rejected: the
-# ``BeforeValidator`` above intercepts it and rewrites it to ``""``
-# (the documented disable sentinel) before Pydantic's type check
-# runs.
+# ``"false"``) and normalises them to ``""``. The two booleans are
+# handled asymmetrically on purpose:
+#
+# * ``False`` is the documented disable sentinel. The
+#   ``BeforeValidator`` above catches it and rewrites it to ``""``
+#   before Pydantic's standard ``str`` check runs, so the value
+#   reaches the typed field as a valid string and the downstream
+#   ``if url`` filter drops it.
+# * ``True`` has no semantic meaning on a URL field ("enable the
+#   URL" is not a thing - either set a real URL or leave the
+#   default). ``_normalize_dataset_url`` deliberately does NOT catch
+#   it, so it flows through to Pydantic's ``str`` check and is
+#   rejected at validation time (``True`` is not a string). An
+#   operator who sets ``CONFIG_SECTORS_FILE_URL=True`` therefore
+#   gets a clear ``ConfigValidationError`` at startup instead of a
+#   confusing ``TypeError`` from inside
+#   ``urllib.request.urlopen(True)`` on the first scheduled run.
 DatasetUrl = Annotated[str, BeforeValidator(_normalize_dataset_url)]
 
 

--- a/external-import/opencti/src/connector/settings.py
+++ b/external-import/opencti/src/connector/settings.py
@@ -11,29 +11,44 @@ from pydantic import BeforeValidator, Field
 
 
 def _normalize_dataset_url(v):
-    """Normalise the documented "set to ``false`` to disable" UX onto a plain ``str``.
+    """Normalise every documented "disable this dataset" sentinel onto a plain ``str``.
 
-    The dataset URL fields are documented to accept the literal value
-    ``false`` (real YAML boolean or env-var string ``"false"``, case-
-    insensitive, surrounding whitespace tolerated) as a sentinel that
-    disables the dataset. Previously the field was typed
-    ``str | Literal[False]`` to model that contract directly, but the
-    resulting JSON Schema (``anyOf: [{"type": "string"}, {"const": false,
-    "type": "boolean"}]``) is rejected by the OpenCTI Manager / XTM
-    Composer UI - every URL field rendered as
-    "CONFIG_SECTORS_FILE_URL - Unsupported" and could not be edited.
+    The dataset URL fields are documented (README + ``config.yml.sample``)
+    to accept several equivalent ways of disabling a dataset:
 
-    Normalise both shapes to an empty string ``""``; the downstream
-    consumer (`OpenCTI.__init__`) then filters disabled URLs out with a
-    plain truthy check (``if url``). This preserves backwards
-    compatibility for every documented input - real YAML ``false``,
-    env-var ``"false"`` / ``"FALSE"`` / ``"  false  "`` - while exposing
-    a clean ``{"type": "string"}`` to the schema generator.
+    - real YAML boolean ``false`` (``sectors_file_url: false``),
+    - env-var / Docker string ``"false"`` (case-insensitive, surrounding
+      whitespace tolerated),
+    - YAML ``null`` / a missing key (``sectors_file_url:`` with no
+      value, which PyYAML surfaces as Python ``None``),
+    - the operator-friendly empty / whitespace-only string (UI input
+      or env var trimmed to nothing).
+
+    Previously the field was typed ``str | Literal[False]`` to model the
+    ``false`` contract directly, but the resulting JSON Schema
+    (``anyOf: [{"type": "string"}, {"const": false, "type": "boolean"}]``)
+    is rejected by the OpenCTI Manager / XTM Composer UI - every URL
+    field rendered as "CONFIG_SECTORS_FILE_URL - Unsupported" and could
+    not be edited. Normalise every disable shape to the empty string
+    ``""``; the downstream consumer (`OpenCTI.__init__`) then filters
+    disabled URLs out with a plain truthy check (``if url``). This
+    preserves backwards compatibility for every documented input while
+    exposing a clean ``{"type": "string"}`` to the schema generator.
+
+    Anything that is not a recognised disable sentinel falls through to
+    Pydantic's standard ``str`` validation - in particular real ``True``
+    is still rejected (``True`` is not a string and this validator does
+    not coerce it) so a bogus ``True`` fails fast at startup instead of
+    crashing inside ``urllib.request.urlopen`` on the first scheduled
+    run. Real URL strings are passed through unchanged (no stripping)
+    so an operator-supplied URL keeps its exact value.
     """
-    if v is False:
+    if v is None or v is False:
         return ""
-    if isinstance(v, str) and v.strip().lower() == "false":
-        return ""
+    if isinstance(v, str):
+        stripped = v.strip()
+        if not stripped or stripped.lower() == "false":
+            return ""
     return v
 
 

--- a/external-import/opencti/src/connector/settings.py
+++ b/external-import/opencti/src/connector/settings.py
@@ -59,10 +59,15 @@ def _normalize_dataset_url(v):
 # Plain ``str`` field that accepts the documented "false to disable"
 # sentinels (real bool ``False`` and the case-insensitive string
 # ``"false"``) and normalises them to ``""``. Anything else passes
-# through to Pydantic's standard ``str`` validation, which rejects real
-# booleans (``True`` is not a string) - so a bogus ``True`` still fails
-# fast at startup instead of crashing inside ``urllib.request.urlopen``
-# on the first scheduled run.
+# through to Pydantic's standard ``str`` validation; the only boolean
+# that survives that step is ``True``, which is rejected (``True`` is
+# not a string and ``_normalize_dataset_url`` deliberately does not
+# coerce it) - so a bogus ``True`` still fails fast at startup
+# instead of crashing inside ``urllib.request.urlopen`` on the first
+# scheduled run. ``False`` is intentionally NOT rejected: the
+# ``BeforeValidator`` above intercepts it and rewrites it to ``""``
+# (the documented disable sentinel) before Pydantic's type check
+# runs.
 DatasetUrl = Annotated[str, BeforeValidator(_normalize_dataset_url)]
 
 

--- a/external-import/opencti/src/connector/settings.py
+++ b/external-import/opencti/src/connector/settings.py
@@ -19,8 +19,12 @@ def _normalize_dataset_url(v):
     - real YAML boolean ``false`` (``sectors_file_url: false``),
     - env-var / Docker string ``"false"`` (case-insensitive, surrounding
       whitespace tolerated),
-    - YAML ``null`` / a missing key (``sectors_file_url:`` with no
-      value, which PyYAML surfaces as Python ``None``),
+    - an explicit YAML null value (key present with no value -
+      ``sectors_file_url:`` or ``sectors_file_url: null`` - both of
+      which PyYAML surfaces as Python ``None`` and route into this
+      validator). Note: omitting the key entirely from ``config.yml``
+      uses the field's default URL via Pydantic's standard
+      missing-key handling and never reaches this validator.
     - the operator-friendly empty / whitespace-only string (UI input
       or env var trimmed to nothing).
 

--- a/external-import/opencti/src/connector/settings.py
+++ b/external-import/opencti/src/connector/settings.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Annotated, Literal
+from typing import Annotated
 
 from connectors_sdk import (
     BaseConfigModel,
@@ -10,35 +10,41 @@ from connectors_sdk import (
 from pydantic import BeforeValidator, Field
 
 
-def _coerce_false(v):
-    """Coerce the literal string ``"false"`` (case-insensitive) to the bool ``False``.
+def _normalize_dataset_url(v):
+    """Normalise the documented "set to ``false`` to disable" UX onto a plain ``str``.
 
-    The dataset URL fields document a "set to ``false`` to disable" toggle, but
-    Pydantic / Docker / YAML / env-var configuration delivers booleans as strings
-    in many setups (`CONFIG_SECTORS_FILE_URL=false` lands as the string
-    ``"false"``). Without this coercion the typed ``str`` field happily stores
-    the literal string ``"false"``, the downstream filter
-    ``url is not False`` never matches, and the connector then tries to fetch
-    the URL ``"false"`` and logs an error. Coerce up-front so the disable
-    contract works as documented.
+    The dataset URL fields are documented to accept the literal value
+    ``false`` (real YAML boolean or env-var string ``"false"``, case-
+    insensitive, surrounding whitespace tolerated) as a sentinel that
+    disables the dataset. Previously the field was typed
+    ``str | Literal[False]`` to model that contract directly, but the
+    resulting JSON Schema (``anyOf: [{"type": "string"}, {"const": false,
+    "type": "boolean"}]``) is rejected by the OpenCTI Manager / XTM
+    Composer UI - every URL field rendered as
+    "CONFIG_SECTORS_FILE_URL - Unsupported" and could not be edited.
+
+    Normalise both shapes to an empty string ``""``; the downstream
+    consumer (`OpenCTI.__init__`) then filters disabled URLs out with a
+    plain truthy check (``if url``). This preserves backwards
+    compatibility for every documented input - real YAML ``false``,
+    env-var ``"false"`` / ``"FALSE"`` / ``"  false  "`` - while exposing
+    a clean ``{"type": "string"}`` to the schema generator.
     """
+    if v is False:
+        return ""
     if isinstance(v, str) and v.strip().lower() == "false":
-        return False
+        return ""
     return v
 
 
-# Either a URL string (the active dataset endpoint) or the bool ``False``
-# (dataset disabled). The type is intentionally ``str | Literal[False]``
-# rather than ``str | bool`` so a real ``True`` (or the literal string
-# ``"true"`` after the upstream Docker / YAML coercion) fails Pydantic
-# validation up-front instead of silently surviving the typed field and
-# blowing up later in ``urllib.request.urlopen(True)``. The disable
-# contract is strictly "string URL OR ``false``" — there is no semantic
-# meaning to ``True`` here. The downstream filter
-# ``[url for url in urls if url is not False]`` only ever needs to
-# distinguish the disabled case from a real URL, so ``Literal[False]``
-# is exactly the right shape.
-FalsableUrl = Annotated[str | Literal[False], BeforeValidator(_coerce_false)]
+# Plain ``str`` field that accepts the documented "false to disable"
+# sentinels (real bool ``False`` and the case-insensitive string
+# ``"false"``) and normalises them to ``""``. Anything else passes
+# through to Pydantic's standard ``str`` validation, which rejects real
+# booleans (``True`` is not a string) - so a bogus ``True`` still fails
+# fast at startup instead of crashing inside ``urllib.request.urlopen``
+# on the first scheduled run.
+DatasetUrl = Annotated[str, BeforeValidator(_normalize_dataset_url)]
 
 
 class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
@@ -70,16 +76,16 @@ class OpenctiConfig(BaseConfigModel):
     Define parameters and/or defaults for the configuration specific to the `OpenctiConnector`.
     """
 
-    sectors_file_url: FalsableUrl = Field(
-        description="URL to sectors dataset (set to `false` to disable).",
+    sectors_file_url: DatasetUrl = Field(
+        description="URL to sectors dataset (set to `false` or leave empty to disable).",
         default="https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/sectors.json",
     )
-    geography_file_url: FalsableUrl = Field(
-        description="URL to geography dataset (set to `false` to disable).",
+    geography_file_url: DatasetUrl = Field(
+        description="URL to geography dataset (set to `false` or leave empty to disable).",
         default="https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/geography.json",
     )
-    companies_file_url: FalsableUrl = Field(
-        description="URL to companies dataset (set to `false` to disable).",
+    companies_file_url: DatasetUrl = Field(
+        description="URL to companies dataset (set to `false` or leave empty to disable).",
         default="https://raw.githubusercontent.com/OpenCTI-Platform/datasets/master/data/companies.json",
     )
     remove_creator: bool = Field(

--- a/external-import/opencti/src/connector/settings.py
+++ b/external-import/opencti/src/connector/settings.py
@@ -21,10 +21,14 @@ def _normalize_dataset_url(v):
       whitespace tolerated),
     - an explicit YAML null value (key present with no value -
       ``sectors_file_url:`` or ``sectors_file_url: null`` - both of
-      which PyYAML surfaces as Python ``None`` and route into this
-      validator). Note: omitting the key entirely from ``config.yml``
-      uses the field's default URL via Pydantic's standard
-      missing-key handling and never reaches this validator.
+      which PyYAML surfaces as Python ``None``). The ``None`` -> ``""``
+      branch below covers this case. (When the key is omitted
+      entirely, Pydantic substitutes the field's default URL; that
+      default still flows through this validator because
+      ``BaseConfigModel`` sets ``validate_default=True``, but the
+      default is a real URL string that simply passes through
+      unchanged - it is not a disable sentinel and the dataset
+      stays enabled.)
     - the operator-friendly empty / whitespace-only string (UI input
       or env var trimmed to nothing).
 

--- a/external-import/opencti/tests/tests_connector/test_settings.py
+++ b/external-import/opencti/tests/tests_connector/test_settings.py
@@ -176,26 +176,48 @@ def test_settings_should_raise_when_invalid_input(settings_dict, expected_field)
         pytest.param("false", "", id="literal_string_false"),
         pytest.param("FALSE", "", id="uppercase_string_false"),
         pytest.param("  false  ", "", id="whitespace_string_false"),
+        # YAML ``null`` / a missing key (``sectors_file_url:`` with no
+        # value in ``config.yml``) surfaces as Python ``None`` after the
+        # YAML loader runs. Without normalisation Pydantic would reject
+        # ``None`` against the ``str`` field at validation time, which
+        # would block the connector from starting instead of honouring
+        # the README's "leave empty to disable" contract.
+        pytest.param(None, "", id="real_none"),
+        # The empty / whitespace-only strings are the operator-friendly
+        # disable sentinels (UI input, env-var trimmed to nothing). All
+        # of them collapse to ``""`` so the connector filters them out
+        # the same way as the explicit ``false`` form. Without this a
+        # value like ``"   "`` would survive validation, pass the
+        # truthy filter, and crash the connector with
+        # ``urllib.request.urlopen("   ")`` on the first scheduled run.
+        pytest.param("", "", id="empty_string"),
+        pytest.param("   ", "", id="whitespace_only_string"),
+        pytest.param("\t\n  ", "", id="tab_newline_whitespace_string"),
         # Any other string is preserved as-is (still a real URL).
         pytest.param(
             "https://example.invalid/x.json",
             "https://example.invalid/x.json",
             id="url_string",
         ),
-        # An empty string is a valid disable sentinel too: the
-        # connector filters it out via a plain truthy check.
-        pytest.param("", "", id="empty_string"),
     ],
 )
 def test_dataset_url_disable_sentinels_are_normalised(raw_value, expected):
     """Disable sentinels normalise to ``""`` (the connector then filters truthy).
 
-    Pins the disable-via-config-false contract so a future refactor of
-    the ``BeforeValidator`` cannot silently re-introduce the bug where
-    the typed ``str`` field stored the literal string ``"false"`` and
-    the downstream URL filter never matched (leading the connector to
-    issue an HTTP GET for the URL ``"false"`` and log an error). Also
-    pins that we expose a plain ``str`` field to the JSON schema
+    Pins the full disable-via-config contract so a future refactor of
+    the ``BeforeValidator`` cannot silently re-introduce one of the
+    historical bugs:
+
+    - typed ``str`` field stored the literal string ``"false"`` and the
+      downstream URL filter never matched, so the connector issued an
+      HTTP GET for the URL ``"false"`` and logged an error;
+    - YAML ``null`` (``sectors_file_url:`` with no value) raised a
+      ``ConfigValidationError`` instead of honouring the README's
+      "leave empty to disable" UX;
+    - a whitespace-only string survived validation and crashed
+      ``urllib.request.urlopen`` on the first scheduled run.
+
+    Also pins that we expose a plain ``str`` field to the JSON schema
     generator - the previous ``str | Literal[False]`` union produced an
     ``anyOf`` schema that the OpenCTI Manager / XTM Composer UI tags as
     "Unsupported" and refuses to render.

--- a/external-import/opencti/tests/tests_connector/test_settings.py
+++ b/external-import/opencti/tests/tests_connector/test_settings.py
@@ -166,30 +166,39 @@ def test_settings_should_raise_when_invalid_input(settings_dict, expected_field)
 @pytest.mark.parametrize(
     "raw_value,expected",
     [
-        # Real YAML boolean (from ``config.yml``) is preserved.
-        pytest.param(False, False, id="real_bool_false"),
+        # Real YAML boolean (from ``config.yml``) is normalised to the
+        # empty-string sentinel that disables the dataset downstream.
+        pytest.param(False, "", id="real_bool_false"),
         # Env-var / Docker-compose string "false" (case-insensitive +
-        # surrounding whitespace) is coerced to ``False`` so the
-        # README's "set to ``false`` to disable" UX works end-to-end.
-        pytest.param("false", False, id="literal_string_false"),
-        pytest.param("FALSE", False, id="uppercase_string_false"),
-        pytest.param("  false  ", False, id="whitespace_string_false"),
+        # surrounding whitespace) is coerced to ``""`` so the README's
+        # "set to ``false`` to disable" UX works end-to-end no matter
+        # how the value arrives.
+        pytest.param("false", "", id="literal_string_false"),
+        pytest.param("FALSE", "", id="uppercase_string_false"),
+        pytest.param("  false  ", "", id="whitespace_string_false"),
         # Any other string is preserved as-is (still a real URL).
         pytest.param(
             "https://example.invalid/x.json",
             "https://example.invalid/x.json",
             id="url_string",
         ),
+        # An empty string is a valid disable sentinel too: the
+        # connector filters it out via a plain truthy check.
+        pytest.param("", "", id="empty_string"),
     ],
 )
-def test_falsable_url_coercion(raw_value, expected):
-    """``"false"`` (any casing / surrounding whitespace) coerces to ``False``.
+def test_dataset_url_disable_sentinels_are_normalised(raw_value, expected):
+    """Disable sentinels normalise to ``""`` (the connector then filters truthy).
 
-    Pins the disable-via-config-false contract so a future refactor of the
-    ``BeforeValidator`` cannot silently re-introduce the bug where the typed
-    ``str`` field stored the literal string ``"false"`` and the downstream
-    ``url is not False`` filter never matched (leading the connector to
-    issue an HTTP GET for the URL ``"false"`` and log an error).
+    Pins the disable-via-config-false contract so a future refactor of
+    the ``BeforeValidator`` cannot silently re-introduce the bug where
+    the typed ``str`` field stored the literal string ``"false"`` and
+    the downstream URL filter never matched (leading the connector to
+    issue an HTTP GET for the URL ``"false"`` and log an error). Also
+    pins that we expose a plain ``str`` field to the JSON schema
+    generator - the previous ``str | Literal[False]`` union produced an
+    ``anyOf`` schema that the OpenCTI Manager / XTM Composer UI tags as
+    "Unsupported" and refuses to render.
     """
 
     class FakeConnectorSettings(ConnectorSettings):
@@ -211,37 +220,26 @@ def test_falsable_url_coercion(raw_value, expected):
     "raw_value",
     [
         # Real YAML boolean ``True`` is meaningless for a URL field
-        # ("enable the URL" is not a thing — either set a URL or
-        # leave the default) and would otherwise survive a plain
-        # ``str | bool`` typing all the way to
-        # ``urllib.request.urlopen(True)`` which raises ``TypeError``
-        # at runtime. The ``str | Literal[False]`` typing on
-        # ``FalsableUrl`` rejects it at validation time so the
-        # operator sees a clear ``ConfigValidationError`` at startup
-        # instead of a runtime crash on the first scheduled run.
+        # ("enable the URL" is not a thing - either set a URL or leave
+        # the default) and would otherwise survive any laxer typing all
+        # the way to ``urllib.request.urlopen(True)`` which raises
+        # ``TypeError`` at runtime. With the plain ``str`` typing on
+        # ``DatasetUrl`` Pydantic rejects ``True`` at validation time
+        # (``True`` is not a string, and the ``BeforeValidator`` only
+        # normalises ``False``), so the operator sees a clear
+        # ``ConfigValidationError`` at startup instead of a runtime
+        # crash on the first scheduled run.
         pytest.param(True, id="real_bool_true"),
-        # The string ``"true"`` does NOT pass through the
-        # ``_coerce_false`` coercion (it only knows ``"false"``), so
-        # it lands in the union as a plain string. Pydantic will
-        # accept it as a ``str`` candidate of the union — but the
-        # next pass through the URL field at runtime would fail to
-        # open it. Documenting the current behaviour here makes the
-        # contract explicit: ``"true"`` is treated as a (broken) URL
-        # string, not as the boolean ``True``. If the disable-only
-        # contract is ever extended to enable / disable both ways,
-        # this case has to flip to ``pytest.raises``.
-        pytest.param("true", id="literal_string_true_treated_as_url_string"),
     ],
 )
-def test_falsable_url_rejects_true(raw_value):
+def test_dataset_url_rejects_true(raw_value):
     """Real ``True`` is rejected at validation time.
 
-    Pins the ``str | Literal[False]`` typing on ``FalsableUrl`` so a
-    future refactor that relaxes the union back to ``str | bool``
-    cannot silently let ``True`` flow into the URL list and crash
-    the connector on the first run with a confusing
-    ``TypeError: cannot read object of type bool`` from inside
-    ``urllib.request.urlopen``.
+    Pins the ``DatasetUrl`` contract so a future refactor that swaps
+    the field back to a permissive ``str | bool`` (or drops the
+    ``BeforeValidator``) cannot silently let ``True`` flow into the
+    URL list and crash the connector on the first run with a confusing
+    ``TypeError`` from inside ``urllib.request.urlopen``.
     """
     from connectors_sdk import ConfigValidationError as _CVE
 
@@ -256,12 +254,58 @@ def test_falsable_url_rejects_true(raw_value):
                 }
             )
 
-    if raw_value is True:
-        with pytest.raises(_CVE, match="Error validating configuration"):
-            FakeConnectorSettings()
-    else:
-        # ``"true"`` lands as a plain string (no coercion path). The
-        # field accepts any string in the union, so validation passes
-        # and the value round-trips verbatim.
-        settings = FakeConnectorSettings()
-        assert settings.config.sectors_file_url == "true"
+    with pytest.raises(_CVE, match="Error validating configuration"):
+        FakeConnectorSettings()
+
+
+def test_dataset_url_literal_string_true_is_kept_as_url_string():
+    """``"true"`` (string) lands verbatim - the disable contract is one-way.
+
+    The ``BeforeValidator`` only normalises ``False`` / ``"false"`` so
+    the operator-friendly disable sentinel is unambiguous. ``"true"``
+    is not a disable sentinel and there is no ``"enable"`` semantics
+    on a URL field - it is treated as a (broken) URL string and round
+    trips verbatim. Documenting it here makes the contract explicit;
+    if the disable-only contract is ever extended both ways, flip this
+    case to ``pytest.raises``.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(
+                {
+                    "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                    "connector": {"id": "connector-id"},
+                    "config": {"sectors_file_url": "true"},
+                }
+            )
+
+    settings = FakeConnectorSettings()
+    assert settings.config.sectors_file_url == "true"
+
+
+def test_dataset_url_schema_is_plain_string():
+    """The dataset URL fields MUST expose ``{"type": "string"}`` in the JSON schema.
+
+    Pins the fix for the OpenCTI Manager / XTM Composer
+    "CONFIG_*_FILE_URL - Unsupported" regression: the previous
+    ``str | Literal[False]`` typing emitted an
+    ``anyOf: [{"type": "string"}, {"const": false, "type": "boolean"}]``
+    that those UIs reject. The contract we ship to the Manager
+    therefore MUST be a plain string type - the disable sentinel is
+    enforced at the Pydantic validator level, not the JSON Schema
+    level.
+    """
+    from connector.settings import OpenctiConfig
+
+    schema = OpenctiConfig.model_json_schema()
+    for field in ("sectors_file_url", "geography_file_url", "companies_file_url"):
+        field_schema = schema["properties"][field]
+        assert (
+            field_schema.get("type") == "string"
+        ), f"{field} must be a plain string in JSON Schema, got {field_schema!r}"
+        assert "anyOf" not in field_schema, (
+            f"{field} must NOT expose an anyOf schema (UI renders it as "
+            f"Unsupported), got {field_schema!r}"
+        )

--- a/external-import/opencti/tests/tests_connector/test_settings.py
+++ b/external-import/opencti/tests/tests_connector/test_settings.py
@@ -176,12 +176,16 @@ def test_settings_should_raise_when_invalid_input(settings_dict, expected_field)
         pytest.param("false", "", id="literal_string_false"),
         pytest.param("FALSE", "", id="uppercase_string_false"),
         pytest.param("  false  ", "", id="whitespace_string_false"),
-        # YAML ``null`` / a missing key (``sectors_file_url:`` with no
-        # value in ``config.yml``) surfaces as Python ``None`` after the
-        # YAML loader runs. Without normalisation Pydantic would reject
-        # ``None`` against the ``str`` field at validation time, which
-        # would block the connector from starting instead of honouring
-        # the README's "leave empty to disable" contract.
+        # Explicit YAML null value: key present with no value
+        # (``sectors_file_url:`` or ``sectors_file_url: null``) - both
+        # surface as Python ``None`` after the YAML loader runs and
+        # route into the validator. Without normalisation Pydantic
+        # would reject ``None`` against the ``str`` field at
+        # validation time, which would block the connector from
+        # starting instead of honouring the README's "leave empty to
+        # disable" contract. (Omitting the key entirely is a separate
+        # path that hits Pydantic's missing-key default and never
+        # reaches this validator.)
         pytest.param(None, "", id="real_none"),
         # The empty / whitespace-only strings are the operator-friendly
         # disable sentinels (UI input, env-var trimmed to nothing). All
@@ -211,7 +215,8 @@ def test_dataset_url_disable_sentinels_are_normalised(raw_value, expected):
     - typed ``str`` field stored the literal string ``"false"`` and the
       downstream URL filter never matched, so the connector issued an
       HTTP GET for the URL ``"false"`` and logged an error;
-    - YAML ``null`` (``sectors_file_url:`` with no value) raised a
+    - an explicit YAML null value (key present with no value -
+      ``sectors_file_url:`` or ``sectors_file_url: null``) raised a
       ``ConfigValidationError`` instead of honouring the README's
       "leave empty to disable" UX;
     - a whitespace-only string survived validation and crashed

--- a/external-import/opencti/tests/tests_connector/test_settings.py
+++ b/external-import/opencti/tests/tests_connector/test_settings.py
@@ -184,8 +184,11 @@ def test_settings_should_raise_when_invalid_input(settings_dict, expected_field)
         # validation time, which would block the connector from
         # starting instead of honouring the README's "leave empty to
         # disable" contract. (Omitting the key entirely is a separate
-        # path that hits Pydantic's missing-key default and never
-        # reaches this validator.)
+        # path: Pydantic substitutes the field's default URL, which
+        # also goes through this validator because ``BaseConfigModel``
+        # sets ``validate_default=True`` - but the default is a real
+        # URL string, not a disable sentinel, so it just passes
+        # through unchanged and the dataset stays enabled.)
         pytest.param(None, "", id="real_none"),
         # The empty / whitespace-only strings are the operator-friendly
         # disable sentinels (UI input, env-var trimmed to nothing). All


### PR DESCRIPTION
## Summary

Fixes #6532.

PR #5869 ported the OpenCTI Datasets connector to `connectors-sdk` / Pydantic and typed the three dataset URL fields as `FalsableUrl = Annotated[str | Literal[False], BeforeValidator(_coerce_false)]` to keep the documented "set to `false` to disable" UX. The resulting JSON Schema (`anyOf: [{"type": "string"}, {"const": false, "type": "boolean"}]`) is not understood by the OpenCTI Manager / XTM Composer renderer, so every URL field shows up as `CONFIG_*_FILE_URL - Unsupported` and the operator cannot edit or even read its value from the UI.

This PR switches the field typing to a plain `str` annotated with a `BeforeValidator` that normalises every documented disable shape onto the empty string `""`: real YAML `False`, env-var string `"false"` (any casing, surrounding whitespace), YAML `null` / a missing key (`sectors_file_url:` with no value, which PyYAML surfaces as Python `None`), the operator-friendly empty string, and any whitespace-only string. The downstream filter in `OpenCTI.__init__` switches from `url is not False` to a plain truthy check (`if url`), so disabled URLs are still dropped. Real `True` is still rejected at validation time (it is not a string and the `BeforeValidator` doesn't coerce it), so the previous safeguard against `urllib.request.urlopen(True)` runtime crashes is preserved. Real URL strings are passed through unchanged - the validator only strips for the disable check, never for the value the connector ultimately fetches.

The regenerated `__metadata__/connector_config_schema.json` and `__metadata__/CONNECTOR_CONFIG_DOC.md` now expose `{"type": "string"}` for `CONFIG_{SECTORS,GEOGRAPHY,COMPANIES}_FILE_URL`, unblocking the Manager UI. This pattern matches what every other URL-shaped connector field in the repo does (e.g. MITRE's `enterprise_file_url: str`).

### Changes

- `connector/settings.py`: drop `FalsableUrl` (the `str | Literal[False]` union). Introduce `DatasetUrl = Annotated[str, BeforeValidator(_normalize_dataset_url)]`; the validator maps every documented disable sentinel - real `False`, `"false"` / `"FALSE"` / `"  false  "`, Python `None` (YAML `null` / missing key), the empty string, and any whitespace-only string - to `""` (the sentinel the connector treats as "disabled").
- `connector/connector.py`: replace the `url is not False` filter with a plain truthy check (`if url`); the validator does the heavy lifting upstream so the filter only has to drop empty strings.
- `tests/tests_connector/test_settings.py`: replace the `test_falsable_url_*` cases with `test_dataset_url_*` cases that pin the full contract - every disable sentinel (`False`, `"false"` in any casing, `None`, `""`, `"   "`, `"\t\n  "`) normalises to `""`, real `True` is rejected, `"true"` round-trips verbatim, and `OpenctiConfig.model_json_schema()` MUST emit `{"type": "string"}` (no `anyOf`) so the Manager UI keeps rendering the field after future refactors.
- `__metadata__/connector_config_schema.json` & `__metadata__/CONNECTOR_CONFIG_DOC.md`: regenerated from the new model.
- `README.md`: clarify the disable sentinel - both `false` and empty are accepted.

### Why preserve the `false` disable contract instead of dropping it?

The "set the URL to `false` to skip" UX is documented in the README and `config.yml.sample` since the connector exists; the pre-#5869 implementation backed it with `pycti.get_config_variable`'s automatic `"false"` -> `bool` coercion + a `lambda url: url is not False` filter. Dropping it would break every existing deployment that disables a dataset. The fix keeps the contract end-to-end and just routes it through a string-typed field so the Manager UI renders, while also formalising the additional disable shapes (YAML `null`, empty / whitespace-only string) the README already advertises as "leave empty to disable".

## Test plan

- [x] `pytest external-import/opencti/tests/` (20 passed - includes parametrised cases for every disable sentinel: real `False`, `"false"` in any casing, `None`, `""`, `"   "`, `"\t\n  "`; plus `True` rejection, `"true"` round-trip, and the JSON Schema shape).
- [x] `black --check` / `isort --profile black --check` / `flake8` on the touched files.
- [x] Regenerated `__metadata__/connector_config_schema.json` via the repository's schema generator (`shared/tools/composer/generate_connectors_config_schemas/generate_connector_config_json_schema.py.sample`) - the three URL fields are now plain `{"type": "string"}`.
- [x] Regenerated `__metadata__/CONNECTOR_CONFIG_DOC.md` via the matching doc generator - Possible Values column now reads `string` (was `False and/or string`).
- [ ] Manual: open the Manager / XTM Composer "Add connector -> OpenCTI Datasets" flow and confirm the three `CONFIG_*_FILE_URL` fields now render as editable string inputs with their default URLs prefilled.
