### PR TITLE
[google-secops-siem-incidents] Create file observables even when only a hash is available

### DIFF
--- a/external-import/google-secops-siem-incidents/src/google_secops_siem_incidents/mappers/file_mapper.py
+++ b/external-import/google-secops-siem-incidents/src/google_secops_siem_incidents/mappers/file_mapper.py
@@ -1,5 +1,6 @@
 """Map alert outcomes to File observables."""
 
+from itertools import zip_longest
 from typing import Any
 
 from connectors_sdk.models import File
@@ -49,16 +50,15 @@ def map_files(
         path_outcomes = find_all_outcomes(outcomes, path_name)
         sha256_outcomes = find_all_outcomes(outcomes, sha256_name)
 
-        for i, path_outcome in enumerate(path_outcomes):
-            if not path_outcome.string_val:
+        for path_outcome, sha256_outcome in zip_longest(path_outcomes, sha256_outcomes):
+            path = path_outcome.string_val if path_outcome is not None else None
+            name = _basename(path) if path else None
+
+            sha256 = sha256_outcome.string_val if sha256_outcome is not None else None
+            hashes = {HashAlgorithm.SHA256: sha256} if sha256 else None
+
+            if name is None and hashes is None:
                 continue
-
-            path = path_outcome.string_val
-            name = _basename(path)
-
-            hashes = None
-            if i < len(sha256_outcomes) and sha256_outcomes[i].string_val:
-                hashes = {HashAlgorithm.SHA256: sha256_outcomes[i].string_val}
 
             result.append(
                 File(

--- a/external-import/google-secops-siem-incidents/tests/tests_converter_stix/mappers/test_file_mapper.py
+++ b/external-import/google-secops-siem-incidents/tests/tests_converter_stix/mappers/test_file_mapper.py
@@ -104,6 +104,36 @@ class TestFileMapper:
         assert result[0].name == "curl"
         assert result[0].hashes is None
 
+    def test_then_hash_only_creates_file_without_name(self):
+        """Given principal sha256 but no path → File(name=None, hashes={SHA256: ...})."""
+        # _given_
+        outcomes = make_file_outcomes(
+            principal_sha256=_SHA256_A,
+        )
+
+        # _when_
+        result = _when_map_files(outcomes)
+
+        # _then_
+        assert len(result) == 1
+        assert result[0].name is None
+        assert result[0].hashes == {HashAlgorithm.SHA256: _SHA256_A}
+
+    def test_then_target_hash_only_creates_file_without_name(self):
+        """Given target sha256 but no path → File(name=None, hashes={SHA256: ...})."""
+        # _given_
+        outcomes = make_file_outcomes(
+            target_sha256=_SHA256_B,
+        )
+
+        # _when_
+        result = _when_map_files(outcomes)
+
+        # _then_
+        assert len(result) == 1
+        assert result[0].name is None
+        assert result[0].hashes == {HashAlgorithm.SHA256: _SHA256_B}
+
     def test_then_all_file_outcomes_empty_returns_empty(self):
         """Given all file outcomes empty → returns []."""
         # _given_
@@ -114,6 +144,22 @@ class TestFileMapper:
 
         # _then_
         assert result == []
+
+    def test_then_empty_sha256_treated_as_absent(self):
+        """Given path present but sha256 is empty string → File(name=..., hashes=None)."""
+        # _given_
+        outcomes = make_file_outcomes(
+            principal_path="/usr/bin/curl",
+            principal_sha256="",
+        )
+
+        # _when_
+        result = _when_map_files(outcomes)
+
+        # _then_
+        assert len(result) == 1
+        assert result[0].name == "curl"
+        assert result[0].hashes is None
 
     def test_then_empty_outcomes_list_returns_empty(self):
         """Trap guard: Given all file outcomes empty → returns []."""


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* feat: Create file observables even when only a hash is available

### Related issues

* closes #5406

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
