### PR TITLE
ci: add workflow to check connector identity uniqueness (#6599)

### DIFF
--- a/.github/scripts/check_connector_identity_uniqueness.py
+++ b/.github/scripts/check_connector_identity_uniqueness.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Check connector identity uniqueness constraints used by CI image naming.
+
+This validates:
+- manifest identity fields that should stay unique repository-wide
+- connector folder basenames, because current CI derives image names from them
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+CONNECTOR_TYPE_DIRS = [
+    "external-import",
+    "internal-enrichment",
+    "internal-export-file",
+    "internal-import-file",
+    "stream",
+]
+
+FIELDS_TO_CHECK = ["slug", "container_image"]
+
+
+def list_manifest_paths_from_fs() -> list[str]:
+    paths: list[str] = []
+    for connector_type in CONNECTOR_TYPE_DIRS:
+        root = Path(connector_type)
+        if not root.exists():
+            continue
+        for entry in root.iterdir():
+            if not entry.is_dir() or entry.name.startswith("."):
+                continue
+            manifest_path = entry / "__metadata__" / "connector_manifest.json"
+            if manifest_path.exists():
+                paths.append(manifest_path.as_posix())
+    return sorted(paths)
+
+
+def list_connector_dirs_from_fs() -> list[Path]:
+    paths: list[Path] = []
+    for connector_type in CONNECTOR_TYPE_DIRS:
+        root = Path(connector_type)
+        if not root.exists():
+            continue
+        for entry in root.iterdir():
+            if entry.is_dir() and not entry.name.startswith("."):
+                paths.append(entry)
+    return sorted(paths)
+
+
+def load_json_from_fs(path: str) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def collect_duplicates(
+    manifests: list[tuple[str, dict[str, Any]]],
+) -> dict[str, dict[str, list[str]]]:
+    seen: dict[str, dict[str, list[str]]] = {field: {} for field in FIELDS_TO_CHECK}
+
+    for path, data in manifests:
+        for field in FIELDS_TO_CHECK:
+            raw_value = data.get(field)
+            if not isinstance(raw_value, str) or not raw_value.strip():
+                raise ValueError(
+                    f"{path}: manifest field {field!r} must be a non-empty string"
+                )
+            value = raw_value.strip()
+            seen[field].setdefault(value, []).append(path)
+
+    duplicates: dict[str, dict[str, list[str]]] = {
+        field: {} for field in FIELDS_TO_CHECK
+    }
+    for field in FIELDS_TO_CHECK:
+        for value, paths in seen[field].items():
+            if len(paths) > 1:
+                duplicates[field][value] = sorted(paths)
+    return duplicates
+
+
+def collect_folder_name_duplicates(connector_dirs: list[Path]) -> dict[str, list[str]]:
+    seen: dict[str, list[str]] = {}
+    for connector_dir in connector_dirs:
+        seen.setdefault(connector_dir.name, []).append(connector_dir.as_posix())
+
+    duplicates: dict[str, list[str]] = {}
+    for name, paths in seen.items():
+        if len(paths) > 1:
+            duplicates[name] = sorted(paths)
+    return duplicates
+
+
+def main() -> int:
+    connector_dirs = list_connector_dirs_from_fs()
+    manifests = [
+        (path, load_json_from_fs(path)) for path in list_manifest_paths_from_fs()
+    ]
+    duplicates = collect_duplicates(manifests)
+    folder_duplicates = collect_folder_name_duplicates(connector_dirs)
+
+    has_failure = any(duplicates[field] for field in FIELDS_TO_CHECK) or bool(
+        folder_duplicates
+    )
+    if not has_failure:
+        print("No connector identity duplicates detected.")
+        return 0
+
+    print("Found connector identity duplicate issues:")
+    for folder_name, paths in sorted(folder_duplicates.items()):
+        print(f"- [folder_name] {folder_name}")
+        for path in paths:
+            print(f"  - {path}")
+
+    for field in FIELDS_TO_CHECK:
+        for value, paths in sorted(duplicates[field].items()):
+            print(f"- [{field}] {value}")
+            for path in paths:
+                print(f"  - {path}")
+
+    print("\nFix by ensuring each connector has unique manifest values for:")
+    print("- connector folder basename (used by CI to build Docker image names)")
+    print("- slug")
+    print("- container_image")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/check-connector-identity-uniqueness.yml
+++ b/.github/workflows/check-connector-identity-uniqueness.yml
@@ -1,0 +1,38 @@
+name: Connector Identity Uniqueness
+
+on:
+  push:
+    paths:
+      - 'external-import/**/__metadata__/connector_manifest.json'
+      - 'internal-enrichment/**/__metadata__/connector_manifest.json'
+      - 'internal-export-file/**/__metadata__/connector_manifest.json'
+      - 'internal-import-file/**/__metadata__/connector_manifest.json'
+      - 'stream/**/__metadata__/connector_manifest.json'
+      - '.github/workflows/check-connector-identity-uniqueness.yml'
+  pull_request:
+    paths:
+      - 'external-import/**/__metadata__/connector_manifest.json'
+      - 'internal-enrichment/**/__metadata__/connector_manifest.json'
+      - 'internal-export-file/**/__metadata__/connector_manifest.json'
+      - 'internal-import-file/**/__metadata__/connector_manifest.json'
+      - 'stream/**/__metadata__/connector_manifest.json'
+      - '.github/workflows/check-connector-identity-uniqueness.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: check-connector-identity-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-connector-identity:
+    name: Check connector identity uniqueness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Validate connector manifest identity uniqueness
+        run: python3 .github/scripts/check_connector_identity_uniqueness.py


### PR DESCRIPTION
### Proposed changes

* Add `.github/scripts/check_connector_identity_uniqueness.py` — a Python script that scans every connector directory across all five connector-type roots and asserts that three identity fields are unique repository-wide: the connector **folder basename** (used by CI to derive Docker image names), `slug`, and `container_image` from `connector_manifest.json`.
* Add `.github/workflows/check-connector-identity-uniqueness.yml` — a GitHub Actions workflow that runs the script automatically on every push that touches a `connector_manifest.json` file, also available via `workflow_dispatch`. Runs with minimal permissions (`contents: read`) and pins checkout to a full commit SHA.

### Related issues

* Closes #6599

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The script is intentionally stdlib-only so it runs directly with system Python 3 on `ubuntu-latest` without any install step. The workflow is path-scoped to only trigger on manifest changes, with a `concurrency` group to cancel redundant back-to-back runs. The folder-basename check is separate from manifest field checks because folder names are not declared in manifests but are implicitly used by the CI image-naming convention.

**NOTE**: This PR must be merged after https://github.com/OpenCTI-Platform/connectors/pull/6691