### PR TITLE
[CI] Add --pull flag to docker buildx build commands

### DIFF
--- a/.circleci/templates/dynamic.yml.j2
+++ b/.circleci/templates/dynamic.yml.j2
@@ -54,7 +54,7 @@ jobs:
             find . -name pyproject.toml -exec sed "s|connectors-sdk.*$|connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@$RELEASE_REF#subdirectory=connectors-sdk\",|" -i {} \;
                 {% endif %}
             {% endif -%}
-            docker buildx build . \
+            docker buildx build --pull . \
              {% for tag in tags -%}
              --tag {{repo}}/connector-{{sub_dir}}:{{tag}} \
              --tag ghcr.io/opencti-platform/{{repo}}/connector-{{sub_dir}}:{{tag}} \
@@ -63,7 +63,7 @@ jobs:
              --push
 
             {% if param['images'][image_key] is defined and param['images'][image_key]['fips'] == true -%}
-            docker buildx build -f Dockerfile_fips . \
+            docker buildx build --pull -f Dockerfile_fips . \
              {% for tag in tags -%}
              --tag {{repo}}/connector-{{sub_dir}}:{{tag}}-fips \
              --tag ghcr.io/opencti-platform/{{repo}}/connector-{{sub_dir}}:{{tag}}-fips \

--- a/build_ubi9.sh
+++ b/build_ubi9.sh
@@ -55,7 +55,7 @@ else
     RUNTIME=docker
 fi
 
-${RUNTIME} build "$@"
+${RUNTIME} build --pull "$@"
 
 if [ "${PUSH}" = true ]; then
     echo "Pushing ${IMAGE}..."


### PR DESCRIPTION
### Proposed changes

* Add `--pull` flag to `docker buildx build` commands in the CircleCI dynamic template to ensure base images are always pulled fresh during builds
* Apply the flag to both standard and FIPS Dockerfile builds for consistency

### Related issues

* Closes #6546

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The `--pull` flag instructs Docker to always attempt to pull the latest version of base images referenced in `FROM` directives before building. Without it, Docker may use a stale cached base image, which can lead to builds missing critical security patches or dependency updates. This aligns with the approach already used in the OpenCTI platform CI pipeline.