### PR TITLE
[SigmaHQ] Fix asset matching to use current release filename format

### DIFF
--- a/external-import/sigmahq/src/connector/connector.py
+++ b/external-import/sigmahq/src/connector/connector.py
@@ -57,21 +57,16 @@ class SigmaHQConnector:
         # download or zip extraction fails; iterating over the empty default
         # is safe and lets the connector log a graceful "nothing to do" run.
         rules: list[dict[str, str]] = []
-        # SigmaHQ release assets are named ``<rule_package>_<date>.zip``
-        # (e.g. ``sigma_core_20251119.zip`` / ``sigma_core+_20251119.zip`` /
-        # ``sigma_core++_20251119.zip``). A naive ``rule_package in
-        # asset["name"]`` substring match would let ``sigma_core`` also
-        # match ``sigma_core+`` and ``sigma_core++`` assets, and (without
-        # ``break``) the loop would have overwritten ``rules`` with the
-        # *last* matching asset on every iteration — silently downloading
-        # the wrong package whenever GitHub returns the assets in a
-        # different order. Match on the canonical ``<rule_package>_``
-        # prefix so the three overlapping ``sigma_core`` variants are
-        # disambiguated, and ``break`` on first match so the result is
-        # deterministic regardless of asset ordering.
-        asset_prefix = f"{rule_package}_"
+        # SigmaHQ release assets are named ``<rule_package>.zip``
+        # (e.g. ``sigma_core.zip`` / ``sigma_core+.zip`` /
+        # ``sigma_core++.zip``). A naive ``rule_package in asset["name"]``
+        # substring match would let ``sigma_core`` also match ``sigma_core+``
+        # and ``sigma_core++`` assets. Matching on the full filename
+        # ``<rule_package>.zip`` disambiguates the three variants; ``break``
+        # on first match keeps the result deterministic regardless of the
+        # order in which GitHub returns the assets.
         for asset in release_metadata["assets"]:
