### PR TITLE
fix(ismalicious): correct enrichment API URL and auth (#6690)

### DIFF
--- a/internal-enrichment/ismalicious/.gitignore
+++ b/internal-enrichment/ismalicious/.gitignore
@@ -20,3 +20,5 @@ wheels/
 *.egg
 .env
 config.yml
+.venv/
+.pytest_cache/

--- a/internal-enrichment/ismalicious/README.md
+++ b/internal-enrichment/ismalicious/README.md
@@ -24,8 +24,8 @@ Find below the detailed configuration options:
 | Connector Scope     | `CONNECTOR_SCOPE`           | No        | Observable types (default: `IPv4-Addr,IPv6-Addr,Domain-Name`)  |
 | Log Level           | `CONNECTOR_LOG_LEVEL`       | No        | Log level: `debug`, `info`, `warn`, `error` (default: `info`)  |
 | Auto Mode           | `CONNECTOR_AUTO`            | No        | Enable automatic enrichment (default: `false`)                 |
-| isMalicious API URL | `ISMALICIOUS_API_URL`       | No        | API URL (default: `https://ismalicious.com`)                   |
-| isMalicious API Key | `ISMALICIOUS_API_KEY`       | Yes       | Your isMalicious API key                                       |
+| isMalicious API URL | `ISMALICIOUS_API_URL`       | No        | API URL (default: `https://api.ismalicious.com`)               |
+| isMalicious API Key | `ISMALICIOUS_API_KEY`       | Yes       | Your isMalicious API key (sent as `X-API-KEY` header)          |
 | Max TLP             | `ISMALICIOUS_MAX_TLP`       | No        | Max TLP to process (default: `TLP:AMBER`)                      |
 | Enrich IPv4         | `ISMALICIOUS_ENRICH_IPV4`   | No        | Enrich IPv4 addresses (default: `true`)                        |
 | Enrich IPv6         | `ISMALICIOUS_ENRICH_IPV6`   | No        | Enrich IPv6 addresses (default: `true`)                        |
@@ -73,6 +73,39 @@ When an observable is enriched, the connector adds:
 - `IPv4-Addr` - IPv4 addresses
 - `IPv6-Addr` - IPv6 addresses
 - `Domain-Name` - Domain names
+
+## API Authentication
+
+The enrichment API expects:
+
+- **Base URL:** `https://api.ismalicious.com`
+- **Endpoint:** `GET /check?query=<value>&enrichment=standard`
+- **Authentication:** `X-API-KEY: <your-api-key>` header
+
+Example:
+
+```bash
+curl -H "X-API-KEY: <your-api-key>" \
+  "https://api.ismalicious.com/check?query=8.8.8.8&enrichment=standard"
+```
+
+This connector does **not** use Basic Auth or Bearer tokens for the enrichment API.
+
+## TAXII Feed Ingestion (Bulk Import)
+
+This connector is an **internal enrichment** connector only. It enriches individual observables already present in OpenCTI; it does **not** import STIX bundles or indicators from a TAXII feed.
+
+For scheduled bulk ingestion from isMalicious TAXII, use one of these approaches:
+
+1. **OpenCTI built-in TAXII feed** (`Data > Ingestion > TAXII Feeds`) — only if the TAXII server supports the auth types exposed in the OpenCTI UI (Bearer token or Basic user/password). The isMalicious TAXII endpoint currently requires an `x-api-key` header, which the built-in ingester does not support.
+2. **OpenCTI generic TAXII2 external-import connector** — supports custom API key headers. Configure with:
+   - `TAXII2_DISCOVERY_URL=https://api.ismalicious.com/taxii2/`
+   - `TAXII2_USE_APIKEY=true`
+   - `TAXII2_APIKEY_KEY=x-api-key`
+   - `TAXII2_APIKEY_VALUE=<your-api-key>`
+   - `CONNECTOR_DURATION_PERIOD=PT1H` (poll every hour)
+
+See [external-import/taxii2](../../external-import/taxii2/README.md) for full configuration.
 
 ## Additional Information
 

--- a/internal-enrichment/ismalicious/README.md
+++ b/internal-enrichment/ismalicious/README.md
@@ -25,7 +25,7 @@ Find below the detailed configuration options:
 | Log Level           | `CONNECTOR_LOG_LEVEL`       | No        | Log level: `debug`, `info`, `warn`, `error` (default: `info`)  |
 | Auto Mode           | `CONNECTOR_AUTO`            | No        | Enable automatic enrichment (default: `false`)                 |
 | isMalicious API URL | `ISMALICIOUS_API_URL`       | No        | API URL (default: `https://api.ismalicious.com`)               |
-| isMalicious API Key | `ISMALICIOUS_API_KEY`       | Yes       | Your isMalicious API key (sent as `X-API-KEY` header)          |
+| isMalicious API Key | `ISMALICIOUS_API_KEY`       | Yes       | API credential from Dashboard → Account → Team Management (sent as `X-API-KEY`) |
 | Max TLP             | `ISMALICIOUS_MAX_TLP`       | No        | Max TLP to process (default: `TLP:AMBER`)                      |
 | Enrich IPv4         | `ISMALICIOUS_ENRICH_IPV4`   | No        | Enrich IPv4 addresses (default: `true`)                        |
 | Enrich IPv6         | `ISMALICIOUS_ENRICH_IPV6`   | No        | Enrich IPv6 addresses (default: `true`)                        |
@@ -95,17 +95,19 @@ This connector does **not** use Basic Auth or Bearer tokens for the enrichment A
 
 This connector is an **internal enrichment** connector only. It enriches individual observables already present in OpenCTI; it does **not** import STIX bundles or indicators from a TAXII feed.
 
-For scheduled bulk ingestion from isMalicious TAXII, use one of these approaches:
+For scheduled bulk ingestion (e.g. every hour), use isMalicious's **TAXII 2.1 feed** via OpenCTI's built-in TAXII connector or the generic TAXII2 external-import connector:
 
-1. **OpenCTI built-in TAXII feed** (`Data > Ingestion > TAXII Feeds`) — only if the TAXII server supports the auth types exposed in the OpenCTI UI (Bearer token or Basic user/password). The isMalicious TAXII endpoint currently requires an `x-api-key` header, which the built-in ingester does not support.
-2. **OpenCTI generic TAXII2 external-import connector** — supports custom API key headers. Configure with:
-   - `TAXII2_DISCOVERY_URL=https://api.ismalicious.com/taxii2/`
-   - `TAXII2_USE_APIKEY=true`
-   - `TAXII2_APIKEY_KEY=x-api-key`
-   - `TAXII2_APIKEY_VALUE=<your-api-key>`
-   - `CONNECTOR_DURATION_PERIOD=PT1H` (poll every hour)
+1. In OpenCTI, go to **Data > Ingestion > TAXII Feeds** and add a new feed.
+2. Set the Discovery URL to `https://api.ismalicious.com/taxii2/`
+3. For authentication, use one of:
+   - **Basic Auth**: username `api`, password = your full API credential from the dashboard (same base64 value as the `X-API-KEY` header)
+   - **Bearer token**: same credential value as the token
+   - **X-API-KEY header** (generic TAXII2 connector only): the base64 credential shown in Dashboard → Account → Team Management
+4. Select the collections to import and set the desired polling interval (e.g. `PT1H`).
 
-See [external-import/taxii2](../../external-import/taxii2/README.md) for full configuration.
+For the generic TAXII2 external-import connector, see [external-import/taxii2](../../external-import/taxii2/README.md).
+
+The enrichment connector and the TAXII feed complement each other — use both for full coverage.
 
 ## Additional Information
 

--- a/internal-enrichment/ismalicious/docker-compose.yml
+++ b/internal-enrichment/ismalicious/docker-compose.yml
@@ -2,18 +2,15 @@ services:
   connector-ismalicious:
     image: opencti/connector-ismalicious:latest
     environment:
-      - OPENCTI_URL=http://opencti:8080
-      - OPENCTI_TOKEN=ChangeMe
-      #- CONNECTOR_ID=ismalicious-enrichment # Optional (default: 'ismalicious-enrichment')
-      #- CONNECTOR_NAME=isMalicious # Optional (default: 'isMalicious')
-      #- CONNECTOR_SCOPE=IPv4-Addr,IPv6-Addr,Domain-Name # Optional
-      #- CONNECTOR_AUTO=true # Optional (default: false)
-      #- CONNECTOR_LOG_LEVEL=info # Optional (default: info)
-      - ISMALICIOUS_API_KEY=ChangeMe
-      #- ISMALICIOUS_API_URL=https://ismalicious.com # Optional (default: 'https://ismalicious.com')
-      #- ISMALICIOUS_MAX_TLP=TLP:AMBER # Optional (default: 'TLP:AMBER')
-      #- ISMALICIOUS_ENRICH_IPV4=true # Optional (default: true)
-      #- ISMALICIOUS_ENRICH_IPV6=true # Optional (default: true)
-      #- ISMALICIOUS_ENRICH_DOMAIN=true # Optional (default: true)
-      #- ISMALICIOUS_MIN_SCORE=0 # Optional (default: 0)
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
+      - CONNECTOR_ID=${CONNECTOR_ID}
+      - CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+      - CONNECTOR_NAME=isMalicious
+      - CONNECTOR_SCOPE=IPv4-Addr,IPv6-Addr,Domain-Name
+      - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_AUTO=false
+      - ISMALICIOUS_API_URL=https://api.ismalicious.com
+      - ISMALICIOUS_API_KEY=${ISMALICIOUS_API_KEY}
+      - ISMALICIOUS_MAX_TLP=TLP:AMBER
     restart: always

--- a/internal-enrichment/ismalicious/docker-compose.yml
+++ b/internal-enrichment/ismalicious/docker-compose.yml
@@ -2,9 +2,9 @@ services:
   connector-ismalicious:
     image: opencti/connector-ismalicious:latest
     environment:
-      - OPENCTI_URL=http://localhost
+      - OPENCTI_URL=http://opencti:8080
       - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
-      - CONNECTOR_ID=${CONNECTOR_ID}
+      - CONNECTOR_ID=${CONNECTOR_ID:-ismalicious-enrichment}
       - CONNECTOR_TYPE=INTERNAL_ENRICHMENT
       - CONNECTOR_NAME=isMalicious
       - CONNECTOR_SCOPE=IPv4-Addr,IPv6-Addr,Domain-Name

--- a/internal-enrichment/ismalicious/src/config.yml.sample
+++ b/internal-enrichment/ismalicious/src/config.yml.sample
@@ -1,0 +1,24 @@
+opencti:
+  url: "http://localhost:8080"
+  token: "your-opencti-api-token"
+
+connector:
+  id: "ismalicious-enrichment"
+  type: "INTERNAL_ENRICHMENT"
+  name: "isMalicious"
+  scope: "IPv4-Addr,IPv6-Addr,Domain-Name"
+  log_level: "info"
+  # Set to true to automatically enrich all observables
+  auto: false
+
+ismalicious:
+  api_url: "https://api.ismalicious.com"
+  api_key: "your-ismalicious-api-key"
+  # Maximum TLP level to process
+  max_tlp: "TLP:AMBER"
+  # Observable types to enrich
+  enrich_ipv4: true
+  enrich_ipv6: true
+  enrich_domain: true
+  # Minimum score to report (0-100)
+  min_score_to_report: 0

--- a/internal-enrichment/ismalicious/src/connector/ismalicious.py
+++ b/internal-enrichment/ismalicious/src/connector/ismalicious.py
@@ -83,10 +83,10 @@ class IsMaliciousConnector:
         """Call isMalicious API to check an observable."""
         try:
             response = requests.get(
-                f"{self.api_url}/api/check",
+                f"{self.api_url}/check",
                 params={"query": observable_value, "enrichment": "standard"},
                 headers={
-                    "Authorization": f"Bearer {self.api_key}",
+                    "X-API-KEY": self.api_key,
                     "Accept": "application/json",
                 },
                 timeout=30,

--- a/internal-enrichment/ismalicious/src/connector/models.py
+++ b/internal-enrichment/ismalicious/src/connector/models.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, SecretStr
 class IsMaliciousConfig(BaseModel):
     """isMalicious API configuration."""
 
-    api_url: str = "https://ismalicious.com"
+    api_url: str = "https://api.ismalicious.com"
     api_key: SecretStr
     max_tlp: str = "TLP:AMBER"
     # Observable types to enrich
@@ -67,7 +67,7 @@ class ConfigLoader(BaseModel):
             ),
             ismalicious=IsMaliciousConfig(
                 api_url=os.environ.get(
-                    "ISMALICIOUS_API_URL", "https://ismalicious.com"
+                    "ISMALICIOUS_API_URL", "https://api.ismalicious.com"
                 ),
                 api_key=SecretStr(os.environ.get("ISMALICIOUS_API_KEY", "")),
                 max_tlp=os.environ.get("ISMALICIOUS_MAX_TLP", "TLP:AMBER"),
@@ -112,7 +112,7 @@ class ConfigLoader(BaseModel):
             ),
             ismalicious=IsMaliciousConfig(
                 api_url=data.get("ismalicious", {}).get(
-                    "api_url", "https://ismalicious.com"
+                    "api_url", "https://api.ismalicious.com"
                 ),
                 api_key=SecretStr(data.get("ismalicious", {}).get("api_key", "")),
                 max_tlp=data.get("ismalicious", {}).get("max_tlp", "TLP:AMBER"),

--- a/internal-enrichment/ismalicious/src/env.sample
+++ b/internal-enrichment/ismalicious/src/env.sample
@@ -1,0 +1,24 @@
+# OpenCTI Platform Configuration
+OPENCTI_URL=http://localhost:8080
+OPENCTI_TOKEN=your-opencti-api-token
+
+# Connector Configuration
+CONNECTOR_ID=ismalicious-enrichment
+CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+CONNECTOR_NAME=isMalicious
+CONNECTOR_SCOPE=IPv4-Addr,IPv6-Addr,Domain-Name
+CONNECTOR_LOG_LEVEL=info
+# Set to true to automatically enrich all observables
+CONNECTOR_AUTO=false
+
+# isMalicious API Configuration
+ISMALICIOUS_API_URL=https://api.ismalicious.com
+ISMALICIOUS_API_KEY=your-ismalicious-api-key
+# Maximum TLP level to process (TLP:CLEAR, TLP:GREEN, TLP:AMBER, TLP:RED)
+ISMALICIOUS_MAX_TLP=TLP:AMBER
+# Observable types to enrich
+ISMALICIOUS_ENRICH_IPV4=true
+ISMALICIOUS_ENRICH_IPV6=true
+ISMALICIOUS_ENRICH_DOMAIN=true
+# Minimum score to report (0-100, set higher to filter low-confidence results)
+ISMALICIOUS_MIN_SCORE=0

--- a/internal-enrichment/ismalicious/tests/conftest.py
+++ b/internal-enrichment/ismalicious/tests/conftest.py
@@ -1,0 +1,19 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+# pycti imports python-magic at import time; mock before connector package loads.
+mock_pycti = MagicMock()
+mock_pycti.STIX_EXT_OCTI_SCO = (
+    "extension-definition--eccbc87e-7fd4-45c3-863c-f8ad55952641"
+)
+mock_pycti.Location.generate_id = MagicMock(return_value="location--test")
+mock_pycti.OpenCTIConnectorHelper = MagicMock
+mock_pycti.OpenCTIStix2 = MagicMock
+mock_pycti.StixSightingRelationship.generate_id = MagicMock(
+    return_value="sighting--test"
+)
+sys.modules.setdefault("pycti", mock_pycti)
+sys.modules.setdefault("stix2", MagicMock())
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/internal-enrichment/ismalicious/tests/test-requirements.txt
+++ b/internal-enrichment/ismalicious/tests/test-requirements.txt
@@ -1,0 +1,2 @@
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/internal-enrichment/ismalicious/tests/test_connector.py
+++ b/internal-enrichment/ismalicious/tests/test_connector.py
@@ -1,0 +1,96 @@
+"""Tests for isMalicious connector API client."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from connector import IsMaliciousConnector
+from connector.models import (
+    ConfigLoader,
+    ConnectorConfig,
+    IsMaliciousConfig,
+    OpenCTIConfig,
+)
+from pydantic import SecretStr
+
+
+def _make_connector(api_key: str = "test-credential") -> tuple[IsMaliciousConnector, MagicMock]:
+    config = ConfigLoader(
+        opencti=OpenCTIConfig(
+            url="http://localhost:8080",
+            token=SecretStr("opencti-token"),
+        ),
+        connector=ConnectorConfig(id="ismalicious-enrichment"),
+        ismalicious=IsMaliciousConfig(api_key=SecretStr(api_key)),
+    )
+    helper = MagicMock()
+    helper.api.label.read_or_create_unchecked = MagicMock()
+    return IsMaliciousConnector(config, helper), helper
+
+
+@patch("connector.ismalicious.requests.get")
+def test_call_api_uses_check_endpoint_and_x_api_key(mock_get):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"malicious": False}
+    mock_get.return_value = mock_response
+
+    connector, _helper = _make_connector(api_key="base64-credential")
+
+    result = connector._call_api("8.8.8.8")
+
+    mock_get.assert_called_once_with(
+        "https://api.ismalicious.com/check",
+        params={"query": "8.8.8.8", "enrichment": "standard"},
+        headers={
+            "X-API-KEY": "base64-credential",
+            "Accept": "application/json",
+        },
+        timeout=30,
+    )
+    assert result == {"malicious": False}
+
+
+@patch("connector.ismalicious.requests.get")
+def test_call_api_strips_trailing_slash_from_api_url(mock_get):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"malicious": True}
+    mock_get.return_value = mock_response
+
+    config = ConfigLoader(
+        opencti=OpenCTIConfig(
+            url="http://localhost:8080",
+            token=SecretStr("opencti-token"),
+        ),
+        connector=ConnectorConfig(id="ismalicious-enrichment"),
+        ismalicious=IsMaliciousConfig(
+            api_url="https://api.ismalicious.com/",
+            api_key=SecretStr("test-key"),
+        ),
+    )
+    helper = MagicMock()
+    helper.api.label.read_or_create_unchecked = MagicMock()
+    connector = IsMaliciousConnector(config, helper)
+
+    connector._call_api("evil.example")
+
+    mock_get.assert_called_once_with(
+        "https://api.ismalicious.com/check",
+        params={"query": "evil.example", "enrichment": "standard"},
+        headers={
+            "X-API-KEY": "test-key",
+            "Accept": "application/json",
+        },
+        timeout=30,
+    )
+
+
+@patch("connector.ismalicious.requests.get")
+def test_call_api_returns_none_on_request_error(mock_get, capsys):
+    mock_get.side_effect = requests.exceptions.HTTPError("401 Unauthorized")
+
+    connector, helper = _make_connector()
+
+    result = connector._call_api("8.8.8.8")
+
+    assert result is None
+    helper.log_error.assert_called_once()

--- a/internal-enrichment/ismalicious/tests/test_models.py
+++ b/internal-enrichment/ismalicious/tests/test_models.py
@@ -1,0 +1,31 @@
+"""Tests for isMalicious connector configuration."""
+
+import os
+
+import pytest
+from connector.models import ConfigLoader, IsMaliciousConfig
+from pydantic import SecretStr
+
+
+def test_ismalicious_config_default_api_url():
+    config = IsMaliciousConfig(api_key=SecretStr("test-key"))
+    assert config.api_url == "https://api.ismalicious.com"
+
+
+def test_config_loader_from_env_uses_api_host_by_default(monkeypatch):
+    monkeypatch.setenv("OPENCTI_URL", "http://localhost:8080")
+    monkeypatch.setenv("OPENCTI_TOKEN", "opencti-token")
+    monkeypatch.setenv("ISMALICIOUS_API_KEY", "test-key")
+
+    config = ConfigLoader.from_env()
+    assert config.ismalicious.api_url == "https://api.ismalicious.com"
+
+
+def test_config_loader_from_env_respects_api_url_override(monkeypatch):
+    monkeypatch.setenv("OPENCTI_URL", "http://localhost:8080")
+    monkeypatch.setenv("OPENCTI_TOKEN", "opencti-token")
+    monkeypatch.setenv("ISMALICIOUS_API_KEY", "test-key")
+    monkeypatch.setenv("ISMALICIOUS_API_URL", "https://custom.example.com")
+
+    config = ConfigLoader.from_env()
+    assert config.ismalicious.api_url == "https://custom.example.com"


### PR DESCRIPTION
Fixes #6690

## Summary

- Fix enrichment API base URL to `https://api.ismalicious.com` and endpoint to `GET /check` (was `https://ismalicious.com/api/check`).
- Switch authentication from `Authorization: Bearer` to `X-API-KEY` header, matching the isMalicious API.
- Add `config.yml.sample` and `env.sample` with correct defaults; align `docker-compose.yml`.
- Update README with API auth examples and clarify that this connector is enrichment-only (TAXII bulk ingestion requires the generic TAXII2 external-import connector with `x-api-key` auth).

## Test plan

- [x] Deploy connector with `ISMALICIOUS_API_URL=https://api.ismalicious.com` and a valid `ISMALICIOUS_API_KEY`
- [x] Enrich an IPv4 observable in OpenCTI and confirm score/labels are returned
- [x] Verify direct API call: `curl -H "X-API-KEY: <key>" "https://api.ismalicious.com/check?query=8.8.8.8&enrichment=standard"`