### PR TITLE
[tenable-vuln-management]: Fix crash when DomainName creation has a non-compliant value

### DIFF
--- a/external-import/tenable-vuln-management/src/tenable_vuln_management/converter_to_stix.py
+++ b/external-import/tenable-vuln-management/src/tenable_vuln_management/converter_to_stix.py
@@ -252,11 +252,10 @@ class ConverterToStix:
             asset (Asset): The asset containing the fully qualified domain name (FQDN).
 
         Returns:
-            DomainName | None: A DomainName object for the asset if an FQDN is available, otherwise None.
+            DomainName | None: A DomainName object for the asset if a valid FQDN is available, otherwise None.
         """
-
-        return (
-            DomainName(
+        if asset.fqdn and validators.domain(asset.fqdn):
+            return DomainName(
                 author=self.author,
                 object_marking_refs=self.object_marking_refs,
                 value=asset.fqdn,
@@ -264,9 +263,12 @@ class ConverterToStix:
                 resolves_to_ips=[self._make_ipv4_address(asset)]
                 + ([self._make_ipv6_address(asset)] if asset.ipv6 is not None else []),
             )
-            if asset.fqdn and validators.domain(asset.fqdn)
-            else None
-        )
+        else:
+            self.helper.connector_logger.warning(
+                "fqdn empty or non-RFC-compliant. It will be ignored.",
+                {"fqdn_value": asset.fqdn},
+            )
+            return None
 
     def process_asset(self, asset: Asset) -> dict[str, Any]:
         system = self._make_system(asset=asset)

--- a/external-import/tenable-vuln-management/src/tenable_vuln_management/converter_to_stix.py
+++ b/external-import/tenable-vuln-management/src/tenable_vuln_management/converter_to_stix.py
@@ -6,6 +6,7 @@ import re
 from typing import TYPE_CHECKING, Any, Literal
 
 import stix2
+import validators
 
 from .config_variables import ConfigConnector
 from .models.opencti import (
@@ -263,7 +264,7 @@ class ConverterToStix:
                 resolves_to_ips=[self._make_ipv4_address(asset)]
                 + ([self._make_ipv6_address(asset)] if asset.ipv6 is not None else []),
             )
-            if asset.fqdn
+            if asset.fqdn and validators.domain(asset.fqdn)
             else None
         )
 

--- a/external-import/tenable-vuln-management/tests/test_converter_to_stix.py
+++ b/external-import/tenable-vuln-management/tests/test_converter_to_stix.py
@@ -13,6 +13,7 @@ from tenable_vuln_management.converter_to_stix import (
     tlp_marking_definition_handler,
 )
 from tenable_vuln_management.models.opencti import (
+    DomainName,
     HasRelationship,
     System,
     Vulnerability,
@@ -395,26 +396,41 @@ def test_converter_to_stix_make_operating_systems(mock_helper, mock_config, fake
     assert operating_systems[0].name == "Microsoft Windows Server 2016 Standard"
 
 
-def test_converter_to_stix_make_domain_name(mock_helper, mock_config, fake_asset):
+@pytest.mark.parametrize(
+    "domain_value, is_domain_name_created, expected_value",
+    [
+        (
+            "sharepoint2016.target.example.com",
+            True,
+            "sharepoint2016.target.example.com",
+        ),
+        (None, False, None),
+        ("test..com", False, None),
+        ("test_domain.com", False, None),
+    ],
+)
+def test_converter_to_stix_make_domain_name(
+    mock_helper,
+    mock_config,
+    fake_asset,
+    domain_value,
+    is_domain_name_created,
+    expected_value,
+):
     # Given a converter to stix instance
     converter_to_stix = ConverterToStix(
         helper=mock_helper, config=mock_config, default_marking="TLP:CLEAR"
     )
 
-    # Case 1: Asset with a valid FQDN
-    asset_with_fqdn = fake_asset
-    domain_name = converter_to_stix._make_domain_name(asset_with_fqdn)
+    # When calling _make_domain_name
+    asset_without_fqdn = fake_asset.model_copy(update={"fqdn": domain_value})
+    domain_name = converter_to_stix._make_domain_name(asset_without_fqdn)
 
-    # Then it should return a valid DomainName object
-    assert domain_name.value == "sharepoint2016.target.example.com"
-    assert len(domain_name.resolves_to_ips) == 2
-
-    # Case 2: Asset without an FQDN
-    asset_without_fqdn = fake_asset.model_copy(update={"fqdn": None})
-    domain_name_none = converter_to_stix._make_domain_name(asset_without_fqdn)
-
-    # Then it should return None
-    assert domain_name_none is None
+    # Then it should return a valid DomainName object or None
+    assert isinstance(domain_name, DomainName) == is_domain_name_created
+    if domain_name:
+        assert domain_name.value == expected_value
+        assert len(domain_name.resolves_to_ips) == 2
 
 
 def test_converter_to_stix_make_targeted_software_s(


### PR DESCRIPTION
### Proposed changes

*  Skip the DomainName object creation if the value is non-RFC-compliant FQDNs with a warning message

### Related issues

* Close #6325

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
