### PR TITLE
chore: align CI PR-title check & complete issue templates (#6641)

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -85,6 +85,10 @@ labels (e.g. `frontend`, `backend`, `connector: <name>`, `collector: <name>`,
 `agents`, `authentication`). They add routing context and an issue may carry
 more than one. They are not listed in `labels.yml`.
 
+All label names are **lowercase**. Repository-specific labels use a neutral grey
+color (`ededed`); only the shared labels above carry color, so the common
+taxonomy stands out consistently across every Filigran repository.
+
 ## 5. Deprecated labels — do not use
 
 - `enhancement` — use `feature`.

--- a/.github/workflows/pr-check-conventions.yml
+++ b/.github/workflows/pr-check-conventions.yml
@@ -64,6 +64,6 @@ jobs:
     steps:
       - uses: Slashgear/action-check-pr-title@76166c63ec0b25cdbe693e5e972e83ca186313fb
         with:
-          regexp: '^\[\w+.+\].+$'
+          regexp: '^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(\([a-z0-9._/-]+\))?!?: .+ \(#[0-9]+\)$'
           flags: "gm"
-          helpMessage: "Format: '[Connector Name] Message' for example '[MISP] updating a doc page'. see https://github.com/OpenCTI-Platform/connectors/blob/master/CONTRIBUTING.md#contributing"
+          helpMessage: "Format: 'type(scope?): description (#issue)' - e.g. 'feat(misp): add new mapping (#1234)'. Use the connector name as the scope. See https://github.com/OpenCTI-Platform/connectors/blob/master/CONTRIBUTING.md"


### PR DESCRIPTION
## Summary

Aligns CI PR-title validation with Conventional Commits, completes the shared issue templates, and documents the lowercase + grey label rule.

Closes #6641