### PR TITLE
[crowdstrike] Snort parser fails on single-line rules missing trailing newline

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_services/utils/snort_parser.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_services/utils/snort_parser.py
@@ -72,7 +72,9 @@ class SnortParser:
             if rule_buffer is not None:
                 rule_buffer.write(line)
 
-            if rule_buffer is not None and line.endswith(cls._RULE_ENDS):
+            if rule_buffer is not None and (
+                line.endswith(cls._RULE_ENDS) or line.rstrip("\n").endswith(";)")
+            ):
                 rule = rule_buffer.getvalue()
                 result.append(rule)
 

--- a/external-import/crowdstrike/src/crowdstrike_feeds_services/utils/snort_parser.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_services/utils/snort_parser.py
@@ -27,7 +27,6 @@ class SnortParser:
     """Snort rules parser."""
 
     _RULE_STARTS: tuple[str] = ("alert",)
-    _RULE_ENDS = (";)\n",)
 
     _NAME_PATTERN = r"msg: \".*\[(CS[A-Z]+-\d+)\]\";"
     _NAME_REGEX = re.compile(_NAME_PATTERN, re.MULTILINE)
@@ -72,9 +71,7 @@ class SnortParser:
             if rule_buffer is not None:
                 rule_buffer.write(line)
 
-            if rule_buffer is not None and (
-                line.endswith(cls._RULE_ENDS) or line.rstrip("\n").endswith(";)")
-            ):
+            if rule_buffer is not None and line.rstrip("\n").endswith(";)"):
                 rule = rule_buffer.getvalue()
                 result.append(rule)
 

--- a/external-import/crowdstrike/tests/test_snort_parser_trailing_newline.py
+++ b/external-import/crowdstrike/tests/test_snort_parser_trailing_newline.py
@@ -1,0 +1,62 @@
+"""Tests for Snort parser handling of rules without trailing newline (issue #6427)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from crowdstrike_feeds_services.utils.snort_parser import SnortParser
+
+SINGLE_RULE = (
+    "alert tcp $HOME_NET any -> $EXTERNAL_NET $HTTP_PORTS "
+    '(msg: "Malware CrowdStrike MALWARE_NAME Outbound [CSIT-00001]"; '
+    'content:"evil"; rev:20250528; sid:1000001;)'
+)
+
+
+class TestSplitSnortRulesTrailingNewline:
+    """Test _split_snort_rules with and without trailing newline."""
+
+    def test_rule_with_trailing_newline(self):
+        """Rule ending with newline should be parsed (existing behavior)."""
+        rules_str = SINGLE_RULE + "\n"
+        result = SnortParser._split_snort_rules(rules_str)
+        assert len(result) == 1
+
+    def test_rule_without_trailing_newline(self):
+        """Rule without trailing newline should still be parsed (bug #6427)."""
+        result = SnortParser._split_snort_rules(SINGLE_RULE)
+        assert len(result) == 1, "Rule without trailing newline was dropped — bug #6427"
+
+    def test_two_rules_last_without_newline(self):
+        """Two rules where the last has no trailing newline."""
+        rules_str = SINGLE_RULE + "\n" + SINGLE_RULE
+        result = SnortParser._split_snort_rules(rules_str)
+        assert (
+            len(result) == 2
+        ), "Last rule without trailing newline was dropped — bug #6427"
+
+    def test_multiple_rules_all_with_newline(self):
+        """Multiple rules all ending with newline."""
+        rules_str = (SINGLE_RULE + "\n") * 3
+        result = SnortParser._split_snort_rules(rules_str)
+        assert len(result) == 3
+
+
+class TestSnortParserFullParse:
+    """Test full parse of Snort rules without trailing newline."""
+
+    def test_parse_single_rule_no_trailing_newline(self):
+        """Full parse should work without trailing newline."""
+        result = SnortParser.parse(SINGLE_RULE)
+        assert (
+            len(result) == 1
+        ), "Full parse lost rule without trailing newline — bug #6427"
+        assert "CSIT-00001" in result[0].name
+        assert "MALWARE_NAME" in result[0].description
+
+    def test_parse_single_rule_with_trailing_newline(self):
+        """Full parse with trailing newline (baseline)."""
+        result = SnortParser.parse(SINGLE_RULE + "\n")
+        assert len(result) == 1
+        assert "CSIT-00001" in result[0].name


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Handle snort rule without trailing new lines
* Add tests

### Related issues

* Closes: #6427 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments
I didn't manage to reproduce the issue from crowdstrike data.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
