### PR TITLE
[GH Actions] Add backport-candidate auto-label on security/critical issues

### DIFF
--- a/.github/workflows/auto-backport-label.yml
+++ b/.github/workflows/auto-backport-label.yml
@@ -1,0 +1,22 @@
+name: Auto-label backport-candidate
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  add-backport-label:
+    if: github.event.label.name == 'security' || github.event.label.name == 'critical'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['backport-candidate']
+            });


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that automatically labels an issue with `backport-candidate` whenever the `security` or `critical` label is added.

## Why

When a bug is classified as security-related or critical, the team needs a visual reminder to evaluate whether the fix should be backported to older release branches. This automation removes the need to remember to add that label manually.

## How it works

- Trigger: `issues: labeled`
- Condition: the newly-added label is `security` or `critical`
- Action: adds `backport-candidate` label via `actions/github-script@v8`

No change is made on PR events or on issue open/reopen.

Closes #6605