### PR TITLE
chore(renovate): emit Conventional Commits titles (#6643)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    ":semanticCommits",
     "config:recommended"
   ],
   "pre-commit": {
@@ -11,7 +12,6 @@
     "filigran team"
   ],
   "prConcurrentLimit": 2,
-  "commitMessagePrefix": "[tool] chore(deps):",
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
## Summary

Renovate now emits Conventional Commits titles (`chore(deps): ...`) instead of the old `[deps]` bracket prefix.

Closes #6643