### PR TITLE
ci: add connector-linter workflow for verified/manager-supported connectors (#6598)

### DIFF
--- a/.github/scripts/build_linter_matrix.py
+++ b/.github/scripts/build_linter_matrix.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+Generate the GitHub Actions matrix for connector-linter runs.
+
+Scans all connector_manifest.json files and selects connectors that are
+either **verified** (verified=true AND last_verified_date is set) or
+**manager_supported** (manager_supported=true).
+
+On non-master branches the list is further narrowed to connectors whose
+files actually changed, using the same git-diff logic as build_test_matrix.py.
+"""
+
+import json
+import math
+import os
+import subprocess
+from pathlib import Path
+
+GITHUB_ACTIONS_JOB_LIMIT = 256
+
+CONNECTOR_DIRS = [
+    "external-import",
+    "internal-enrichment",
+    "internal-export-file",
+    "internal-import-file",
+    "stream",
+]
+
+
+# ---------------------------------------------------------------------------
+# Git helpers (same as build_test_matrix.py)
+# ---------------------------------------------------------------------------
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git"] + list(args), capture_output=True, text=True
+    ).stdout.strip()
+
+
+def get_base_commit() -> str | None:
+    release_ref = os.environ.get("RELEASE_REF", "master")
+    commit = git("merge-base", f"origin/{release_ref}", "HEAD")
+    return commit or None
+
+
+def has_changes(base_commit: str, *pathspecs: str) -> bool:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", base_commit, "HEAD", "--"] + list(pathspecs),
+        capture_output=True,
+        text=True,
+    )
+    return bool(result.stdout.strip())
+
+
+# ---------------------------------------------------------------------------
+# Manifest scanning
+# ---------------------------------------------------------------------------
+
+
+def is_eligible(manifest: dict) -> bool:
+    """Return True if connector is verified-with-date or manager-supported."""
+    verified = manifest.get("verified", False) is True
+    has_date = manifest.get("last_verified_date") not in (None, "", False)
+    manager = manifest.get("manager_supported", False) is True
+    return (verified and has_date) or manager
+
+
+def discover_eligible_connectors() -> list[Path]:
+    """Return connector root dirs whose manifest passes eligibility."""
+    eligible: list[Path] = []
+    for ctype in CONNECTOR_DIRS:
+        ctype_dir = Path(ctype)
+        if not ctype_dir.is_dir():
+            continue
+        for manifest_path in sorted(
+            ctype_dir.rglob("__metadata__/connector_manifest.json")
+        ):
+            try:
+                manifest = json.loads(manifest_path.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+            if is_eligible(manifest):
+                # connector root is two levels up from __metadata__/connector_manifest.json
+                eligible.append(manifest_path.parent.parent)
+    return eligible
+
+
+# ---------------------------------------------------------------------------
+# Filtering (change-based, mirrors build_test_matrix.py)
+# ---------------------------------------------------------------------------
+
+
+def should_run(
+    connector_root: Path,
+    base_commit: str | None,
+) -> bool:
+    if base_commit is None:
+        return True
+
+    if has_changes(base_commit, str(connector_root)):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Matrix building
+# ---------------------------------------------------------------------------
+
+
+def make_entry(connector_roots: list[Path]) -> dict:
+    names = [
+        f"{p.parent.name}/{p.name}" if len(p.parts) >= 2 else str(p)
+        for p in connector_roots
+    ]
+    paths = [str(p) for p in connector_roots]
+    return {
+        "name": (
+            ", ".join(names)
+            if len(names) <= 3
+            else f"{names[0]} (+{len(names) - 1} more)"
+        ),
+        "connector_paths": "\n".join(paths),
+    }
+
+
+def build_matrix(roots: list[Path]) -> list[dict]:
+    if len(roots) <= GITHUB_ACTIONS_JOB_LIMIT:
+        return [make_entry([r]) for r in roots]
+
+    # Batch by connector type to stay under the limit
+    groups: dict[str, list[Path]] = {}
+    for r in roots:
+        ctype = r.parts[0] if r.parts else "unknown"
+        groups.setdefault(ctype, []).append(r)
+
+    batch_size = math.ceil(len(roots) / GITHUB_ACTIONS_JOB_LIMIT)
+    entries = []
+    for _, cpaths in sorted(groups.items()):
+        for i in range(0, len(cpaths), batch_size):
+            entries.append(make_entry(cpaths[i : i + batch_size]))
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def write_output(key: str, value: str) -> None:
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    line = f"{key}={value}\n"
+    if output_file:
+        with Path(output_file).open("a") as f:
+            f.write(line)
+    else:
+        print(line, end="")
+
+
+def main() -> None:
+    base_commit = get_base_commit()
+
+    eligible = discover_eligible_connectors()
+    print(f"Total eligible connectors (verified/manager-supported): {len(eligible)}")
+
+    filtered = [r for r in eligible if should_run(r, base_commit)]
+    print(f"Connectors selected for this run: {len(filtered)}")
+
+    if not filtered:
+        print("No connectors to lint, skipping.")
+        write_output("has_connectors", "false")
+        write_output("matrix", json.dumps({"include": []}, separators=(",", ":")))
+        return
+
+    entries = build_matrix(filtered)
+    print(f"Matrix jobs: {len(entries)}")
+    write_output("has_connectors", "true")
+    write_output("matrix", json.dumps({"include": entries}, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/connector-verified-linter.yml
+++ b/.github/workflows/connector-verified-linter.yml
@@ -1,0 +1,100 @@
+name: Connector Verified Linter
+
+on:
+  push:
+    branches-ignore:
+      - master
+      - 'release/*'
+      - 'lts/*'
+    paths:
+      - 'connectors-sdk/**'
+      - 'external-import/**'
+      - 'internal-enrichment/**'
+      - 'internal-export-file/**'
+      - 'internal-import-file/**'
+      - 'stream/**'
+      - 'shared/**'
+  workflow_call:
+
+concurrency:
+  group: connector-verified-linter-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  detect-connectors:
+    name: Detect eligible connectors
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has_connectors: ${{ steps.set-matrix.outputs.has_connectors }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve RELEASE_REF
+        run: |
+          PR_BASE_REF="${{ github.base_ref }}"
+
+          if [ -n "${PR_BASE_REF:-}" ]; then
+            case "${PR_BASE_REF}" in
+              master|release/6.9.x|lts/*)
+                RESOLVED_RELEASE_REF="${PR_BASE_REF}"
+                echo "Using PR base branch for RELEASE_REF: ${RESOLVED_RELEASE_REF}"
+                ;;
+              *)
+                RESOLVED_RELEASE_REF="$(bash ./shared/tools/ci/detect-base-branch.sh origin)"
+                echo "PR base '${PR_BASE_REF}' is outside allowed refs, using fallback RELEASE_REF: ${RESOLVED_RELEASE_REF}"
+                ;;
+            esac
+          else
+            RESOLVED_RELEASE_REF="$(bash ./shared/tools/ci/detect-base-branch.sh origin)"
+            echo "Using detected fallback RELEASE_REF: ${RESOLVED_RELEASE_REF}"
+          fi
+          echo "RELEASE_REF=${RESOLVED_RELEASE_REF}" >> "$GITHUB_ENV"
+
+      - id: set-matrix
+        name: Build linter matrix from connector manifests
+        run: python .github/scripts/build_linter_matrix.py
+
+  vclint:
+    name: Lint ${{ matrix.name }}
+    needs:
+      - detect-connectors
+    if: needs.detect-connectors.outputs.has_connectors == 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.detect-connectors.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: false
+          python-version: "3.12"
+
+      - name: Create virtual environment
+        run: uv venv
+
+      - name: Install connector-linter
+        run: uv pip install ./shared/tools/connector_linter
+
+      - name: Run connector-linter
+        run: |
+          exit_code=0
+          while IFS= read -r connector_path; do
+            [ -z "$connector_path" ] && continue
+            echo "::group::Linting ${connector_path}"
+            uv run connector-linter check "$connector_path" --format github || exit_code=$?
+            uv run connector-linter check "$connector_path" --format markdown --verbose >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "::endgroup::"
+          done <<< "${{ matrix.connector_paths }}"
+          exit "$exit_code"


### PR DESCRIPTION
### Proposed changes

- **Add `build_linter_matrix.py` script** (`.github/scripts/`): Scans all `connector_manifest.json` files and selects connectors that are either verified (`verified: true` + `last_verified_date` is set) or manager-supported (`manager_supported: true`). On non-master branches, further filters to only connectors with actual changes (same git-diff logic as `build_test_matrix.py`). Also excludes `.github/` from the "outside scope" check to avoid triggering a full run on CI-only changes.
- **Add `connector-verified-linter.yml` workflow** (`.github/workflows/`): Runs `connector-linter check` on eligible connectors with two output formats:
  - `--format github` for `::error`/`::warning` workflow annotations
  - `--format markdown --verbose` written to `$GITHUB_STEP_SUMMARY` for a rich linter report visible in each job's Summary tab
- **Triggers**: `push` (non-master/release/lts branches) and `workflow_call`, with path filters for connector/shared directories. Uses same `RELEASE_REF` resolution and concurrency control as `tests-connectors.yml`.
- **Non-blocking**: The lint job uses `continue-on-error: true` — purely informative, never blocks merges.

### Related issues

Closes #6598

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The matrix builder found **95 eligible connectors** in the current codebase. Each gets its own matrix job with `fail-fast: false`. The linter produces both GitHub Actions annotations and a markdown step summary so results are always visible from the workflow run page.