### PR TITLE
chore: audit & align issue templates (#6647)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 *.iml
 test
 config.yml
+!.github/ISSUE_TEMPLATE/config.yml
 docker-compose-test.yml
 Pipfile*
 .DS_Store


### PR DESCRIPTION
## Summary

Audit and align the GitHub issue templates of `OpenCTI-Platform/connectors` to the shared Filigran convention.

- Verified `bug_report.md`, `feature_request.md`, `question.md`, and `documentation.yaml` are byte-identical to the canonical Filigran templates (product = the OpenCTI connectors) — no changes needed.
- Added the PUBLIC chooser config `config.yml` (`blank_issues_enabled: true` only). No "Report a security vulnerability" contact link is added because this public repository already has native private vulnerability reporting enabled (avoids a duplicate). No "Filigran community Slack" link.
- Added a `.gitignore` negation for `.github/ISSUE_TEMPLATE/config.yml` so the chooser config is tracked despite the global `config.yml` ignore used by connector runtime configs.

No pycti-specific templates apply to this repository. No stray or duplicate template files were found.

## Test plan

- [ ] GitHub renders the issue chooser with Bug report, Feature request, Question, and Documentation request, plus a blank-issue option.
- [ ] No duplicate "Report a security vulnerability" entry appears (native private vulnerability reporting remains the single path).

Closes #6647
