### PR TITLE
[email-intel-imap] use plain text body when HTML is not available

### DIFF
--- a/external-import/email-intel-imap/src/email_intel_imap/converter.py
+++ b/external-import/email-intel-imap/src/email_intel_imap/converter.py
@@ -64,7 +64,7 @@ class ConnectorConverter(BaseConverter):
                 name=name,
                 published=entity.date,
                 report_types=[REPORT_TYPE_THREAT_REPORT],
-                x_opencti_content=entity.html,
+                x_opencti_content=entity.html or entity.text,
                 x_opencti_files=[
                     OpenCTIFile(
                         name=attachment.filename,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

When receiving plain text emails (no HTML part), the `content` field of the
created Report was empty because `converter.py` only referenced `entity.html`.

This fix falls back to `entity.text` when `entity.html` is empty, ensuring
plain text emails are correctly ingested into OpenCTI Reports.

```python
# Before
x_opencti_content=entity.html,

# After
x_opencti_content=entity.html or entity.text,
```

### Related issues

Fixes #6548

### Checklist

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The `email-intel-microsoft` connector does not have this issue because it uses
Microsoft Graph API's `body.content`, which returns content regardless of
whether the email is HTML or plain text.

The `imap-tools` library used by this connector returns:
- `entity.html` → empty string (`""`) for plain text emails
- `entity.text` → contains the plain text body