### PR TITLE
[TAXII POST] Fix incorrect Content-Type header

### DIFF
--- a/stream/taxii-post/src/taxii_post_connector/__init__.py
+++ b/stream/taxii-post/src/taxii_post_connector/__init__.py
@@ -1,3 +1,7 @@
-from .connector import TaxiiPostConnector
+from taxii_post_connector.connector import TaxiiPostConnector
+from taxii_post_connector.settings import ConnectorSettings
 
-__all__ = ["TaxiiPostConnector"]
+__all__ = [
+    "TaxiiPostConnector",
+    "ConnectorSettings",
+]

--- a/stream/taxii-post/src/taxii_post_connector/connector.py
+++ b/stream/taxii-post/src/taxii_post_connector/connector.py
@@ -21,11 +21,18 @@ def parse_version(version) -> Tuple[int, int, int]:
     return nums[0], nums[1], nums[2]
 
 
-def media_type_by_version(version: str) -> str:
+def accept_header_by_taxii_version(version: str) -> str:
     if parse_version(version) >= (2, 1, 0):
         return f"application/taxii+json; version={version}"
     else:
         return f"application/vnd.oasis.taxii+json; version={version}"
+
+
+def content_type_by_stix_version(version: str) -> str:
+    if parse_version(version) >= (2, 1, 0):
+        return f"application/stix+json; version={version}"
+    else:
+        return f"application/vnd.oasis.stix+json; version={version}"
 
 
 class TaxiiPostConnector:
@@ -59,8 +66,8 @@ class TaxiiPostConnector:
             + "/objects/"
         )
         headers = {
-            "Content-Type": media_type_by_version(self.config.stix_version),
-            "Accept": media_type_by_version(self.config.version),
+            "Content-Type": content_type_by_stix_version(self.config.stix_version),
+            "Accept": accept_header_by_taxii_version(self.config.version),
         }
         try:
             data_object = data

--- a/stream/taxii-post/tests/test_connector.py
+++ b/stream/taxii-post/tests/test_connector.py
@@ -1,0 +1,41 @@
+import pytest
+from taxii_post_connector.connector import (
+    accept_header_by_taxii_version,
+    content_type_by_stix_version,
+)
+
+# --------------------------
+# --- Scenario Functions ---
+# --------------------------
+
+
+# Scenario: If accept header is correct depending on taxii version
+@pytest.mark.parametrize(
+    "taxii_version, expected_result",
+    [
+        ("2.0.0", "application/vnd.oasis.taxii+json; version=2.0.0"),
+        ("2.1.0", "application/taxii+json; version=2.1.0"),
+        ("2.2.0", "application/taxii+json; version=2.2.0"),
+    ],
+)
+def test_accept_header_by_taxii_version(taxii_version, expected_result):
+    # When we call accept_header_by_taxii_version function
+    result = accept_header_by_taxii_version(taxii_version)
+    # Then the custom properties are correctly formatted
+    assert result == expected_result
+
+
+# Scenario: If content type is correct depending on stix version
+@pytest.mark.parametrize(
+    "stix_version, expected_result",
+    [
+        ("2.0.0", "application/vnd.oasis.stix+json; version=2.0.0"),
+        ("2.1.0", "application/stix+json; version=2.1.0"),
+        ("2.2.0", "application/stix+json; version=2.2.0"),
+    ],
+)
+def test_content_type_by_stix_version(stix_version, expected_result):
+    # When we call content_type_by_stix_version function
+    result = content_type_by_stix_version(stix_version)
+    # Then the custom properties are correctly formatted
+    assert result == expected_result

--- a/stream/taxii-post/tests/test_main.py
+++ b/stream/taxii-post/tests/test_main.py
@@ -1,0 +1,111 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pycti import OpenCTIConnectorHelper
+from taxii_post_connector import ConnectorSettings, TaxiiPostConnector
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+    It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "live_stream_id": "live",
+                    "live_stream_listen_delete": True,
+                    "live_stream_no_dependencies": True,
+                },
+                "taxii": {
+                    "url": "http://test.com",
+                    "ssl_verify": True,
+                    "api_root": "root",
+                    "collection_id": "collection-id",
+                    "token": "test token",
+                    "login": "test login",
+                    "password": "test password",
+                    "version": "2.1",
+                    "stix_version": "2.1",
+                    "delete_created_by_ref": True,
+                    "delete_marking_definition": True,
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that the implementation of `BaseConnectorSettings` (from `connectors-sdk`) can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from `BaseConnectorSettings`)
+        - the method `to_helper_config` MUST return a dict (as in base class)
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that `OpenCTIConnectorHelper` (from `pycti`) can be instantiated successfully:
+        - the value of `settings.to_helper_config` MUST be the expected dict for `OpenCTIConnectorHelper`
+        - the helper MUST be able to get its instance's attributes from the config dict
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "Test Connector"
+    assert helper.connect_scope == "test,connector"
+    assert helper.log_level == "ERROR"
+    assert helper.connect_live_stream_id == "live"
+    assert helper.connect_live_stream_listen_delete
+    assert helper.connect_live_stream_no_dependencies
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST be able to access env/config vars through `self.config`
+        - the connector's main class MUST be able to access `pycti` API through `self.helper`
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    connector = TaxiiPostConnector(config=settings, helper=helper)
+
+    assert connector.config == settings.taxii
+    assert connector.helper == helper


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Create a separate function for content type that returns application/vnd.oasis.stix+json; version={version} for versions < 2.1

### Related issues

* Close #6428

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
