### PR TITLE
chore: align issue templates across repositories (#6645)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,10 @@
 ---
 name: Bug report
-about: Create a bug report to help us improve OpenCTI
+about: Create a bug report to help us improve the OpenCTI connectors
 title: 'fix: '
-labels: bug, needs triage
+labels: needs triage, bug
 assignees: ''
+type: bug
 
 ---
 
@@ -13,28 +14,25 @@ assignees: ''
 
 ## Environment
 
-1. OS (where OpenCTI server runs): { e.g. Mac OS 10, Windows 10, Ubuntu 16.4, etc. }
-2. OpenCTI version: { e.g. OpenCTI 1.0.2 }
-3. OpenCTI client: { e.g. frontend or python }
-4. Other environment details:
+1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
+2. Version: { e.g. 1.2.3 }
+3. Other environment details:
 
-## Reproducible Steps
+## Reproducible steps
 
 Steps to create the smallest reproducible scenario:
 1. { e.g. Run ... }
 2. { e.g. Click ... }
 3. { e.g. Error ... }
 
-## Expected Output
+## Expected output
 
 <!-- Please describe what you expected to happen. -->
 
-## Actual Output
+## Actual output
 
 <!-- Please describe what actually happened. -->
 
 ## Additional information
 
 <!-- Any additional information, including logs or screenshots if you have any. -->
-
-## Screenshots (optional)

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,22 @@
+name: Documentation request
+description: Request new or improved documentation for the OpenCTI connectors.
+title: "docs: "
+labels:
+  - needs triage
+  - documentation
+body:
+  - type: textarea
+    id: request-details
+    attributes:
+      label: Documentation request
+      description: "Please explain what you want to document or clarify."
+      placeholder: "Describe the missing documentation, unclear section, or new topic you would like to see covered."
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: "Any links, screenshots or references that help."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,9 +1,10 @@
 ---
 name: Feature request
-about: Ask for a new feature/connector to be implemented in OpenCTI
+about: Suggest a new feature or capability for the OpenCTI connectors
 title: 'feat: '
-labels: feature, needs triage
+labels: needs triage, feature
 assignees: ''
+type: feature
 
 ---
 
@@ -11,20 +12,18 @@ assignees: ''
 
 <!-- Please describe the use case for which you need a solution. -->
 
-## Current Workaround
+## Current workaround
 
-<!-- Please describe how you currently solve or work around this problem, given OpenCTI's limitation. -->
+<!-- Please describe how you currently solve or work around this problem. -->
 
-## Proposed Solution
+## Proposed solution
 
-<!-- Please describe the solution you would like OpenCTI to provide, to solve the problem above. -->
+<!-- Please describe the solution you would like to be provided. -->
 
-## Additional Information
+## Additional information
 
 <!-- Any additional information, including logs or screenshots if you have any. -->
 
-## Would you be willing to submit a PR?
+## If the feature request is approved, would you be willing to submit a PR?
 
-<!-- A PR is a shortcut for a "pull request". Here more details on the idea behind a PR https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests -->
-
-We strongly encourage you to submit a PR if you want and whenever you want. If your issue concern a "Community-support" connector, your PR will probably be accepted after some review. If the connector is "Partner-support" or "Filigran-support", a dev team make take over but will base its work on your PR, speeding the process. It will be much appreciated.
+Yes / No (help can be provided if you need assistance submitting a PR)

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Ask a question concerning OpenCTI connectors
+about: Ask a question about the OpenCTI connectors
 title: ''
 labels: needs triage, question
 assignees: ''
@@ -9,9 +9,9 @@ assignees: ''
 
 ## Prerequisites
 
-- [ ] I read the [Deployment and Setup](https://docs.opencti.io/latest/deployment/overview/) section of the OpenCTI documentation as well as the [Troubleshooting](https://docs.opencti.io/latest/deployment/troubleshooting/) page and didn't find anything relevant to my problem.
-- [ ] I went through old GitHub issues and couldn't find anything relevant
-- [ ] I googled the issue and didn't find anything relevant
+- [ ] I read the documentation and didn't find anything relevant to my problem.
+- [ ] I went through old GitHub issues and couldn't find anything relevant.
+- [ ] I searched the web and didn't find anything relevant.
 
 ## Description
 
@@ -19,17 +19,9 @@ assignees: ''
 
 ## Environment
 
-1. OS (where OpenCTI server runs): { e.g. Mac OS 10, Windows 10, Ubuntu 16.4, etc. }
-2. OpenCTI version: { e.g. OpenCTI 1.0.2 }
-3. OpenCTI client: { e.g. frontend or python }
-4. Other environment details:
-
-## Reproducible Steps
-
-Steps to create the smallest reproducible scenario:
-1. { e.g. Run ... }
-2. { e.g. Click ... }
-3. { e.g. Error ... }
+1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
+2. Version: { e.g. 1.2.3 }
+3. Other environment details:
 
 ## Additional information
 


### PR DESCRIPTION
## Summary

Aligns the issue templates across all Filigran repositories (identical bug / feature / question + a security vulnerability link), adds a documentation request template where the repo ships docs, and keeps client-python templates where applicable.

Closes #6645