### PR TITLE
[Repository] Make Codecov patch coverage blocking (#6534)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,3 +15,4 @@ coverage:
     patch:
       default:
         target: 80%
+        informational: false


### PR DESCRIPTION
Fixes #6534

This PR makes patch coverage status explicitly blocking by setting:
- `coverage.status.patch.default.informational: false`

Reference validation case: https://github.com/OpenCTI-Platform/connectors/pull/6529
