### PR TITLE
fix(export-file-csv): align hashes_MD5 header with row-processing prefix check

### DIFF
--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -35,7 +35,7 @@ class ExportFileCsv:
         headers = sorted(set().union(*(d.keys() for d in data)))
         if "hashes" in headers:
             headers = headers + [
-                "hashes.MD5",
+                "hashes_MD5",
                 "hashes_SHA-1",
                 "hashes_SHA-256",
                 "hashes_SHA-512",


### PR DESCRIPTION
### Proposed changes

* Align the synthesized `hashes_MD5` column header with the `startswith("hashes_")` prefix check used by the row builder, so the MD5 column is populated instead of always-empty.

### Related issues

* (No tracking issue filed; surfaced while reading the same file for #6574 / #6128.)

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

In `internal-export-file/export-file-csv/src/export-file-csv.py`, line 38 reads `"hashes.MD5"` while the other four synthesized hash columns (`hashes_SHA-1`, `hashes_SHA-256`, `hashes_SHA-512`, `hashes_SSDEEP`) use an underscore. The row-processing branch at line 49 is gated on `if h.startswith("hashes_") and "hashes" in d:`, so the dot header never matches that branch, falls through to `elif h not in d:` at line 57, and is exported as `""`.

In practice: every CSV export of a file observable today has an `hashes.MD5` column that is always empty, even when `d["hashes"]` contains an `MD5` entry.

Minimal repro mirroring the relevant header + row logic:

```
sample = [{"id": "file--1", "hashes": [
    {"algorithm": "MD5",   "hash": "d41d8cd98f00b204e9800998ecf8427e"},
    {"algorithm": "SHA-1", "hash": "da39a3ee5e6b4b0d3255bfef95601890afd80709"},
]}]
```

Before (current `master`):
```
"hashes";"id";"hashes.MD5";"hashes_SHA-1";"hashes_SHA-256"
"[{...MD5..., ...SHA-1...}]";"file--1";"";"da39...";""
```

After (this PR):
```
"hashes";"id";"hashes_MD5";"hashes_SHA-1";"hashes_SHA-256"
"[{...MD5..., ...SHA-1...}]";"file--1";"d41d8cd98f00b204e9800998ecf8427e";"da39...";""
```

The ODS export connector uses dot notation throughout (its `lib/headers.py` strips the `hashes.` prefix in its own row builder), but that's a separate connector with its own convention. This PR only aligns the CSV connector internally — five sibling header entries that should all share the same prefix.

Docs checkbox left unchecked because the CSV connector's README does not enumerate column names; only the ODS connector's README documents column names (which already use the dot convention and are unaffected).

No new test file added: there is currently no `tests/` directory under `internal-export-file/export-file-csv/`, so adding a single regression test would be net-new test infrastructure. Happy to bootstrap that in a follow-up PR if it would be useful.
