### PR TITLE
ci: enforce conventional commits format for PR titles (#6609)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,14 @@
 Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!
 
 Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
+
+PR TITLE FORMAT (enforced by CI):
+  type(scope?)!?: description (#123)
+  - type: feat | fix | chore | docs | style | refactor | perf | test | build | ci | revert
+  - scope: optional, e.g. connector name
+  - description: must start with a lowercase letter
+  - (#123): required linked issue number
+  Example: feat(alienvault): add pagination support (#42)
 -->
 
 ### Proposed changes

--- a/.github/workflows/pr-check-conventions.yml
+++ b/.github/workflows/pr-check-conventions.yml
@@ -61,9 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      checks: write
     steps:
-      - uses: Slashgear/action-check-pr-title@76166c63ec0b25cdbe693e5e972e83ca186313fb
+      - name: Validate PR title and create check
+        uses: FiligranHQ/filigran-ci-tools/actions/pr-title-check@main
         with:
-          regexp: '^\[\w+.+\].+$'
-          flags: "gm"
-          helpMessage: "Format: '[Connector Name] Message' for example '[MISP] updating a doc page'. see https://github.com/OpenCTI-Platform/connectors/blob/master/CONTRIBUTING.md#contributing"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -465,7 +465,18 @@ When your connector is ready:
 1. **Ensure all quality checks pass** (linting, tests, documentation)
 2. **Test in a production-like environment**
 3. **Create a Pull Request** on the [connectors repository](https://github.com/OpenCTI-Platform/connectors)
-   - Always start your PR title with _[Connector Name]_ followed by a meaningful description
+   - PR titles **must** follow [Conventional Commits](https://www.conventionalcommits.org/) format, enforced automatically by CI:
+     ```
+     type(scope?)!?: description (#123)
+     ```
+     - **type**: one of `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `revert`
+     - **scope**: optional — use the connector name or affected area (e.g. `alienvault`)
+     - **description**: must start with a lowercase letter
+     - **`(#123)`**: required — the linked issue number at the end
+   - Examples:
+     - `feat(alienvault): add pagination support (#42)`
+     - `fix: resolve config loading issue (#99)`
+     - `feat(misp)!: remove deprecated feed endpoint (#150)`
    - Describe the changes introduced by the PR
    - Reference any issues that will be closed upon merging, using the _Close_ keyword followed by the GitHub issue link
 4. **Respond to review feedback** from maintainers

--- a/external-import/group-ib/README_dev.md
+++ b/external-import/group-ib/README_dev.md
@@ -73,7 +73,8 @@ $ isort --profile black .
 # Fixing /path/to/connector/file.py
 # Push you feature/fix on Github
 $ git add [file(s)]
-$ git commit -m "[connector_name] descriptive message"
+$ git commit -m "feat(group-ib): descriptive message"
 $ git push origin [branch-name]
-# Open a pull request with the title "[connector_name] message"
+# Open a pull request whose title follows Conventional Commits: "type(scope?): description (#issue)"
+# Example: "feat(group-ib): add pagination support (#42)"
 ```

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     "filigran team"
   ],
   "prConcurrentLimit": 2,
-  "commitMessagePrefix": "[tool] chore(deps):",
+  "commitMessagePrefix": "chore(renovate):",
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
### Proposed changes

- **Replace PR title check action**: Migrates from `Slashgear/action-check-pr-title` (regex `^\[\w+.+\].+$`, format `[Connector Name] message`) to `FiligranHQ/filigran-ci-tools/actions/pr-title-check@main`, which validates PR titles against [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope?)!?: description (#123)`).
- **Add `checks: write` permission**: Required by the new action to create GitHub check runs on the PR.
- **Update `CONTRIBUTING.md`**: Replaces the old `[Connector Name] message` PR title instruction with the full Conventional Commits format spec, valid types, examples, and a note that CI enforces it automatically.
- **Update PR template**: Adds the format spec as a comment in `.github/PULL_REQUEST_TEMPLATE.md` so contributors see it when opening a PR.
- **Update Renovate config**: Changes `commitMessagePrefix` from `"[tool] chore(deps):"` to `"chore(renovate):"` to align Renovate PRs with the new conventional commits format (Renovate is still skipped from title validation).
- **Update `group-ib` dev README**: Updates the example commit and PR title to use conventional commit syntax.

### Related issues

Closes #6609

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The new `pr-title-check` action validates PR titles against `type(scope?)!?: description (#123)` and creates a GitHub check run with detailed diagnostics. Renovate PRs are automatically skipped via the `if:` condition on the job. `GITHUB_TOKEN` with `checks: write` is sufficient — no GitHub App token is required.