### PR TITLE
docs: add commit message Conventional Commits guidance to CONTRIBUTING.md (#6686)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -464,7 +464,11 @@ When your connector is ready:
 
 1. **Ensure all quality checks pass** (linting, tests, documentation)
 2. **Test in a production-like environment**
-3. **Create a Pull Request** on the [connectors repository](https://github.com/OpenCTI-Platform/connectors)
+3. **Follow the commit message convention** — individual commit messages should use the same [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format as PR titles:
+   ```
+   type(scope?)!?: description (#123)
+   ```
+4. **Create a Pull Request** on the [connectors repository](https://github.com/OpenCTI-Platform/connectors)
    - PR titles **must** follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, enforced automatically by CI:
      ```
      type(scope?)!?: description (#123)
@@ -479,8 +483,8 @@ When your connector is ready:
      - `feat(misp)!: remove deprecated feed endpoint (#150)`
    - Describe the changes introduced by the PR
    - Reference any issues that will be closed upon merging, using the _Close_ keyword followed by the GitHub issue link
-4. **Respond to review feedback** from maintainers
-5. **Update documentation** as needed
+5. **Respond to review feedback** from maintainers
+6. **Update documentation** as needed
 
 > [!IMPORTANT]  
 > When creating a Pull Request on this repository, ALWAYS create along with an associated GitHub issue describing the purpose of your contribution (what problem it fixes, what improvement it brings, or what new integration it provides).


### PR DESCRIPTION
## Summary

The CONTRIBUTING.md currently documents the Conventional Commits format only in the "Create a Pull Request" step. Contributors may not realise that individual commit messages should also follow the same convention.

This PR adds an explicit step (step 3) in the "When your connector is ready" checklist, clarifying that:
- **Commit messages should** follow the Conventional Commits format (good practice, keeps history readable)
- **PR titles must** follow it (enforced by CI — and become the squash-merge commit message)

## Changes

- **`CONTRIBUTING.md`**: added step 3 "Follow the commit message convention" with the format reminder and a note that individual commits are not CI-checked but the PR title is

Closes #6686