### PR TITLE
feat(hygiene): add MISP warning list source as Note on matched indicators (#4215)

### DIFF
--- a/internal-enrichment/hygiene/src/connector/hygiene.py
+++ b/internal-enrichment/hygiene/src/connector/hygiene.py
@@ -326,10 +326,12 @@ class HygieneConnector:
             serialized_bundle = self.helper.stix2_create_bundle(stix_objects)
             self.helper.send_stix2_bundle(serialized_bundle)
 
+        entity_label = (
+            "indicator" if opencti_entity["entity_type"] == "Indicator" else "observable"
+        )
         note_lines = [f"- **{wl.name}**: {wl.description}" for wl in warninglist_hits]
         note_content = (
-            "This indicator was found in the following MISP warning list(s):\n\n"
-            + "\n".join(note_lines)
+            f"This {entity_label} was found in the following MISP warning list(s):\n\n" + "\n".join(note_lines)
         )
         note = stix2.Note(
             type="note",

--- a/internal-enrichment/hygiene/src/connector/hygiene.py
+++ b/internal-enrichment/hygiene/src/connector/hygiene.py
@@ -3,6 +3,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List, Optional, Tuple
 
+import stix2
 import tldextract
 from pycti import (
     STIX_EXT_OCTI,
@@ -73,6 +74,12 @@ class HygieneConnector:
             raise ValueError(
                 "The hygiene label could not be created. If your connector does not have the permission to create labels, please create it manually before launching"
             )
+
+        self.identity = self.helper.api.identity.create(
+            type="Organization",
+            name="Hygiene",
+            description="MISP Warning Lists hygiene connector.",
+        )["standard_id"]
 
         self.helper.log_info(
             f"Thread pool initialized with {self.max_workers} max workers"
@@ -318,6 +325,28 @@ class HygieneConnector:
 
             serialized_bundle = self.helper.stix2_create_bundle(stix_objects)
             self.helper.send_stix2_bundle(serialized_bundle)
+
+        note_lines = [f"- **{wl.name}**: {wl.description}" for wl in warninglist_hits]
+        note_content = (
+            "This indicator was found in the following MISP warning list(s):\n\n"
+            + "\n".join(note_lines)
+        )
+        note = stix2.Note(
+            type="note",
+            id=self.helper.api.note.generate_id(
+                created=None,
+                content=note_content,
+            ),
+            abstract="Hygiene: MISP Warning List match",
+            content=note_content,
+            object_refs=[stix_entity["id"]],
+            created_by_ref=self.identity,
+            custom_properties={"note_types": ["external"]},
+        )
+        stix_objects.append(note)
+        serialized_bundle = self.helper.stix2_create_bundle(stix_objects)
+        self.helper.send_stix2_bundle(serialized_bundle)
+
         return score
 
     def _add_label_to_entity(

--- a/internal-enrichment/hygiene/src/connector/hygiene.py
+++ b/internal-enrichment/hygiene/src/connector/hygiene.py
@@ -327,11 +327,14 @@ class HygieneConnector:
             self.helper.send_stix2_bundle(serialized_bundle)
 
         entity_label = (
-            "indicator" if opencti_entity["entity_type"] == "Indicator" else "observable"
+            "indicator"
+            if opencti_entity["entity_type"] == "Indicator"
+            else "observable"
         )
         note_lines = [f"- **{wl.name}**: {wl.description}" for wl in warninglist_hits]
         note_content = (
-            f"This {entity_label} was found in the following MISP warning list(s):\n\n" + "\n".join(note_lines)
+            f"This {entity_label} was found in the following MISP warning list(s):\n\n"
+            + "\n".join(note_lines)
         )
         note = stix2.Note(
             type="note",
@@ -345,8 +348,7 @@ class HygieneConnector:
             created_by_ref=self.identity,
             custom_properties={"note_types": ["external"]},
         )
-        stix_objects.append(note)
-        serialized_bundle = self.helper.stix2_create_bundle(stix_objects)
+        serialized_bundle = self.helper.stix2_create_bundle([note])
         self.helper.send_stix2_bundle(serialized_bundle)
 
         return score

--- a/internal-enrichment/hygiene/tests/conftest.py
+++ b/internal-enrichment/hygiene/tests/conftest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from pycti import Note
 
 TEST_DIR = Path(__file__).parent
 SRC_DIR = TEST_DIR.parent / "src"
@@ -35,7 +36,12 @@ def mock_config():
 
 @pytest.fixture
 def mock_helper():
-    return MagicMock()
+    helper = MagicMock()
+    helper.api.identity.create.return_value = {
+        "standard_id": f"identity--{uuid.uuid4()}"
+    }
+    helper.api.note.generate_id.side_effect = Note.generate_id
+    return helper
 
 
 @pytest.fixture(name="mock_opencti")

--- a/internal-enrichment/hygiene/tests/test_hygiene_enrichment.py
+++ b/internal-enrichment/hygiene/tests/test_hygiene_enrichment.py
@@ -1,9 +1,12 @@
+import uuid
+
 import pytest
 from src.connector.hygiene import HygieneConnector
 
 
 def _generate_mock_stix_domain_entity(domain_name: str) -> dict:
     entity = {
+        "id": f"domain-name--{uuid.uuid4()}",
         "type": "domain-name",
         "value": domain_name,
         "labels": [],


### PR DESCRIPTION
Observables and indicators matched by the connector now get a Note attached, listing each matched warning list with its name and description. This restores the source visibility that was lost when external references were removed in #4214.

The note ID is computed from the content only, so repeated enrichment runs on the same entity produce no duplicates. A new note is created only when the matched lists change, which lets analysts track when an entity started appearing on additional lists.

Closes https://github.com/OpenCTI-Platform/connectors/issues/4215


### Proposed changes

* When an observable or indicator matches a MISP warning list, a `stix2.Note` is added  listing each matched list with its name and description
* The note ID is computed from the content only (no timestamp), so repeated enrichment  runs on the same entity produce no duplicates. A new note is created only when the  matched lists change, which keeps a history of when an entity started appearing on additional lists.
* A `Hygiene` Organization identity is created as `created_by_ref` on the note

### Related issues

* Close https://github.com/OpenCTI-Platform/connectors/issues/4215


### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

