### PR TITLE
[polyswarm-enrichment] skip polykg lookups when POLYKG_API_URL is unset

### DIFF
--- a/internal-enrichment/polyswarm-enrichment/src/polyswarm_enrichment/client_api.py
+++ b/internal-enrichment/polyswarm-enrichment/src/polyswarm_enrichment/client_api.py
@@ -143,10 +143,20 @@ class ConnectorClient:
         self._polykg_url = config.polykg_api_url
         if self._polykg_url:
             self._polykg_url = self._polykg_url.rstrip("/")
+        # polykg enrichment is opt-in: a blank POLYKG_API_URL disables every
+        # profile / attack-pattern lookup. Guard on this flag rather than
+        # building a schemeless "/v3/kg/..." URL, which raises MissingSchema.
+        self._polykg_enabled = bool(self._polykg_url)
         self._circuit_breakers["polykg"] = CircuitBreaker(
             failure_threshold=1, cooldown_seconds=300
         )
-        self._check_polykg_connectivity()
+        if self._polykg_enabled:
+            self._check_polykg_connectivity()
+        else:
+            self.helper.log_info(
+                "[CLIENT] polykg enrichment disabled (POLYKG_API_URL not set); "
+                "skipping malware-profile and attack-pattern lookups"
+            )
 
     def _validate_api_access(self) -> None:
         """Verify API key and community access. Raises on auth failure."""
@@ -757,6 +767,8 @@ class ConnectorClient:
 
         Returns the profile dict or None if not found / unreachable.
         """
+        if not self._polykg_enabled:
+            return None
         if not family_name:
             return None
 
@@ -799,6 +811,8 @@ class ConnectorClient:
 
     def has_profiles(self) -> bool:
         """Check if the polykg profile endpoint is reachable."""
+        if not self._polykg_enabled:
+            return False
         try:
             resp = requests.get(
                 f"{self._polykg_url}/v3/kg/profile",
@@ -815,6 +829,8 @@ class ConnectorClient:
         Returns dict with 'techniques' and 'type_mappings' keys,
         or None if polykg is unreachable.
         """
+        if not self._polykg_enabled:
+            return None
         circuit = self._circuit_breakers["polykg"]
         can_execute, reason = circuit.can_execute()
         if not can_execute:

--- a/internal-enrichment/polyswarm-enrichment/tests/test_polykg_disabled.py
+++ b/internal-enrichment/polyswarm-enrichment/tests/test_polykg_disabled.py
@@ -1,0 +1,76 @@
+"""Regression tests for polykg enrichment disabled via blank POLYKG_API_URL.
+
+Guards the bug where a blank ``POLYKG_API_URL`` still built a schemeless
+``/v3/kg/profile`` URL and raised ``requests.exceptions.MissingSchema`` on
+every malware-family lookup (logged as an ERROR per family). Disabled mode
+must be silent: no HTTP attempt, no error, clean None/False returns.
+"""
+
+import polyswarm_enrichment.client_api as client_api
+import pytest
+from conftest import StubConfig, StubHelper
+from polyswarm_enrichment.client_api import ConnectorClient
+
+
+@pytest.fixture()
+def no_kg_config():
+    """StubConfig with polykg disabled (blank URL), like a default deployment."""
+    cfg = StubConfig()
+    cfg.polykg_api_url = ""
+    return cfg
+
+
+@pytest.fixture()
+def kg_call_spy(monkeypatch):
+    """Record any HTTP call client_api attempts; fail loud if polykg is hit."""
+    calls = []
+
+    def _record(method):
+        def _spy(url, **kwargs):
+            calls.append((method, url))
+            raise AssertionError(
+                f"polykg disabled but client attempted {method.upper()} {url!r}"
+            )
+
+        return _spy
+
+    monkeypatch.setattr(client_api.requests, "get", _record("get"))
+    monkeypatch.setattr(client_api.requests, "post", _record("post"))
+    return calls
+
+
+class TestPolykgDisabled:
+    def test_init_makes_no_kg_call(self, no_kg_config, kg_call_spy):
+        # Construction must not run the connectivity probe when disabled.
+        ConnectorClient(StubHelper(), no_kg_config)
+        assert kg_call_spy == []
+
+    def test_disabled_flag_set(self, no_kg_config, kg_call_spy):
+        client = ConnectorClient(StubHelper(), no_kg_config)
+        assert client._polykg_enabled is False
+
+    def test_get_profile_returns_none_without_call(self, no_kg_config, kg_call_spy):
+        client = ConnectorClient(StubHelper(), no_kg_config)
+        assert client.get_profile("FunkSec") is None
+        assert kg_call_spy == []
+
+    def test_has_profiles_returns_false_without_call(self, no_kg_config, kg_call_spy):
+        client = ConnectorClient(StubHelper(), no_kg_config)
+        assert client.has_profiles() is False
+        assert kg_call_spy == []
+
+    def test_fetch_attack_patterns_returns_none_without_call(
+        self, no_kg_config, kg_call_spy
+    ):
+        client = ConnectorClient(StubHelper(), no_kg_config)
+        assert client.fetch_attack_patterns() is None
+        assert kg_call_spy == []
+
+
+class TestPolykgEnabledStillWorks:
+    """Sanity check the guard does not break the normal (URL set) path."""
+
+    def test_enabled_flag_true(self, stub_config, mock_polykg):
+        client = ConnectorClient(StubHelper(), stub_config)
+        assert client._polykg_enabled is True
+        assert client.has_profiles() is True


### PR DESCRIPTION
Closes #6576

## Summary
PolyKG enrichment is opt-in and disabled by default (blank POLYKG_API_URL). When
unset, the client still built a schemeless "/v3/kg/profile" URL, raising
requests.exceptions.MissingSchema. It was caught (no crash) but produced a spurious
startup warning, an error log on every malware-family lookup, and a wasted HTTP
attempt each time.

This guards the four polykg call sites on a flag derived from the configured URL.
Disabled mode now logs one info line at startup and makes zero polykg calls.

## Tests
- Adds a regression test covering both the disabled contract (no HTTP attempt, clean
  None/False returns) and the enabled path
- Full enrichment suite green
