### PR TITLE
style(ismalicious): fix black formatting and remove unused test imports (#6697)

### DIFF
--- a/internal-enrichment/ismalicious/tests/test_connector.py
+++ b/internal-enrichment/ismalicious/tests/test_connector.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 import requests
 from connector import IsMaliciousConnector
 from connector.models import (
@@ -14,7 +13,9 @@ from connector.models import (
 from pydantic import SecretStr
 
 
-def _make_connector(api_key: str = "test-credential") -> tuple[IsMaliciousConnector, MagicMock]:
+def _make_connector(
+    api_key: str = "test-credential",
+) -> tuple[IsMaliciousConnector, MagicMock]:
     config = ConfigLoader(
         opencti=OpenCTIConfig(
             url="http://localhost:8080",

--- a/internal-enrichment/ismalicious/tests/test_models.py
+++ b/internal-enrichment/ismalicious/tests/test_models.py
@@ -1,8 +1,5 @@
 """Tests for isMalicious connector configuration."""
 
-import os
-
-import pytest
 from connector.models import ConfigLoader, IsMaliciousConfig
 from pydantic import SecretStr
 


### PR DESCRIPTION
### Proposed changes

Fixes the repo-wide lint failures on `master` coming from `internal-enrichment/ismalicious/tests/`:

* Apply **black** to `tests/test_connector.py` (wraps an over-length function signature).
* Remove three **flake8 F401** unused imports: `pytest` in `tests/test_connector.py`, `os` and `pytest` in `tests/test_models.py`.

Because the "Lint & Format" workflow runs `black --check .` / `flake8 --ignore=E,W .` repo-wide, these failures currently turn the lint check red on **every** PR branch containing current master (e.g. after "Update branch"). This unblocks them all.

Verified locally: `black --check .`, `isort --profile black --line-length 88 --check-only .` and `flake8 --ignore=E,W .` all pass repo-wide, and the ismalicious test suite still passes (6 passed).

### Related issues

* Closes #6697

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Documentation: no documentation changes are required — this is a lint-only fix in test files; no behavior, configuration, or public interface changed. The refactoring box reflects the nature of the change itself: formatting and dead-import removal to restore repo-wide lint compliance.
