### PR TITLE
fix(thehive): enforce TLP filter on cases and fix marking/relation crashes (#6670)

### DIFF
--- a/external-import/thehive/src/connector/connector.py
+++ b/external-import/thehive/src/connector/connector.py
@@ -280,6 +280,7 @@ class TheHive:
                 self.helper.send_stix2_bundle(
                     self.helper.stix2_create_bundle(attachments),
                     work_id=work_id,
+                    cleanup_inconsistent_bundle=True,
                 )
 
             except Exception as e:

--- a/external-import/thehive/src/connector/connector.py
+++ b/external-import/thehive/src/connector/connector.py
@@ -146,7 +146,13 @@ class TheHive:
         )
 
     def generate_alert_bundle(self, alert, work_id=None):
-        """Generate a STIX bundle from a given alert."""
+        """Generate and return a STIX bundle from a given alert.
+
+        The returned bundle is sent by ``process_items`` under ``work_id``.
+        ``work_id`` is accepted only for a signature consistent with
+        ``generate_case_bundle`` and is unused here (alerts have no background
+        artifact sends).
+        """
         self.helper.connector_logger.info(
             f"Starting import for alert '{alert.get('title')}'"
         )
@@ -187,7 +193,13 @@ class TheHive:
             return {}
 
     def generate_case_bundle(self, case, work_id=None):
-        """Generates a STIX bundle from a TheHive case, with attachments."""
+        """Generate and return a STIX bundle from a TheHive case.
+
+        The main case bundle is returned for ``process_items`` to send under
+        ``work_id`` (so the TLP filter applies and the case is not sent twice).
+        ``work_id`` is used here to attach the separate background attachments
+        bundle to the same work.
+        """
         self.helper.connector_logger.info(
             f"Starting generation of STIX bundle for case: {case.get('title')}"
         )
@@ -356,12 +368,14 @@ class TheHive:
                     work_id=work_id,
                     cleanup_inconsistent_bundle=True,
                 )
-
-                updated_last_date = self.get_updated_date(item, updated_last_date)
             else:
                 self.helper.connector_logger.warning(
                     f"Ignoring {item.get('title')} due to TLP too high."
                 )
+            # Advance the watermark for every fetched item, including those skipped
+            # by the TLP filter, so skipped items are not refetched on every run
+            # (and an all-skipped batch does not stall state forever).
+            updated_last_date = self.get_updated_date(item, updated_last_date)
         message = f"Processing complete, last update: {updated_last_date}"
         self.helper.api.work.to_processed(work_id, message)
         return updated_last_date

--- a/external-import/thehive/src/connector/connector.py
+++ b/external-import/thehive/src/connector/connector.py
@@ -145,12 +145,13 @@ class TheHive:
             },
         )
 
-    def generate_alert_bundle(self, alert):
+    def generate_alert_bundle(self, alert, work_id=None):
         """Generate a STIX bundle from a given alert."""
         self.helper.connector_logger.info(
             f"Starting import for alert '{alert.get('title')}'"
         )
-        bundle_objects = [self.identity]
+        bundle_objects = []
+        markings = []
         try:
             markings = self.process_markings(alert)
             bundle_objects.extend(markings)
@@ -185,12 +186,13 @@ class TheHive:
             )
             return {}
 
-    def generate_case_bundle(self, case):
+    def generate_case_bundle(self, case, work_id=None):
         """Generates a STIX bundle from a TheHive case, with attachments."""
         self.helper.connector_logger.info(
             f"Starting generation of STIX bundle for case: {case.get('title')}"
         )
-        bundle_objects = [self.identity]
+        bundle_objects = []
+        markings = []
 
         try:
             markings = self.process_markings(case)
@@ -245,7 +247,8 @@ class TheHive:
             self.helper.connector_logger.info(
                 f"Completed generation of STIX bundle for case: {case.get('title')}"
             )
-            self.helper.send_stix2_bundle(bundle, cleanup_inconsistent_bundle=True)
+            # The main bundle is sent by process_items() with the work_id, after the
+            # TLP filter has been applied. Sending it here would bypass that filter.
 
         except Exception as e:
             self.helper.connector_logger.error(
@@ -253,6 +256,7 @@ class TheHive:
             )
             return {}
 