-            if asset["name"].startswith(asset_prefix):
+            if asset["name"] == f"{rule_package}.zip":
                 rules = (
                     self.client.download_and_convert_package(
                         asset["browser_download_url"]

--- a/external-import/sigmahq/tests/test_asset_matching.py
+++ b/external-import/sigmahq/tests/test_asset_matching.py
@@ -1,11 +1,11 @@
 """Regression tests for the rule-package asset selector.
 
-SigmaHQ release assets are named ``<rule_package>_<date>.zip`` and the
+SigmaHQ release assets are named ``<rule_package>.zip`` and the
 three ``sigma_core`` variants overlap by prefix:
 
-    sigma_core_<date>.zip
-    sigma_core+_<date>.zip
-    sigma_core++_<date>.zip
+    sigma_core.zip
+    sigma_core+.zip
+    sigma_core++.zip
 
 A naive ``rule_package in asset["name"]`` substring match would let
 ``sigma_core`` also match the ``+`` / ``++`` variants (and, without
@@ -43,7 +43,7 @@ def _make_connector(monkeypatch=None) -> SigmaHQConnector:
 def _release(*asset_names: str) -> dict:
     """Build a fake GitHub release-metadata payload."""
     return {
-        "tag": "v20251119",
+        "tag": "r2026-04-01",
         "assets": [
             {
                 "name": name,
@@ -57,24 +57,24 @@ def _release(*asset_names: str) -> dict:
 @pytest.mark.parametrize(
     ("rule_package", "expected_asset"),
     [
-        ("sigma_core", "sigma_core_20251119.zip"),
-        ("sigma_core+", "sigma_core+_20251119.zip"),
-        ("sigma_core++", "sigma_core++_20251119.zip"),
-        ("sigma_all_rules", "sigma_all_rules_20251119.zip"),
+        ("sigma_core", "sigma_core.zip"),
+        ("sigma_core+", "sigma_core+.zip"),
+        ("sigma_core++", "sigma_core++.zip"),
+        ("sigma_all_rules", "sigma_all_rules.zip"),
         (
             "sigma_emerging_threats_addon",
-            "sigma_emerging_threats_addon_20251119.zip",
+            "sigma_emerging_threats_addon.zip",
         ),
     ],
 )
 def test_overlapping_rule_packages_disambiguate(rule_package, expected_asset):
     connector = _make_connector()
     release_metadata = _release(
-        "sigma_all_rules_20251119.zip",
-        "sigma_core_20251119.zip",
-        "sigma_core+_20251119.zip",
-        "sigma_core++_20251119.zip",
-        "sigma_emerging_threats_addon_20251119.zip",
+        "sigma_all_rules.zip",
+        "sigma_core.zip",
+        "sigma_core+.zip",
+        "sigma_core++.zip",
+        "sigma_emerging_threats_addon.zip",
     )
     connector._collect_intelligence(release_metadata, rule_package)
     # The client is called exactly once with the disambiguated asset.
@@ -96,19 +96,19 @@ def test_first_matching_asset_wins_regardless_of_order():
         # ``sigma_core++`` first — a naive selector that uses
         # ``rule_package in asset['name']`` without ``break`` would
         # have overwritten the result on every later iteration.
-        "sigma_core++_20251119.zip",
-        "sigma_core+_20251119.zip",
-        "sigma_core_20251119.zip",
+        "sigma_core++.zip",
+        "sigma_core+.zip",
+        "sigma_core.zip",
     )
     connector._collect_intelligence(release_metadata, "sigma_core")
     connector.client.download_and_convert_package.assert_called_once_with(
-        "https://example.invalid/sigma_core_20251119.zip"
+        "https://example.invalid/sigma_core.zip"
     )
 
 
 def test_no_match_does_not_call_client():
     connector = _make_connector()
-    release_metadata = _release("some_other_package_20251119.zip")
+    release_metadata = _release("some_other_package.zip")
     connector._collect_intelligence(release_metadata, "sigma_core")
     connector.client.download_and_convert_package.assert_not_called()
 
@@ -126,7 +126,7 @@ def test_collect_intelligence_resets_converter_dedup_state():
     itself) is caught here, not as an integration regression.
     """
     connector = _make_connector()
-    release_metadata = _release("sigma_core_20251119.zip")
+    release_metadata = _release("sigma_core.zip")
     connector._collect_intelligence(release_metadata, "sigma_core")
     connector.converter_to_stix.reset_dedup_state.assert_called_once()
 


### PR DESCRIPTION
Asset selector used startswith('<rule_package>_') which never matched the actual SigmaHQ release filenames (<rule_package>.zip). No rules were imported on any run as a result.

Fix by matching the exact filename instead. Update the comment above the selector and the test fixtures to reflect the real naming format.

Verified against release r2026-04-01: 3,419 rules imported successfully.

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix `_collect_intelligence` in `src/connector/connector.py` to match assets by
  exact filename (`<rule_package>.zip`) instead of prefix (`<rule_package>_`),
  reflecting the actual SigmaHQ release naming convention
* Update the inline comment above the selector to correctly describe the filename
  format and remove the reference to the non-existent `_<date>` suffix
* Update `tests/test_asset_matching.py` to use the real asset filenames from
  current SigmaHQ releases

### Related issues

* Close https://github.com/OpenCTI-Platform/connectors/issues/6590

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


### Further comments

The `_<date>` filename format described in the original comment has never existed
in any SigmaHQ release. All releases since at least r2024-03-26 (the earliest
available via the GitHub API) use the format `sigma_core.zip` / `sigma_core+.zip`
/ `sigma_core++.zip`.

The change is minimal: one line of code removed, one line changed, the comment
updated to reflect reality, and the test fixtures updated to match actual release
filenames. The disambiguation between `sigma_core`, `sigma_core+` and `sigma_core++`
is preserved — none of them equal another when compared as full filenames.

Tested locally against a running OpenCTI 7.260515.0 instance: 3,419 rules
successfully imported from release r2026-04-01.
