### PR TITLE
chore(connectors): generate remaining config schema

### DIFF
--- a/external-import/anyrun-feed/__metadata__/connector_config_schema.json
+++ b/external-import/anyrun-feed/__metadata__/connector_config_schema.json
@@ -30,7 +30,7 @@
       "type": "array"
     },
     "CONNECTOR_LOG_LEVEL": {
-      "default": "info",
+      "default": "error",
       "description": "The minimum level of logs to display.",
       "enum": [
         "debug",
@@ -46,10 +46,11 @@
       "default": "EXTERNAL_IMPORT",
       "type": "string"
     },
-    "CONNECTOR_UPDATE_EXISTING_DATA": {
-      "default": false,
-      "description": "Whether to update data already ingested into the platform.",
-      "type": "boolean"
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT120M",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
     },
     "ANYRUN_API_KEY": {
       "description": "ANY.RUN TI Feeds API key. See 'Generate your API key' section in the README file.",

--- a/external-import/anyrun-feed/__metadata__/connector_manifest.json
+++ b/external-import/anyrun-feed/__metadata__/connector_manifest.json
@@ -15,7 +15,7 @@
   "support_version": ">=6.0.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/anyrun-feed",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-anyrun-feed",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/citalid/__metadata__/connector_config_schema.json
+++ b/external-import/citalid/__metadata__/connector_config_schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/citalid_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Citalid",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "citalid"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT24H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "CITALID_CUSTOMER_SUB_DOMAIN_URL": {
+      "description": "URL of your Citalid instance (customer subdomain).",
+      "format": "uri",
+      "type": "string"
+    },
+    "CITALID_USER": {
+      "description": "Username with access to the Citalid instance.",
+      "type": "string"
+    },
+    "CITALID_PASSWORD": {
+      "description": "Password for the Citalid user.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CITALID_INTERVAL": {
+      "default": 24,
+      "description": "Polling interval in hours between connector runs.",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CITALID_CUSTOMER_SUB_DOMAIN_URL",
+    "CITALID_USER",
+    "CITALID_PASSWORD"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/citalid/__metadata__/connector_manifest.json
+++ b/external-import/citalid/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.5.4",
   "subscription_link": "https://citalid.com/book-a-demo/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/citalid",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-citalid",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/cofense-threathq/__metadata__/connector_config_schema.json
+++ b/external-import/cofense-threathq/__metadata__/connector_config_schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/cofense-threathq_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The OpenCTI platform URL.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The token of the user who represents the connector in the OpenCTI platform.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Cofense ThreatHQ",
+      "description": "Name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "Cofense ThreatHQ"
+      ],
+      "description": "The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "Determines the verbosity of the logs.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT5H",
+      "description": "Duration between two scheduled runs of the connector (ISO 8601 format).",
+      "format": "duration",
+      "type": "string"
+    },
+    "COFENSE_THREATHQ_TOKEN_USER": {
+      "description": "Token User associated with the user to access the Cofense ThreatHQ API.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "COFENSE_THREATHQ_TOKEN_PASSWORD": {
+      "description": "Token Password associated with the user to access the Cofense ThreatHQ API.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "COFENSE_THREATHQ_IMPORT_START_DATE": {
+      "default": "P30D",
+      "description": "Start date of first import (ISO date format or ISO 8601 duration).",
+      "type": "string"
+    },
+    "COFENSE_THREATHQ_API_BASE_URL": {
+      "default": "https://www.threathq.com/apiv1/",
+      "description": "Base URL of the Cofense ThreatHQ API.",
+      "format": "uri",
+      "type": "string"
+    },
+    "COFENSE_THREATHQ_API_LEAKY_BUCKET_RATE": {
+      "default": 10,
+      "description": "Api leaky bucket rate.",
+      "type": "integer"
+    },
+    "COFENSE_THREATHQ_API_LEAKY_BUCKET_CAPACITY": {
+      "default": 10,
+      "description": "Api leaky bucket capacity.",
+      "type": "integer"
+    },
+    "COFENSE_THREATHQ_API_RETRY": {
+      "default": 5,
+      "description": "Maximum number of retry attempts in case of API failure.",
+      "type": "integer"
+    },
+    "COFENSE_THREATHQ_API_BACKOFF": {
+      "default": "PT30S",
+      "description": "Exponential backoff duration between API retries (ISO 8601 duration format).",
+      "format": "duration",
+      "type": "string"
+    },
+    "COFENSE_THREATHQ_IMPACT_TO_EXCLUDE": {
+      "default": null,
+      "description": "List of impact types to exclude: none, moderate, major.",
+      "items": {
+        "enum": [
+          "none",
+          "moderate",
+          "major"
+        ],
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "COFENSE_THREATHQ_IMPORT_REPORT_PDF": {
+      "default": true,
+      "description": "Import Cofense ThreatHQ reports in pdf format.",
+      "type": "boolean"
+    },
+    "COFENSE_THREATHQ_TLP_LEVEL": {
+      "default": "amber+strict",
+      "description": "Traffic Light Protocol (TLP) level to apply on objects imported into OpenCTI.",
+      "enum": [
+        "clear",
+        "green",
+        "amber",
+        "amber+strict",
+        "red"
+      ],
+      "type": "string"
+    },
+    "COFENSE_THREATHQ_PROMOTE_OBSERVABLES_AS_INDICATORS": {
+      "default": true,
+      "description": "Boolean to promote observables into indicators.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "COFENSE_THREATHQ_TOKEN_USER",
+    "COFENSE_THREATHQ_TOKEN_PASSWORD"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/cofense-threathq/__metadata__/connector_manifest.json
+++ b/external-import/cofense-threathq/__metadata__/connector_manifest.json
@@ -12,7 +12,7 @@
   "support_version": ">=6.8.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/cofense-threathq",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-cofense-threathq",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/comlaude/__metadata__/connector_config_schema.json
+++ b/external-import/comlaude/__metadata__/connector_config_schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/comlaude_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Comlaude",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "comlaude",
+        "stix"
+      ],
+      "description": "The scope or type of data the connector is importing.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT2H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "CONNECTOR_RUN_AND_TERMINATE": {
+      "default": false,
+      "description": "Terminate the container after a successful execution.",
+      "type": "boolean"
+    },
+    "CONNECTOR_QUEUE_THRESHOLD": {
+      "default": "500MB",
+      "description": "Optional queue threshold (e.g., 500MB).",
+      "type": "string"
+    },
+    "COMLAUDE_USERNAME": {
+      "description": "Username for the account with API access in Comlaude.",
+      "type": "string"
+    },
+    "COMLAUDE_PASSWORD": {
+      "description": "Password for the account with API access in Comlaude.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "COMLAUDE_API_KEY": {
+      "description": "API Key for the account with API access in Comlaude.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "COMLAUDE_GROUP_ID": {
+      "description": "Group ID for the Comlaude API domain search.",
+      "type": "string"
+    },
+    "COMLAUDE_SCORE": {
+      "default": 15,
+      "description": "Default score value to be assigned to domains (0 to 100).",
+      "type": "integer"
+    },
+    "COMLAUDE_START_TIME": {
+      "description": "Earliest entry to retrieve (e.g., 1970-01-01T00:00:00Z).",
+      "type": "string"
+    },
+    "COMLAUDE_LABELS": {
+      "default": "comlaude,safelist",
+      "description": "Comma-separated labels to apply to STIX Objects.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "COMLAUDE_USERNAME",
+    "COMLAUDE_PASSWORD",
+    "COMLAUDE_API_KEY",
+    "COMLAUDE_GROUP_ID",
+    "COMLAUDE_START_TIME"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/comlaude/__metadata__/connector_manifest.json
+++ b/external-import/comlaude/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.0.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/comlaude",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-comlaude",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/cybelangel/__metadata__/connector_config_schema.json
+++ b/external-import/cybelangel/__metadata__/connector_config_schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/cybelangel_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "CybelAngel",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "all"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT6H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "CYBELANGEL_CLIENT_ID": {
+      "description": "OAuth2 client ID for the CybelAngel platform API.",
+      "type": "string"
+    },
+    "CYBELANGEL_CLIENT_SECRET": {
+      "description": "OAuth2 client secret for the CybelAngel platform API.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CYBELANGEL_API_URL": {
+      "default": "https://platform.cybelangel.com",
+      "description": "Base URL of the CybelAngel platform API.",
+      "format": "uri",
+      "type": "string"
+    },
+    "CYBELANGEL_AUTH_URL": {
+      "default": "https://auth.cybelangel.com/oauth/token",
+      "description": "OAuth2 token endpoint URL for CybelAngel authentication.",
+      "format": "uri",
+      "type": "string"
+    },
+    "CYBELANGEL_AUDIENCE": {
+      "default": null,
+      "description": "OAuth2 audience claim. Defaults to CYBELANGEL_API_URL with a trailing slash.",
+      "type": "string"
+    },
+    "CYBELANGEL_MARKING": {
+      "default": "TLP:AMBER+STRICT",
+      "description": "TLP marking level applied to imported data.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    },
+    "CYBELANGEL_FETCH_PERIOD": {
+      "default": "7",
+      "description": "Number of days to look back on the first run. Use \"all\" to fetch all available data.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CYBELANGEL_CLIENT_ID",
+    "CYBELANGEL_CLIENT_SECRET"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/cybelangel/__metadata__/connector_manifest.json
+++ b/external-import/cybelangel/__metadata__/connector_manifest.json
@@ -15,7 +15,7 @@
   "support_version": ">=6.7.0",
   "subscription_link": "https://cybelangel.com/contact-us/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/cybelangel",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-cybelangel",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/elastic-security-incidents/__metadata__/connector_config_schema.json
+++ b/external-import/elastic-security-incidents/__metadata__/connector_config_schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/elastic-security-incidents_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Elastic Security Incidents",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "elastic-security-incidents"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT30M",
+      "description": "The period of time to await between two runs of the connector (ISO-8601 duration format).",
+      "format": "duration",
+      "type": "string"
+    },
+    "ELASTIC_SECURITY_URL": {
+      "description": "Elasticsearch cluster URL.",
+      "type": "string"
+    },
+    "ELASTIC_SECURITY_KIBANA_URL": {
+      "default": null,
+      "description": "Kibana URL (optional, will use Elasticsearch URL conversion if not provided).",
+      "type": "string"
+    },
+    "ELASTIC_SECURITY_API_KEY": {
+      "description": "API key for Elasticsearch.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "ELASTIC_SECURITY_VERIFY_SSL": {
+      "default": true,
+      "description": "Whether to verify SSL certificates when connecting to Elasticsearch.",
+      "type": "boolean"
+    },
+    "ELASTIC_SECURITY_CA_CERT": {
+      "default": null,
+      "description": "Path to CA certificate file for SSL verification.",
+      "type": "string"
+    },
+    "ELASTIC_SECURITY_IMPORT_START_DATE": {
+      "default": null,
+      "description": "Initial import start date in ISO-8601 format (defaults to 7 days ago if not set).",
+      "type": "string"
+    },
+    "ELASTIC_SECURITY_IMPORT_ALERTS": {
+      "default": true,
+      "description": "Whether to import security alerts from Elastic.",
+      "type": "boolean"
+    },
+    "ELASTIC_SECURITY_IMPORT_CASES": {
+      "default": true,
+      "description": "Whether to import security cases from Elastic.",
+      "type": "boolean"
+    },
+    "ELASTIC_SECURITY_ALERT_STATUSES": {
+      "default": null,
+      "description": "Comma-separated list of alert statuses to import (e.g. open,acknowledged,closed). Leave empty to import all.",
+      "type": "string"
+    },
+    "ELASTIC_SECURITY_ALERT_RULE_TAGS": {
+      "default": null,
+      "description": "Comma-separated list of alert rule tags to filter by (e.g. Domain: Endpoint,OS: Windows). Leave empty to import all.",
+      "type": "string"
+    },
+    "ELASTIC_SECURITY_CASE_STATUSES": {
+      "default": null,
+      "description": "Comma-separated list of case statuses to import (e.g. open,in-progress,closed). Leave empty to import all.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "ELASTIC_SECURITY_URL",
+    "ELASTIC_SECURITY_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/elastic-security-incidents/__metadata__/connector_manifest.json
+++ b/external-import/elastic-security-incidents/__metadata__/connector_manifest.json
@@ -15,7 +15,7 @@
   "support_version": ">=6.7.19",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/elastic-security-incidents",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-elastic-security-incidents",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/first-epss-bulk/__metadata__/connector_config_schema.json
+++ b/external-import/first-epss-bulk/__metadata__/connector_config_schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/first-epss-bulk_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "External Import First EPSS Connector",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "vulnerability"
+      ],
+      "description": "The scope or type of data the connector is importing.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT24H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "FIRST_EPSS_API_BASE_URL": {
+      "default": "https://epss.cyentia.com",
+      "description": "FIRST EPSS API base URL.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/first-epss-bulk/__metadata__/connector_manifest.json
+++ b/external-import/first-epss-bulk/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.8.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/first-epss-bulk",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-first-epss-bulk",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/group-ib/__metadata__/connector_config_schema.json
+++ b/external-import/group-ib/__metadata__/connector_config_schema.json
@@ -1,0 +1,762 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/group-ib_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Group-IB Connector",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": ["stix2", "ipv4-addr", "ipv6-addr", "vulnerability", "domain", "url", "StixFile"],
+      "description": "The scope or type of data the connector is importing.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": ["debug", "info", "warn", "warning", "error"],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT4H",
+      "description": "The period of time to await between two runs of the connector in ISO 8601 duration format.",
+      "format": "duration",
+      "type": "string"
+    },
+    "TI_API__URL": {
+      "default": "https://tap.group-ib.com/api/v2/",
+      "description": "Group-IB Threat Intelligence API URL.",
+      "type": "string"
+    },
+    "TI_API__USERNAME": {
+      "description": "Threat Intelligence Portal profile email (username).",
+      "type": "string"
+    },
+    "TI_API__TOKEN": {
+      "description": "Threat Intelligence API Token.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TI_API__PROXY__IP": {
+      "default": null,
+      "description": "Proxy server IP address.",
+      "type": ["string", "null"]
+    },
+    "TI_API__PROXY__PORT": {
+      "default": null,
+      "description": "Proxy server port.",
+      "type": ["integer", "null"]
+    },
+    "TI_API__PROXY__PROTOCOL": {
+      "default": null,
+      "description": "Proxy protocol (http or https).",
+      "type": ["string", "null"]
+    },
+    "TI_API__PROXY__USERNAME": {
+      "default": null,
+      "description": "Proxy authentication username.",
+      "type": ["string", "null"]
+    },
+    "TI_API__PROXY__PASSWORD": {
+      "default": null,
+      "description": "Proxy authentication password.",
+      "format": "password",
+      "type": ["string", "null"],
+      "writeOnly": true
+    },
+    "TI_API__EXTRA_SETTINGS__IGNORE_NON_INDICATOR_THREAT_REPORTS": {
+      "default": false,
+      "description": "Ignore threat reports that do not contain indicators.",
+      "type": "boolean"
+    },
+    "TI_API__EXTRA_SETTINGS__IGNORE_NON_INDICATOR_THREATS": {
+      "default": false,
+      "description": "Ignore threats that do not contain indicators.",
+      "type": "boolean"
+    },
+    "TI_API__EXTRA_SETTINGS__IGNORE_NON_MALWARE_DDOS": {
+      "default": true,
+      "description": "Ignore DDoS attacks that are not related to malware.",
+      "type": "boolean"
+    },
+    "TI_API__EXTRA_SETTINGS__INTRUSION_SET_INSTEAD_OF_THREAT_ACTOR": {
+      "default": false,
+      "description": "Use Intrusion Set instead of Threat Actor for APT groups.",
+      "type": "boolean"
+    },
+    "TI_API__EXTRA_SETTINGS__SCHEDULE_TIME": {
+      "default": "00:00",
+      "description": "Scheduled time for collection processing (HH:MM format).",
+      "type": "string"
+    },
+    "TI_API__EXTRA_SETTINGS__TIME_OUTPUT_FORMAT": {
+      "default": "%Y-%m-%d %H:%M:%S",
+      "description": "Output format for timestamps in logs.",
+      "type": "string"
+    },
+    "TI_API__EXTRA_SETTINGS__ENABLE_STATEMENT_MARKING": {
+      "default": false,
+      "description": "Enable statement marking on created STIX objects.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__APT_THREAT__ENABLE": {
+      "default": false,
+      "description": "Enable the APT Threat collection (indicators and MITRE ATT&CK matrix).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__APT_THREAT__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for APT Threat collection (e.g. 2025-01-01). Leave empty to use default.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__APT_THREAT__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to APT Threat collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__APT_THREAT__TTL": {
+      "default": 1460,
+      "description": "Time-to-live in days for APT Threat collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__APT_THREAT__USE_HUNTING_RULES": {
+      "default": false,
+      "description": "Enable hunting rules for APT Threat collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__APT_THREAT_ACTOR__ENABLE": {
+      "default": false,
+      "description": "Enable the APT Threat Actor collection (cybercriminal groups).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__APT_THREAT_ACTOR__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for APT Threat Actor collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__APT_THREAT_ACTOR__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to APT Threat Actor collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__APT_THREAT_ACTOR__TTL": {
+      "default": 1460,
+      "description": "Time-to-live in days for APT Threat Actor collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__ATTACKS_DDOS__ENABLE": {
+      "default": false,
+      "description": "Enable the DDoS Attacks collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__ATTACKS_DDOS__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for DDoS Attacks collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__ATTACKS_DDOS__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to DDoS Attacks collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__ATTACKS_DDOS__TTL": {
+      "default": 10,
+      "description": "Time-to-live in days for DDoS Attacks collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__ATTACKS_DEFACE__ENABLE": {
+      "default": false,
+      "description": "Enable the Deface Attacks collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__ATTACKS_DEFACE__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Deface Attacks collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__ATTACKS_DEFACE__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Deface Attacks collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__ATTACKS_DEFACE__TTL": {
+      "default": 10,
+      "description": "Time-to-live in days for Deface Attacks collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__ATTACKS_PHISHING_GROUP__ENABLE": {
+      "default": false,
+      "description": "Enable the Phishing Group collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__ATTACKS_PHISHING_GROUP__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Phishing Group collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__ATTACKS_PHISHING_GROUP__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Phishing Group collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__ATTACKS_PHISHING_GROUP__TTL": {
+      "default": 5,
+      "description": "Time-to-live in days for Phishing Group collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__ATTACKS_PHISHING_KIT__ENABLE": {
+      "default": false,
+      "description": "Enable the Phishing Kit collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__ATTACKS_PHISHING_KIT__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Phishing Kit collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__ATTACKS_PHISHING_KIT__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Phishing Kit collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__ATTACKS_PHISHING_KIT__TTL": {
+      "default": 30,
+      "description": "Time-to-live in days for Phishing Kit collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_ACCESS__ENABLE": {
+      "default": false,
+      "description": "Enable the Compromised Access collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_ACCESS__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Compromised Access collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_ACCESS__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Compromised Access collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_ACCESS__TTL": {
+      "default": 1460,
+      "description": "Time-to-live in days for Compromised Access collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_ACCOUNT_GROUP__ENABLE": {
+      "default": false,
+      "description": "Enable the Compromised Account Group collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_ACCOUNT_GROUP__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Compromised Account Group collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_ACCOUNT_GROUP__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Compromised Account Group collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_ACCOUNT_GROUP__TTL": {
+      "default": 1460,
+      "description": "Time-to-live in days for Compromised Account Group collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_BANK_CARD_GROUP__ENABLE": {
+      "default": false,
+      "description": "Enable the Compromised Bank Card Group collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_BANK_CARD_GROUP__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Compromised Bank Card Group collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_BANK_CARD_GROUP__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Compromised Bank Card Group collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_BANK_CARD_GROUP__TTL": {
+      "default": 730,
+      "description": "Time-to-live in days for Compromised Bank Card Group collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_DISCORD__ENABLE": {
+      "default": false,
+      "description": "Enable the Compromised Discord collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_DISCORD__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Compromised Discord collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_DISCORD__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Compromised Discord collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_DISCORD__TTL": {
+      "default": 30,
+      "description": "Time-to-live in days for Compromised Discord collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_IMEI__ENABLE": {
+      "default": false,
+      "description": "Enable the Compromised IMEI collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_IMEI__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Compromised IMEI collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_IMEI__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Compromised IMEI collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_IMEI__TTL": {
+      "default": 30,
+      "description": "Time-to-live in days for Compromised IMEI collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_MASKED_CARD__ENABLE": {
+      "default": false,
+      "description": "Enable the Compromised Masked Card collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_MASKED_CARD__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Compromised Masked Card collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_MASKED_CARD__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Compromised Masked Card collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_MASKED_CARD__TTL": {
+      "default": 90,
+      "description": "Time-to-live in days for Compromised Masked Card collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_MESSENGER__ENABLE": {
+      "default": false,
+      "description": "Enable the Compromised Messenger collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_MESSENGER__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Compromised Messenger collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_MESSENGER__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Compromised Messenger collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_MESSENGER__TTL": {
+      "default": 30,
+      "description": "Time-to-live in days for Compromised Messenger collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_MULE__ENABLE": {
+      "default": false,
+      "description": "Enable the Compromised Mule collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_MULE__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Compromised Mule collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_MULE__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Compromised Mule collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__COMPROMISED_MULE__TTL": {
+      "default": 30,
+      "description": "Time-to-live in days for Compromised Mule collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__HI_OPEN_THREATS__ENABLE": {
+      "default": false,
+      "description": "Enable the HI Open Threats collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__HI_OPEN_THREATS__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for HI Open Threats collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__HI_OPEN_THREATS__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to HI Open Threats collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__HI_OPEN_THREATS__TTL": {
+      "default": null,
+      "description": "Time-to-live in days for HI Open Threats collection objects.",
+      "type": ["integer", "null"]
+    },
+    "TI_API__COLLECTIONS__HI_THREAT__ENABLE": {
+      "default": false,
+      "description": "Enable the HI Threat collection (indicators and MITRE ATT&CK matrix).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__HI_THREAT__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for HI Threat collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__HI_THREAT__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to HI Threat collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__HI_THREAT__TTL": {
+      "default": 1460,
+      "description": "Time-to-live in days for HI Threat collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__HI_THREAT__USE_HUNTING_RULES": {
+      "default": false,
+      "description": "Enable hunting rules for HI Threat collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__HI_THREAT_ACTOR__ENABLE": {
+      "default": false,
+      "description": "Enable the HI Threat Actor collection (cybercriminal groups).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__HI_THREAT_ACTOR__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for HI Threat Actor collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__HI_THREAT_ACTOR__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to HI Threat Actor collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__HI_THREAT_ACTOR__TTL": {
+      "default": 1460,
+      "description": "Time-to-live in days for HI Threat Actor collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__IOC_COMMON__ENABLE": {
+      "default": false,
+      "description": "Enable the Common IoC collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__IOC_COMMON__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Common IoC collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__IOC_COMMON__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Common IoC collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__IOC_COMMON__TTL": {
+      "default": 90,
+      "description": "Time-to-live in days for Common IoC collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__MALWARE_CNC__ENABLE": {
+      "default": false,
+      "description": "Enable the Malware CNC collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__MALWARE_CNC__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Malware CNC collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__MALWARE_CNC__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Malware CNC collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__MALWARE_CNC__TTL": {
+      "default": 90,
+      "description": "Time-to-live in days for Malware CNC collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__MALWARE_CONFIG__ENABLE": {
+      "default": false,
+      "description": "Enable the Malware Config collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__MALWARE_CONFIG__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Malware Config collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__MALWARE_CONFIG__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Malware Config collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__MALWARE_CONFIG__TTL": {
+      "default": 90,
+      "description": "Time-to-live in days for Malware Config collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__MALWARE_MALWARE__ENABLE": {
+      "default": false,
+      "description": "Enable the Malware collection (detailed malware information).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__MALWARE_MALWARE__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Malware collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__MALWARE_MALWARE__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Malware collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__MALWARE_MALWARE__TTL": {
+      "default": 1460,
+      "description": "Time-to-live in days for Malware collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__MALWARE_SIGNATURE__ENABLE": {
+      "default": false,
+      "description": "Enable the Malware Signature collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__MALWARE_SIGNATURE__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Malware Signature collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__MALWARE_SIGNATURE__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Malware Signature collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__MALWARE_SIGNATURE__TTL": {
+      "default": 30,
+      "description": "Time-to-live in days for Malware Signature collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__MALWARE_YARA__ENABLE": {
+      "default": false,
+      "description": "Enable the Malware YARA collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__MALWARE_YARA__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Malware YARA collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__MALWARE_YARA__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Malware YARA collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__MALWARE_YARA__TTL": {
+      "default": 30,
+      "description": "Time-to-live in days for Malware YARA collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__OSI_GIT_REPOSITORY__ENABLE": {
+      "default": false,
+      "description": "Enable the OSI Git Repository collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__OSI_GIT_REPOSITORY__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for OSI Git Repository collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__OSI_GIT_REPOSITORY__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to OSI Git Repository collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__OSI_GIT_REPOSITORY__TTL": {
+      "default": 30,
+      "description": "Time-to-live in days for OSI Git Repository collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__OSI_PUBLIC_LEAK__ENABLE": {
+      "default": false,
+      "description": "Enable the OSI Public Leak collection (not implemented in current version).",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__OSI_PUBLIC_LEAK__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for OSI Public Leak collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__OSI_PUBLIC_LEAK__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to OSI Public Leak collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__OSI_PUBLIC_LEAK__TTL": {
+      "default": 15,
+      "description": "Time-to-live in days for OSI Public Leak collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__OSI_VULNERABILITY__ENABLE": {
+      "default": false,
+      "description": "Enable the OSI Vulnerability collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__OSI_VULNERABILITY__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for OSI Vulnerability collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__OSI_VULNERABILITY__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to OSI Vulnerability collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__OSI_VULNERABILITY__TTL": {
+      "default": 90,
+      "description": "Time-to-live in days for OSI Vulnerability collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_OPEN_PROXY__ENABLE": {
+      "default": false,
+      "description": "Enable the Suspicious IP Open Proxy collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_OPEN_PROXY__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Suspicious IP Open Proxy collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_OPEN_PROXY__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Suspicious IP Open Proxy collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_OPEN_PROXY__TTL": {
+      "default": 5,
+      "description": "Time-to-live in days for Suspicious IP Open Proxy collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_SCANNER__ENABLE": {
+      "default": false,
+      "description": "Enable the Suspicious IP Scanner collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_SCANNER__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Suspicious IP Scanner collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_SCANNER__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Suspicious IP Scanner collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_SCANNER__TTL": {
+      "default": 5,
+      "description": "Time-to-live in days for Suspicious IP Scanner collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_SOCKS_PROXY__ENABLE": {
+      "default": false,
+      "description": "Enable the Suspicious IP SOCKS Proxy collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_SOCKS_PROXY__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Suspicious IP SOCKS Proxy collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_SOCKS_PROXY__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Suspicious IP SOCKS Proxy collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_SOCKS_PROXY__TTL": {
+      "default": 5,
+      "description": "Time-to-live in days for Suspicious IP SOCKS Proxy collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_TOR_NODE__ENABLE": {
+      "default": false,
+      "description": "Enable the Suspicious IP Tor Node collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_TOR_NODE__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Suspicious IP Tor Node collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_TOR_NODE__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Suspicious IP Tor Node collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_TOR_NODE__TTL": {
+      "default": 5,
+      "description": "Time-to-live in days for Suspicious IP Tor Node collection objects.",
+      "type": "integer"
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_VPN__ENABLE": {
+      "default": false,
+      "description": "Enable the Suspicious IP VPN collection.",
+      "type": "boolean"
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_VPN__DEFAULT_DATE": {
+      "default": null,
+      "description": "Start date for Suspicious IP VPN collection.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_VPN__LOCAL_CUSTOM_TAG": {
+      "default": null,
+      "description": "Custom tag to apply to Suspicious IP VPN collection objects.",
+      "type": ["string", "null"]
+    },
+    "TI_API__COLLECTIONS__SUSPICIOUS_IP_VPN__TTL": {
+      "default": 5,
+      "description": "Time-to-live in days for Suspicious IP VPN collection objects.",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "TI_API__USERNAME",
+    "TI_API__TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/group-ib/__metadata__/connector_manifest.json
+++ b/external-import/group-ib/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.2.12",
   "subscription_link": "https://www.group-ib.com",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/group-ib",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-group-ib",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/ibm-xti/__metadata__/connector_config_schema.json
+++ b/external-import/ibm-xti/__metadata__/connector_config_schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/ibm-xti_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "IBMXTIConnector",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "ibm-xti"
+      ],
+      "description": "The scope or type of data the connector is importing.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT5M",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "CONNECTOR_IBM_XTI_TAXII_SERVER_URL": {
+      "description": "The base URL of the IBM X-Force PTI TAXII Server.",
+      "format": "uri",
+      "type": "string"
+    },
+    "CONNECTOR_IBM_XTI_TAXII_USER": {
+      "description": "Your TAXII Server username.",
+      "type": "string"
+    },
+    "CONNECTOR_IBM_XTI_TAXII_PASS": {
+      "description": "Your TAXII Server password.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_IBM_XTI_TAXII_COLLECTIONS": {
+      "default": "",
+      "description": "Comma-separated list of collection IDs to ingest.",
+      "type": "string"
+    },
+    "CONNECTOR_IBM_XTI_CREATE_OBSERVABLES": {
+      "default": false,
+      "description": "Create observables from indicators.",
+      "type": "boolean"
+    },
+    "CONNECTOR_IBM_XTI_DEBUG": {
+      "default": false,
+      "description": "Enable debug mode (developers only).",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_IBM_XTI_TAXII_SERVER_URL",
+    "CONNECTOR_IBM_XTI_TAXII_USER",
+    "CONNECTOR_IBM_XTI_TAXII_PASS"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/ibm-xti/__metadata__/connector_manifest.json
+++ b/external-import/ibm-xti/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">= 6.5.1",
   "subscription_link": "https://www.ibm.com/services/threat-intelligence",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/ibm-xti",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-ibm-xti",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/infoblox/__metadata__/connector_config_schema.json
+++ b/external-import/infoblox/__metadata__/connector_config_schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/infoblox_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "INFOBLOX",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "infoblox"
+      ],
+      "description": "The scope or type of data the connector is importing.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT12H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "INFOBLOX_API_KEY": {
+      "description": "Your Infoblox TIDE API key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "INFOBLOX_URL": {
+      "default": "https://csp.infoblox.com/tide/api/data/threats",
+      "description": "Infoblox TIDE API endpoint URL.",
+      "type": "string"
+    },
+    "INFOBLOX_INTERVAL": {
+      "default": 12,
+      "description": "Polling interval in hours.",
+      "type": "integer"
+    },
+    "INFOBLOX_IOC_LIMIT": {
+      "default": 10000,
+      "description": "Maximum number of IOCs to fetch per type per run.",
+      "type": "integer"
+    },
+    "INFOBLOX_MARKING": {
+      "default": "TLP:AMBER+STRICT",
+      "description": "TLP marking for imported data.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "INFOBLOX_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/infoblox/__metadata__/connector_manifest.json
+++ b/external-import/infoblox/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">= 6.5.1",
   "subscription_link": "https://www.infoblox.com/threat-intel/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/infoblox",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-infoblox",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/intel471/__metadata__/connector_config_schema.json
+++ b/external-import/intel471/__metadata__/connector_config_schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/intel471_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Intel471",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "malware",
+        "vulnerability",
+        "indicator"
+      ],
+      "description": "The scope or type of data the connector is importing.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "INTEL471_API_USERNAME": {
+      "description": "Titan API username.",
+      "type": "string"
+    },
+    "INTEL471_API_KEY": {
+      "description": "Titan API key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "INTEL471_INTERVAL_INDICATORS": {
+      "default": 60,
+      "description": "Minutes between indicator fetches. Set to 0 to disable.",
+      "type": "integer"
+    },
+    "INTEL471_INITIAL_HISTORY_INDICATORS": {
+      "default": 0,
+      "description": "Epoch milliseconds for initial indicators fetch start date.",
+      "type": "integer"
+    },
+    "INTEL471_INTERVAL_YARA": {
+      "default": 60,
+      "description": "Minutes between YARA rule fetches. Set to 0 to disable.",
+      "type": "integer"
+    },
+    "INTEL471_INITIAL_HISTORY_YARA": {
+      "default": 0,
+      "description": "Epoch milliseconds for initial YARA fetch start date.",
+      "type": "integer"
+    },
+    "INTEL471_INTERVAL_CVES": {
+      "default": 120,
+      "description": "Minutes between CVE report fetches. Set to 0 to disable.",
+      "type": "integer"
+    },
+    "INTEL471_INITIAL_HISTORY_CVES": {
+      "default": 0,
+      "description": "Epoch milliseconds for initial CVE fetch start date.",
+      "type": "integer"
+    },
+    "INTEL471_INTERVAL_IOCS": {
+      "default": 120,
+      "description": "Minutes between IOC fetches. Set to 0 to disable.",
+      "type": "integer"
+    },
+    "INTEL471_INITIAL_HISTORY_IOCS": {
+      "default": 0,
+      "description": "Epoch milliseconds for initial IOC fetch start date.",
+      "type": "integer"
+    },
+    "INTEL471_PROXY": {
+      "default": null,
+      "description": "Optional proxy URL (e.g., http://user:pass@localhost:3128).",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "INTEL471_API_USERNAME",
+    "INTEL471_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/intel471/__metadata__/connector_manifest.json
+++ b/external-import/intel471/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.5.4",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/intel471",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-intel471",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/ipsum/__metadata__/connector_config_schema.json
+++ b/external-import/ipsum/__metadata__/connector_config_schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/ipsum_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The default admin token set in the OpenCTI platform.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "IPsum",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "ipsum"
+      ],
+      "description": "The scope or type of data the connector is importing.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "Determines the verbosity of logs.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT6H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "CONNECTOR_IPSUM_API_BASE_URL": {
+      "default": "https://raw.githubusercontent.com/stamparm/ipsum/refs/heads/master/levels/5.txt",
+      "description": "IPsum feed URL (levels 1-8 available).",
+      "type": "string"
+    },
+    "CONNECTOR_IPSUM_API_KEY": {
+      "description": "GitHub API key (optional, for rate limiting).",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true,
+      "default": null
+    },
+    "CONNECTOR_IPSUM_DEFAULT_X_OPENCTI_SCORE": {
+      "default": 60,
+      "description": "Default x_opencti_score for indicators.",
+      "type": "integer"
+    },
+    "CONNECTOR_IPSUM_TLP_LEVEL": {
+      "default": "white",
+      "description": "TLP marking for imported data.",
+      "enum": [
+        "white",
+        "green",
+        "amber",
+        "amber+strict",
+        "red"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/ipsum/__metadata__/connector_manifest.json
+++ b/external-import/ipsum/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.4.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/ipsum",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-ipsum",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/malcore/__metadata__/connector_config_schema.json
+++ b/external-import/malcore/__metadata__/connector_config_schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/malcore_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Malcore",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "malcore"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT12H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "MALCORE_API_URL": {
+      "default": "https://api.malcore.io/api/feed",
+      "description": "Malcore API endpoint URL.",
+      "type": "string"
+    },
+    "MALCORE_API_KEY": {
+      "description": "Your Malcore API key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "MALCORE_SCORE": {
+      "default": 100,
+      "description": "Default indicator/observable score. Parameter reserved for future use.",
+      "type": "integer"
+    },
+    "MALCORE_LIMIT": {
+      "default": 10000,
+      "description": "Maximum number of entities to retrieve per request. Parameter reserved for future use.",
+      "type": "integer"
+    },
+    "MALCORE_INTERVAL": {
+      "default": 12,
+      "description": "Interval between two executions, in hours (must be strictly greater than 1).",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "MALCORE_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/malcore/__metadata__/connector_manifest.json
+++ b/external-import/malcore/__metadata__/connector_manifest.json
@@ -12,7 +12,7 @@
   "support_version": ">=6.8.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/malcore",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-malcore",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/maltiverse/__metadata__/connector_config_schema.json
+++ b/external-import/maltiverse/__metadata__/connector_config_schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/maltiverse_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "MALTIVERSE",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "ipv4-addr",
+        "ipv6-addr",
+        "vulnerability",
+        "domain",
+        "url",
+        "file-sha256",
+        "file-md5",
+        "file-sha1"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "MALTIVERSE_USER": {
+      "description": "Maltiverse account username/email.",
+      "type": "string"
+    },
+    "MALTIVERSE_PASSWD": {
+      "description": "Maltiverse account password.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "MALTIVERSE_FEEDS": {
+      "description": "Comma-separated list of feed/collection IDs to fetch from Maltiverse.",
+      "type": "string"
+    },
+    "MALTIVERSE_POLL_INTERVAL": {
+      "description": "Polling interval in hours between connector runs.",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "MALTIVERSE_USER",
+    "MALTIVERSE_PASSWD",
+    "MALTIVERSE_FEEDS",
+    "MALTIVERSE_POLL_INTERVAL"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/maltiverse/__metadata__/connector_manifest.json
+++ b/external-import/maltiverse/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.5.4",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/maltiverse",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-maltiverse",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/microsoft-defender-incidents/__metadata__/connector_config_schema.json
+++ b/external-import/microsoft-defender-incidents/__metadata__/connector_config_schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/microsoft-defender-incidents_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Microsoft Defender Incidents",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "defender"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT1H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "MICROSOFT_DEFENDER_INCIDENTS_TENANT_ID": {
+      "description": "Your Azure App Tenant ID.",
+      "type": "string"
+    },
+    "MICROSOFT_DEFENDER_INCIDENTS_CLIENT_ID": {
+      "description": "Your Azure App Client ID.",
+      "type": "string"
+    },
+    "MICROSOFT_DEFENDER_INCIDENTS_CLIENT_SECRET": {
+      "description": "Your Azure App Client Secret.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "MICROSOFT_DEFENDER_INCIDENTS_API_BASE_URL": {
+      "default": "https://graph.microsoft.com/v1.0",
+      "description": "The Microsoft Graph API base URL.",
+      "type": "string"
+    },
+    "MICROSOFT_DEFENDER_INCIDENTS_INCIDENT_PATH": {
+      "default": "/security/incidents",
+      "description": "The incident URL path that will be used.",
+      "type": "string"
+    },
+    "MICROSOFT_DEFENDER_INCIDENTS_IMPORT_START_DATE": {
+      "default": null,
+      "description": "Import starting date (in YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ format). Defaults to 2020-01-01T00:00:00Z if not set.",
+      "type": ["string", "null"]
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "MICROSOFT_DEFENDER_INCIDENTS_TENANT_ID",
+    "MICROSOFT_DEFENDER_INCIDENTS_CLIENT_ID",
+    "MICROSOFT_DEFENDER_INCIDENTS_CLIENT_SECRET"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/microsoft-defender-incidents/__metadata__/connector_manifest.json
+++ b/external-import/microsoft-defender-incidents/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.5.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/microsoft-defender-incidents",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-microsoft-defender-incidents",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/proofpoint-et-reputation/__metadata__/connector_config_schema.json
+++ b/external-import/proofpoint-et-reputation/__metadata__/connector_config_schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/proofpoint-et-reputation_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ProofPoint ET Reputation",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "IPv4-Addr",
+        "Domain-Name"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT24H",
+      "description": "The period of time to await between two runs of the connector (ISO 8601 duration format).",
+      "format": "duration",
+      "type": "string"
+    },
+    "PROOFPOINT_ET_REPUTATION_API_TOKEN": {
+      "description": "API token used for authentication with the ProofPoint ET Reputation API.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "PROOFPOINT_ET_REPUTATION_CREATE_INDICATOR": {
+      "default": true,
+      "description": "Whether to create indicators from the reputation data. If true, indicators and relationships will be generated; otherwise, only observables will be created.",
+      "type": "boolean"
+    },
+    "PROOFPOINT_ET_REPUTATION_MIN_SCORE": {
+      "default": 20,
+      "description": "Minimum score threshold for processing reputation data. Must be between 20 and 100.",
+      "minimum": 20,
+      "maximum": 100,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "PROOFPOINT_ET_REPUTATION_API_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/proofpoint-et-reputation/__metadata__/connector_manifest.json
+++ b/external-import/proofpoint-et-reputation/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.4.11",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/proofpoint-et-reputation",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-proofpoint-et-reputation",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/rst-report-hub/__metadata__/connector_config_schema.json
+++ b/external-import/rst-report-hub/__metadata__/connector_config_schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/rst-report-hub_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "RST Report Hub",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "application/json",
+        "application/pdf"
+      ],
+      "description": "The scope or type of data the connector is importing, either a MIME type or Stix Object.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT5M",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "RST_REPORT_HUB_BASE_URL": {
+      "default": "https://api.rstcloud.net/v1",
+      "description": "The base URL of the RST Cloud API. In some cases, you may want to use a local API endpoint.",
+      "type": "string"
+    },
+    "RST_REPORT_HUB_API_KEY": {
+      "description": "Your API Key for accessing RST Cloud.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "RST_REPORT_HUB_CONNECTION_TIMEOUT": {
+      "default": 30,
+      "description": "Connection timeout to the API in seconds.",
+      "type": "integer"
+    },
+    "RST_REPORT_HUB_READ_TIMEOUT": {
+      "default": 60,
+      "description": "Read timeout for each feed in seconds. If the connector is unable to fetch a report in time, increase the read timeout.",
+      "type": "integer"
+    },
+    "RST_REPORT_HUB_RETRY_DELAY": {
+      "default": 30,
+      "description": "Specifies how long to wait in seconds before next attempt to connect to the API.",
+      "type": "integer"
+    },
+    "RST_REPORT_HUB_RETRY_ATTEMPTS": {
+      "default": 5,
+      "description": "Number of retry attempts when failing to connect to the API.",
+      "type": "integer"
+    },
+    "RST_REPORT_HUB_IMPORT_START_DATE": {
+      "default": null,
+      "description": "The date from which to retrieve reports in the format YYYYMMDD (e.g. 20240527). By default, calculated as 7 days ago.",
+      "type": ["string", "null"]
+    },
+    "RST_REPORT_HUB_FETCH_INTERVAL": {
+      "default": 300,
+      "description": "The interval in seconds between data fetch operations.",
+      "type": "integer"
+    },
+    "RST_REPORT_HUB_LANGUAGE": {
+      "default": "eng",
+      "description": "The language for reports. Reach out to support@rstcloud.net to update this parameter.",
+      "type": "string"
+    },
+    "RST_REPORT_HUB_CREATE_OBSERVABLES": {
+      "default": false,
+      "description": "Whether to create observables in addition to indicators.",
+      "type": "boolean"
+    },
+    "RST_REPORT_HUB_CREATE_RELATED_TO": {
+      "default": true,
+      "description": "Whether to create related-to relationships.",
+      "type": "boolean"
+    },
+    "RST_REPORT_HUB_CREATE_CUSTOM_TTPS": {
+      "default": true,
+      "description": "Whether to create attack-pattern objects with custom names not yet present in the MITRE ATT&CK framework.",
+      "type": "boolean"
+    },
+    "RST_REPORT_HUB_SET_DETECTION_FLAG": {
+      "default": false,
+      "description": "Whether to set the detection flag on indicators from reports.",
+      "type": "boolean"
+    },
+    "RST_REPORT_HUB_REPORT_LABELS_DISABLED": {
+      "default": [],
+      "description": "A comma-separated list of labels to ignore when creating Report objects.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "RST_REPORT_HUB_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/rst-report-hub/__metadata__/connector_manifest.json
+++ b/external-import/rst-report-hub/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.12.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/rst-report-hub",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-rst-report-hub",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/rst-threat-feed/__metadata__/connector_config_schema.json
+++ b/external-import/rst-threat-feed/__metadata__/connector_config_schema.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/rst-threat-feed_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "RST Threat Feed",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "application/json"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "P1D",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "RST_THREAT_FEED_BASEURL": {
+      "default": "https://api.rstcloud.net/v1",
+      "description": "The base URL of the RST Cloud API.",
+      "type": "string"
+    },
+    "RST_THREAT_FEED_APIKEY": {
+      "description": "The API key for accessing the RST Cloud threat feed.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "RST_THREAT_FEED_SSL_VERIFY": {
+      "default": true,
+      "description": "Whether to verify SSL certificates when connecting to the API.",
+      "type": "boolean"
+    },
+    "RST_THREAT_FEED_CONTIMEOUT": {
+      "default": 30,
+      "description": "Connection timeout in seconds for feed downloads.",
+      "type": "integer"
+    },
+    "RST_THREAT_FEED_READTIMEOUT": {
+      "default": 120,
+      "description": "Read timeout in seconds for feed downloads.",
+      "type": "integer"
+    },
+    "RST_THREAT_FEED_RETRY": {
+      "default": 2,
+      "description": "Number of retries for feed download attempts.",
+      "type": "integer"
+    },
+    "RST_THREAT_FEED_INTERVAL": {
+      "default": 86400,
+      "description": "Feed download interval in seconds.",
+      "type": "integer"
+    },
+    "RST_THREAT_FEED_MAX_RETRIES": {
+      "default": 3,
+      "description": "Maximum number of retries for connection issues when sending the STIX bundle to OpenCTI.",
+      "type": "integer"
+    },
+    "RST_THREAT_FEED_RETRY_DELAY": {
+      "default": 10,
+      "description": "Initial delay in seconds between retries when sending the STIX bundle to OpenCTI.",
+      "type": "integer"
+    },
+    "RST_THREAT_FEED_RETRY_BACKOFF_MULTIPLIER": {
+      "default": 2.0,
+      "description": "Multiplier applied to the retry delay for exponential backoff.",
+      "type": "number"
+    },
+    "RST_THREAT_FEED_IP": {
+      "default": true,
+      "description": "Whether to import IP address indicators.",
+      "type": "boolean"
+    },
+    "RST_THREAT_FEED_DOMAIN": {
+      "default": true,
+      "description": "Whether to import domain name indicators.",
+      "type": "boolean"
+    },
+    "RST_THREAT_FEED_URL": {
+      "default": true,
+      "description": "Whether to import URL indicators.",
+      "type": "boolean"
+    },
+    "RST_THREAT_FEED_HASH": {
+      "default": true,
+      "description": "Whether to import file hash indicators.",
+      "type": "boolean"
+    },
+    "RST_THREAT_FEED_LATEST": {
+      "default": "day",
+      "description": "Time range for the feed data to retrieve.",
+      "enum": [
+        "1h",
+        "4h",
+        "12h",
+        "day"
+      ],
+      "type": "string"
+    },
+    "RST_THREAT_FEED_MIN_SCORE_IMPORT": {
+      "default": 20,
+      "description": "Minimum score threshold for importing indicators. Indicators below this score will be ignored.",
+      "type": "integer"
+    },
+    "RST_THREAT_FEED_MIN_SCORE_DETECTION_IP": {
+      "default": 45,
+      "description": "Minimum score to set x_opencti_detection to true for IP indicators.",
+      "type": "integer"
+    },
+    "RST_THREAT_FEED_MIN_SCORE_DETECTION_DOMAIN": {
+      "default": 45,
+      "description": "Minimum score to set x_opencti_detection to true for domain indicators.",
+      "type": "integer"
+    },
+    "RST_THREAT_FEED_MIN_SCORE_DETECTION_URL": {
+      "default": 45,
+      "description": "Minimum score to set x_opencti_detection to true for URL indicators.",
+      "type": "integer"
+    },
+    "RST_THREAT_FEED_MIN_SCORE_DETECTION_HASH": {
+      "default": 45,
+      "description": "Minimum score to set x_opencti_detection to true for hash indicators.",
+      "type": "integer"
+    },
+    "RST_THREAT_FEED_ONLY_NEW": {
+      "default": true,
+      "description": "Whether to import only new indicators (not previously seen).",
+      "type": "boolean"
+    },
+    "RST_THREAT_FEED_ONLY_ATTRIBUTED": {
+      "default": false,
+      "description": "Whether to import only indicators attributed to a specific threat actor or malware.",
+      "type": "boolean"
+    },
+    "RST_THREAT_FEED_KEEP_NAMED_VULNS": {
+      "default": true,
+      "description": "Whether to keep named vulnerabilities in the feed data.",
+      "type": "boolean"
+    },
+    "RST_THREAT_FEED_CREATE_MITRE_TTPS": {
+      "default": false,
+      "description": "Whether to create relationships between indicators and MITRE ATT&CK TTPs. Enabling this will create a large number of relationships.",
+      "type": "boolean"
+    },
+    "RST_THREAT_FEED_CREATE_CUSTOM_TTPS": {
+      "default": true,
+      "description": "Whether to create custom Attack-Pattern objects and relationships for named techniques not yet covered by MITRE.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "RST_THREAT_FEED_APIKEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/rst-threat-feed/__metadata__/connector_manifest.json
+++ b/external-import/rst-threat-feed/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.12.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/rst-threat-feed",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-rst-threat-feed",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/s3/__metadata__/connector_config_schema.json
+++ b/external-import/s3/__metadata__/connector_config_schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/s3_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "S3 Bucket",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "s3"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "S3_REGION": {
+      "default": "us-east-1",
+      "description": "S3 Region for Amazon.",
+      "type": "string"
+    },
+    "S3_ENDPOINT_URL": {
+      "default": null,
+      "description": "S3 Endpoint URL for S3-compatible services.",
+      "type": "string"
+    },
+    "S3_ACCESS_KEY_ID": {
+      "description": "S3 Access Key ID.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "S3_SECRET_ACCESS_KEY": {
+      "description": "S3 Secret Access Key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "S3_BUCKET_NAME": {
+      "description": "S3 Bucket Name.",
+      "type": "string"
+    },
+    "S3_BUCKET_PREFIXES": {
+      "default": "ACI_TI,ACI_Vuln",
+      "description": "Comma-separated S3 Bucket Prefixes to process.",
+      "type": "string"
+    },
+    "S3_AUTHOR": {
+      "default": null,
+      "description": "Organization name for created_by_ref if not present in data.",
+      "type": "string"
+    },
+    "S3_MARKING": {
+      "default": "TLP:GREEN",
+      "description": "Default marking definition if not present in data.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:RED"
+      ],
+      "type": "string"
+    },
+    "S3_INTERVAL": {
+      "default": 30,
+      "description": "Polling interval in seconds to check the S3 bucket.",
+      "type": "integer"
+    },
+    "S3_ATTACH_ORIGINAL_FILE": {
+      "default": false,
+      "description": "Attach the original JSON file to vulnerabilities.",
+      "type": "boolean"
+    },
+    "S3_DELETE_AFTER_IMPORT": {
+      "default": true,
+      "description": "Delete files from S3 after successful processing.",
+      "type": "boolean"
+    },
+    "S3_NO_SPLIT_BUNDLES": {
+      "default": true,
+      "description": "Do not split STIX bundles before sending to OpenCTI.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "S3_ACCESS_KEY_ID",
+    "S3_SECRET_ACCESS_KEY",
+    "S3_BUCKET_NAME"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/s3/__metadata__/connector_manifest.json
+++ b/external-import/s3/__metadata__/connector_manifest.json
@@ -12,7 +12,7 @@
   "support_version": ">=6.8.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/s3",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-s3",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/servicenow/__metadata__/connector_config_schema.json
+++ b/external-import/servicenow/__metadata__/connector_config_schema.json
@@ -15,8 +15,8 @@
       "type": "string"
     },
     "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
       "default": "EXTERNAL_IMPORT",
-      "description": "Should always be set to EXTERNAL_IMPORT for this connector.",
       "type": "string"
     },
     "CONNECTOR_NAME": {
@@ -25,9 +25,12 @@
       "type": "string"
     },
     "CONNECTOR_SCOPE": {
-      "default": "ServiceNow",
+      "default": ["ServiceNow"],
       "description": "The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only).",
-      "type": "string"
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
     },
     "CONNECTOR_LOG_LEVEL": {
       "default": "error",
@@ -197,6 +200,11 @@
     "SERVICENOW_PROMOTE_OBSERVABLES_AS_INDICATORS": {
       "default": true,
       "description": "Boolean to promote observables into indicators.",
+      "type": "boolean"
+    },
+    "SERVICENOW_SYSPARM_DISPLAY_VALUE": {
+      "default": true,
+      "description": "Controls the sysparm_display_value query parameter sent to ServiceNow on every Table API call. Set to false on instances that return non-ISO 8601 datetimes when display values are enabled.",
       "type": "boolean"
     }
   },

--- a/external-import/servicenow/__metadata__/connector_manifest.json
+++ b/external-import/servicenow/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">= 6.5.1",
   "subscription_link": "https://www.servicenow.com/contact-us.html",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/servicenow",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-servicenow",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/socprime/__metadata__/connector_config_schema.json
+++ b/external-import/socprime/__metadata__/connector_config_schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/socprime_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "SocPrime",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "socprime"
+      ],
+      "description": "The scope or type of data the connector is importing.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warning",
+        "error",
+        "critical"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT1H",
+      "description": "The period of time to wait between two connector runs (ISO-8601 duration format).",
+      "format": "duration",
+      "type": "string"
+    },
+    "SOCPRIME_API_KEY": {
+      "description": "The SOC Prime CCM API Key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "SOCPRIME_CONTENT_LIST_NAME": {
+      "default": [],
+      "description": "Comma-separated content list names from which rules will be downloaded. At least one of content_list_name and job_ids must be provided.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "SOCPRIME_INDICATOR_SIEM_TYPE": {
+      "default": "sigma",
+      "description": "Security platform format in which rules will be downloaded. Applicable only to content_list_name.",
+      "type": "string"
+    },
+    "SOCPRIME_JOB_IDS": {
+      "default": [],
+      "description": "Comma-separated job IDs from which rules will be downloaded. At least one of content_list_name and job_ids must be provided.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "SOCPRIME_SIEM_TYPE": {
+      "default": [],
+      "description": "Security platform formats for which external links will be generated (comma-separated).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "SOCPRIME_TLP_LEVEL": {
+      "default": "amber+strict",
+      "description": "The TLP level to use for imported elements missing a TLP level.",
+      "enum": [
+        "clear",
+        "white",
+        "green",
+        "amber",
+        "amber+strict",
+        "red"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "SOCPRIME_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/socprime/__metadata__/connector_manifest.json
+++ b/external-import/socprime/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">= 6.5.1",
   "subscription_link": "https://socprime.com/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/socprime",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-socprime",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/taxii2/__metadata__/connector_config_schema.json
+++ b/external-import/taxii2/__metadata__/connector_config_schema.json
@@ -1,0 +1,339 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/taxii2_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "TAXII2",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "ipv4-addr",
+        "ipv6-addr",
+        "vulnerability",
+        "domain",
+        "url",
+        "file-sha256",
+        "file-md5",
+        "file-sha1"
+      ],
+      "description": "The scope of the connector (comma-separated observable types to import).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT60M",
+      "description": "The period of time to await between two runs of the connector (ISO 8601 duration format).",
+      "format": "duration",
+      "type": "string"
+    },
+    "TAXII2_DISCOVERY_URL": {
+      "description": "TAXII 2 server discovery URL.",
+      "type": "string"
+    },
+    "TAXII2_CERT_PATH": {
+      "default": null,
+      "description": "Path to client certificate for mTLS authentication.",
+      "type": "string"
+    },
+    "TAXII2_USERNAME": {
+      "default": null,
+      "description": "Username for basic authentication.",
+      "type": "string"
+    },
+    "TAXII2_PASSWORD": {
+      "default": null,
+      "description": "Password for basic authentication.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TAXII2_USE_TOKEN": {
+      "default": false,
+      "description": "Use bearer token authentication.",
+      "type": "boolean"
+    },
+    "TAXII2_TOKEN": {
+      "default": null,
+      "description": "Bearer token value.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TAXII2_USE_APIKEY": {
+      "default": false,
+      "description": "Use API key authentication.",
+      "type": "boolean"
+    },
+    "TAXII2_APIKEY_KEY": {
+      "default": null,
+      "description": "API key header name.",
+      "type": "string"
+    },
+    "TAXII2_APIKEY_VALUE": {
+      "default": null,
+      "description": "API key value.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TAXII2_USE_CERT": {
+      "default": false,
+      "description": "Use client certificate (mTLS) authentication.",
+      "type": "boolean"
+    },
+    "TAXII2_V21": {
+      "default": true,
+      "description": "Use TAXII 2.1 protocol (set to false for TAXII 2.0).",
+      "type": "boolean"
+    },
+    "TAXII2_COLLECTIONS": {
+      "default": "*.*",
+      "description": "Collections to poll (format: api_root.collection, or *. * for all).",
+      "type": "string"
+    },
+    "TAXII2_INITIAL_HISTORY": {
+      "default": 24,
+      "description": "Hours of history to fetch on first run.",
+      "type": "integer"
+    },
+    "TAXII2_VERIFY_SSL": {
+      "default": true,
+      "description": "Verify SSL certificates when connecting to the TAXII server.",
+      "type": "boolean"
+    },
+    "TAXII2_CREATE_INDICATORS": {
+      "default": true,
+      "description": "Create indicators from STIX data.",
+      "type": "boolean"
+    },
+    "TAXII2_CREATE_OBSERVABLES": {
+      "default": true,
+      "description": "Create observables from STIX data.",
+      "type": "boolean"
+    },
+    "TAXII2_ADD_CUSTOM_LABEL": {
+      "default": false,
+      "description": "Add a custom label to all imported objects.",
+      "type": "boolean"
+    },
+    "TAXII2_CUSTOM_LABEL": {
+      "default": null,
+      "description": "Custom label value to add to imported objects.",
+      "type": "string"
+    },
+    "TAXII2_FORCE_PATTERN_AS_NAME": {
+      "default": false,
+      "description": "Use indicator pattern as the indicator name.",
+      "type": "boolean"
+    },
+    "TAXII2_FORCE_MULTIPLE_PATTERN_NAME": {
+      "default": null,
+      "description": "Name to use for indicators with multiple patterns.",
+      "type": "string"
+    },
+    "TAXII2_STIX_CUSTOM_PROPERTY_TO_LABEL": {
+      "default": false,
+      "description": "Convert custom STIX properties to labels.",
+      "type": "boolean"
+    },
+    "TAXII2_STIX_CUSTOM_PROPERTY": {
+      "default": null,
+      "description": "Custom STIX property name to convert to label.",
+      "type": "string"
+    },
+    "TAXII2_ENABLE_URL_QUERY_LIMIT": {
+      "default": false,
+      "description": "Enable the query limit parameter in TAXII requests.",
+      "type": "boolean"
+    },
+    "TAXII2_URL_QUERY_LIMIT": {
+      "default": 100,
+      "description": "Maximum number of objects to request per TAXII query.",
+      "type": "integer"
+    },
+    "TAXII2_DETERMINE_X_OPENCTI_SCORE_BY_LABEL": {
+      "default": false,
+      "description": "Determine the x_opencti_score based on indicator labels.",
+      "type": "boolean"
+    },
+    "TAXII2_DEFAULT_X_OPENCTI_SCORE": {
+      "default": 50,
+      "description": "Default x_opencti_score value for indicators.",
+      "type": "integer"
+    },
+    "TAXII2_INDICATOR_HIGH_SCORE_LABELS": {
+      "default": "high",
+      "description": "Comma-separated labels that trigger a high score.",
+      "type": "string"
+    },
+    "TAXII2_INDICATOR_HIGH_SCORE": {
+      "default": 80,
+      "description": "Score value assigned to indicators with high score labels.",
+      "type": "integer"
+    },
+    "TAXII2_INDICATOR_MEDIUM_SCORE_LABELS": {
+      "default": "medium",
+      "description": "Comma-separated labels that trigger a medium score.",
+      "type": "string"
+    },
+    "TAXII2_INDICATOR_MEDIUM_SCORE": {
+      "default": 60,
+      "description": "Score value assigned to indicators with medium score labels.",
+      "type": "integer"
+    },
+    "TAXII2_INDICATOR_LOW_SCORE_LABELS": {
+      "default": "low",
+      "description": "Comma-separated labels that trigger a low score.",
+      "type": "string"
+    },
+    "TAXII2_INDICATOR_LOW_SCORE": {
+      "default": 40,
+      "description": "Score value assigned to indicators with low score labels.",
+      "type": "integer"
+    },
+    "TAXII2_SET_INDICATOR_AS_DETECTION": {
+      "default": false,
+      "description": "Mark imported indicators as detection.",
+      "type": "boolean"
+    },
+    "TAXII2_CREATE_AUTHOR": {
+      "default": false,
+      "description": "Create an author identity for imported objects.",
+      "type": "boolean"
+    },
+    "TAXII2_AUTHOR_NAME": {
+      "default": null,
+      "description": "Name for the author identity.",
+      "type": "string"
+    },
+    "TAXII2_AUTHOR_DESCRIPTION": {
+      "default": null,
+      "description": "Description for the author identity.",
+      "type": "string"
+    },
+    "TAXII2_AUTHOR_RELIABILITY": {
+      "default": null,
+      "description": "Reliability level for the author identity.",
+      "type": "string"
+    },
+    "TAXII2_EXCLUDE_SPECIFIC_LABELS": {
+      "default": false,
+      "description": "Enable exclusion of objects with specific labels.",
+      "type": "boolean"
+    },
+    "TAXII2_LABELS_TO_EXCLUDE": {
+      "default": "",
+      "description": "Comma-separated labels to exclude from import.",
+      "type": "string"
+    },
+    "TAXII2_REPLACE_CHARACTERS_IN_LABEL": {
+      "default": false,
+      "description": "Enable character replacement in labels.",
+      "type": "boolean"
+    },
+    "TAXII2_CHARACTERS_TO_REPLACE_IN_LABEL": {
+      "default": "",
+      "description": "Comma-separated characters to replace in labels.",
+      "type": "string"
+    },
+    "TAXII2_IGNORE_PATTERN_TYPES": {
+      "default": false,
+      "description": "Enable ignoring indicators with specific pattern types.",
+      "type": "boolean"
+    },
+    "TAXII2_PATTERN_TYPES_TO_IGNORE": {
+      "default": "",
+      "description": "Comma-separated pattern types to ignore.",
+      "type": "string"
+    },
+    "TAXII2_IGNORE_OBJECT_TYPES": {
+      "default": false,
+      "description": "Enable ignoring specific STIX object types.",
+      "type": "boolean"
+    },
+    "TAXII2_OBJECT_TYPES_TO_IGNORE": {
+      "default": "",
+      "description": "Comma-separated STIX object types to ignore.",
+      "type": "string"
+    },
+    "TAXII2_IGNORE_SPECIFIC_PATTERNS": {
+      "default": false,
+      "description": "Enable ignoring indicators with specific patterns.",
+      "type": "boolean"
+    },
+    "TAXII2_PATTERNS_TO_IGNORE": {
+      "default": "",
+      "description": "Comma-separated patterns to ignore.",
+      "type": "string"
+    },
+    "TAXII2_IGNORE_SPECIFIC_NOTES": {
+      "default": false,
+      "description": "Enable ignoring specific notes.",
+      "type": "boolean"
+    },
+    "TAXII2_NOTES_TO_IGNORE": {
+      "default": "",
+      "description": "Comma-separated note contents to ignore.",
+      "type": "string"
+    },
+    "TAXII2_SAVE_ORIGINAL_INDICATOR_ID_TO_NOTE": {
+      "default": false,
+      "description": "Save original indicator ID as a note.",
+      "type": "boolean"
+    },
+    "TAXII2_SAVE_ORIGINAL_INDICATOR_ID_ABSTRACT": {
+      "default": null,
+      "description": "Abstract text for the note containing the original indicator ID.",
+      "type": "string"
+    },
+    "TAXII2_CHANGE_REPORT_STATUS": {
+      "default": false,
+      "description": "Change the status of imported reports.",
+      "type": "boolean"
+    },
+    "TAXII2_CHANGE_REPORT_STATUS_X_OPENCTI_WORKFLOW_ID": {
+      "default": null,
+      "description": "Workflow ID to set on imported reports.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "TAXII2_DISCOVERY_URL"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/taxii2/__metadata__/connector_manifest.json
+++ b/external-import/taxii2/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.5.4",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/taxii2",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-taxii2",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/teamt5/__metadata__/connector_config_schema.json
+++ b/external-import/teamt5/__metadata__/connector_config_schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/teamt5_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Team T5 External Import Connector",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "teamt5"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "P1D",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "TEAMT5_API_BASE_URL": {
+      "default": "https://api.threatvision.org/",
+      "description": "Base URL of the TeamT5 ThreatVision API.",
+      "type": "string"
+    },
+    "TEAMT5_CLIENT_ID": {
+      "default": null,
+      "description": "OAuth 2.0 client ID. Requires `client_secret` to also be set.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TEAMT5_CLIENT_SECRET": {
+      "default": null,
+      "description": "OAuth 2.0 client secret. Requires `client_id` to also be set.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TEAMT5_API_KEY": {
+      "default": null,
+      "description": "Deprecated. Static API key for authentication to TeamT5's ThreatVision Platform. Prefer `client_id` + `client_secret`.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TEAMT5_TLP_LEVEL": {
+      "default": "clear",
+      "description": "Default TLP level of the imported entities.",
+      "enum": [
+        "clear",
+        "white",
+        "green",
+        "amber",
+        "amber+strict",
+        "red"
+      ],
+      "type": "string"
+    },
+    "TEAMT5_FIRST_RUN_RETRIEVAL_TIMESTAMP": {
+      "default": 0,
+      "description": "Unix timestamp indicating the earliest point in time from which intel should be retrieved from the TeamT5 API. Used only on the connector's first run.",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/teamt5/__metadata__/connector_manifest.json
+++ b/external-import/teamt5/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.8.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/teamt5",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-teamt5",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/tenable-vuln-management/__metadata__/connector_config_schema.json
+++ b/external-import/tenable-vuln-management/__metadata__/connector_config_schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/tenable-vuln-management_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Tenable Vuln Management",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "vulnerability"
+      ],
+      "description": "The scope or type of data the connector is importing.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT30M",
+      "description": "The period of time to await between two runs of the connector in ISO-8601 format.",
+      "format": "duration",
+      "type": "string"
+    },
+    "TIO_NUM_THREADS": {
+      "default": 1,
+      "description": "Number of threads to use for the connector.",
+      "type": "integer"
+    },
+    "TIO_API_BASE_URL": {
+      "description": "Base URL for the Tenable API.",
+      "type": "string"
+    },
+    "TIO_API_ACCESS_KEY": {
+      "description": "Tenable API access key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TIO_API_SECRET_KEY": {
+      "description": "Tenable API secret key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TIO_API_TIMEOUT": {
+      "default": 30,
+      "description": "Timeout for API requests in seconds.",
+      "type": "integer"
+    },
+    "TIO_API_BACKOFF": {
+      "default": 1,
+      "description": "Time in seconds to wait before retrying after receiving a 429 response from the API.",
+      "type": "integer"
+    },
+    "TIO_API_RETRIES": {
+      "default": 5,
+      "description": "Number of retries in case of failure.",
+      "type": "integer"
+    },
+    "TIO_EXPORT_SINCE": {
+      "default": "1970-01-01T00:00:00+00",
+      "description": "Date from which to start pulling vulnerability data in ISO-8601 format.",
+      "type": "string"
+    },
+    "TIO_MIN_SEVERITY": {
+      "default": "low",
+      "description": "The minimum severity level of vulnerabilities to import.",
+      "enum": [
+        "info",
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ],
+      "type": "string"
+    },
+    "TIO_MARKING_DEFINITION": {
+      "default": "TLP:CLEAR",
+      "description": "Default TLP marking definition for imported data.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "TIO_API_BASE_URL",
+    "TIO_API_ACCESS_KEY",
+    "TIO_API_SECRET_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/tenable-vuln-management/__metadata__/connector_manifest.json
+++ b/external-import/tenable-vuln-management/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">= 6.5.1",
   "subscription_link": "",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/tenable-vuln-management",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-tenable-vuln-management",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/thehive/__metadata__/connector_config_schema.json
+++ b/external-import/thehive/__metadata__/connector_config_schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/thehive_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "TheHive",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "thehive"
+      ],
+      "description": "The scope or type of data the connector is importing.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT5M",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "THEHIVE_URL": {
+      "description": "URL of the TheHive instance.",
+      "format": "uri",
+      "type": "string"
+    },
+    "THEHIVE_API_KEY": {
+      "description": "TheHive API key for authentication.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "THEHIVE_CHECK_SSL": {
+      "default": true,
+      "description": "Verify SSL certificates when connecting to TheHive.",
+      "type": "boolean"
+    },
+    "THEHIVE_ORGANIZATION_NAME": {
+      "description": "TheHive organization name used as the identity in OpenCTI.",
+      "type": "string"
+    },
+    "THEHIVE_IMPORT_FROM_DATE": {
+      "default": null,
+      "description": "Start date for importing data from TheHive (ISO 8601 format, e.g. 2021-01-01T00:00:00).",
+      "format": "date-time",
+      "type": "string"
+    },
+    "THEHIVE_IMPORT_ONLY_TLP": {
+      "default": "0,1,2,3,4",
+      "description": "Comma-separated TLP levels to import (0=clear, 1=green, 2=amber, 3=amber+strict, 4=red).",
+      "type": "string"
+    },
+    "THEHIVE_IMPORT_ALERTS": {
+      "default": true,
+      "description": "Import alerts from TheHive in addition to cases.",
+      "type": "boolean"
+    },
+    "THEHIVE_IMPORT_ATTACHMENTS": {
+      "default": false,
+      "description": "Enable or disable the import of case attachments from TheHive.",
+      "type": "boolean"
+    },
+    "THEHIVE_SEVERITY_MAPPING": {
+      "default": "1:low,2:medium,3:high,4:critical",
+      "description": "Mapping of TheHive severity levels to OpenCTI severity labels (format: level:label,level:label).",
+      "type": "string"
+    },
+    "THEHIVE_CASE_STATUS_MAPPING": {
+      "default": "",
+      "description": "Mapping of TheHive case statuses to OpenCTI status IDs (format: TheHiveStatus:OpenCTI_Status_ID).",
+      "type": "string"
+    },
+    "THEHIVE_TASK_STATUS_MAPPING": {
+      "default": "",
+      "description": "Mapping of TheHive task statuses to OpenCTI status IDs (format: Waiting:ID1,InProgress:ID2,Completed:ID3).",
+      "type": "string"
+    },
+    "THEHIVE_ALERT_STATUS_MAPPING": {
+      "default": "",
+      "description": "Mapping of TheHive alert statuses to OpenCTI status IDs (format: TheHiveStatus:OpenCTI_Status_ID).",
+      "type": "string"
+    },
+    "THEHIVE_USER_MAPPING": {
+      "default": "",
+      "description": "Mapping of TheHive assignee emails to OpenCTI user IDs (format: email1:userID1,email2:userID2).",
+      "type": "string"
+    },
+    "THEHIVE_INTERVAL": {
+      "default": 5,
+      "description": "Polling interval in minutes between data fetches from TheHive.",
+      "type": "integer"
+    },
+    "THEHIVE_CASE_TAG_WHITELIST": {
+      "default": "",
+      "description": "Comma-separated list of tags; only cases with these tags will be imported.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "THEHIVE_URL",
+    "THEHIVE_API_KEY",
+    "THEHIVE_ORGANIZATION_NAME"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/thehive/__metadata__/connector_manifest.json
+++ b/external-import/thehive/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.5.4",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/thehive",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-thehive",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/threatmatch/__metadata__/connector_config_schema.json
+++ b/external-import/threatmatch/__metadata__/connector_config_schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/threatmatch_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ThreatMatch",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "threatmatch"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "P1D",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "THREATMATCH_URL": {
+      "default": "https://eu.threatmatch.com",
+      "description": "Base URL of the ThreatMatch API.",
+      "format": "uri",
+      "type": "string"
+    },
+    "THREATMATCH_CLIENT_ID": {
+      "description": "OAuth2 client id (Client Credentials).",
+      "type": "string"
+    },
+    "THREATMATCH_CLIENT_SECRET": {
+      "description": "OAuth2 client secret.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "THREATMATCH_IMPORT_FROM_DATE": {
+      "default": "P30D",
+      "description": "Relative ISO-8601 duration (e.g., P30D) to set the first import window. Used only on first run.",
+      "format": "duration",
+      "type": "string"
+    },
+    "THREATMATCH_IMPORT_PROFILES": {
+      "default": true,
+      "description": "Import ThreatMatch profiles dataset.",
+      "type": "boolean"
+    },
+    "THREATMATCH_IMPORT_ALERTS": {
+      "default": true,
+      "description": "Import ThreatMatch alerts dataset.",
+      "type": "boolean"
+    },
+    "THREATMATCH_IMPORT_IOCS": {
+      "default": true,
+      "description": "Import ThreatMatch IOCs dataset.",
+      "type": "boolean"
+    },
+    "THREATMATCH_TLP_LEVEL": {
+      "default": "amber",
+      "description": "Default TLP marking for imported data when missing on source objects.",
+      "enum": [
+        "clear",
+        "white",
+        "green",
+        "amber",
+        "amber+strict",
+        "red"
+      ],
+      "type": "string"
+    },
+    "THREATMATCH_THREAT_ACTOR_AS_INSTRUSION_SET": {
+      "default": true,
+      "description": "Map ThreatMatch threat-actor to STIX intrusion-set.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "THREATMATCH_CLIENT_ID",
+    "THREATMATCH_CLIENT_SECRET"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/threatmatch/__metadata__/connector_manifest.json
+++ b/external-import/threatmatch/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.5.4",
   "subscription_link": "https://www.secalliance.com/threat-intelligence-portal",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/threatmatch",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-threatmatch",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/tweetfeed/__metadata__/connector_config_schema.json
+++ b/external-import/tweetfeed/__metadata__/connector_config_schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/tweetfeed_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Tweetfeed",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT1H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "TWEETFEED_CONFIDENCE_LEVEL": {
+      "default": 25,
+      "description": "Confidence of the ingested data from 0-100.",
+      "type": "integer"
+    },
+    "TWEETFEED_CREATE_INDICATORS": {
+      "default": true,
+      "description": "True or False, enable the creation of indicators.",
+      "type": "boolean"
+    },
+    "TWEETFEED_CREATE_OBSERVABLES": {
+      "default": true,
+      "description": "True or False, enable the creation of observables.",
+      "type": "boolean"
+    },
+    "TWEETFEED_INTERVAL": {
+      "description": "In day when the connector will run.",
+      "type": "integer"
+    },
+    "TWEETFEED_ORG_DESCRIPTION": {
+      "description": "Organization description, which will be referred to data injected.",
+      "type": "string"
+    },
+    "TWEETFEED_ORG_NAME": {
+      "description": "Organization name, which will be referred to data injected.",
+      "type": "string"
+    },
+    "TWEETFEED_DAYS_BACK_IN_TIME": {
+      "default": 30,
+      "description": "Number of days to retrieve data back in time.",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "TWEETFEED_INTERVAL",
+    "TWEETFEED_ORG_DESCRIPTION",
+    "TWEETFEED_ORG_NAME"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/tweetfeed/__metadata__/connector_manifest.json
+++ b/external-import/tweetfeed/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.8.0",
   "subscription_link": "https://tweetfeed.live",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/tweetfeed",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-tweetfeed",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/urlscan/__metadata__/connector_config_schema.json
+++ b/external-import/urlscan/__metadata__/connector_config_schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/urlscan_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Urlscan",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "urlscan"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT24H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "CONNECTOR_INTERVAL": {
+      "default": 86400,
+      "description": "The interval (in seconds) for data gathering from Urlscan.",
+      "type": "integer"
+    },
+    "CONNECTOR_LOOKBACK": {
+      "default": 3,
+      "description": "How far to look back in days if the connector has never run or the last run is older than this value.",
+      "type": "integer"
+    },
+    "URLSCAN_URL": {
+      "default": "https://urlscan.io/api/v1/pro/phishfeed?format=json",
+      "description": "The Urlscan API endpoint URL.",
+      "type": "string"
+    },
+    "URLSCAN_API_KEY": {
+      "description": "The Urlscan API key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "URLSCAN_CREATE_INDICATORS": {
+      "default": true,
+      "description": "Whether to create indicators for each observable processed.",
+      "type": "boolean"
+    },
+    "URLSCAN_UPDATE_EXISTING_DATA": {
+      "default": true,
+      "description": "Whether to update existing data if an entity already exists.",
+      "type": "boolean"
+    },
+    "URLSCAN_DEFAULT_TLP": {
+      "default": "white",
+      "description": "The TLP marking to apply to indicators and observables.",
+      "enum": [
+        "white",
+        "green",
+        "amber",
+        "red"
+      ],
+      "type": "string"
+    },
+    "URLSCAN_DEFAULT_X_OPENCTI_SCORE": {
+      "default": 50,
+      "description": "The default x_opencti_score to use across observable and indicator types.",
+      "type": "integer"
+    },
+    "URLSCAN_X_OPENCTI_SCORE_DOMAIN": {
+      "default": null,
+      "description": "The x_opencti_score to use for Domain-Name observables and indicators. Defaults to the default score if not set.",
+      "type": ["integer", "null"]
+    },
+    "URLSCAN_X_OPENCTI_SCORE_URL": {
+      "default": null,
+      "description": "The x_opencti_score to use for URL observables and indicators. Defaults to the default score if not set.",
+      "type": ["integer", "null"]
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "URLSCAN_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/urlscan/__metadata__/connector_manifest.json
+++ b/external-import/urlscan/__metadata__/connector_manifest.json
@@ -15,7 +15,7 @@
   "support_version": ">=6.8.0",
   "subscription_link": "https://urlscan.io/pricing/phishingfeed/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/urlscan",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-urlscan",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/virustotal-livehunt-notifications/__metadata__/connector_config_schema.json
+++ b/external-import/virustotal-livehunt-notifications/__metadata__/connector_config_schema.json
@@ -1,0 +1,209 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/virustotal-livehunt-notifications_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "VirusTotal Livehunt Notifications",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "StixFile",
+        "Indicator",
+        "Incident",
+        "Domain-Name",
+        "Url",
+        "IPv4-Addr",
+        "IPv6-Addr"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT5M",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_API_KEY": {
+      "description": "VirusTotal Premium API key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_TLP_LEVEL": {
+      "default": "clear",
+      "description": "Default TLP level of the imported entities.",
+      "enum": [
+        "clear",
+        "white",
+        "green",
+        "amber",
+        "amber+strict",
+        "red"
+      ],
+      "type": "string"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_CREATE_ALERT": {
+      "default": true,
+      "description": "Create incident/alert for each notification.",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_ALERT_PREFIX": {
+      "default": "VT ",
+      "description": "Prefix that is added in alerts titles.",
+      "type": "string"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_DELETE_NOTIFICATION": {
+      "default": false,
+      "description": "Delete notification from VT after processing.",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_FILTER_WITH_TAG": {
+      "default": null,
+      "description": "Only process notifications with this tag.",
+      "type": ["string", "null"]
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_CREATE_FILE": {
+      "default": true,
+      "description": "Create file observable for matched files.",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_EXTENSIONS": {
+      "default": [],
+      "description": "Comma-separated file extensions to filter (e.g., exe,dll).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_MAX_AGE_DAYS": {
+      "default": 3,
+      "description": "Only process files submitted within this many days.",
+      "type": "integer"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_MIN_FILE_SIZE": {
+      "default": 1000,
+      "description": "Minimum file size in bytes to download.",
+      "type": "integer"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_MAX_FILE_SIZE": {
+      "default": 52428800,
+      "description": "Maximum file size in bytes to download (default: 50MB).",
+      "type": "integer"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_MIN_POSITIVES": {
+      "default": 1,
+      "description": "Minimum number of vendors marking file to download as malicious.",
+      "type": "integer"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_UPLOAD_ARTIFACT": {
+      "default": false,
+      "description": "Upload file to OpenCTI as artifact.",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_CREATE_YARA_RULE": {
+      "default": true,
+      "description": "Create YARA indicator for the matching rule.",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_AV_LIST": {
+      "default": [],
+      "description": "Comma-separated list of AVs to add in description (e.g., Kaspersky,Symantec).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_LIVEHUNT_TAG_PREFIX": {
+      "default": "",
+      "description": "Prefix used to state that the tag is imported from Livehunt.",
+      "type": "string"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_YARA_LABEL_PREFIX": {
+      "default": "vt:yara:",
+      "description": "Prefix that is added in yara labels.",
+      "type": "string"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_LIVEHUNT_LABEL_PREFIX": {
+      "default": "vt:lh:",
+      "description": "Prefix that is added in livehunt labels.",
+      "type": "string"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_ENABLE_LABEL_ENRICHMENT": {
+      "default": true,
+      "description": "Add livehunt name and matched yara rules label to the alert.",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_GET_MALWARE_CONFIG": {
+      "default": false,
+      "description": "Extract C2 infrastructure (domains, IPs, URLs) from VirusTotal malware configuration analysis. Only effective when create_file is true.",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_CREATE_FILE_INDICATORS": {
+      "default": false,
+      "description": "Create a File indicator (SHA-256 pattern) for each matched file. Only effective when create_file is true.",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_CREATE_DOMAIN_NAME_INDICATORS": {
+      "default": false,
+      "description": "Create Domain-Name indicators for domains extracted from the malware configuration.",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_CREATE_IP_INDICATORS": {
+      "default": false,
+      "description": "Create IPv4/IPv6 indicators for IP addresses extracted from the malware configuration.",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_CREATE_URL_INDICATORS": {
+      "default": false,
+      "description": "Create URL indicators for URLs extracted from the malware configuration.",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_LIMIT": {
+      "default": null,
+      "description": "Maximum number of notifications to process per run. Leave unset to process every available notification.",
+      "type": ["integer", "null"],
+      "minimum": 1
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "VIRUSTOTAL_LIVEHUNT_NOTIFICATIONS_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/virustotal-livehunt-notifications/__metadata__/connector_manifest.json
+++ b/external-import/virustotal-livehunt-notifications/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.5.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/virustotal-livehunt-notifications",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-virustotal-livehunt-notifications",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/vulncheck/__metadata__/connector_config_schema.json
+++ b/external-import/vulncheck/__metadata__/connector_config_schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/vulncheck_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "VulnCheck Connector",
+      "description": "The name of the connector as it will appear in OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "vulnerability",
+        "malware",
+        "threat-actor",
+        "infrastructure",
+        "location",
+        "ip-addr",
+        "indicator",
+        "external-reference",
+        "software",
+        "report"
+      ],
+      "description": "The scope of data to import, a list of STIX object types.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT1H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "CONNECTOR_VULNCHECK_API_KEY": {
+      "description": "The API key for authenticating with VulnCheck's API.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_VULNCHECK_API_BASE_URL": {
+      "default": "https://api.vulncheck.com/v3",
+      "description": "The base URL for the VulnCheck API.",
+      "type": "string"
+    },
+    "CONNECTOR_VULNCHECK_DATA_SOURCES": {
+      "default": [
+        "vulncheck-kev",
+        "nist-nvd2"
+      ],
+      "description": "List of data sources to collect intelligence from.",
+      "items": {
+        "enum": [
+          "botnets",
+          "epss",
+          "exploits",
+          "initial-access",
+          "ipintel",
+          "nist-nvd2",
+          "ransomware",
+          "snort",
+          "suricata",
+          "threat-actors",
+          "vulncheck-kev",
+          "vulncheck-nvd2"
+        ],
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_VULNCHECK_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/vulncheck/__metadata__/connector_manifest.json
+++ b/external-import/vulncheck/__metadata__/connector_manifest.json
@@ -15,7 +15,7 @@
   "support_version": ">= 6.5.1",
   "subscription_link": "https://www.vulncheck.com/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/vulncheck",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-vulncheck",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/zerofox/__metadata__/connector_config_schema.json
+++ b/external-import/zerofox/__metadata__/connector_config_schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/zerofox_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Zerofox",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "zerofox"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "P1D",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "CONNECTOR_FIRST_RUN": {
+      "default": "1d",
+      "description": "The scope of data queried when the connector is initialized, in format {number}{s,m,h,d}.",
+      "type": "string"
+    },
+    "ZEROFOX_USERNAME": {
+      "description": "A ZeroFox platform username.",
+      "type": "string"
+    },
+    "ZEROFOX_PASSWORD": {
+      "description": "A personal access token for accessing the ZeroFox API.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "ZEROFOX_COLLECTORS": {
+      "default": null,
+      "description": "A comma-separated list of collector names to use. Uses all available collectors if omitted.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "ZEROFOX_USERNAME",
+    "ZEROFOX_PASSWORD"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/zerofox/__metadata__/connector_manifest.json
+++ b/external-import/zerofox/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.8.0",
   "subscription_link": "https://www.zerofox.com/threat-intelligence/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/zerofox",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-zerofox",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/zvelo/__metadata__/connector_config_schema.json
+++ b/external-import/zvelo/__metadata__/connector_config_schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/zvelo_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Zvelo",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "ipv4-addr",
+        "ipv6-addr",
+        "domain",
+        "url",
+        "indicator",
+        "malware"
+      ],
+      "description": "The scope or type of data the connector is importing.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT1H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "ZVELO_CLIENT_ID": {
+      "description": "Zvelo client ID for API authentication.",
+      "type": "string"
+    },
+    "ZVELO_CLIENT_SECRET": {
+      "description": "Zvelo client secret for API authentication.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "ZVELO_COLLECTIONS": {
+      "default": [
+        "phish",
+        "malicious",
+        "threat"
+      ],
+      "description": "Data collections to fetch from Zvelo API. Possible values: phish, malicious, threat.",
+      "items": {
+        "enum": [
+          "phish",
+          "malicious",
+          "threat"
+        ],
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "ZVELO_CLIENT_ID",
+    "ZVELO_CLIENT_SECRET"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/zvelo/__metadata__/connector_manifest.json
+++ b/external-import/zvelo/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">= 6.4.0",
   "subscription_link": "https://zvelo.com/zvelocti-cyber-threat-intelligence/malicious-detailed-detection-feed/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/zvelo",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-zvelo",
   "container_type": "EXTERNAL_IMPORT"

--- a/internal-enrichment/greynoise-vuln/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/greynoise-vuln/__metadata__/connector_config_schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/greynoise-vuln_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "GreyNoise Vulnerability Enrichment",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "vulnerability"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": true,
+      "description": "Enable or disable auto-enrichment of vulnerability entities.",
+      "type": "boolean"
+    },
+    "GREYNOISE_KEY": {
+      "description": "The GreyNoise API key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "GREYNOISE_MAX_TLP": {
+      "default": "TLP:AMBER",
+      "description": "Maximum TLP level for data processing.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    },
+    "GREYNOISE_NAME": {
+      "default": "GreyNoise Internet Scanner",
+      "description": "The GreyNoise organization name used for the identity.",
+      "type": "string"
+    },
+    "GREYNOISE_DESCRIPTION": {
+      "default": "GreyNoise collects and analyzes opportunistic scan and attack activity for devices connected directly to the Internet.",
+      "description": "The GreyNoise organization description used for the identity.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "GREYNOISE_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/greynoise-vuln/__metadata__/connector_manifest.json
+++ b/internal-enrichment/greynoise-vuln/__metadata__/connector_manifest.json
@@ -15,7 +15,7 @@
   "support_version": ">=6.3.4",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/greynoise-vuln",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-greynoise-vuln",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-enrichment/greynoise/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/greynoise/__metadata__/connector_config_schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/greynoise_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "GreyNoise IP Enrichment",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "IPv4-Addr"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": true,
+      "description": "Enable or disable auto-enrichment of observables.",
+      "type": "boolean"
+    },
+    "GREYNOISE_KEY": {
+      "description": "The GreyNoise API key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "GREYNOISE_MAX_TLP": {
+      "default": "TLP:AMBER",
+      "description": "Maximum TLP marking level allowed for enrichment.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    },
+    "GREYNOISE_SIGHTING_NOT_SEEN": {
+      "default": false,
+      "description": "Whether to create a sighting when the IP address is not seen by GreyNoise.",
+      "type": "boolean"
+    },
+    "GREYNOISE_NO_SIGHTINGS": {
+      "default": false,
+      "description": "Whether to disable creation of sightings entirely.",
+      "type": "boolean"
+    },
+    "GREYNOISE_NAME": {
+      "default": "GreyNoise Intelligence",
+      "description": "The name of the GreyNoise identity used in STIX objects.",
+      "type": "string"
+    },
+    "GREYNOISE_DESCRIPTION": {
+      "default": "GreyNoise collects and analyzes untargeted, widespread, and opportunistic scan and attack activity that reaches every server directly connected to the Internet.",
+      "description": "The description of the GreyNoise identity used in STIX objects.",
+      "type": "string"
+    },
+    "GREYNOISE_INDICATOR_SCORE_MALICIOUS": {
+      "default": 75,
+      "description": "The indicator score assigned to IPs classified as malicious.",
+      "type": "integer"
+    },
+    "GREYNOISE_INDICATOR_SCORE_SUSPICIOUS": {
+      "default": 50,
+      "description": "The indicator score assigned to IPs classified as suspicious.",
+      "type": "integer"
+    },
+    "GREYNOISE_INDICATOR_SCORE_BENIGN": {
+      "default": 20,
+      "description": "The indicator score assigned to IPs classified as benign.",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "GREYNOISE_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/greynoise/__metadata__/connector_manifest.json
+++ b/internal-enrichment/greynoise/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/greynoise",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-greynoise",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-enrichment/hatching-triage-sandbox/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/hatching-triage-sandbox/__metadata__/connector_config_schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/hatching-triage-sandbox_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Hatching Triage Sandbox",
+      "description": "The name of the connector instance.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "Artifact",
+        "Url"
+      ],
+      "description": "The scope of the connector (supported: Artifact, Url).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Enable or disable auto-enrichment of observables.",
+      "type": "boolean"
+    },
+    "HATCHING_TRIAGE_SANDBOX_BASE_URL": {
+      "default": "https://tria.ge/api",
+      "description": "Hatching Triage API base URL.",
+      "type": "string"
+    },
+    "HATCHING_TRIAGE_SANDBOX_TOKEN": {
+      "description": "Hatching Triage API token.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "HATCHING_TRIAGE_SANDBOX_USE_EXISTING_ANALYSIS": {
+      "default": true,
+      "description": "If true, reuse existing analysis results if available.",
+      "type": "boolean"
+    },
+    "HATCHING_TRIAGE_SANDBOX_FAMILY_COLOR": {
+      "default": "#0059f7",
+      "description": "Label color for malware family tags.",
+      "type": "string"
+    },
+    "HATCHING_TRIAGE_SANDBOX_BOTNET_COLOR": {
+      "default": "#f79e00",
+      "description": "Label color for botnet tags.",
+      "type": "string"
+    },
+    "HATCHING_TRIAGE_SANDBOX_CAMPAIGN_COLOR": {
+      "default": "#7a01e5",
+      "description": "Label color for campaign tags.",
+      "type": "string"
+    },
+    "HATCHING_TRIAGE_SANDBOX_TAG_COLOR": {
+      "default": "#54483b",
+      "description": "Label color for all other tags.",
+      "type": "string"
+    },
+    "HATCHING_TRIAGE_SANDBOX_MAX_TLP": {
+      "default": "TLP:AMBER",
+      "description": "Maximum TLP marking level for submission to the sandbox.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "HATCHING_TRIAGE_SANDBOX_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/hatching-triage-sandbox/__metadata__/connector_manifest.json
+++ b/internal-enrichment/hatching-triage-sandbox/__metadata__/connector_manifest.json
@@ -16,7 +16,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/hatching-triage-sandbox",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-hatching-triage-sandbox",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-enrichment/import-external-reference/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/import-external-reference/__metadata__/connector_config_schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/import-external-reference_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ImportExternalReference",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "External-Reference"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Enable or disable auto-import of external references.",
+      "type": "boolean"
+    },
+    "CONNECTOR_CONFIDENCE_LEVEL": {
+      "default": 15,
+      "description": "The confidence level for the connector (0-100).",
+      "type": "integer"
+    },
+    "IMPORT_EXTERNAL_REFERENCE_IMPORT_AS_PDF": {
+      "default": true,
+      "description": "Import external reference content as a PDF file.",
+      "type": "boolean"
+    },
+    "IMPORT_EXTERNAL_REFERENCE_IMPORT_AS_MD": {
+      "default": true,
+      "description": "Import external reference content as a Markdown file.",
+      "type": "boolean"
+    },
+    "IMPORT_EXTERNAL_REFERENCE_IMPORT_PDF_AS_MD": {
+      "default": true,
+      "description": "If import as Markdown is enabled, try to convert PDF content to Markdown.",
+      "type": "boolean"
+    },
+    "IMPORT_EXTERNAL_REFERENCE_TIMESTAMP_FILES": {
+      "default": false,
+      "description": "Timestamp imported files to prevent overwriting previous versions.",
+      "type": "boolean"
+    },
+    "IMPORT_EXTERNAL_REFERENCE_CACHE_SIZE": {
+      "default": 32,
+      "description": "Size of the LRU URL cache to prevent fetching the same object repeatedly.",
+      "type": "integer"
+    },
+    "IMPORT_EXTERNAL_REFERENCE_CACHE_TTL": {
+      "default": 3600,
+      "description": "Time-to-live in seconds for cache entries.",
+      "type": "integer"
+    },
+    "IMPORT_EXTERNAL_REFERENCE_BROWSER_WORKER_COUNT": {
+      "default": 4,
+      "description": "Number of browser worker threads to use for rendering.",
+      "type": "integer"
+    },
+    "IMPORT_EXTERNAL_REFERENCE_MAX_DOWNLOAD_SIZE": {
+      "default": 52428800,
+      "description": "Maximum download size in bytes (default: 50 MB).",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/import-external-reference/__metadata__/connector_manifest.json
+++ b/internal-enrichment/import-external-reference/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/import-external-reference",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-import-external-reference",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-enrichment/joe-sandbox/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/joe-sandbox/__metadata__/connector_config_schema.json
@@ -1,0 +1,311 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/joe-sandbox_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Joe Sandbox",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "Artifact",
+        "Url"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Enable or disable auto-enrichment of observables.",
+      "type": "boolean"
+    },
+    "CONNECTOR_CONFIDENCE_LEVEL": {
+      "default": 50,
+      "description": "The confidence level of the connector, from 0 (Unknown) to 100 (Fully trusted).",
+      "type": "integer"
+    },
+    "JOE_SANDBOX_REPORT_TYPES": {
+      "default": "executive,html,iochtml,iocjson,iocxml,unpackpe,stix,ida,pdf,pdfexecutive,misp,pcap,maec,memdumps,json,lightjsonfixed,xml,lightxml,pcapunified,pcapsslinspection",
+      "description": "Comma-separated list of report types to download/upload as external reference files. json/xml are only allowed with Joe Sandbox Cloud Pro.",
+      "type": "string"
+    },
+    "JOE_SANDBOX_API_URL": {
+      "default": "https://jbxcloud.joesecurity.org/api",
+      "description": "The Joe Sandbox API URL. Cloud Pro: https://jbxcloud.joesecurity.org/api, Cloud Basic: https://joesandbox.com/api.",
+      "type": "string"
+    },
+    "JOE_SANDBOX_API_KEY": {
+      "description": "The Joe Sandbox API key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "JOE_SANDBOX_ANALYSIS_URL": {
+      "default": "https://jbxcloud.joesecurity.org/analysis",
+      "description": "The Joe Sandbox analysis URL. Cloud Pro: https://jbxcloud.joesecurity.org/analysis, Cloud Basic: https://joesandbox.com/analysis.",
+      "type": "string"
+    },
+    "JOE_SANDBOX_ACCEPT_TAC": {
+      "default": true,
+      "description": "If true, you accept Terms and Conditions at https://jbxcloud.joesecurity.org/tandc.",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_API_TIMEOUT": {
+      "default": 30,
+      "description": "Time in seconds to timeout after calling Joe Sandbox API.",
+      "type": "integer"
+    },
+    "JOE_SANDBOX_VERIFY_SSL": {
+      "default": true,
+      "description": "Enable or disable SSL certificate verification for API calls.",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_API_RETRIES": {
+      "default": 5,
+      "description": "How many times to retry API calls before giving up.",
+      "type": "integer"
+    },
+    "JOE_SANDBOX_PROXIES": {
+      "default": null,
+      "description": "A JSON encoded map of proxies to use for API calls. See https://requests.readthedocs.io/en/latest/user/advanced/?highlight=proxy#proxies.",
+      "type": ["string", "null"]
+    },
+    "JOE_SANDBOX_USER_AGENT": {
+      "default": "OpenCTI",
+      "description": "The user agent string for Joe Sandbox API requests.",
+      "type": "string"
+    },
+    "JOE_SANDBOX_SYSTEMS": {
+      "default": "w10x64_office",
+      "description": "Comma-separated list of analysis systems to use.",
+      "type": "string"
+    },
+    "JOE_SANDBOX_ANALYSIS_TIME": {
+      "default": 300,
+      "description": "Timeout for the analysis in seconds.",
+      "type": "integer"
+    },
+    "JOE_SANDBOX_INTERNET_ACCESS": {
+      "default": true,
+      "description": "Enable full internet access in the analysis (must be false if internet simulation is true).",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_INTERNET_SIMULATION": {
+      "default": false,
+      "description": "Enable internet simulation (must be false if internet access is true).",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_HYBRID_CODE_ANALYSIS": {
+      "default": true,
+      "description": "Enable Hybrid Code Analysis (HCA).",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_HYBRID_DECOMPILATION": {
+      "default": true,
+      "description": "Enable Hybrid Decompilation (DEC).",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_REPORT_CACHE": {
+      "default": false,
+      "description": "Enable the report cache. Check the cache for existing reports before running a full analysis.",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_APK_INSTRUMENTATION": {
+      "default": true,
+      "description": "Perform APK DEX code instrumentation.",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_AMSI_UNPACKING": {
+      "default": true,
+      "description": "Perform generic unpacking using the Microsoft Antimalware Scan Interface (AMSI).",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_SSL_INSPECTION": {
+      "default": true,
+      "description": "Enable HTTPS inspection.",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_VBA_INSTRUMENTATION": {
+      "default": false,
+      "description": "Enable VBA instrumentation (two analyses are performed).",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_JS_INSTRUMENTATION": {
+      "default": false,
+      "description": "Enable Javascript instrumentation (two analyses are performed).",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_JAVA_JAR_TRACING": {
+      "default": false,
+      "description": "Enable JAVA JAR tracing (two analyses are performed).",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_DOTNET_TRACING": {
+      "default": false,
+      "description": "Enable .NET tracing (two analyses are performed).",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_START_AS_NORMAL_USER": {
+      "default": false,
+      "description": "Start the sample with normal user privileges.",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_SYSTEM_DATE": {
+      "default": null,
+      "description": "Change the analyzer's system date (helpful for date-aware samples), format is YYYY-MM-DD.",
+      "type": ["string", "null"]
+    },
+    "JOE_SANDBOX_LANGUAGE_AND_LOCALE": {
+      "default": null,
+      "description": "Change the language and locale of the analysis machine.",
+      "type": ["string", "null"]
+    },
+    "JOE_SANDBOX_LOCALIZED_INTERNET_COUNTRY": {
+      "default": null,
+      "description": "Select the country to use for routing internet access through.",
+      "type": ["string", "null"]
+    },
+    "JOE_SANDBOX_EMAIL_NOTIFICATION": {
+      "default": false,
+      "description": "Enable email notification on analysis completion.",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_ARCHIVE_NO_UNPACK": {
+      "default": false,
+      "description": "Do not unpack archives (zip, 7z etc) containing multiple files.",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_HYPERVISOR_BASED_INSPECTION": {
+      "default": false,
+      "description": "Enable Hypervisor based Inspection.",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_FAST_MODE": {
+      "default": false,
+      "description": "Fast Mode focuses on fast analysis and detection versus deep forensic analysis.",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_SECONDARY_RESULTS": {
+      "default": true,
+      "description": "Enable secondary results such as Yara rule generation, classification via Joe Sandbox Class, and several detail reports.",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_COOKBOOK_FILE_PATH": {
+      "default": null,
+      "description": "Path to a cookbook to run for the analysis.",
+      "type": ["string", "null"]
+    },
+    "JOE_SANDBOX_DOCUMENT_PASSWORD": {
+      "default": "1234",
+      "description": "Password for decrypting documents like MS Office and PDFs.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "JOE_SANDBOX_ARCHIVE_PASSWORD": {
+      "default": "infected",
+      "description": "Password used to decrypt archives (zip, 7z, rar etc.).",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "JOE_SANDBOX_COMMAND_LINE_ARGUMENT": {
+      "default": null,
+      "description": "Start the sample with the given command-line argument. Currently only available on Windows analyzers.",
+      "type": ["string", "null"]
+    },
+    "JOE_SANDBOX_ENCRYPT_WITH_PASSWORD": {
+      "default": null,
+      "description": "Encryption password for analyses. AES-256 is used to encrypt files and the password is deleted on the backend after encrypting files.",
+      "format": "password",
+      "type": ["string", "null"],
+      "writeOnly": true
+    },
+    "JOE_SANDBOX_BROWSER": {
+      "default": false,
+      "description": "Use a browser for analysis of URLs (false means download/execute).",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_URL_REPUTATION": {
+      "default": false,
+      "description": "Lookup the reputation of URLs and domains to improve the analysis. This will send URLs and domains to third party services and WHOIS servers.",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_EXPORT_TO_JBXVIEW": {
+      "default": false,
+      "description": "Export the report(s) from this analysis to Joe Sandbox View.",
+      "type": "boolean"
+    },
+    "JOE_SANDBOX_DELETE_AFTER_DAYS": {
+      "default": 30,
+      "description": "Delete the analysis after the specified number of days. If not set, the default value is used.",
+      "type": "integer"
+    },
+    "JOE_SANDBOX_PRIORITY": {
+      "default": null,
+      "description": "On-premise exclusive parameter. Set the priority of the submission between 1 and 10, high value means higher priority.",
+      "type": ["integer", "null"]
+    },
+    "JOE_SANDBOX_DEFAULT_TLP": {
+      "default": "TLP:CLEAR",
+      "description": "The default TLP marking for newly created STIX objects.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    },
+    "JOE_SANDBOX_YARA_COLOR": {
+      "default": "#0059f7",
+      "description": "The color for YARA labels applied to the observable.",
+      "type": "string"
+    },
+    "JOE_SANDBOX_DEFAULT_COLOR": {
+      "default": "#54483b",
+      "description": "The color for default labels.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "JOE_SANDBOX_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/joe-sandbox/__metadata__/connector_manifest.json
+++ b/internal-enrichment/joe-sandbox/__metadata__/connector_manifest.json
@@ -16,7 +16,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/joe-sandbox",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-joe-sandbox",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-enrichment/malbeacon/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/malbeacon/__metadata__/connector_config_schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/malbeacon_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Malbeacon",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "IPv4-Addr",
+        "IPv6-Addr",
+        "Domain-Name"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Enable or disable auto-enrichment of observables.",
+      "type": "boolean"
+    },
+    "MALBEACON_API_KEY": {
+      "description": "Malbeacon API key for authentication.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "MALBEACON_API_BASE_URL": {
+      "default": "https://api.malbeacon.com/v1/",
+      "description": "The base URL of the Malbeacon API.",
+      "type": "string"
+    },
+    "MALBEACON_INDICATOR_SCORE_LEVEL": {
+      "default": 50,
+      "description": "Default indicator score level for created indicators.",
+      "type": "integer"
+    },
+    "MALBEACON_MAX_TLP": {
+      "description": "Maximum TLP marking level for processing observables.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "MALBEACON_API_KEY",
+    "MALBEACON_MAX_TLP"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/malbeacon/__metadata__/connector_manifest.json
+++ b/internal-enrichment/malbeacon/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": "https://www.malbeacon.com",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/malbeacon",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-malbeacon",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-enrichment/proofpoint-et-intelligence/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/proofpoint-et-intelligence/__metadata__/connector_config_schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/proofpoint-et-intelligence_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The OpenCTI platform URL.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token for authentication to the OpenCTI platform.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ProofPoint ET Intelligence",
+      "description": "The name of the connector as it will appear in OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "IPv4-Addr",
+        "Domain-Name",
+        "StixFile"
+      ],
+      "description": "List of scopes for the connector. Allowed values are 'IPv4-Addr', 'Domain-Name', 'StixFile'.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": true,
+      "description": "Enables or disables automatic enrichment of observables for OpenCTI.",
+      "type": "boolean"
+    },
+    "PROOFPOINT_ET_INTELLIGENCE_API_BASE_URL": {
+      "default": "https://api.emergingthreats.net/v1/",
+      "description": "The base URL used to connect to the ProofPoint ET Intelligence API endpoint.",
+      "format": "uri",
+      "type": "string"
+    },
+    "PROOFPOINT_ET_INTELLIGENCE_API_KEY": {
+      "description": "The API key used for authentication to access the ProofPoint ET Intelligence API.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "PROOFPOINT_ET_INTELLIGENCE_MAX_TLP": {
+      "default": "TLP:AMBER+STRICT",
+      "description": "The maximum TLP (Traffic Light Protocol) level the connector is authorized to enrich.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    },
+    "PROOFPOINT_ET_INTELLIGENCE_IMPORT_LAST_SEEN_TIME_WINDOW": {
+      "default": "P30D",
+      "description": "The time window for importing 'last_seen' data, specified in ISO 8601 duration format.",
+      "format": "duration",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "PROOFPOINT_ET_INTELLIGENCE_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/proofpoint-et-intelligence/__metadata__/connector_manifest.json
+++ b/internal-enrichment/proofpoint-et-intelligence/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.5.2",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/proofpoint-et-intelligence",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-proofpoint-et-intelligence",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-enrichment/reversinglabs-malware-presence/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/reversinglabs-malware-presence/__metadata__/connector_config_schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/reversinglabs-malware-presence_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ReversingLabs Malware Presence",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "StixFile",
+        "File",
+        "File-sha1",
+        "File-sha256",
+        "Artifact",
+        "IPv4-Addr",
+        "IPv6-Addr",
+        "Url",
+        "Domain-Name"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": true,
+      "description": "Enable or disable auto-enrichment of observables.",
+      "type": "boolean"
+    },
+    "CONNECTOR_CONFIDENCE_LEVEL": {
+      "default": 100,
+      "description": "The default confidence level for created entities (0-100).",
+      "type": "integer"
+    },
+    "REVERSINGLABS_TITANIUMCLOUD_URL": {
+      "default": "data.reversinglabs.com",
+      "description": "ReversingLabs Spectra Intelligence (TitaniumCloud) API URL.",
+      "type": "string"
+    },
+    "REVERSINGLABS_TITANIUMCLOUD_USERNAME": {
+      "description": "ReversingLabs Spectra Intelligence API username.",
+      "type": "string"
+    },
+    "REVERSINGLABS_TITANIUMCLOUD_PASSWORD": {
+      "description": "ReversingLabs Spectra Intelligence API password.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "REVERSINGLABS_MAX_TLP": {
+      "default": "TLP:AMBER",
+      "description": "Maximum TLP marking level for enrichment.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    },
+    "REVERSINGLABS_CREATE_INDICATORS": {
+      "default": true,
+      "description": "Whether to create indicators from enriched observables.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "REVERSINGLABS_TITANIUMCLOUD_USERNAME",
+    "REVERSINGLABS_TITANIUMCLOUD_PASSWORD"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/reversinglabs-malware-presence/__metadata__/connector_manifest.json
+++ b/internal-enrichment/reversinglabs-malware-presence/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.2.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/reversinglabs-malware-presence",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-reversinglabs-malware-presence",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-enrichment/reversinglabs-spectra-analyze/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/reversinglabs-spectra-analyze/__metadata__/connector_config_schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/reversinglabs-spectra-analyze_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ReversingLabs Spectra Analyze",
+      "description": "The name of the connector instance.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "Artifact",
+        "IPv4-Addr",
+        "Domain-Name"
+      ],
+      "description": "Comma-separated list of entity types the connector will enrich.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Enable or disable auto-enrichment of observables.",
+      "type": "boolean"
+    },
+    "REVERSINGLABS_SPECTRA_ANALYZE_URL": {
+      "description": "ReversingLabs Spectra Analyze appliance API base URL.",
+      "type": "string"
+    },
+    "REVERSINGLABS_SPECTRA_ANALYZE_TOKEN": {
+      "description": "API authentication token for Spectra Analyze.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "REVERSINGLABS_SPECTRA_ANALYZE_MAX_TLP": {
+      "default": "TLP:AMBER",
+      "description": "Maximum TLP level for entities that the connector can enrich.",
+      "enum": [
+        "TLP:WHITE",
+        "TLP:CLEAR",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    },
+    "REVERSINGLABS_SPECTRA_ANALYZE_SANDBOX_OS": {
+      "default": "windows10",
+      "description": "The sandbox operating system platform to execute samples on.",
+      "enum": [
+        "windows11",
+        "windows10",
+        "windows7",
+        "macos11",
+        "linux"
+      ],
+      "type": "string"
+    },
+    "REVERSINGLABS_SPECTRA_ANALYZE_CLOUD_ANALYSIS": {
+      "default": true,
+      "description": "Enable cloud analysis for submitted samples.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "REVERSINGLABS_SPECTRA_ANALYZE_URL",
+    "REVERSINGLABS_SPECTRA_ANALYZE_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/reversinglabs-spectra-analyze/__metadata__/connector_manifest.json
+++ b/internal-enrichment/reversinglabs-spectra-analyze/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.3.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/reversinglabs-spectra-analyze",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-reversinglabs-spectra-analyze",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-enrichment/reversinglabs-spectra-intel-submission/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/reversinglabs-spectra-intel-submission/__metadata__/connector_config_schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/reversinglabs-spectra-intel-submission_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ReversingLabs Spectra Intelligence Submission",
+      "description": "The name of the connector instance.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "Artifact",
+        "Url",
+        "StixFile",
+        "File"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Enable or disable auto-enrichment of observables.",
+      "type": "boolean"
+    },
+    "CONNECTOR_CONFIDENCE_LEVEL": {
+      "default": 100,
+      "description": "The default confidence level for created entities (0-100).",
+      "type": "integer"
+    },
+    "REVERSINGLABS_SPECTRA_INTELLIGENCE_URL": {
+      "default": "data.reversinglabs.com",
+      "description": "ReversingLabs Spectra Intelligence API URL.",
+      "type": "string"
+    },
+    "REVERSINGLABS_SPECTRA_INTELLIGENCE_USERNAME": {
+      "description": "ReversingLabs Spectra Intelligence API username.",
+      "type": "string"
+    },
+    "REVERSINGLABS_SPECTRA_INTELLIGENCE_PASSWORD": {
+      "description": "ReversingLabs Spectra Intelligence API password.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "REVERSINGLABS_MAX_TLP": {
+      "default": "TLP:AMBER",
+      "description": "Maximum TLP marking level for enrichment.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    },
+    "REVERSINGLABS_SANDBOX_OS": {
+      "default": "windows10",
+      "description": "Sandbox operating system for dynamic analysis.",
+      "enum": [
+        "windows7",
+        "windows10",
+        "windows11",
+        "macos11",
+        "linux"
+      ],
+      "type": "string"
+    },
+    "REVERSINGLABS_SANDBOX_INTERNET_SIM": {
+      "default": false,
+      "description": "Use simulated internet during sandbox analysis instead of real connectivity.",
+      "type": "boolean"
+    },
+    "REVERSINGLABS_CREATE_INDICATORS": {
+      "default": true,
+      "description": "Whether to create indicators from analysis results.",
+      "type": "boolean"
+    },
+    "REVERSINGLABS_POLL_INTERVAL": {
+      "default": 250,
+      "description": "Poll interval in seconds to check for analysis completion (minimum 250).",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "REVERSINGLABS_SPECTRA_INTELLIGENCE_USERNAME",
+    "REVERSINGLABS_SPECTRA_INTELLIGENCE_PASSWORD"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/reversinglabs-spectra-intel-submission/__metadata__/connector_manifest.json
+++ b/internal-enrichment/reversinglabs-spectra-intel-submission/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.2.14",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/reversinglabs-spectra-intel-submission",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-reversinglabs-spectra-intel-submission",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-enrichment/shodan-internetdb/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/shodan-internetdb/__metadata__/connector_config_schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/shodan-internetdb_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Shodan InternetDB",
+      "description": "The name of the connector instance.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "IPv4-Addr"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": true,
+      "description": "Enable or disable auto-enrichment of observables.",
+      "type": "boolean"
+    },
+    "SHODAN_MAX_TLP": {
+      "default": "TLP:WHITE",
+      "description": "Maximum TLP marking level for processing observables.",
+      "enum": [
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:RED",
+        "TLP:CLEAR",
+        "TLP:AMBER+STRICT"
+      ],
+      "type": "string"
+    },
+    "SHODAN_SSL_VERIFY": {
+      "default": true,
+      "description": "Whether to verify SSL connections to the Shodan InternetDB API.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/shodan-internetdb/__metadata__/connector_manifest.json
+++ b/internal-enrichment/shodan-internetdb/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.6.8",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/shodan-internetdb",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-shodan-internetdb",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-export-file/export-file-csv/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-file-csv/__metadata__/connector_config_schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/export-file-csv_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ExportFileCsv",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "text/csv"
+      ],
+      "description": "The MIME type scope for CSV export.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_EXPORT_FILE",
+      "default": "INTERNAL_EXPORT_FILE",
+      "type": "string"
+    },
+    "CONNECTOR_CONFIDENCE_LEVEL": {
+      "default": 100,
+      "description": "The confidence level for this connector, from 0 (Unknown) to 100 (Fully trusted).",
+      "type": "integer"
+    },
+    "EXPORT_FILE_CSV_DELIMITER": {
+      "default": ";",
+      "description": "CSV field delimiter character (e.g. ';', ',', '\\t').",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-export-file/export-file-csv/__metadata__/connector_manifest.json
+++ b/internal-export-file/export-file-csv/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-export-file/export-file-csv",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-export-file-csv",
   "container_type": "INTERNAL_EXPORT_FILE"

--- a/internal-export-file/export-file-stix/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-file-stix/__metadata__/connector_config_schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/export-file-stix_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ExportFileStix",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "application/vnd.oasis.stix+json"
+      ],
+      "description": "The MIME type scope for STIX JSON export.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_EXPORT_FILE",
+      "default": "INTERNAL_EXPORT_FILE",
+      "type": "string"
+    },
+    "CONNECTOR_CONFIDENCE_LEVEL": {
+      "default": 100,
+      "description": "The confidence level for this connector, from 0 (Unknown) to 100 (Fully trusted).",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-export-file/export-file-stix/__metadata__/connector_manifest.json
+++ b/internal-export-file/export-file-stix/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-export-file/export-file-stix",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-export-file-stix",
   "container_type": "INTERNAL_EXPORT_FILE"

--- a/internal-export-file/export-file-txt/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-file-txt/__metadata__/connector_config_schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/export-file-txt_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ExportFileTxt",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "text/plain"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_EXPORT_FILE",
+      "default": "INTERNAL_EXPORT_FILE",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-export-file/export-file-txt/__metadata__/connector_manifest.json
+++ b/internal-export-file/export-file-txt/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-export-file/export-file-txt",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-export-file-txt",
   "container_type": "INTERNAL_EXPORT_FILE"

--- a/internal-export-file/export-report-pdf/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-report-pdf/__metadata__/connector_config_schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/export-report-pdf_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ExportReportPdf",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "application/pdf"
+      ],
+      "description": "The MIME type scope for PDF file exports.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_EXPORT_FILE",
+      "default": "INTERNAL_EXPORT_FILE",
+      "type": "string"
+    },
+    "EXPORT_REPORT_PDF_PRIMARY_COLOR": {
+      "default": null,
+      "description": "Primary color for the PDF output (hex format, e.g., #ff8c00).",
+      "type": "string"
+    },
+    "EXPORT_REPORT_PDF_SECONDARY_COLOR": {
+      "default": null,
+      "description": "Secondary color for the PDF output (hex format, e.g., #000000).",
+      "type": "string"
+    },
+    "EXPORT_REPORT_PDF_COMPANY_ADDRESS_LINE_1": {
+      "default": null,
+      "description": "First line of company address (e.g., company name).",
+      "type": "string"
+    },
+    "EXPORT_REPORT_PDF_COMPANY_ADDRESS_LINE_2": {
+      "default": null,
+      "description": "Second line of company address (e.g., street address).",
+      "type": "string"
+    },
+    "EXPORT_REPORT_PDF_COMPANY_ADDRESS_LINE_3": {
+      "default": null,
+      "description": "Third line of company address (e.g., city, state, country).",
+      "type": "string"
+    },
+    "EXPORT_REPORT_PDF_COMPANY_PHONE_NUMBER": {
+      "default": null,
+      "description": "Company phone number for the PDF footer.",
+      "type": "string"
+    },
+    "EXPORT_REPORT_PDF_COMPANY_EMAIL": {
+      "default": null,
+      "description": "Company email for the PDF footer.",
+      "type": "string"
+    },
+    "EXPORT_REPORT_PDF_COMPANY_WEBSITE": {
+      "default": null,
+      "description": "Company website URL for the PDF footer.",
+      "type": "string"
+    },
+    "EXPORT_REPORT_PDF_INDICATORS_ONLY": {
+      "default": false,
+      "description": "If true, only include observables that have indicator status in the report.",
+      "type": "boolean"
+    },
+    "EXPORT_REPORT_PDF_DEFANG_URLS": {
+      "default": true,
+      "description": "If true, replace http with hxxp in URL observables for safe sharing.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-export-file/export-report-pdf/__metadata__/connector_manifest.json
+++ b/internal-export-file/export-report-pdf/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-export-file/export-report-pdf",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-export-report-pdf",
   "container_type": "INTERNAL_EXPORT_FILE"

--- a/internal-export-file/export-ttps-file-navigator/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-ttps-file-navigator/__metadata__/connector_config_schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/export-ttps-file-navigator_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ExportTTPsFileNavigator",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "application/vnd.mitre.navigator+json"
+      ],
+      "description": "The scope of the connector (MIME types it can export).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_EXPORT_FILE",
+      "default": "INTERNAL_EXPORT_FILE",
+      "type": "string"
+    },
+    "CONNECTOR_CONFIDENCE_LEVEL": {
+      "default": 100,
+      "description": "The confidence level of the connector, from 0 (Unknown) to 100 (Fully trusted).",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-export-file/export-ttps-file-navigator/__metadata__/connector_manifest.json
+++ b/internal-export-file/export-ttps-file-navigator/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.12.10",
   "subscription_link": "https://mitre-attack.github.io/attack-navigator",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-export-file/export-ttps-file-navigator",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-export-ttps-file-navigator",
   "container_type": "INTERNAL_EXPORT_FILE"

--- a/internal-import-file/import-document-ai/__metadata__/connector_config_schema.json
+++ b/internal-import-file/import-document-ai/__metadata__/connector_config_schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/import-document-ai_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The default admin token set in the OpenCTI platform.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ImportDocumentAI",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "application/pdf",
+        "text/plain",
+        "text/html",
+        "text/markdown"
+      ],
+      "description": "Comma-separated list of supported MIME types.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "Determines the verbosity of the logs. Options are debug, info, warn, or error.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_IMPORT_FILE",
+      "default": "INTERNAL_IMPORT_FILE",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Enable/disable automatic import of files matching the scope.",
+      "type": "boolean"
+    },
+    "CONNECTOR_VALIDATE_BEFORE_IMPORT": {
+      "default": false,
+      "description": "If enabled, bundles are sent for validation before import.",
+      "type": "boolean"
+    },
+    "CONNECTOR_XTM_ONE_INTENT": {
+      "default": "cti.stix_harvester",
+      "description": "Intent used by XTM One to bind this connector to specific AI agents.",
+      "type": "string"
+    },
+    "IMPORT_DOCUMENT_AI_API_BASE_URL": {
+      "default": "https://importdoc.ariane.filigran.io",
+      "description": "[DEPRECATED] The URL of the Ariane extraction service running the AI model.",
+      "type": "string"
+    },
+    "IMPORT_DOCUMENT_AI_API_KEY": {
+      "default": null,
+      "description": "[DEPRECATED] The Enterprise Edition license certificate in PEM format.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "IMPORT_DOCUMENT_AI_CREATE_INDICATOR": {
+      "default": false,
+      "description": "If true, creates an Indicator for each extracted observable.",
+      "type": "boolean"
+    },
+    "IMPORT_DOCUMENT_AI_INCLUDE_RELATIONSHIPS": {
+      "default": true,
+      "description": "If false, removes all ML-predicted relationships from the imported bundle.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-import-file/import-document-ai/__metadata__/connector_manifest.json
+++ b/internal-import-file/import-document-ai/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.6.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-import-file/import-document-ai",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-import-document-ai",
   "container_type": "INTERNAL_IMPORT_FILE"

--- a/internal-import-file/import-document/__metadata__/connector_config_schema.json
+++ b/internal-import-file/import-document/__metadata__/connector_config_schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/import-document_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ImportDocument",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "application/pdf",
+        "text/plain",
+        "text/html",
+        "text/markdown"
+      ],
+      "description": "Comma-separated list of supported MIME types.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_IMPORT_FILE",
+      "default": "INTERNAL_IMPORT_FILE",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Enable or disable automatic import of files matching the scope.",
+      "type": "boolean"
+    },
+    "CONNECTOR_ONLY_CONTEXTUAL": {
+      "default": false,
+      "description": "If true, only extract data when an entity context is provided.",
+      "type": "boolean"
+    },
+    "CONNECTOR_VALIDATE_BEFORE_IMPORT": {
+      "default": true,
+      "description": "If enabled, bundles are sent for validation before import.",
+      "type": "boolean"
+    },
+    "IMPORT_DOCUMENT_CREATE_INDICATOR": {
+      "default": false,
+      "description": "If true, creates an Indicator for each extracted observable.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-import-file/import-document/__metadata__/connector_manifest.json
+++ b/internal-import-file/import-document/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-import-file/import-document",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-import-document",
   "container_type": "INTERNAL_IMPORT_FILE"

--- a/internal-import-file/import-file-misp/__metadata__/connector_config_schema.json
+++ b/internal-import-file/import-file-misp/__metadata__/connector_config_schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/import-file-misp_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ImportFileMISP",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "application/json"
+      ],
+      "description": "Supported MIME type (JSON for MISP exports).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_IMPORT_FILE",
+      "default": "INTERNAL_IMPORT_FILE",
+      "type": "string"
+    },
+    "MISP_IMPORT_FILE_IMPORT_FROM_DATE": {
+      "default": null,
+      "description": "Only import MISP events from this date onwards.",
+      "type": "string"
+    },
+    "MISP_IMPORT_FILE_CREATE_REPORTS": {
+      "default": true,
+      "description": "Create a Report entity for each MISP event.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_REPORT_TYPE": {
+      "default": "misp-event",
+      "description": "Report type to use for imported events.",
+      "type": "string"
+    },
+    "MISP_IMPORT_FILE_CREATE_INDICATORS": {
+      "default": true,
+      "description": "Create Indicator entities from MISP attributes.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_CREATE_OBSERVABLES": {
+      "default": true,
+      "description": "Create Observable entities from MISP attributes.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_CREATE_OBJECT_OBSERVABLES": {
+      "default": true,
+      "description": "Create observables from MISP objects.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_CREATE_TAGS_AS_LABELS": {
+      "default": true,
+      "description": "Convert MISP tags to OpenCTI labels.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_GUESS_THREAT_FROM_TAGS": {
+      "default": false,
+      "description": "Attempt to identify threats (malware, intrusion sets, etc.) from MISP tags when they are present in OpenCTI.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_AUTHOR_FROM_TAGS": {
+      "default": false,
+      "description": "Map creator:XX=YY tags to set report author.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_MARKINGS_FROM_TAGS": {
+      "default": false,
+      "description": "Extract TLP/PAP markings from MISP tags.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_IMPORT_TO_IDS_NO_SCORE": {
+      "default": 40,
+      "description": "Score to assign to indicators/observables when the attribute to_ids is false.",
+      "type": "integer"
+    },
+    "MISP_IMPORT_FILE_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT": {
+      "default": false,
+      "description": "Import unsupported observable types as Text observables.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT_TRANSPARENT": {
+      "default": true,
+      "description": "Use only the value for unsupported observables imported as text.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_IMPORT_WITH_ATTACHMENTS": {
+      "default": false,
+      "description": "Import PDF attachments from MISP attributes.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-import-file/import-file-misp/__metadata__/connector_manifest.json
+++ b/internal-import-file/import-file-misp/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.3.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-import-file/import-file-misp",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-import-file-misp",
   "container_type": "INTERNAL_IMPORT_FILE"

--- a/internal-import-file/import-file-stix/__metadata__/connector_config_schema.json
+++ b/internal-import-file/import-file-stix/__metadata__/connector_config_schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/import-file-stix_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The default admin token set in the OpenCTI platform.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ImportFileStix",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "application/json",
+        "text/xml"
+      ],
+      "description": "Supported MIME types (JSON for STIX 2.1, XML for STIX 1.2).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_IMPORT_FILE",
+      "default": "INTERNAL_IMPORT_FILE",
+      "type": "string"
+    },
+    "CONNECTOR_VALIDATE_BEFORE_IMPORT": {
+      "default": true,
+      "description": "Validate STIX bundles before importing.",
+      "type": "boolean"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Enable automatic import of uploaded STIX files.",
+      "type": "boolean"
+    },
+    "CONNECTOR_CONFIDENCE_LEVEL": {
+      "default": 15,
+      "description": "Default confidence level for imported entities (from 0 to 100).",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-import-file/import-file-stix/__metadata__/connector_manifest.json
+++ b/internal-import-file/import-file-stix/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-import-file/import-file-stix",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-import-file-stix",
   "container_type": "INTERNAL_IMPORT_FILE"

--- a/internal-import-file/import-file-yara/__metadata__/connector_config_schema.json
+++ b/internal-import-file/import-file-yara/__metadata__/connector_config_schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/import-file-yara_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The default admin token set in the OpenCTI platform.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ImportFileYARA",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "text/yara+plain"
+      ],
+      "description": "The MIME type of files this connector handles.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "Determines the verbosity of the logs.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_IMPORT_FILE",
+      "default": "INTERNAL_IMPORT_FILE",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Enable/disable automatic import of files matching the scope.",
+      "type": "boolean"
+    },
+    "CONNECTOR_VALIDATE_BEFORE_IMPORT": {
+      "default": true,
+      "description": "If enabled, bundles are sent for validation before import.",
+      "type": "boolean"
+    },
+    "CONNECTOR_CONFIDENCE_LEVEL": {
+      "default": 15,
+      "description": "Default confidence level for created indicators (0-100).",
+      "type": "integer"
+    },
+    "YARA_IMPORT_FILE_SPLIT_RULES": {
+      "default": true,
+      "description": "If true, each YARA rule becomes a separate indicator. If false, all rules become one indicator.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-import-file/import-file-yara/__metadata__/connector_manifest.json
+++ b/internal-import-file/import-file-yara/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.5.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-import-file/import-file-yara",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-import-file-yara",
   "container_type": "INTERNAL_IMPORT_FILE"

--- a/internal-import-file/import-ttps-file-navigator/__metadata__/connector_config_schema.json
+++ b/internal-import-file/import-ttps-file-navigator/__metadata__/connector_config_schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/import-ttps-file-navigator_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ImportTTPsFileNavigator",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "application/json"
+      ],
+      "description": "The MIME type of files this connector handles.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "Determines the verbosity of the logs.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_IMPORT_FILE",
+      "default": "INTERNAL_IMPORT_FILE",
+      "type": "string"
+    },
+    "CONNECTOR_VALIDATE_BEFORE_IMPORT": {
+      "default": true,
+      "description": "If enabled, bundles are sent for validation before import.",
+      "type": "boolean"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Enable/disable automatic import of files matching the scope.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-import-file/import-ttps-file-navigator/__metadata__/connector_manifest.json
+++ b/internal-import-file/import-ttps-file-navigator/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.7.10",
   "subscription_link": "https://mitre-attack.github.io/attack-navigator/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-import-file/import-ttps-file-navigator",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-import-ttps-file-navigator",
   "container_type": "INTERNAL_IMPORT_FILE"

--- a/shared/tools/composer/generate_global_manifest/generate_global_manifest.py
+++ b/shared/tools/composer/generate_global_manifest/generate_global_manifest.py
@@ -29,7 +29,9 @@ class ManifestGenerator:
         Gather all connector contract paths
         """
         for repository_subdirectory in REPOSITORY_SUBDIRECTORIES_TO_INCLUDE:
-            for root, _, files in os.walk(repository_subdirectory):
+            for root, _, files in sorted(
+                os.walk(repository_subdirectory), key=lambda x: x[0]
+            ):
                 if os.path.basename(root) == __CONNECTOR_METADATA_DIRECTORY__:
                     connector_manifest_file_path = None
                     connector_config_json_schema_file_path = None

--- a/stream/jira/__metadata__/connector_config_schema.json
+++ b/stream/jira/__metadata__/connector_config_schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/jira_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_NAME": {
+      "default": "Atlassian JIRA",
+      "description": "Name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "jira"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "STREAM",
+      "default": "STREAM",
+      "description": "The type of the connector. Must be STREAM.",
+      "type": "string"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "Determines the verbosity of the logs.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_ID": {
+      "description": "The ID of the live stream created in the OpenCTI UI.",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_LISTEN_DELETE": {
+      "default": true,
+      "description": "Whether to listen to delete events in the stream.",
+      "type": "boolean"
+    },
+    "CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES": {
+      "default": true,
+      "description": "Set to true unless synchronizing between OpenCTI platforms.",
+      "type": "boolean"
+    },
+    "JIRA_URL": {
+      "description": "The URL of the Jira server (e.g., https://yourinstance.atlassian.net).",
+      "format": "uri",
+      "type": "string"
+    },
+    "JIRA_SSL_VERIFY": {
+      "default": true,
+      "description": "Whether to verify SSL certificates when connecting to Jira.",
+      "type": "boolean"
+    },
+    "JIRA_LOGIN_EMAIL": {
+      "description": "Email address for Jira account with API access.",
+      "type": "string"
+    },
+    "JIRA_API_TOKEN": {
+      "description": "API token for Jira authentication.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "JIRA_PROJECT_KEY": {
+      "description": "Jira project key (not name) for issue creation.",
+      "type": "string"
+    },
+    "JIRA_ISSUE_TYPE_NAME": {
+      "default": "Task",
+      "description": "Issue type to create in Jira (e.g., Epic, Task, Bug, Story).",
+      "type": "string"
+    },
+    "JIRA_CUSTOM_FIELDS_KEYS": {
+      "default": "",
+      "description": "Comma-separated custom field IDs (e.g., customfield_10039).",
+      "type": "string"
+    },
+    "JIRA_CUSTOM_FIELDS_VALUES": {
+      "default": "",
+      "description": "Comma-separated values for custom fields (same order as keys).",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_LIVE_STREAM_ID",
+    "JIRA_URL",
+    "JIRA_LOGIN_EMAIL",
+    "JIRA_API_TOKEN",
+    "JIRA_PROJECT_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/stream/jira/__metadata__/connector_manifest.json
+++ b/stream/jira/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.2.2",
   "subscription_link": "https://www.atlassian.com/software/jira",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/stream/jira",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-jira",
   "container_type": "STREAM"

--- a/stream/microsoft-graph-security-intel/__metadata__/connector_config_schema.json
+++ b/stream/microsoft-graph-security-intel/__metadata__/connector_config_schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/microsoft-graph-security-intel_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The URL of the OpenCTI platform.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Microsoft Graph Security Intel",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "indicator"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "STREAM",
+      "default": "STREAM",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_ID": {
+      "description": "The Live Stream ID of the stream created in the OpenCTI interface.",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_LISTEN_DELETE": {
+      "default": true,
+      "description": "Whether to listen to delete events from the live stream.",
+      "type": "boolean"
+    },
+    "CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES": {
+      "default": true,
+      "description": "Set to true unless synchronizing between OpenCTI platforms.",
+      "type": "boolean"
+    },
+    "MICROSOFT_GRAPH_SECURITY_INTEL_TENANT_ID": {
+      "description": "Azure AD Tenant ID.",
+      "type": "string"
+    },
+    "MICROSOFT_GRAPH_SECURITY_INTEL_CLIENT_ID": {
+      "description": "Azure AD Application Client ID.",
+      "type": "string"
+    },
+    "MICROSOFT_GRAPH_SECURITY_INTEL_CLIENT_SECRET": {
+      "description": "Azure AD Application Client Secret.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "MICROSOFT_GRAPH_SECURITY_INTEL_LOGIN_URL": {
+      "default": "https://login.microsoft.com",
+      "description": "Microsoft login URL.",
+      "type": "string"
+    },
+    "MICROSOFT_GRAPH_SECURITY_INTEL_BASE_URL": {
+      "default": "https://graph.microsoft.com",
+      "description": "Microsoft Graph API base URL.",
+      "type": "string"
+    },
+    "MICROSOFT_GRAPH_SECURITY_INTEL_RESOURCE_PATH": {
+      "default": "/beta/security/tiIndicators",
+      "description": "API endpoint path for tiIndicators.",
+      "type": "string"
+    },
+    "MICROSOFT_GRAPH_SECURITY_INTEL_EXPIRE_TIME": {
+      "default": 30,
+      "description": "Days before indicators expire (when no valid_until is set).",
+      "type": "integer"
+    },
+    "MICROSOFT_GRAPH_SECURITY_INTEL_TARGET_PRODUCT": {
+      "default": "Azure Sentinel",
+      "description": "Target Microsoft product for indicator submission.",
+      "enum": [
+        "Azure Sentinel",
+        "Microsoft Defender ATP"
+      ],
+      "type": "string"
+    },
+    "MICROSOFT_GRAPH_SECURITY_INTEL_ACTION": {
+      "default": null,
+      "description": "Action to apply to indicators. If not set, action is determined based on score.",
+      "enum": [
+        "unknown",
+        "allow",
+        "block",
+        "alert",
+        null
+      ]
+    },
+    "MICROSOFT_GRAPH_SECURITY_INTEL_TLP_LEVEL": {
+      "default": null,
+      "description": "Override TLP level for indicators.",
+      "enum": [
+        "unknown",
+        "white",
+        "green",
+        "amber",
+        "red",
+        null
+      ]
+    },
+    "MICROSOFT_GRAPH_SECURITY_INTEL_PASSIVE_ONLY": {
+      "default": false,
+      "description": "Silent/audit mode without user notification.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_LIVE_STREAM_ID",
+    "MICROSOFT_GRAPH_SECURITY_INTEL_TENANT_ID",
+    "MICROSOFT_GRAPH_SECURITY_INTEL_CLIENT_ID",
+    "MICROSOFT_GRAPH_SECURITY_INTEL_CLIENT_SECRET"
+  ],
+  "additionalProperties": true
+}

--- a/stream/microsoft-graph-security-intel/__metadata__/connector_manifest.json
+++ b/stream/microsoft-graph-security-intel/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.5.11",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/stream/microsoft-graph-security-intel",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-microsoft-graph-security-intel",
   "container_type": "STREAM"

--- a/stream/splunk/__metadata__/connector_config_schema.json
+++ b/stream/splunk/__metadata__/connector_config_schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/splunk_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "OpenCTI Splunk Connector",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "splunk"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "STREAM",
+      "default": "STREAM",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_ID": {
+      "description": "The Live Stream ID of the stream created in the OpenCTI interface.",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_LISTEN_DELETE": {
+      "default": true,
+      "description": "Whether to listen for delete events from the live stream.",
+      "type": "boolean"
+    },
+    "CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES": {
+      "default": true,
+      "description": "Whether to ignore dependencies in the live stream.",
+      "type": "boolean"
+    },
+    "CONNECTOR_LIVE_STREAM_START_TIMESTAMP": {
+      "default": null,
+      "description": "Start timestamp used on connector first start.",
+      "type": "string"
+    },
+    "CONNECTOR_CONSUMER_COUNT": {
+      "default": 10,
+      "description": "Number of consumer/worker threads used to push data to Splunk.",
+      "type": "integer"
+    },
+    "CONNECTOR_CONFIDENCE_LEVEL": {
+      "default": 80,
+      "description": "Default confidence level for the connector (0-100).",
+      "type": "integer"
+    },
+    "SPLUNK_URL": {
+      "description": "Splunk REST API URL (e.g. https://splunk.example.com:8089).",
+      "format": "uri",
+      "type": "string"
+    },
+    "SPLUNK_TOKEN": {
+      "description": "Splunk API token or Base64(user:password) for Basic auth.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "SPLUNK_AUTH_TYPE": {
+      "default": "Bearer",
+      "description": "Authentication type for Splunk API.",
+      "enum": [
+        "Bearer",
+        "Basic"
+      ],
+      "type": "string"
+    },
+    "SPLUNK_OWNER": {
+      "description": "KV Store owner (recommended: nobody).",
+      "type": "string"
+    },
+    "SPLUNK_SSL_VERIFY": {
+      "default": true,
+      "description": "Whether to verify SSL certificates when connecting to Splunk.",
+      "type": "boolean"
+    },
+    "SPLUNK_APP": {
+      "description": "Splunk app name for the KV Store.",
+      "type": "string"
+    },
+    "SPLUNK_KV_STORE_NAME": {
+      "description": "Name of the KV Store collection in Splunk.",
+      "type": "string"
+    },
+    "SPLUNK_IGNORE_TYPES": {
+      "description": "Comma-separated list of STIX entity types to ignore.",
+      "type": "string"
+    },
+    "METRICS_ENABLE": {
+      "default": false,
+      "description": "Whether to enable Prometheus metrics.",
+      "type": "boolean"
+    },
+    "METRICS_ADDR": {
+      "default": "0.0.0.0",
+      "description": "Bind IP address for the Prometheus metrics endpoint.",
+      "type": "string"
+    },
+    "METRICS_PORT": {
+      "default": 9113,
+      "description": "Port for the Prometheus metrics endpoint.",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_LIVE_STREAM_ID",
+    "SPLUNK_URL",
+    "SPLUNK_TOKEN",
+    "SPLUNK_OWNER",
+    "SPLUNK_APP",
+    "SPLUNK_KV_STORE_NAME",
+    "SPLUNK_IGNORE_TYPES"
+  ],
+  "additionalProperties": true
+}

--- a/stream/splunk/__metadata__/connector_manifest.json
+++ b/stream/splunk/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/stream/splunk",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-splunk",
   "container_type": "STREAM"

--- a/stream/taxii-post/__metadata__/connector_config_schema.json
+++ b/stream/taxii-post/__metadata__/connector_config_schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/taxii-post_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "TAXII POST",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "taxii"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "STREAM",
+      "default": "STREAM",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_ID": {
+      "description": "The ID of the live stream to connect to.",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_LISTEN_DELETE": {
+      "default": true,
+      "description": "Whether to listen to delete events from the live stream.",
+      "type": "boolean"
+    },
+    "CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES": {
+      "default": true,
+      "description": "Set to true unless synchronizing between OpenCTI platforms.",
+      "type": "boolean"
+    },
+    "CONNECTOR_CONFIDENCE_LEVEL": {
+      "default": 80,
+      "description": "Default confidence level for the connector (0-100).",
+      "type": "integer"
+    },
+    "TAXII_URL": {
+      "description": "The URL of the TAXII server.",
+      "format": "uri",
+      "type": "string"
+    },
+    "TAXII_SSL_VERIFY": {
+      "default": true,
+      "description": "Whether to verify SSL certificates.",
+      "type": "boolean"
+    },
+    "TAXII_API_ROOT": {
+      "default": "root",
+      "description": "The TAXII API root path segment between server URL and /collections/.",
+      "type": "string"
+    },
+    "TAXII_COLLECTION_ID": {
+      "description": "The target TAXII collection ID.",
+      "type": "string"
+    },
+    "TAXII_TOKEN": {
+      "default": null,
+      "description": "Bearer token for authentication. Takes precedence over basic auth.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TAXII_LOGIN": {
+      "default": null,
+      "description": "Username for basic authentication.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TAXII_PASSWORD": {
+      "default": null,
+      "description": "Password for basic authentication.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TAXII_VERSION": {
+      "default": "2.1",
+      "description": "TAXII protocol version.",
+      "enum": [
+        "2.0",
+        "2.1"
+      ],
+      "type": "string"
+    },
+    "TAXII_STIX_VERSION": {
+      "default": "2.1",
+      "description": "STIX output version.",
+      "enum": [
+        "2.0",
+        "2.1"
+      ],
+      "type": "string"
+    },
+    "TAXII_DELETE_CREATED_BY_REF": {
+      "default": true,
+      "description": "Strip created_by_ref from objects before posting.",
+      "type": "boolean"
+    },
+    "TAXII_DELETE_MARKING_DEFINITION": {
+      "default": true,
+      "description": "Strip object_marking_refs from objects before posting.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_LIVE_STREAM_ID",
+    "TAXII_URL",
+    "TAXII_COLLECTION_ID"
+  ],
+  "additionalProperties": true
+}

--- a/stream/taxii-post/__metadata__/connector_manifest.json
+++ b/stream/taxii-post/__metadata__/connector_manifest.json
@@ -12,7 +12,7 @@
   "support_version": ">=5.9.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/stream/taxii-post",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-taxii-post",
   "container_type": "STREAM"

--- a/stream/zscaler/__metadata__/connector_config_schema.json
+++ b/stream/zscaler/__metadata__/connector_config_schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/zscaler_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "OPENCTI_SSL_VERIFY": {
+      "default": false,
+      "description": "Verify SSL certificates when connecting to OpenCTI.",
+      "type": "boolean"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ZscalerConnector",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "Zscaler"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "STREAM",
+      "default": "STREAM",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_ID": {
+      "description": "The Live Stream ID of the stream created in the OpenCTI interface.",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_LISTEN_DELETE": {
+      "default": true,
+      "description": "Whether the connector listens to delete events from the live stream.",
+      "type": "boolean"
+    },
+    "CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES": {
+      "default": true,
+      "description": "Set to true unless synchronizing between OpenCTI platforms.",
+      "type": "boolean"
+    },
+    "ZSCALER_USERNAME": {
+      "description": "Zscaler username for API authentication.",
+      "type": "string"
+    },
+    "ZSCALER_PASSWORD": {
+      "description": "Zscaler password for API authentication.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "ZSCALER_API_KEY": {
+      "description": "Zscaler API key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "ZSCALER_BLACKLIST_NAME": {
+      "default": "BLACK_LIST_DYNDNS",
+      "description": "Name of the Zscaler URL category to manage.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_LIVE_STREAM_ID",
+    "ZSCALER_USERNAME",
+    "ZSCALER_PASSWORD",
+    "ZSCALER_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/stream/zscaler/__metadata__/connector_manifest.json
+++ b/stream/zscaler/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.4.0",
   "subscription_link": "https://www.zscaler.com",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/stream/zscaler",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-zscaler",
   "container_type": "STREAM"


### PR DESCRIPTION
### Proposed changes

* Use prompts from https://github.com/OpenCTI-Platform/connectors/tree/feat/4857-create-migration-scripts-for-manager-support to generate schema for this set of connectors

### Related issues

*

### Checklist

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