+        # Send STIX Artifacts (attachments) under the same work as the case.
         if attachments:
             try:
                 self.helper.connector_logger.info(
@@ -260,7 +264,7 @@ class TheHive:
                 )
                 self.helper.send_stix2_bundle(
                     self.helper.stix2_create_bundle(attachments),
-                    cleanup_inconsistent_bundle=True,
+                    work_id=work_id,
                 )
 
             except Exception as e:
@@ -344,9 +348,9 @@ class TheHive:
             self.helper.connect_id, friendly_name
         )
         for item in items:
-            self.helper.connector_logger.debug(f"item: {items}")
+            self.helper.connector_logger.debug(f"item: {item}")
             if str(item.get("tlp")) in self.thehive_import_only_tlp:
-                stix_bundle = process_func(item)
+                stix_bundle = process_func(item, work_id)
                 self.helper.send_stix2_bundle(
                     stix_bundle,
                     work_id=work_id,
@@ -365,7 +369,7 @@ class TheHive:
     def process_logic(self, type, last_date_key, bundle_func):
         """Process case or alert based on returned query. Update state once complete."""
         self.helper.connector_logger.info(
-            f"here the current state of the connector : {self.current_state}..."
+            f"Current state of the connector: {self.current_state}"
         )
         last_date = self.get_last_date(last_date_key, self.thehive_import_from_date)
         self.helper.connector_logger.info(f"Last Date: {last_date}(s)...")
@@ -454,11 +458,7 @@ class TheHive:
         """Process all observables from a case."""
         try:
             case_id = case.get("_id")
-
-            self.helper.connector_logger.info(
-                f"!!! here the value of case_id : {case_id}"
-            )
-            response = self.thehive_api.case.find_observables(case_id=case.get("_id"))
+            response = self.thehive_api.case.find_observables(case_id=case_id)
             if response and len(response) > 0:
                 observables = response
                 self.helper.connector_logger.info(
@@ -466,10 +466,7 @@ class TheHive:
                 )
                 processed_observables = []
                 object_refs = []
-                i = 1
                 for observable in observables:
-                    self.helper.connector_logger.info(f"!!! !!! observable n° {i}")
-                    i += 1
                     stix_observable = self.convert_observable(observable, markings)
                     if stix_observable:
                         if hasattr(stix_observable, "id"):
@@ -482,8 +479,8 @@ class TheHive:
                                 processed_observables.append(sighting)
                 return processed_observables, object_refs
             else:
-                self.helper.connector_logger.error(
-                    f"Failed to get observables for case: {case.get('title')}"
+                self.helper.connector_logger.info(
+                    f"No observables found for case: {case.get('title')}"
                 )
                 return [], []
         except Exception as e:
@@ -494,6 +491,8 @@ class TheHive:
 
     def process_observables_and_relations(self, observable, markings, stix_incident):
         """Function to process observables and create related STIX relations."""
+        stix_observable = None
+        stix_observable_relation = None
         try:
             stix_observable = self.convert_observable(observable, markings)
             if not stix_observable:
@@ -579,7 +578,7 @@ class TheHive:
             created_at = comment.get("_createdAt")
             if created_at is None:
                 self.helper.connector_logger.warning(
-                    f"Comment {comment.get('_id')} without '_createdAt'. Use the case creation date."
+                    f"Comment {comment.get('_id')} without '_createdAt'. Using the case creation date."
                 )
                 created_at = case.get("_createdAt")
                 if created_at is None:
@@ -617,7 +616,7 @@ class TheHive:
                     try:
                         url = f"{self.thehive_url}/api/v1/attachment/{file_id}/download"
                         self.helper.connector_logger.info(
-                            f"Download attachment {file_name} from {url}"
+                            f"Downloading attachment {file_name} from {url}"
                         )
 
                         response = requests.get(

--- a/external-import/thehive/src/connector/connector.py
+++ b/external-import/thehive/src/connector/connector.py
@@ -352,7 +352,12 @@ class TheHive:
         raise Exception({"message": api_error_msg})
 
     def process_items(self, type, items, process_func, last_date_key):
-        """Process items, execute process_func, and send_stix2_bundle."""
+        """Convert and send items under a single work, updating the watermark.
+
+        For each item allowed by the TLP filter, ``process_func(item, work_id)``
+        must return a STIX bundle, which is then sent under ``work_id``. The
+        watermark advances for every fetched item, including TLP-skipped ones.
+        """
         friendly_name = f"TheHive processing ({type}) @ {datetime.now().isoformat()}"
         self.helper.connector_logger.info(
             f"Processing type ({type}) and ({len(items)}) item(s)."
@@ -365,7 +370,7 @@ class TheHive:
         for item in items:
             self.helper.connector_logger.debug(f"item: {item}")
             if str(item.get("tlp")) in self.thehive_import_only_tlp:
-                stix_bundle = process_func(item, work_id)
+                stix_bundle = process_func(item, work_id=work_id)
                 self.helper.send_stix2_bundle(
                     stix_bundle,
                     work_id=work_id,

--- a/external-import/thehive/src/connector/connector.py
+++ b/external-import/thehive/src/connector/connector.py
@@ -156,7 +156,7 @@ class TheHive:
         self.helper.connector_logger.info(
             f"Starting import for alert '{alert.get('title')}'"
         )
-        bundle_objects = []
+        bundle_objects = [self.identity]
         markings = []
         try:
             markings = self.process_markings(alert)
@@ -206,7 +206,7 @@ class TheHive:
         self.helper.connector_logger.info(
             f"Starting generation of STIX bundle for case: {case.get('title')}"
         )
-        bundle_objects = []
+        bundle_objects = [self.identity]
         markings = []
 
         try:
@@ -278,7 +278,7 @@ class TheHive:
                     "Sending STIX artifacts bundle (attachments)..."
                 )
                 self.helper.send_stix2_bundle(
-                    self.helper.stix2_create_bundle(attachments),
+                    self.helper.stix2_create_bundle([self.identity] + attachments),
                     work_id=work_id,
                     cleanup_inconsistent_bundle=True,
                 )

--- a/external-import/thehive/src/connector/connector.py
+++ b/external-import/thehive/src/connector/connector.py
@@ -179,7 +179,10 @@ class TheHive:
             )
             if stix_observable:
                 bundle_objects.append(stix_observable)
-                bundle_objects.append(stix_relation)
+                # The relation can be None (e.g. relationship construction failed);
+                # a None element in the bundle aborts the whole send downstream.
+                if stix_relation:
+                    bundle_objects.append(stix_relation)
         try:
             bundle = self.helper.stix2_create_bundle(bundle_objects)
             self.helper.connector_logger.info(

--- a/external-import/thehive/tests/test_thehive.py
+++ b/external-import/thehive/tests/test_thehive.py
@@ -124,7 +124,7 @@ class TheHiveTest(unittest.TestCase):
         )
 
         # Only the allowed item is converted and sent, and it carries the work_id.
-        process_func.assert_called_once_with(allowed, work_id)
+        process_func.assert_called_once_with(allowed, work_id=work_id)
         _connector.helper.send_stix2_bundle.assert_called_once_with(
             sentinel.bundle, work_id=work_id
         )

--- a/external-import/thehive/tests/test_thehive.py
+++ b/external-import/thehive/tests/test_thehive.py
@@ -205,3 +205,59 @@ class TheHiveTest(unittest.TestCase):
 
         self.assertIs(stix_observable, observable_without_id)
         self.assertIsNone(relation)
+
+    def test_generate_case_bundle_sends_attachments_with_work_id(
+        self, m_os, m_yaml, m_helper, m_thehiveapi
+    ):
+        """When attachment import is enabled and attachments exist, the attachments
+        bundle must be sent under the caller's work_id, while the main case bundle
+        is still returned (not self-sent)."""
+        m_os.path.isfile.return_value = False
+        _connector = module.TheHive()
+        _connector.thehive_import_attachments = True
+
+        _connector.process_markings = MagicMock(return_value=[])
+        _connector.process_observables = MagicMock(return_value=([], []))
+        _connector.process_main_case = MagicMock(return_value=MagicMock())
+        _connector.process_tasks = MagicMock(return_value=[])
+        _connector.process_comments = MagicMock(return_value=[])
+        # Empty opencti_files keeps the stix_case re-creation path out of the test.
+        _connector.process_attachments = MagicMock(
+            return_value=([sentinel.artifact], [])
+        )
+
+        _now = int(time.time() * 1000)
+        case = {"title": "my case", "_createdAt": _now}
+
+        result = _connector.generate_case_bundle(case, work_id=sentinel.work_id)
+
+        # Only the attachments bundle is sent, and it carries the work_id.
+        _connector.helper.send_stix2_bundle.assert_called_once_with(
+            _connector.helper.stix2_create_bundle.return_value,
+            work_id=sentinel.work_id,
+        )
+        # The main case bundle is still returned for process_items to send.
+        self.assertEqual(result, _connector.helper.stix2_create_bundle.return_value)
+
+    def test_generate_alert_bundle_drops_none_relation(
+        self, m_os, m_yaml, m_helper, m_thehiveapi
+    ):
+        """A None relation (observable converted but relationship missing) must not
+        be appended to the bundle: a None element aborts the send downstream."""
+        m_os.path.isfile.return_value = False
+        _connector = module.TheHive()
+
+        _connector.process_markings = MagicMock(return_value=[])
+        _connector.create_stix_alert_incident = MagicMock(return_value=MagicMock())
+        _connector.process_observables_and_relations = MagicMock(
+            return_value=(sentinel.observable, None)
+        )
+
+        _now = int(time.time() * 1000)
+        alert = {"title": "my alert", "_createdAt": _now, "artifacts": [{}]}
+
+        _connector.generate_alert_bundle(alert, work_id=sentinel.work_id)
+
+        bundle_objects = _connector.helper.stix2_create_bundle.call_args[0][0]
+        self.assertIn(sentinel.observable, bundle_objects)
+        self.assertNotIn(None, bundle_objects)

--- a/external-import/thehive/tests/test_thehive.py
+++ b/external-import/thehive/tests/test_thehive.py
@@ -98,13 +98,10 @@ class TheHiveTest(unittest.TestCase):
 
         self.assertEqual(processed_comments[0]["id"], processed_comments[1]["id"])
 
-    def test_process_items_respects_tlp_filter(
-        self, m_os, m_yaml, m_helper, m_thehiveapi
-    ):
+    def test_process_items_respects_tlp_filter(self, m_thehiveapi):
         """process_items must skip items whose TLP is not in import_only_tlp and
         send allowed items exactly once, under the work_id."""
-        m_os.path.isfile.return_value = False
-        _connector = module.TheHive()
+        _connector = module.TheHive(_make_mock_config(), MagicMock())
         _connector.current_state = {}
         _connector.thehive_import_from_date = 0
         _connector.thehive_import_only_tlp = ["2"]
@@ -126,17 +123,14 @@ class TheHiveTest(unittest.TestCase):
         # Only the allowed item is converted and sent, and it carries the work_id.
         process_func.assert_called_once_with(allowed, work_id=work_id)
         _connector.helper.send_stix2_bundle.assert_called_once_with(
-            sentinel.bundle, work_id=work_id
+            sentinel.bundle, work_id=work_id, cleanup_inconsistent_bundle=True
         )
 
-    def test_process_items_advances_watermark_past_skipped_items(
-        self, m_os, m_yaml, m_helper, m_thehiveapi
-    ):
+    def test_process_items_advances_watermark_past_skipped_items(self, m_thehiveapi):
         """The state watermark must advance even for items skipped by the TLP
         filter, so high-TLP items are not refetched on every run (and an
         all-skipped batch does not stall state forever)."""
-        m_os.path.isfile.return_value = False
-        _connector = module.TheHive()
+        _connector = module.TheHive(_make_mock_config(), MagicMock())
         _connector.current_state = {}
         _connector.thehive_import_from_date = 0
         _connector.thehive_import_only_tlp = ["2"]
@@ -163,14 +157,11 @@ class TheHiveTest(unittest.TestCase):
         # ...yet the watermark advances past it (get_updated_date adds +1s).
         self.assertEqual(updated_last_date, int(blocked_updated_ms / 1000) + 1)
 
-    def test_generate_case_bundle_does_not_self_send_main_bundle(
-        self, m_os, m_yaml, m_helper, m_thehiveapi
-    ):
+    def test_generate_case_bundle_does_not_self_send_main_bundle(self, m_thehiveapi):
         """The main case bundle must be returned for process_items to send under the
         work_id, not sent from within generate_case_bundle. The previous self-send
         bypassed the TLP filter and ingested every case twice."""
-        m_os.path.isfile.return_value = False
-        _connector = module.TheHive()
+        _connector = module.TheHive(_make_mock_config(), MagicMock())
         _connector.thehive_import_attachments = False
 
         _connector.process_markings = MagicMock(return_value=[])
@@ -188,13 +179,10 @@ class TheHiveTest(unittest.TestCase):
         _connector.helper.send_stix2_bundle.assert_not_called()
         self.assertEqual(result, sentinel.bundle)
 
-    def test_process_observables_and_relations_handles_missing_id(
-        self, m_os, m_yaml, m_helper, m_thehiveapi
-    ):
+    def test_process_observables_and_relations_handles_missing_id(self, m_thehiveapi):
         """When the converted observable has no `id`, the function must return
         (observable, None) instead of raising UnboundLocalError."""
-        m_os.path.isfile.return_value = False
-        _connector = module.TheHive()
+        _connector = module.TheHive(_make_mock_config(), MagicMock())
 
         observable_without_id = object()  # truthy, but has no `id` attribute
         _connector.convert_observable = MagicMock(return_value=observable_without_id)
@@ -206,14 +194,11 @@ class TheHiveTest(unittest.TestCase):
         self.assertIs(stix_observable, observable_without_id)
         self.assertIsNone(relation)
 
-    def test_generate_case_bundle_sends_attachments_with_work_id(
-        self, m_os, m_yaml, m_helper, m_thehiveapi
-    ):
+    def test_generate_case_bundle_sends_attachments_with_work_id(self, m_thehiveapi):
         """When attachment import is enabled and attachments exist, the attachments
         bundle must be sent under the caller's work_id, while the main case bundle
         is still returned (not self-sent)."""
-        m_os.path.isfile.return_value = False
-        _connector = module.TheHive()
+        _connector = module.TheHive(_make_mock_config(), MagicMock())
         _connector.thehive_import_attachments = True
 
         _connector.process_markings = MagicMock(return_value=[])
@@ -239,13 +224,10 @@ class TheHiveTest(unittest.TestCase):
         # The main case bundle is still returned for process_items to send.
         self.assertEqual(result, _connector.helper.stix2_create_bundle.return_value)
 
-    def test_generate_alert_bundle_drops_none_relation(
-        self, m_os, m_yaml, m_helper, m_thehiveapi
-    ):
+    def test_generate_alert_bundle_drops_none_relation(self, m_thehiveapi):
         """A None relation (observable converted but relationship missing) must not
         be appended to the bundle: a None element aborts the send downstream."""
-        m_os.path.isfile.return_value = False
-        _connector = module.TheHive()
+        _connector = module.TheHive(_make_mock_config(), MagicMock())
 
         _connector.process_markings = MagicMock(return_value=[])
         _connector.create_stix_alert_incident = MagicMock(return_value=MagicMock())

--- a/external-import/thehive/tests/test_thehive.py
+++ b/external-import/thehive/tests/test_thehive.py
@@ -97,3 +97,77 @@ class TheHiveTest(unittest.TestCase):
         )
 
         self.assertEqual(processed_comments[0]["id"], processed_comments[1]["id"])
+
+    def test_process_items_respects_tlp_filter(
+        self, m_os, m_yaml, m_helper, m_thehiveapi
+    ):
+        """process_items must skip items whose TLP is not in import_only_tlp and
+        send allowed items exactly once, under the work_id."""
+        m_os.path.isfile.return_value = False
+        _connector = module.TheHive()
+        _connector.current_state = {}
+        _connector.thehive_import_from_date = 0
+        _connector.thehive_import_only_tlp = ["2"]
+
+        _now = int(time.time() * 1000)
+        allowed = {"tlp": 2, "title": "allowed", "_updatedAt": _now, "_createdAt": _now}
+        blocked = {"tlp": 3, "title": "blocked", "_updatedAt": _now, "_createdAt": _now}
+
+        process_func = MagicMock(return_value=sentinel.bundle)
+        work_id = _connector.helper.api.work.initiate_work.return_value
+
+        _connector.process_items(
+            type="case",
+            items=[allowed, blocked],
+            process_func=process_func,
+            last_date_key="last_case_date",
+        )
+
+        # Only the allowed item is converted and sent, and it carries the work_id.
+        process_func.assert_called_once_with(allowed, work_id)
+        _connector.helper.send_stix2_bundle.assert_called_once_with(
+            sentinel.bundle, work_id=work_id
+        )
+
+    def test_generate_case_bundle_does_not_self_send_main_bundle(
+        self, m_os, m_yaml, m_helper, m_thehiveapi
+    ):
+        """The main case bundle must be returned for process_items to send under the
+        work_id, not sent from within generate_case_bundle. The previous self-send
+        bypassed the TLP filter and ingested every case twice."""
+        m_os.path.isfile.return_value = False
+        _connector = module.TheHive()
+        _connector.thehive_import_attachments = False
+
+        _connector.process_markings = MagicMock(return_value=[])
+        _connector.process_observables = MagicMock(return_value=([], []))
+        _connector.process_main_case = MagicMock(return_value=MagicMock())
+        _connector.process_tasks = MagicMock(return_value=[])
+        _connector.process_comments = MagicMock(return_value=[])
+        _connector.helper.stix2_create_bundle.return_value = sentinel.bundle
+
+        _now = int(time.time() * 1000)
+        case = {"title": "my case", "_createdAt": _now}
+
+        result = _connector.generate_case_bundle(case)
+
+        _connector.helper.send_stix2_bundle.assert_not_called()
+        self.assertEqual(result, sentinel.bundle)
+
+    def test_process_observables_and_relations_handles_missing_id(
+        self, m_os, m_yaml, m_helper, m_thehiveapi
+    ):
+        """When the converted observable has no `id`, the function must return
+        (observable, None) instead of raising UnboundLocalError."""
+        m_os.path.isfile.return_value = False
+        _connector = module.TheHive()
+
+        observable_without_id = object()  # truthy, but has no `id` attribute
+        _connector.convert_observable = MagicMock(return_value=observable_without_id)
+
+        stix_observable, relation = _connector.process_observables_and_relations(
+            observable={}, markings=[], stix_incident=MagicMock()
+        )
+
+        self.assertIs(stix_observable, observable_without_id)
+        self.assertIsNone(relation)

--- a/external-import/thehive/tests/test_thehive.py
+++ b/external-import/thehive/tests/test_thehive.py
@@ -129,6 +129,40 @@ class TheHiveTest(unittest.TestCase):
             sentinel.bundle, work_id=work_id
         )
 
+    def test_process_items_advances_watermark_past_skipped_items(
+        self, m_os, m_yaml, m_helper, m_thehiveapi
+    ):
+        """The state watermark must advance even for items skipped by the TLP
+        filter, so high-TLP items are not refetched on every run (and an
+        all-skipped batch does not stall state forever)."""
+        m_os.path.isfile.return_value = False
+        _connector = module.TheHive()
+        _connector.current_state = {}
+        _connector.thehive_import_from_date = 0
+        _connector.thehive_import_only_tlp = ["2"]
+
+        blocked_updated_ms = 50_000_000
+        blocked = {
+            "tlp": 3,
+            "title": "blocked",
+            "_updatedAt": blocked_updated_ms,
+            "_createdAt": blocked_updated_ms,
+        }
+        process_func = MagicMock(return_value=sentinel.bundle)
+
+        updated_last_date = _connector.process_items(
+            type="case",
+            items=[blocked],
+            process_func=process_func,
+            last_date_key="last_case_date",
+        )
+
+        # The blocked item is neither converted nor sent...
+        process_func.assert_not_called()
+        _connector.helper.send_stix2_bundle.assert_not_called()
+        # ...yet the watermark advances past it (get_updated_date adds +1s).
+        self.assertEqual(updated_last_date, int(blocked_updated_ms / 1000) + 1)
+
     def test_generate_case_bundle_does_not_self_send_main_bundle(
         self, m_os, m_yaml, m_helper, m_thehiveapi
     ):

--- a/external-import/thehive/tests/test_thehive.py
+++ b/external-import/thehive/tests/test_thehive.py
@@ -220,6 +220,7 @@ class TheHiveTest(unittest.TestCase):
         _connector.helper.send_stix2_bundle.assert_called_once_with(
             _connector.helper.stix2_create_bundle.return_value,
             work_id=sentinel.work_id,
+            cleanup_inconsistent_bundle=True,
         )
         # The main case bundle is still returned for process_items to send.
         self.assertEqual(result, _connector.helper.stix2_create_bundle.return_value)


### PR DESCRIPTION
### Proposed changes

Fixes a TLP-enforcement bug and a few latent crashes / log-quality issues in the `external-import/thehive` connector. Changes are confined to `src/connector/connector.py` (the fix) and `src/tests/test_thehive.py` (regression tests). All changes are intentionally low-risk for this **verified** connector: **no changes to state keys, deterministic IDs, or marking sets**, so there is no re-import or duplication risk on existing deployments.

* **Enforce `THEHIVE_IMPORT_ONLY_TLP` on cases.** `generate_case_bundle` sent its bundle internally *before* `process_items` applied the TLP filter (and sent it again), so cases above the configured TLP were ingested anyway and every case was sent twice (the first send without a `work_id`). The main case bundle is now built in `generate_case_bundle` and sent once by `process_items`, under the work, after the TLP filter. Attachments are now sent with the same `work_id`. This also makes the README's existing description of `IMPORT_ONLY_TLP` accurate for cases.
* **Advance the state watermark past TLP-skipped items.** Previously a trailing high-TLP item was refetched and re-warned on every run, and an all-skipped batch stalled the state watermark indefinitely.
* **Avoid `NameError`.** Default `markings = []` before the marking `try` block in `generate_alert_bundle` and `generate_case_bundle`.
* **Avoid `UnboundLocalError`.** Initialize `stix_observable` / `stix_observable_relation` in `process_observables_and_relations`.
* **Never place `None` in an alert bundle.** A `None` relation passes bundle creation silently but makes the downstream send raise (`'NoneType' object is not subscriptable` in the bundle splitter, verified against pycti 7.260609.0), aborting the run with the work stuck in progress.
* **Correct log level.** A case with zero observables is now logged at info, not error.
* **Log quality and docs.** Removed `!!!` debug markers and an unused loop counter; translated French / curly-quote log strings to clean English; documented the `work_id` contract on the bundle generators and `process_items`.

### Related issues

* Closes #6670

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

All quality gates pass: `black`, `isort --profile black`, `flake8 --ignore=E,W`, the custom STIX pylint plugin (`linter_stix_id_generator`, 10.00/10), and `pytest` (**8 passed**).

Each behavioral change is covered by a dedicated unit test exercising both positive and negative paths:
- `test_process_items_respects_tlp_filter` — TLP-blocked item skipped; allowed item converted and sent once under the `work_id`;
- `test_process_items_advances_watermark_past_skipped_items` — watermark advances past TLP-skipped items (state-stall fix);
- `test_generate_case_bundle_does_not_self_send_main_bundle` — the TLP-bypass / double-ingest fix;
- `test_generate_case_bundle_sends_attachments_with_work_id` — attachments sent under the caller's work, main bundle still returned;
- `test_generate_alert_bundle_drops_none_relation` — a `None` relation never reaches the bundle;
- `test_process_observables_and_relations_handles_missing_id` — no `UnboundLocalError` when an observable has no `id`.

Documentation: docstrings were added/updated for the changed contracts (`generate_alert_bundle`, `generate_case_bundle`, `process_items`). No README changes are required — no configuration option was added, removed, or renamed; the fix makes the README's existing description of `IMPORT_ONLY_TLP` hold true for cases.

Note for reviewers: the Lint & Format check failure is unrelated to this PR — it is the repo-wide lint debt in `internal-enrichment/ismalicious/tests/` on current `master`, fixed separately in #6698.

Broader modernization of this connector to the current template (Pydantic/connectors-sdk settings, `schedule_process()`, package split, deterministic SCO IDs + `cleanup_inconsistent_bundle`, CMD-based Dockerfile) is intentionally **out of scope** here and is tracked in #6672 (#6673–#6676).
