### PR TITLE
fix(cve): add trust_env=True to honor HTTP_PROXY/HTTPS_PROXY environment variables

### DIFF
--- a/external-import/cve/src/services/client/api.py
+++ b/external-import/cve/src/services/client/api.py
@@ -35,6 +35,7 @@ class CVEClient:
             self._session = aiohttp.ClientSession(
                 headers=self._headers,
                 timeout=timeout,
+                trust_env=True,
             )
         return self._session
 


### PR DESCRIPTION
### Proposed changes

* Added `trust_env=True` to `aiohttp.ClientSession()` in `external-import/cve/src/services/client/api.py` to honor `HTTP_PROXY` and `HTTPS_PROXY` environment variables
* Fixed CVE connector connectivity issues behind corporate proxies where direct outbound connections are blocked

### Related issues

*

### Checklist

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This is a minimal one-line fix that addresses a critical connectivity issue for users behind corporate proxies.

**Problem:** The CVE connector was ignoring `HTTP_PROXY` and `HTTPS_PROXY` environment variables when making requests to the NVD API.

**Root Cause:** `aiohttp.ClientSession` was created without `trust_env=True`.

**Solution:** Added `trust_env=True` to the `ClientSession()` constructor.

**Testing:** Verified that the connector now works behind a corporate Squid proxy.

**Impact:** Enables the CVE connector to work in corporate environments where all outbound traffic must go through a proxy.
