### PR TITLE
feat(paloalto-wildfire): add WildFire enrichment connector (#6730)

### DIFF
--- a/internal-enrichment/paloalto-wildfire/Dockerfile
+++ b/internal-enrichment/paloalto-wildfire/Dockerfile
@@ -13,7 +13,5 @@ RUN cd /opt/opencti-connector-paloalto-wildfire && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+WORKDIR /opt/opencti-connector-paloalto-wildfire
+ENTRYPOINT ["python", "main.py"]

--- a/internal-enrichment/paloalto-wildfire/Dockerfile
+++ b/internal-enrichment/paloalto-wildfire/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-alpine
+ENV CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+
+# Copy the connector
+COPY src /opt/opencti-connector-paloalto-wildfire
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk update && apk upgrade && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN cd /opt/opencti-connector-paloalto-wildfire && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/internal-enrichment/paloalto-wildfire/README.md
+++ b/internal-enrichment/paloalto-wildfire/README.md
@@ -46,7 +46,7 @@ turns it into OpenCTI knowledge.
 ### Requirements
 
 - Python >= 3.11
-- OpenCTI Platform >= 6.8.12
+- OpenCTI Platform >= 7.260701.0
 - A Palo Alto Networks WildFire API key
 - [`pycti`](https://pypi.org/project/pycti/) library matching your OpenCTI version
 - [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk) library matching your OpenCTI version

--- a/internal-enrichment/paloalto-wildfire/README.md
+++ b/internal-enrichment/paloalto-wildfire/README.md
@@ -18,7 +18,7 @@ The connector is playbook compatible and always returns the (enriched) bundle.
 
 Table of Contents
 
-- [OpenCTI Palo Alto Networks WildFire Connector](#opencti-internal-enrichment-connector-paloalto-wildfire)
+- [OpenCTI Palo Alto Networks WildFire Connector](#opencti-palo-alto-networks-wildfire-connector)
   - [Introduction](#introduction)
   - [Installation](#installation)
     - [Requirements](#requirements)
@@ -46,7 +46,7 @@ turns it into OpenCTI knowledge.
 ### Requirements
 
 - Python >= 3.11
-- OpenCTI Platform >= 6.8.13
+- OpenCTI Platform >= 6.8.12
 - A Palo Alto Networks WildFire API key
 - [`pycti`](https://pypi.org/project/pycti/) library matching your OpenCTI version
 - [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk) library matching your OpenCTI version
@@ -179,9 +179,8 @@ unknown and a file is attached to the observable, avoiding unnecessary detonatio
 
 ## Debugging
 
-The connector can be debugged by setting the appropiate log level.
-Note that logging messages can be added using `self.helper.connector_logger,{LOG_LEVEL}("Sample message")`, i.
-e., `self.helper.connector_logger.error("An error message")`.
+The connector can be debugged by setting the appropriate log level.
+Note that logging messages can be added using `self.helper.connector_logger.{LOG_LEVEL}("Sample message")`, i.e., `self.helper.connector_logger.error("An error message")`.
 
 <!-- Any additional information to help future users debug and report detailed issues concerning this connector -->
 

--- a/internal-enrichment/paloalto-wildfire/README.md
+++ b/internal-enrichment/paloalto-wildfire/README.md
@@ -1,0 +1,184 @@
+# OpenCTI Palo Alto Networks WildFire Connector
+
+The Palo Alto Networks WildFire connector is an **internal-enrichment** connector that
+enriches `StixFile` and `Artifact` observables with WildFire file verdicts.
+
+For each observable, the connector queries the WildFire public API by hash
+(MD5 / SHA-1 / SHA-256). When WildFire knows the sample, the connector:
+
+- maps the WildFire verdict (benign, grayware, phishing, malware, command-and-control)
+  to an OpenCTI score and a `wildfire:<verdict>` label,
+- completes the file hashes from the WildFire report when available,
+- attaches a STIX Malware Analysis object carrying the WildFire result and an external
+  reference.
+
+The connector is playbook compatible and always returns the (enriched) bundle.
+
+Table of Contents
+
+- [OpenCTI Palo Alto Networks WildFire Connector](#opencti-internal-enrichment-connector-paloalto-wildfire)
+  - [Introduction](#introduction)
+  - [Installation](#installation)
+    - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenCTI environment variables](#opencti-environment-variables)
+    - [Base connector environment variables](#base-connector-environment-variables)
+    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
+
+## Introduction
+
+[Palo Alto Networks WildFire](https://www.paloaltonetworks.com/network-security/wildfire)
+is a cloud-based malware analysis service. This connector uses the WildFire public API
+to retrieve the verdict (and, when available, the report) for a file observable and
+turns it into OpenCTI knowledge.
+
+## Installation
+
+### Requirements
+
+- Python >= 3.11
+- OpenCTI Platform >= 6.8.13
+- A Palo Alto Networks WildFire API key
+- [`pycti`](https://pypi.org/project/pycti/) library matching your OpenCTI version
+- [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk) library matching your OpenCTI version
+
+## Configuration variables
+
+There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
+in `config.yml` (for manual deployment).
+
+### OpenCTI environment variables
+
+Below are the parameters you'll need to set for OpenCTI:
+
+| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
+| ------------- | ---------- | --------------------------- | --------- | ---------------------------------------------------- |
+| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
+| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+
+### Base connector environment variables
+
+Below are the parameters you'll need to set for running the connector properly:
+
+| Parameter       | config.yml     | Docker environment variable | Default         | Mandatory | Description                                                                              |
+| --------------- | -------------- | --------------------------- | --------------- | --------- | ---------------------------------------------------------------------------------------- |
+| Connector ID    | id             | `CONNECTOR_ID`              | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
+| Connector Type  | type           | `CONNECTOR_TYPE`            | EXTERNAL_IMPORT | Yes       | Should always be set to `INTERNAL_ENRICHMENT` for this connector.                        |
+| Connector Name  | name           | `CONNECTOR_NAME`            |                 | Yes       | Name of the connector.                                                                   |
+| Connector Scope | scope          | `CONNECTOR_SCOPE`           |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
+| Log Level       | log_level      | `CONNECTOR_LOG_LEVEL`       | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
+| Connector Auto  | connector_auto | `CONNECTOR_AUTO`            | True            | Yes       | Must be `true` or `false` to enable or disable auto-enrichment of observables            |
+
+### Connector extra parameters environment variables
+
+Below are the parameters you'll need to set for the connector:
+
+| Parameter    | config.yml   | Docker environment variable        | Default                                          | Mandatory | Description                                                                                                |
+| ------------ | ------------ | ---------------------------------- | ------------------------------------------------ | --------- | ---------------------------------------------------------------------------------------------------------- |
+| API key      | api_key      | `PALOALTO_WILDFIRE_API_KEY`        |                                                  | Yes       | The Palo Alto Networks WildFire API key.                                                                   |
+| API base URL | api_base_url | `PALOALTO_WILDFIRE_API_BASE_URL`   | `https://wildfire.paloaltonetworks.com/publicapi` | No        | The WildFire API base URL (use the appropriate cloud region or a WildFire appliance URL).                  |
+| Max TLP      | max_tlp      | `PALOALTO_WILDFIRE_MAX_TLP`        | `TLP:AMBER`                                       | No        | Maximum TLP of the observable the connector is allowed to enrich.                                          |
+
+## Deployment
+
+### Docker Deployment
+
+Before building the Docker container, you need to set the version of pycti in `requirements.txt` equal to whatever
+version of OpenCTI you're running. Example, `pycti==5.12.20`. If you don't, it will take the latest version, but
+sometimes the OpenCTI SDK fails to initialize.
+
+Build a Docker Image using the provided `Dockerfile`.
+
+Example:
+
+```shell
+# Replace the IMAGE NAME with the appropriate value
+docker build . -t [IMAGE NAME]:latest
+```
+
+Make sure to replace the environment variables in `docker-compose.yml` with the appropriate configurations for your
+environment. Then, start the docker container with the provided docker-compose.yml
+
+```shell
+docker compose up -d
+# -d for detached
+```
+
+### Manual Deployment
+
+Create a file `config.yml` based on the provided `config.yml.sample`.
+
+Replace the configuration variables (especially the "**ChangeMe**" variables) with the appropriate configurations for
+you environment.
+
+Install the required python dependencies (preferably in a virtual environment):
+
+```shell
+pip3 install -r requirements.txt
+```
+
+Then, start the connector from `src` directory:
+
+```shell
+python3 main.py
+```
+
+## Usage
+
+After Installation, the connector should require minimal interaction to use, and should update automatically at a regular interval specified in your `docker-compose.yml` or `config.yml` in `duration_period`.
+
+However, if you would like to force an immediate download of a new batch of entities, navigate to:
+
+`Data management` -> `Ingestion` -> `Connectors` in the OpenCTI platform.
+
+Find the connector, and click on the refresh button to reset the connector's state and force a new
+download of data by re-running the connector.
+
+## Behavior
+
+On each enrichment request the connector:
+
+1. Selects the strongest available hash on the observable (SHA-256 > SHA-1 > MD5).
+2. Calls `POST /get/verdict` on the WildFire API. If the hash is unknown (or the
+   verdict is pending/error), the original bundle is returned unchanged.
+3. Calls `POST /get/report` to complete the file hashes and file type when available.
+4. Enriches the observable with an `x_opencti_score`, a `wildfire:<verdict>` label, the
+   resolved hashes, and (for `StixFile`) the file size.
+5. Creates a STIX Malware Analysis object (`product = WildFire`) referencing the
+   observable, with the WildFire result mapped to the STIX `malware-result` vocabulary.
+
+WildFire verdict mapping:
+
+| WildFire verdict | Label                 | Score | Malware Analysis result |
+| ---------------- | --------------------- | ----- | ----------------------- |
+| 0                | benign                | 10    | benign                  |
+| 1                | malware               | 90    | malicious               |
+| 2                | grayware              | 40    | suspicious              |
+| 4                | phishing              | 80    | malicious               |
+| 5                | command-and-control   | 95    | malicious               |
+
+File submission/detonation is out of scope; the connector enriches by hash only.
+
+## Debugging
+
+The connector can be debugged by setting the appropiate log level.
+Note that logging messages can be added using `self.helper.connector_logger,{LOG_LEVEL}("Sample message")`, i.
+e., `self.helper.connector_logger.error("An error message")`.
+
+<!-- Any additional information to help future users debug and report detailed issues concerning this connector -->
+
+## Additional information
+
+<!--
+Any additional information about this connector
+* What information is ingested/updated/changed
+* What should the user take into account when using this connector
+* ...
+-->

--- a/internal-enrichment/paloalto-wildfire/README.md
+++ b/internal-enrichment/paloalto-wildfire/README.md
@@ -6,7 +6,7 @@ enriches `StixFile` and `Artifact` observables with WildFire file verdicts.
 For each observable, the connector queries the WildFire public API by hash
 (MD5 / SHA-1 / SHA-256). When the hash is unknown and the observable carries an uploaded
 file, the connector submits it to WildFire for analysis and polls for the verdict
-(enabled by default via `submit_unknown`). When WildFire has a verdict, the connector:
+(opt-in via `submit_unknown`, disabled by default). When WildFire has a verdict, the connector:
 
 - maps the WildFire verdict (benign, grayware, phishing, malware, command-and-control)
   to an OpenCTI score and a `wildfire:<verdict>` label,
@@ -72,11 +72,11 @@ Below are the parameters you'll need to set for running the connector properly:
 | Parameter       | config.yml     | Docker environment variable | Default         | Mandatory | Description                                                                              |
 | --------------- | -------------- | --------------------------- | --------------- | --------- | ---------------------------------------------------------------------------------------- |
 | Connector ID    | id             | `CONNECTOR_ID`              | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
-| Connector Type  | type           | `CONNECTOR_TYPE`            | EXTERNAL_IMPORT | Yes       | Should always be set to `INTERNAL_ENRICHMENT` for this connector.                        |
-| Connector Name  | name           | `CONNECTOR_NAME`            |                 | Yes       | Name of the connector.                                                                   |
-| Connector Scope | scope          | `CONNECTOR_SCOPE`           |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
-| Log Level       | log_level      | `CONNECTOR_LOG_LEVEL`       | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
-| Connector Auto  | connector_auto | `CONNECTOR_AUTO`            | True            | Yes       | Must be `true` or `false` to enable or disable auto-enrichment of observables            |
+| Connector Type  | type           | `CONNECTOR_TYPE`            | INTERNAL_ENRICHMENT | Yes   | Should always be set to `INTERNAL_ENRICHMENT` for this connector.                        |
+| Connector Name  | name           | `CONNECTOR_NAME`            | Palo Alto Networks WildFire | No | Name of the connector.                                                          |
+| Connector Scope | scope          | `CONNECTOR_SCOPE`           | StixFile,Artifact | No      | The observable types the connector enriches.                                           |
+| Log Level       | log_level      | `CONNECTOR_LOG_LEVEL`       | error           | No        | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
+| Connector Auto  | auto           | `CONNECTOR_AUTO`            | false           | No        | Must be `true` or `false` to enable or disable auto-enrichment of observables            |
 
 ### Connector extra parameters environment variables
 
@@ -86,7 +86,7 @@ Below are the parameters you'll need to set for the connector:
 | ------------ | ------------ | ---------------------------------- | ------------------------------------------------ | --------- | ---------------------------------------------------------------------------------------------------------- |
 | API key      | api_key      | `PALOALTO_WILDFIRE_API_KEY`        |                                                  | Yes       | The Palo Alto Networks WildFire API key.                                                                   |
 | API base URL | api_base_url | `PALOALTO_WILDFIRE_API_BASE_URL`   | `https://wildfire.paloaltonetworks.com/publicapi` | No        | The WildFire API base URL (use the appropriate cloud region or a WildFire appliance URL).                  |
-| Submit unknown | submit_unknown | `PALOALTO_WILDFIRE_SUBMIT_UNKNOWN` | `true`                                         | No        | Submit unknown files (carried by the observable) to WildFire for analysis when no verdict exists yet.      |
+| Submit unknown | submit_unknown | `PALOALTO_WILDFIRE_SUBMIT_UNKNOWN` | `false`                                        | No        | Submit unknown files (carried by the observable) to WildFire for analysis when no verdict exists yet (opt-in). |
 | Max file size | max_file_size | `PALOALTO_WILDFIRE_MAX_FILE_SIZE` | `33554432`                                       | No        | Max size (bytes) of a file the connector downloads from OpenCTI and submits (32 MiB).                      |
 | Submission timeout | submission_timeout | `PALOALTO_WILDFIRE_SUBMISSION_TIMEOUT` | `600`                                 | No        | Max time (seconds) to wait for a submitted file's verdict.                                                 |
 | Max TLP      | max_tlp      | `PALOALTO_WILDFIRE_MAX_TLP`        | `TLP:AMBER`                                       | No        | Maximum TLP of the observable the connector is allowed to enrich.                                          |
@@ -137,14 +137,11 @@ python3 main.py
 
 ## Usage
 
-After Installation, the connector should require minimal interaction to use, and should update automatically at a regular interval specified in your `docker-compose.yml` or `config.yml` in `duration_period`.
+This is an internal-enrichment connector: it runs on demand rather than on a schedule. Once deployed it enriches a `StixFile` or `Artifact` observable when:
 
-However, if you would like to force an immediate download of a new batch of entities, navigate to:
-
-`Data management` -> `Ingestion` -> `Connectors` in the OpenCTI platform.
-
-Find the connector, and click on the refresh button to reset the connector's state and force a new
-download of data by re-running the connector.
+- a user triggers enrichment from the observable's **Enrichment** panel in the OpenCTI platform,
+- it is called from a playbook, or
+- `CONNECTOR_AUTO=true`, in which case it runs automatically whenever an in-scope observable is created or updated.
 
 ## Behavior
 
@@ -152,7 +149,7 @@ On each enrichment request the connector:
 
 1. Selects the strongest available hash on the observable (SHA-256 > SHA-1 > MD5).
 2. Calls `POST /get/verdict` on the WildFire API.
-3. If the hash is unknown and `submit_unknown` is enabled (default) and the observable
+3. If the hash is unknown and `submit_unknown` is enabled (opt-in; disabled by default) and the observable
    carries an uploaded file, the connector downloads the file from OpenCTI storage
    (enforcing `max_file_size` and rejecting empty files), submits it (`POST /submit/file`),
    and polls `POST /get/verdict` until the verdict is final (bounded by

--- a/internal-enrichment/paloalto-wildfire/README.md
+++ b/internal-enrichment/paloalto-wildfire/README.md
@@ -4,7 +4,9 @@ The Palo Alto Networks WildFire connector is an **internal-enrichment** connecto
 enriches `StixFile` and `Artifact` observables with WildFire file verdicts.
 
 For each observable, the connector queries the WildFire public API by hash
-(MD5 / SHA-1 / SHA-256). When WildFire knows the sample, the connector:
+(MD5 / SHA-1 / SHA-256). When the hash is unknown and the observable carries an uploaded
+file, the connector submits it to WildFire for analysis and polls for the verdict
+(enabled by default via `submit_unknown`). When WildFire has a verdict, the connector:
 
 - maps the WildFire verdict (benign, grayware, phishing, malware, command-and-control)
   to an OpenCTI score and a `wildfire:<verdict>` label,
@@ -84,6 +86,9 @@ Below are the parameters you'll need to set for the connector:
 | ------------ | ------------ | ---------------------------------- | ------------------------------------------------ | --------- | ---------------------------------------------------------------------------------------------------------- |
 | API key      | api_key      | `PALOALTO_WILDFIRE_API_KEY`        |                                                  | Yes       | The Palo Alto Networks WildFire API key.                                                                   |
 | API base URL | api_base_url | `PALOALTO_WILDFIRE_API_BASE_URL`   | `https://wildfire.paloaltonetworks.com/publicapi` | No        | The WildFire API base URL (use the appropriate cloud region or a WildFire appliance URL).                  |
+| Submit unknown | submit_unknown | `PALOALTO_WILDFIRE_SUBMIT_UNKNOWN` | `true`                                         | No        | Submit unknown files (carried by the observable) to WildFire for analysis when no verdict exists yet.      |
+| Max file size | max_file_size | `PALOALTO_WILDFIRE_MAX_FILE_SIZE` | `33554432`                                       | No        | Max size (bytes) of a file the connector downloads from OpenCTI and submits (32 MiB).                      |
+| Submission timeout | submission_timeout | `PALOALTO_WILDFIRE_SUBMISSION_TIMEOUT` | `600`                                 | No        | Max time (seconds) to wait for a submitted file's verdict.                                                 |
 | Max TLP      | max_tlp      | `PALOALTO_WILDFIRE_MAX_TLP`        | `TLP:AMBER`                                       | No        | Maximum TLP of the observable the connector is allowed to enrich.                                          |
 
 ## Deployment
@@ -146,12 +151,17 @@ download of data by re-running the connector.
 On each enrichment request the connector:
 
 1. Selects the strongest available hash on the observable (SHA-256 > SHA-1 > MD5).
-2. Calls `POST /get/verdict` on the WildFire API. If the hash is unknown (or the
-   verdict is pending/error), the original bundle is returned unchanged.
-3. Calls `POST /get/report` to complete the file hashes and file type when available.
-4. Enriches the observable with an `x_opencti_score`, a `wildfire:<verdict>` label, the
+2. Calls `POST /get/verdict` on the WildFire API.
+3. If the hash is unknown and `submit_unknown` is enabled (default) and the observable
+   carries an uploaded file, the connector downloads the file from OpenCTI storage
+   (enforcing `max_file_size` and rejecting empty files), submits it (`POST /submit/file`),
+   and polls `POST /get/verdict` until the verdict is final (bounded by
+   `submission_timeout`). This is the primary path for `Artifact` observables uploaded to
+   OpenCTI. If still no verdict, the original bundle is returned unchanged.
+4. Calls `POST /get/report` to complete the file hashes and file type when available.
+5. Enriches the observable with an `x_opencti_score`, a `wildfire:<verdict>` label, the
    resolved hashes, and (for `StixFile`) the file size.
-5. Creates a STIX Malware Analysis object (`product = WildFire`) referencing the
+6. Creates a STIX Malware Analysis object (`product = WildFire`) referencing the
    observable, with the WildFire result mapped to the STIX `malware-result` vocabulary.
 
 WildFire verdict mapping:
@@ -164,7 +174,8 @@ WildFire verdict mapping:
 | 4                | phishing              | 80    | malicious               |
 | 5                | command-and-control   | 95    | malicious               |
 
-File submission/detonation is out of scope; the connector enriches by hash only.
+The connector looks up a verdict by hash first and only submits a file when the hash is
+unknown and a file is attached to the observable, avoiding unnecessary detonations.
 
 ## Debugging
 

--- a/internal-enrichment/paloalto-wildfire/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/paloalto-wildfire/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,18 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| PALOALTO_WILDFIRE_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Palo Alto Networks WildFire API key. |
+| CONNECTOR_NAME | `string` |  | string | `"Palo Alto Networks WildFire"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["StixFile", "Artifact"]` | The scope of the connector (observable types to enrich). |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `INTERNAL_ENRICHMENT` | `"INTERNAL_ENRICHMENT"` |  |
+| CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |
+| PALOALTO_WILDFIRE_API_BASE_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"https://wildfire.paloaltonetworks.com/publicapi"` | WildFire API base URL (cloud region or appliance). |
+| PALOALTO_WILDFIRE_MAX_TLP | `string` |  | `TLP:CLEAR` `TLP:WHITE` `TLP:GREEN` `TLP:AMBER` `TLP:AMBER+STRICT` `TLP:RED` | `"TLP:AMBER"` | Maximum TLP of the observable the connector is allowed to enrich. |

--- a/internal-enrichment/paloalto-wildfire/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/paloalto-wildfire/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -15,4 +15,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | CONNECTOR_TYPE | `const` |  | `INTERNAL_ENRICHMENT` | `"INTERNAL_ENRICHMENT"` |  |
 | CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |
 | PALOALTO_WILDFIRE_API_BASE_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"https://wildfire.paloaltonetworks.com/publicapi"` | WildFire API base URL (cloud region or appliance). |
+| PALOALTO_WILDFIRE_SUBMIT_UNKNOWN | `boolean` |  | boolean | `true` | Submit unknown files (carried by the observable) to WildFire for analysis when no verdict exists yet. Enabled by default so Artifacts uploaded to OpenCTI are detonated. |
+| PALOALTO_WILDFIRE_MAX_FILE_SIZE | `integer` |  | integer | `33554432` | Maximum size (in bytes) of a file the connector will download from OpenCTI and submit to WildFire. |
+| PALOALTO_WILDFIRE_SUBMISSION_TIMEOUT | `integer` |  | integer | `600` | Maximum time (in seconds) to wait for a submitted file's verdict before giving up. |
 | PALOALTO_WILDFIRE_MAX_TLP | `string` |  | `TLP:CLEAR` `TLP:WHITE` `TLP:GREEN` `TLP:AMBER` `TLP:AMBER+STRICT` `TLP:RED` | `"TLP:AMBER"` | Maximum TLP of the observable the connector is allowed to enrich. |

--- a/internal-enrichment/paloalto-wildfire/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/paloalto-wildfire/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -15,7 +15,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | CONNECTOR_TYPE | `const` |  | `INTERNAL_ENRICHMENT` | `"INTERNAL_ENRICHMENT"` |  |
 | CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |
 | PALOALTO_WILDFIRE_API_BASE_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"https://wildfire.paloaltonetworks.com/publicapi"` | WildFire API base URL (cloud region or appliance). |
-| PALOALTO_WILDFIRE_SUBMIT_UNKNOWN | `boolean` |  | boolean | `true` | Submit unknown files (carried by the observable) to WildFire for analysis when no verdict exists yet. Enabled by default so Artifacts uploaded to OpenCTI are detonated. |
+| PALOALTO_WILDFIRE_SUBMIT_UNKNOWN | `boolean` |  | boolean | `false` | Submit unknown files (carried by the observable) to WildFire for analysis when no verdict exists yet. Disabled by default (opt-in): submission uploads the sample to WildFire. |
 | PALOALTO_WILDFIRE_MAX_FILE_SIZE | `integer` |  | integer | `33554432` | Maximum size (in bytes) of a file the connector will download from OpenCTI and submit to WildFire. |
 | PALOALTO_WILDFIRE_SUBMISSION_TIMEOUT | `integer` |  | integer | `600` | Maximum time (in seconds) to wait for a submitted file's verdict before giving up. |
 | PALOALTO_WILDFIRE_MAX_TLP | `string` |  | `TLP:CLEAR` `TLP:WHITE` `TLP:GREEN` `TLP:AMBER` `TLP:AMBER+STRICT` `TLP:RED` | `"TLP:AMBER"` | Maximum TLP of the observable the connector is allowed to enrich. |

--- a/internal-enrichment/paloalto-wildfire/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/paloalto-wildfire/__metadata__/connector_config_schema.json
@@ -66,6 +66,21 @@
       "minLength": 1,
       "type": "string"
     },
+    "PALOALTO_WILDFIRE_SUBMIT_UNKNOWN": {
+      "default": true,
+      "description": "Submit unknown files (carried by the observable) to WildFire for analysis when no verdict exists yet. Enabled by default so Artifacts uploaded to OpenCTI are detonated.",
+      "type": "boolean"
+    },
+    "PALOALTO_WILDFIRE_MAX_FILE_SIZE": {
+      "default": 33554432,
+      "description": "Maximum size (in bytes) of a file the connector will download from OpenCTI and submit to WildFire.",
+      "type": "integer"
+    },
+    "PALOALTO_WILDFIRE_SUBMISSION_TIMEOUT": {
+      "default": 600,
+      "description": "Maximum time (in seconds) to wait for a submitted file's verdict before giving up.",
+      "type": "integer"
+    },
     "PALOALTO_WILDFIRE_MAX_TLP": {
       "default": "TLP:AMBER",
       "description": "Maximum TLP of the observable the connector is allowed to enrich.",

--- a/internal-enrichment/paloalto-wildfire/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/paloalto-wildfire/__metadata__/connector_config_schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/paloalto-wildfire_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Palo Alto Networks WildFire",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "StixFile",
+        "Artifact"
+      ],
+      "description": "The scope of the connector (observable types to enrich).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Whether the connector should run automatically when an entity is created or updated.",
+      "type": "boolean"
+    },
+    "PALOALTO_WILDFIRE_API_KEY": {
+      "description": "Palo Alto Networks WildFire API key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "PALOALTO_WILDFIRE_API_BASE_URL": {
+      "default": "https://wildfire.paloaltonetworks.com/publicapi",
+      "description": "WildFire API base URL (cloud region or appliance).",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "PALOALTO_WILDFIRE_MAX_TLP": {
+      "default": "TLP:AMBER",
+      "description": "Maximum TLP of the observable the connector is allowed to enrich.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "PALOALTO_WILDFIRE_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/paloalto-wildfire/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/paloalto-wildfire/__metadata__/connector_config_schema.json
@@ -67,8 +67,8 @@
       "type": "string"
     },
     "PALOALTO_WILDFIRE_SUBMIT_UNKNOWN": {
-      "default": true,
-      "description": "Submit unknown files (carried by the observable) to WildFire for analysis when no verdict exists yet. Enabled by default so Artifacts uploaded to OpenCTI are detonated.",
+      "default": false,
+      "description": "Submit unknown files (carried by the observable) to WildFire for analysis when no verdict exists yet. Disabled by default (opt-in): submission uploads the sample to WildFire.",
       "type": "boolean"
     },
     "PALOALTO_WILDFIRE_MAX_FILE_SIZE": {

--- a/internal-enrichment/paloalto-wildfire/__metadata__/connector_manifest.json
+++ b/internal-enrichment/paloalto-wildfire/__metadata__/connector_manifest.json
@@ -1,0 +1,23 @@
+{
+  "title": "Palo Alto Networks WildFire",
+  "slug": "paloalto-wildfire",
+  "description": "The OpenCTI Palo Alto Networks WildFire enrichment connector enriches StixFile and Artifact observables with WildFire file verdicts. For each observable it queries the WildFire public API by hash (MD5/SHA-1/SHA-256), maps the WildFire verdict (benign, grayware, phishing, malware, command-and-control) to an OpenCTI score and label, completes the file hashes from the WildFire report when available, and attaches a STIX Malware Analysis object with the WildFire result. The connector is playbook compatible and always returns the enriched bundle.",
+  "short_description": "Enrich StixFile and Artifact observables with Palo Alto Networks WildFire verdicts.",
+  "logo": null,
+  "use_cases": [
+    "Enrichment & Analysis",
+    "Malware Analysis",
+    "Sandbox"
+  ],
+  "verified": true,
+  "last_verified_date": null,
+  "playbook_supported": true,
+  "max_confidence_level": 60,
+  "support_version": ">=6.8.12",
+  "subscription_link": null,
+  "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/paloalto-wildfire",
+  "manager_supported": false,
+  "container_version": "rolling",
+  "container_image": "opencti/connector-paloalto-wildfire",
+  "container_type": "INTERNAL_ENRICHMENT"
+}

--- a/internal-enrichment/paloalto-wildfire/__metadata__/connector_manifest.json
+++ b/internal-enrichment/paloalto-wildfire/__metadata__/connector_manifest.json
@@ -6,17 +6,16 @@
   "logo": null,
   "use_cases": [
     "Enrichment & Analysis",
-    "Malware Analysis",
-    "Sandbox"
+    "Malware Analysis and Sandbox"
   ],
-  "verified": true,
+  "verified": false,
   "last_verified_date": null,
   "playbook_supported": true,
   "max_confidence_level": 60,
-  "support_version": ">=6.8.12",
+  "support_version": ">=7.260701.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/paloalto-wildfire",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-paloalto-wildfire",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-enrichment/paloalto-wildfire/__metadata__/connector_manifest.json
+++ b/internal-enrichment/paloalto-wildfire/__metadata__/connector_manifest.json
@@ -1,7 +1,7 @@
 {
   "title": "Palo Alto Networks WildFire",
   "slug": "paloalto-wildfire",
-  "description": "The OpenCTI Palo Alto Networks WildFire enrichment connector enriches StixFile and Artifact observables with WildFire file verdicts. For each observable it queries the WildFire public API by hash (MD5/SHA-1/SHA-256), maps the WildFire verdict (benign, grayware, phishing, malware, command-and-control) to an OpenCTI score and label, completes the file hashes from the WildFire report when available, and attaches a STIX Malware Analysis object with the WildFire result. The connector is playbook compatible and always returns the enriched bundle.",
+  "description": "The OpenCTI Palo Alto Networks WildFire enrichment connector enriches StixFile and Artifact observables with WildFire file verdicts. For each observable it queries the WildFire public API by hash (MD5/SHA-1/SHA-256) and, when the hash is unknown and a file is attached, submits the file for analysis and polls for the verdict. It maps the WildFire verdict (benign, grayware, phishing, malware, command-and-control) to an OpenCTI score and label, completes the file hashes from the WildFire report, and attaches a STIX Malware Analysis object with the WildFire result. The connector is playbook compatible and always returns the enriched bundle.",
   "short_description": "Enrich StixFile and Artifact observables with Palo Alto Networks WildFire verdicts.",
   "logo": null,
   "use_cases": [

--- a/internal-enrichment/paloalto-wildfire/config.yml.sample
+++ b/internal-enrichment/paloalto-wildfire/config.yml.sample
@@ -13,4 +13,7 @@ connector:
 paloalto_wildfire:
   api_key: 'ChangeMe'
   api_base_url: 'https://wildfire.paloaltonetworks.com/publicapi' # optional (default: cloud endpoint)
+  submit_unknown: true # optional, submit unknown files (carried by the observable) for analysis (default: true)
+  max_file_size: 33554432 # optional, max size in bytes of a file to download/submit (default: 33554432 = 32 MiB)
+  submission_timeout: 600 # optional, max seconds to wait for a submitted file verdict (default: 600)
   max_tlp: 'TLP:AMBER' # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')

--- a/internal-enrichment/paloalto-wildfire/config.yml.sample
+++ b/internal-enrichment/paloalto-wildfire/config.yml.sample
@@ -1,0 +1,16 @@
+opencti:
+  url: 'http://localhost'
+  token: 'ChangeMe'
+
+connector:
+  type: 'INTERNAL_ENRICHMENT'
+  id: 'ChangeMe'
+  name: 'Palo Alto Networks WildFire' # optional (default: 'Palo Alto Networks WildFire')
+  scope: 'StixFile,Artifact' # optional (default: 'StixFile,Artifact')
+  log_level: 'error' # optional (default: 'error')
+  auto: false # optional, enable/disable auto-enrichment of OpenCTI entities (default: false)
+
+paloalto_wildfire:
+  api_key: 'ChangeMe'
+  api_base_url: 'https://wildfire.paloaltonetworks.com/publicapi' # optional (default: cloud endpoint)
+  max_tlp: 'TLP:AMBER' # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')

--- a/internal-enrichment/paloalto-wildfire/config.yml.sample
+++ b/internal-enrichment/paloalto-wildfire/config.yml.sample
@@ -13,7 +13,7 @@ connector:
 paloalto_wildfire:
   api_key: 'ChangeMe'
   api_base_url: 'https://wildfire.paloaltonetworks.com/publicapi' # optional (default: cloud endpoint)
-  submit_unknown: true # optional, submit unknown files (carried by the observable) for analysis (default: true)
+  submit_unknown: false # optional, submit unknown files (carried by the observable) for analysis (default: false)
   max_file_size: 33554432 # optional, max size in bytes of a file to download/submit (default: 33554432 = 32 MiB)
   submission_timeout: 600 # optional, max seconds to wait for a submitted file verdict (default: 600)
   max_tlp: 'TLP:AMBER' # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')

--- a/internal-enrichment/paloalto-wildfire/docker-compose.yml
+++ b/internal-enrichment/paloalto-wildfire/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       # Custom parameters for connector-paloalto-wildfire
       - PALOALTO_WILDFIRE_API_KEY=CHANGEME
       - PALOALTO_WILDFIRE_API_BASE_URL=https://wildfire.paloaltonetworks.com/publicapi # optional (default: cloud endpoint)
-      - PALOALTO_WILDFIRE_SUBMIT_UNKNOWN=true # optional, submit unknown files for analysis (default: true)
+      - PALOALTO_WILDFIRE_SUBMIT_UNKNOWN=false # optional, submit unknown files for analysis (default: false)
       - PALOALTO_WILDFIRE_MAX_FILE_SIZE=33554432 # optional, max bytes to download/submit (default: 33554432 = 32 MiB)
       - PALOALTO_WILDFIRE_SUBMISSION_TIMEOUT=600 # optional, max seconds to wait for a submitted file verdict (default: 600)
       - PALOALTO_WILDFIRE_MAX_TLP=TLP:AMBER # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')

--- a/internal-enrichment/paloalto-wildfire/docker-compose.yml
+++ b/internal-enrichment/paloalto-wildfire/docker-compose.yml
@@ -5,18 +5,18 @@ services:
     environment:
       # Generic parameters (connection with OpenCTI)
       - OPENCTI_URL=http://localhost
-      - OPENCTI_TOKEN=CHANGEME
+      - OPENCTI_TOKEN=ChangeMe
       # Common parameters for connectors of type INTERNAL_ENRICHMENT
-      - CONNECTOR_ID=CHANGEME
-      - CONNECTOR_NAME=Palo Alto Networks WildFire # optional (default: 'Palo Alto Networks WildFire')
-      - CONNECTOR_SCOPE=StixFile,Artifact # optional (default: 'StixFile,Artifact')
-      - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
-      - CONNECTOR_AUTO=false # optional (default: false)
+      - CONNECTOR_ID=ChangeMe
+      # - CONNECTOR_NAME=Palo Alto Networks WildFire # optional (default: 'Palo Alto Networks WildFire')
+      # - CONNECTOR_SCOPE=StixFile,Artifact # optional (default: 'StixFile,Artifact')
+      # - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
+      # - CONNECTOR_AUTO=false # optional (default: false)
       # Custom parameters for connector-paloalto-wildfire
-      - PALOALTO_WILDFIRE_API_KEY=CHANGEME
-      - PALOALTO_WILDFIRE_API_BASE_URL=https://wildfire.paloaltonetworks.com/publicapi # optional (default: cloud endpoint)
-      - PALOALTO_WILDFIRE_SUBMIT_UNKNOWN=false # optional, submit unknown files for analysis (default: false)
-      - PALOALTO_WILDFIRE_MAX_FILE_SIZE=33554432 # optional, max bytes to download/submit (default: 33554432 = 32 MiB)
-      - PALOALTO_WILDFIRE_SUBMISSION_TIMEOUT=600 # optional, max seconds to wait for a submitted file verdict (default: 600)
-      - PALOALTO_WILDFIRE_MAX_TLP=TLP:AMBER # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')
+      - PALOALTO_WILDFIRE_API_KEY=ChangeMe
+      # - PALOALTO_WILDFIRE_API_BASE_URL=https://wildfire.paloaltonetworks.com/publicapi # optional (default: cloud endpoint)
+      # - PALOALTO_WILDFIRE_SUBMIT_UNKNOWN=false # optional, submit unknown files for analysis (default: false)
+      # - PALOALTO_WILDFIRE_MAX_FILE_SIZE=33554432 # optional, max bytes to download/submit (default: 33554432 = 32 MiB)
+      # - PALOALTO_WILDFIRE_SUBMISSION_TIMEOUT=600 # optional, max seconds to wait for a submitted file verdict (default: 600)
+      # - PALOALTO_WILDFIRE_MAX_TLP=TLP:AMBER # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')
     restart: always

--- a/internal-enrichment/paloalto-wildfire/docker-compose.yml
+++ b/internal-enrichment/paloalto-wildfire/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  connector-paloalto-wildfire:
+    image: opencti/connector-paloalto-wildfire:latest # 'paloalto-wildfire' being the name of connector's directory
+    environment:
+      # Generic parameters (connection with OpenCTI)
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=CHANGEME
+      # Common parameters for connectors of type INTERNAL_ENRICHMENT
+      - CONNECTOR_ID=CHANGEME
+      - CONNECTOR_NAME=Palo Alto Networks WildFire # optional (default: 'Palo Alto Networks WildFire')
+      - CONNECTOR_SCOPE=StixFile,Artifact # optional (default: 'StixFile,Artifact')
+      - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
+      - CONNECTOR_AUTO=false # optional (default: false)
+      # Custom parameters for connector-paloalto-wildfire
+      - PALOALTO_WILDFIRE_API_KEY=CHANGEME
+      - PALOALTO_WILDFIRE_API_BASE_URL=https://wildfire.paloaltonetworks.com/publicapi # optional (default: cloud endpoint)
+      - PALOALTO_WILDFIRE_MAX_TLP=TLP:AMBER # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')
+    restart: always

--- a/internal-enrichment/paloalto-wildfire/docker-compose.yml
+++ b/internal-enrichment/paloalto-wildfire/docker-compose.yml
@@ -15,5 +15,8 @@ services:
       # Custom parameters for connector-paloalto-wildfire
       - PALOALTO_WILDFIRE_API_KEY=CHANGEME
       - PALOALTO_WILDFIRE_API_BASE_URL=https://wildfire.paloaltonetworks.com/publicapi # optional (default: cloud endpoint)
+      - PALOALTO_WILDFIRE_SUBMIT_UNKNOWN=true # optional, submit unknown files for analysis (default: true)
+      - PALOALTO_WILDFIRE_MAX_FILE_SIZE=33554432 # optional, max bytes to download/submit (default: 33554432 = 32 MiB)
+      - PALOALTO_WILDFIRE_SUBMISSION_TIMEOUT=600 # optional, max seconds to wait for a submitted file verdict (default: 600)
       - PALOALTO_WILDFIRE_MAX_TLP=TLP:AMBER # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')
     restart: always

--- a/internal-enrichment/paloalto-wildfire/entrypoint.sh
+++ b/internal-enrichment/paloalto-wildfire/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-paloalto-wildfire
-
-# Launch the worker
-python3 main.py

--- a/internal-enrichment/paloalto-wildfire/entrypoint.sh
+++ b/internal-enrichment/paloalto-wildfire/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Go to the right directory
+cd /opt/opencti-connector-paloalto-wildfire
+
+# Launch the worker
+python3 main.py

--- a/internal-enrichment/paloalto-wildfire/src/connector/__init__.py
+++ b/internal-enrichment/paloalto-wildfire/src/connector/__init__.py
@@ -1,0 +1,7 @@
+from connector.connector import PaloaltoWildfireConnector
+from connector.settings import ConnectorSettings
+
+__all__ = [
+    "PaloaltoWildfireConnector",
+    "ConnectorSettings",
+]

--- a/internal-enrichment/paloalto-wildfire/src/connector/connector.py
+++ b/internal-enrichment/paloalto-wildfire/src/connector/connector.py
@@ -42,18 +42,34 @@ _VERDICT_RESULTS = {
 _HASH_PRIORITY = {"SHA-256": 3, "SHA-1": 2, "MD5": 1}
 
 
-def _tlp_clear() -> stix2.MarkingDefinition:
-    # OpenCTI models TLP:CLEAR as a custom statement marking, not as the legacy STIX
-    # TLP:WHITE; using TLP_WHITE would emit the wrong marking in the bundle.
+def _custom_tlp(definition: str) -> stix2.MarkingDefinition:
+    # OpenCTI models TLP:CLEAR and TLP:AMBER+STRICT as custom statement markings,
+    # not as the legacy STIX markings; using TLP_WHITE etc. would emit the wrong
+    # marking id in the bundle.
     return stix2.MarkingDefinition(
-        id=MarkingDefinition.generate_id("TLP", "TLP:CLEAR"),
+        id=MarkingDefinition.generate_id("TLP", definition),
         definition_type="statement",
         definition={"statement": "custom"},
         custom_properties={
             "x_opencti_definition_type": "TLP",
-            "x_opencti_definition": "TLP:CLEAR",
+            "x_opencti_definition": definition,
         },
     )
+
+
+def _tlp_marking(definition: str):
+    """Return the stix2 MarkingDefinition for a TLP definition string, or None."""
+    standard = {
+        "TLP:WHITE": stix2.TLP_WHITE,
+        "TLP:GREEN": stix2.TLP_GREEN,
+        "TLP:AMBER": stix2.TLP_AMBER,
+        "TLP:RED": stix2.TLP_RED,
+    }
+    if definition in standard:
+        return standard[definition]
+    if definition in ("TLP:CLEAR", "TLP:AMBER+STRICT"):
+        return _custom_tlp(definition)
+    return None
 
 
 class PaloaltoWildfireConnector:
@@ -82,7 +98,7 @@ class PaloaltoWildfireConnector:
             identity_class="organization",
             description="File verdicts from Palo Alto Networks WildFire.",
         )
-        self.tlp = _tlp_clear()
+        self.tlp = _custom_tlp("TLP:CLEAR")
         self.stix_objects: list = []
 
     @staticmethod
@@ -230,10 +246,21 @@ class PaloaltoWildfireConnector:
             external_id=report.get("sha256") or result.get("hash"),
             description=f"WildFire verdict: {label}",
         )
-        # Inherit the source observable's markings so the enrichment never produces
-        # an unmarked (TLP-downgraded) Malware Analysis object; fall back to the
-        # connector default marking when the observable carries none.
-        markings = enriched_entity.get("object_marking_refs") or [self.tlp]
+        # Derive the marking from the source observable's OpenCTI markings.
+        # Enrichment messages carry them in opencti_entity["objectMarking"], not
+        # always as STIX object_marking_refs on the observable, so reading the STIX
+        # field would silently downgrade the Malware Analysis object to the default
+        # TLP. Include the resolved marking objects in the bundle so the SDO is
+        # correctly marked and self-contained (not stripped by
+        # cleanup_inconsistent_bundle). Fall back to TLP:CLEAR when none is present.
+        source_markings: list = []
+        for marking_definition in opencti_entity.get("objectMarking") or []:
+            if marking_definition.get("definition_type") == "TLP":
+                marking = _tlp_marking(marking_definition.get("definition"))
+                if marking is not None and marking not in source_markings:
+                    source_markings.append(marking)
+        if not source_markings:
+            source_markings = [self.tlp]
         malware_analysis = stix2.MalwareAnalysis(
             id=MalwareAnalysis.generate_id(result_name, "WildFire"),
             product="WildFire",
@@ -243,12 +270,12 @@ class PaloaltoWildfireConnector:
             result=_VERDICT_RESULTS.get(verdict, "unknown"),
             sample_ref=enriched_entity["id"],
             created_by_ref=self.identity.id,
-            object_marking_refs=markings,
+            object_marking_refs=[marking.id for marking in source_markings],
             external_references=[external_reference],
         )
         enriched_objects.append(malware_analysis)
 
-        return [self.identity, self.tlp] + enriched_objects
+        return [self.identity] + source_markings + enriched_objects
 
     def _process_observable(self, stix_entity: dict, opencti_entity: dict):
         self.helper.connector_logger.info(

--- a/internal-enrichment/paloalto-wildfire/src/connector/connector.py
+++ b/internal-enrichment/paloalto-wildfire/src/connector/connector.py
@@ -1,0 +1,227 @@
+from copy import deepcopy
+from datetime import datetime, timezone
+
+import stix2
+from connector.settings import ConnectorSettings
+from paloalto_wildfire_client import PaloaltoWildfireClient, WildfireAPIError
+from pycti import Identity, MalwareAnalysis, OpenCTIConnectorHelper
+
+# WildFire verdict code -> human readable label.
+_VERDICT_LABELS = {
+    0: "benign",
+    1: "malware",
+    2: "grayware",
+    4: "phishing",
+    5: "command-and-control",
+}
+
+# WildFire verdict code -> OpenCTI score (0-100).
+_VERDICT_SCORES = {
+    0: 10,
+    1: 90,
+    2: 40,
+    4: 80,
+    5: 95,
+}
+
+# WildFire verdict code -> STIX malware-analysis result (malware-result-ov).
+_VERDICT_RESULTS = {
+    0: "benign",
+    1: "malicious",
+    2: "suspicious",
+    4: "malicious",
+    5: "malicious",
+}
+
+# Preference order when several hashes are available on the observable.
+_HASH_PRIORITY = {"SHA-256": 3, "SHA-1": 2, "MD5": 1}
+
+
+class PaloaltoWildfireConnector:
+    """
+    Internal-enrichment connector that enriches file observables with Palo Alto
+    Networks WildFire verdicts.
+    """
+
+    def __init__(self, config: ConnectorSettings, helper: OpenCTIConnectorHelper):
+        self.config = config
+        self.helper = helper
+
+        self.client = PaloaltoWildfireClient(
+            helper,
+            api_key=self.config.paloalto_wildfire.api_key.get_secret_value(),
+            base_url=self.config.paloalto_wildfire.api_base_url,
+        )
+        self.max_tlp = self.config.paloalto_wildfire.max_tlp
+
+        self.identity = stix2.Identity(
+            id=Identity.generate_id(
+                name="Palo Alto Networks WildFire", identity_class="organization"
+            ),
+            name="Palo Alto Networks WildFire",
+            identity_class="organization",
+            description="File verdicts from Palo Alto Networks WildFire.",
+        )
+        self.tlp = stix2.TLP_WHITE
+        self.stix_objects: list = []
+
+    @staticmethod
+    def _extract_hash(opencti_entity: dict):
+        best = None
+        best_rank = 0
+        for entry in opencti_entity.get("hashes", []) or []:
+            rank = _HASH_PRIORITY.get(entry.get("algorithm"), 0)
+            if rank > best_rank:
+                best = entry.get("hash")
+                best_rank = rank
+        return best
+
+    def _search_hash(self, opencti_entity: dict):
+        """Look up the WildFire verdict (and report) for an observable's hash."""
+        file_hash = self._extract_hash(opencti_entity)
+        if not file_hash:
+            self.helper.connector_logger.info("No usable hash on the observable.")
+            return None
+        verdict = self.client.get_verdict(file_hash)
+        if verdict is None:
+            self.helper.connector_logger.info(
+                "Hash unknown to WildFire.", {"hash": file_hash}
+            )
+            return None
+        report = self.client.get_report(file_hash) or {}
+        return {"verdict": verdict, "hash": file_hash, "report": report}
+
+    def _create_knowledge(
+        self, stix_entity: dict, opencti_entity: dict, result: dict
+    ) -> list:
+        """Create the STIX objects enriching the observable from a WildFire result."""
+        verdict = result["verdict"]
+        report = result.get("report", {})
+
+        enriched_entity = deepcopy(stix_entity)
+        enriched_objects = [
+            enriched_entity if obj["id"] == enriched_entity["id"] else obj
+            for obj in self.stix_objects
+        ]
+
+        label = _VERDICT_LABELS.get(verdict, "unknown")
+        score = _VERDICT_SCORES.get(verdict)
+
+        if opencti_entity["entity_type"] in ["StixFile", "Artifact"]:
+            hashes = enriched_entity.get("hashes", {})
+            if report.get("md5"):
+                hashes["MD5"] = report["md5"]
+            if report.get("sha1"):
+                hashes["SHA-1"] = report["sha1"]
+            if report.get("sha256"):
+                hashes["SHA-256"] = report["sha256"]
+            if hashes:
+                enriched_entity["hashes"] = hashes
+
+        if opencti_entity["entity_type"] == "StixFile" and report.get("size"):
+            try:
+                enriched_entity["size"] = int(report["size"])
+            except (TypeError, ValueError):
+                pass
+
+        if score is not None:
+            enriched_entity["x_opencti_score"] = score
+
+        labels = enriched_entity.get("labels") or []
+        wildfire_label = f"wildfire:{label}"
+        if wildfire_label not in labels:
+            labels.append(wildfire_label)
+        enriched_entity["labels"] = labels
+
+        result_name = "WildFire " + (
+            result.get("hash") or opencti_entity.get("observable_value", "")
+        )
+        external_reference = stix2.ExternalReference(
+            source_name="Palo Alto Networks WildFire",
+            url="https://wildfire.paloaltonetworks.com/",
+            external_id=report.get("sha256") or result.get("hash"),
+            description=f"WildFire verdict: {label}",
+        )
+        malware_analysis = stix2.MalwareAnalysis(
+            id=MalwareAnalysis.generate_id(result_name, "WildFire"),
+            product="WildFire",
+            result_name=result_name,
+            analysis_started=datetime.now(tz=timezone.utc),
+            submitted=datetime.now(tz=timezone.utc),
+            result=_VERDICT_RESULTS.get(verdict, "unknown"),
+            sample_ref=enriched_entity["id"],
+            created_by_ref=self.identity.id,
+            external_references=[external_reference],
+        )
+        enriched_objects.append(malware_analysis)
+
+        return [self.identity, self.tlp] + enriched_objects
+
+    def _process_observable(self, stix_entity: dict, opencti_entity: dict):
+        self.helper.connector_logger.info(
+            "Processing the observable",
+            {
+                "observable_type": opencti_entity["entity_type"],
+                "observable_value": opencti_entity.get("observable_value"),
+            },
+        )
+        if opencti_entity["entity_type"] in ["StixFile", "Artifact"]:
+            result = self._search_hash(opencti_entity)
+            if result is None:
+                return None
+            return self._create_knowledge(stix_entity, opencti_entity, result)
+        return None
+
+    def _send_bundle(self, stix_objects: list) -> list:
+        if len(stix_objects) == 0:
+            return []
+        bundle = self.helper.stix2_create_bundle(stix_objects)
+        return self.helper.send_stix2_bundle(bundle, cleanup_inconsistent_bundle=True)
+
+    def _process_message(self, data: dict) -> str:
+        stix_objects = data["stix_objects"]
+        stix_entity = data["stix_entity"]
+        opencti_entity = data["enrichment_entity"]
+
+        self.stix_objects = stix_objects
+        original_stix_objects = deepcopy(stix_objects)
+
+        tlp = "TLP:CLEAR"
+        for marking_definition in opencti_entity["objectMarking"]:
+            if marking_definition["definition_type"] == "TLP":
+                tlp = marking_definition["definition"]
+
+        try:
+            if not OpenCTIConnectorHelper.check_max_tlp(tlp, self.max_tlp):
+                self._send_bundle(original_stix_objects)
+                message = "Do not send any data, TLP of the observable is greater than MAX TLP"
+                self.helper.connector_logger.info(f"[CONNECTOR] {message}")
+                return message
+
+            enriched_objects = self._process_observable(stix_entity, opencti_entity)
+            if enriched_objects:
+                bundles_sent = self._send_bundle(enriched_objects)
+                message = f"Sent {len(bundles_sent)} stix bundle(s) for worker import"
+                self.helper.connector_logger.info(message)
+                return message
+
+            message = "No WildFire verdict found for the observable"
+            self.helper.connector_logger.info(message)
+            self._send_bundle(original_stix_objects)
+            return message
+
+        except WildfireAPIError as err:
+            self.helper.connector_logger.error(
+                f"[CONNECTOR] {err.__class__.__name__}: {str(err)}"
+            )
+            self._send_bundle(original_stix_objects)
+            raise
+        except Exception as err:
+            self.helper.connector_logger.error(
+                "[CONNECTOR] An unexpected error occurred", {"error": str(err)}
+            )
+            self._send_bundle(original_stix_objects)
+            raise
+
+    def run(self) -> None:
+        self.helper.listen(message_callback=self._process_message)

--- a/internal-enrichment/paloalto-wildfire/src/connector/connector.py
+++ b/internal-enrichment/paloalto-wildfire/src/connector/connector.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from datetime import datetime, timezone
+from urllib.parse import urljoin
 
 import stix2
 from connector.settings import ConnectorSettings
@@ -150,9 +151,8 @@ class PaloaltoWildfireConnector:
         if declared_size is not None and int(declared_size) > self.max_file_size:
             return None, None, f"File '{file_name}' exceeds the {max_mb} MB limit."
 
-        api_url = self.helper.api.api_url.replace("/graphql", "")
-        file_uri = f"{api_url}/storage/get/{file_id}"
-        content = self.helper.api.fetch_opencti_file(file_uri, True)
+        file_url = urljoin(str(self.config.opencti.url), f"storage/get/{file_id}")
+        content = self.helper.api.fetch_opencti_file(file_url, True)
         if content is None:
             return None, None, f"Failed to download file '{file_name}' from OpenCTI."
         if len(content) == 0:
@@ -319,6 +319,21 @@ class PaloaltoWildfireConnector:
                 message = "Do not send any data, TLP of the observable is greater than MAX TLP"
                 self.helper.connector_logger.info(f"[CONNECTOR] {message}")
                 return message
+
+            if opencti_entity["entity_type"] not in ["StixFile", "Artifact"]:
+                if not data.get("event_type"):
+                    # Entity bundle passed through a playbook: return the original
+                    # bundle unchanged when the entity is not in the connector scope.
+                    self._send_bundle(original_stix_objects)
+                    message = (
+                        "Observable not in connector scope, original bundle returned"
+                    )
+                    self.helper.connector_logger.info(f"[CONNECTOR] {message}")
+                    return message
+                raise ValueError(
+                    f"Failed to process observable, {opencti_entity['entity_type']} "
+                    "is not a supported entity type."
+                )
 
             enriched_objects = self._process_observable(stix_entity, opencti_entity)
             if enriched_objects:

--- a/internal-enrichment/paloalto-wildfire/src/connector/connector.py
+++ b/internal-enrichment/paloalto-wildfire/src/connector/connector.py
@@ -53,6 +53,7 @@ class PaloaltoWildfireConnector:
             base_url=self.config.paloalto_wildfire.api_base_url,
         )
         self.max_tlp = self.config.paloalto_wildfire.max_tlp
+        self.max_file_size = self.config.paloalto_wildfire.max_file_size
 
         self.identity = stix2.Identity(
             id=Identity.generate_id(
@@ -90,6 +91,65 @@ class PaloaltoWildfireConnector:
             return None
         report = self.client.get_report(file_hash) or {}
         return {"verdict": verdict, "hash": file_hash, "report": report}
+
+    def _download_file(self, opencti_entity: dict):
+        """
+        Download the file attached to an observable from OpenCTI storage.
+
+        Returns a ``(filename, content, error)`` tuple. On success ``error`` is
+        ``None``; on failure ``content`` is ``None`` and ``error`` is a
+        human-readable reason (enforces ``max_file_size`` and rejects empty files).
+        """
+        import_files = opencti_entity.get("importFiles") or []
+        if not import_files:
+            return None, None, "No file attached to the observable."
+        file_entry = import_files[0]
+        file_id = file_entry.get("id")
+        if not file_id:
+            return None, None, "Attached file has no id."
+
+        file_name = file_entry.get("name", "artifact")
+        max_mb = round(self.max_file_size / (1024 * 1024), 1)
+
+        declared_size = file_entry.get("size")
+        if declared_size is not None and int(declared_size) > self.max_file_size:
+            return None, None, f"File '{file_name}' exceeds the {max_mb} MB limit."
+
+        api_url = self.helper.api.api_url.replace("/graphql", "")
+        file_uri = f"{api_url}/storage/get/{file_id}"
+        content = self.helper.api.fetch_opencti_file(file_uri, True)
+        if content is None:
+            return None, None, f"Failed to download file '{file_name}' from OpenCTI."
+        if len(content) == 0:
+            return None, None, f"File '{file_name}' is empty (0 bytes)."
+        if len(content) > self.max_file_size:
+            return None, None, f"File '{file_name}' exceeds the {max_mb} MB limit."
+        return file_name, content, None
+
+    def _submit(self, opencti_entity: dict):
+        """Submit the observable's file to WildFire and poll for a verdict."""
+        file_name, content, error = self._download_file(opencti_entity)
+        if error:
+            self.helper.connector_logger.info(
+                "Skipping WildFire submission.", {"reason": error}
+            )
+            return None
+        sha256 = self.client.submit_file(file_name, content)
+        if not sha256:
+            self.helper.connector_logger.warning(
+                "WildFire did not return a sample id for the submitted file."
+            )
+            return None
+        self.helper.connector_logger.info(
+            "Submitted file to WildFire, waiting for verdict.", {"sha256": sha256}
+        )
+        verdict = self.client.poll_verdict(
+            sha256, max_wait=self.config.paloalto_wildfire.submission_timeout
+        )
+        if verdict is None:
+            return None
+        report = self.client.get_report(sha256) or {}
+        return {"verdict": verdict, "hash": sha256, "report": report}
 
     def _create_knowledge(
         self, stix_entity: dict, opencti_entity: dict, result: dict
@@ -167,6 +227,8 @@ class PaloaltoWildfireConnector:
         )
         if opencti_entity["entity_type"] in ["StixFile", "Artifact"]:
             result = self._search_hash(opencti_entity)
+            if result is None and self.config.paloalto_wildfire.submit_unknown:
+                result = self._submit(opencti_entity)
             if result is None:
                 return None
             return self._create_knowledge(stix_entity, opencti_entity, result)

--- a/internal-enrichment/paloalto-wildfire/src/connector/connector.py
+++ b/internal-enrichment/paloalto-wildfire/src/connector/connector.py
@@ -4,7 +4,12 @@ from datetime import datetime, timezone
 import stix2
 from connector.settings import ConnectorSettings
 from paloalto_wildfire_client import PaloaltoWildfireClient, WildfireAPIError
-from pycti import Identity, MalwareAnalysis, OpenCTIConnectorHelper
+from pycti import (
+    Identity,
+    MalwareAnalysis,
+    MarkingDefinition,
+    OpenCTIConnectorHelper,
+)
 
 # WildFire verdict code -> human readable label.
 _VERDICT_LABELS = {
@@ -37,6 +42,20 @@ _VERDICT_RESULTS = {
 _HASH_PRIORITY = {"SHA-256": 3, "SHA-1": 2, "MD5": 1}
 
 
+def _tlp_clear() -> stix2.MarkingDefinition:
+    # OpenCTI models TLP:CLEAR as a custom statement marking, not as the legacy STIX
+    # TLP:WHITE; using TLP_WHITE would emit the wrong marking in the bundle.
+    return stix2.MarkingDefinition(
+        id=MarkingDefinition.generate_id("TLP", "TLP:CLEAR"),
+        definition_type="statement",
+        definition={"statement": "custom"},
+        custom_properties={
+            "x_opencti_definition_type": "TLP",
+            "x_opencti_definition": "TLP:CLEAR",
+        },
+    )
+
+
 class PaloaltoWildfireConnector:
     """
     Internal-enrichment connector that enriches file observables with Palo Alto
@@ -63,7 +82,7 @@ class PaloaltoWildfireConnector:
             identity_class="organization",
             description="File verdicts from Palo Alto Networks WildFire.",
         )
-        self.tlp = stix2.TLP_WHITE
+        self.tlp = _tlp_clear()
         self.stix_objects: list = []
 
     @staticmethod
@@ -86,7 +105,7 @@ class PaloaltoWildfireConnector:
         verdict = self.client.get_verdict(file_hash)
         if verdict is None:
             self.helper.connector_logger.info(
-                "Hash unknown to WildFire.", {"hash": file_hash}
+                "Hash unknown to WildFire.", meta={"hash": file_hash}
             )
             return None
         report = self.client.get_report(file_hash) or {}
@@ -131,7 +150,7 @@ class PaloaltoWildfireConnector:
         file_name, content, error = self._download_file(opencti_entity)
         if error:
             self.helper.connector_logger.info(
-                "Skipping WildFire submission.", {"reason": error}
+                "Skipping WildFire submission.", meta={"reason": error}
             )
             return None
         sha256 = self.client.submit_file(file_name, content)
@@ -141,7 +160,7 @@ class PaloaltoWildfireConnector:
             )
             return None
         self.helper.connector_logger.info(
-            "Submitted file to WildFire, waiting for verdict.", {"sha256": sha256}
+            "Submitted file to WildFire, waiting for verdict.", meta={"sha256": sha256}
         )
         verdict = self.client.poll_verdict(
             sha256, max_wait=self.config.paloalto_wildfire.submission_timeout
@@ -184,6 +203,15 @@ class PaloaltoWildfireConnector:
             except (TypeError, ValueError):
                 pass
 
+        if (
+            opencti_entity["entity_type"] == "StixFile"
+            and report.get("filetype")
+            and not enriched_entity.get("mime_type")
+        ):
+            # Complete the file type from the WildFire report (mapped onto the STIX
+            # File mime_type field) when the observable does not already carry one.
+            enriched_entity["mime_type"] = report["filetype"]
+
         if score is not None:
             enriched_entity["x_opencti_score"] = score
 
@@ -202,6 +230,10 @@ class PaloaltoWildfireConnector:
             external_id=report.get("sha256") or result.get("hash"),
             description=f"WildFire verdict: {label}",
         )
+        # Inherit the source observable's markings so the enrichment never produces
+        # an unmarked (TLP-downgraded) Malware Analysis object; fall back to the
+        # connector default marking when the observable carries none.
+        markings = enriched_entity.get("object_marking_refs") or [self.tlp]
         malware_analysis = stix2.MalwareAnalysis(
             id=MalwareAnalysis.generate_id(result_name, "WildFire"),
             product="WildFire",
@@ -211,6 +243,7 @@ class PaloaltoWildfireConnector:
             result=_VERDICT_RESULTS.get(verdict, "unknown"),
             sample_ref=enriched_entity["id"],
             created_by_ref=self.identity.id,
+            object_marking_refs=markings,
             external_references=[external_reference],
         )
         enriched_objects.append(malware_analysis)
@@ -220,7 +253,7 @@ class PaloaltoWildfireConnector:
     def _process_observable(self, stix_entity: dict, opencti_entity: dict):
         self.helper.connector_logger.info(
             "Processing the observable",
-            {
+            meta={
                 "observable_type": opencti_entity["entity_type"],
                 "observable_value": opencti_entity.get("observable_value"),
             },
@@ -280,7 +313,7 @@ class PaloaltoWildfireConnector:
             raise
         except Exception as err:
             self.helper.connector_logger.error(
-                "[CONNECTOR] An unexpected error occurred", {"error": str(err)}
+                "[CONNECTOR] An unexpected error occurred", meta={"error": str(err)}
             )
             self._send_bundle(original_stix_objects)
             raise

--- a/internal-enrichment/paloalto-wildfire/src/connector/settings.py
+++ b/internal-enrichment/paloalto-wildfire/src/connector/settings.py
@@ -1,0 +1,65 @@
+from typing import Literal
+
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseInternalEnrichmentConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field, HttpUrl, SecretStr
+
+
+class InternalEnrichmentConnectorConfig(BaseInternalEnrichmentConnectorConfig):
+    """
+    Override the `BaseInternalEnrichmentConnectorConfig` to add parameters and/or defaults
+    to the configuration for connectors of type `INTERNAL_ENRICHMENT`.
+    """
+
+    name: str = Field(
+        description="The name of the connector.",
+        default="Palo Alto Networks WildFire",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector (observable types to enrich).",
+        default=["StixFile", "Artifact"],
+    )
+
+
+class PaloaltoWildfireConfig(BaseConfigModel):
+    """
+    Define parameters and/or defaults for the configuration specific to the
+    `PaloaltoWildfireConnector`.
+    """
+
+    api_key: SecretStr = Field(
+        description="Palo Alto Networks WildFire API key.",
+    )
+    api_base_url: HttpUrl = Field(
+        description="WildFire API base URL (cloud region or appliance).",
+        default="https://wildfire.paloaltonetworks.com/publicapi",
+    )
+    max_tlp: Literal[
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED",
+    ] = Field(
+        description="Maximum TLP of the observable the connector is allowed to enrich.",
+        default="TLP:AMBER",
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """
+    Override `BaseConnectorSettings` to include `InternalEnrichmentConnectorConfig` and
+    `PaloaltoWildfireConfig`.
+    """
+
+    connector: InternalEnrichmentConnectorConfig = Field(
+        default_factory=InternalEnrichmentConnectorConfig
+    )
+    paloalto_wildfire: PaloaltoWildfireConfig = Field(
+        default_factory=PaloaltoWildfireConfig
+    )

--- a/internal-enrichment/paloalto-wildfire/src/connector/settings.py
+++ b/internal-enrichment/paloalto-wildfire/src/connector/settings.py
@@ -38,6 +38,28 @@ class PaloaltoWildfireConfig(BaseConfigModel):
         description="WildFire API base URL (cloud region or appliance).",
         default="https://wildfire.paloaltonetworks.com/publicapi",
     )
+    submit_unknown: bool = Field(
+        description=(
+            "Submit unknown files (carried by the observable) to WildFire for analysis "
+            "when no verdict exists yet. Enabled by default so Artifacts uploaded to "
+            "OpenCTI are detonated."
+        ),
+        default=True,
+    )
+    max_file_size: int = Field(
+        description=(
+            "Maximum size (in bytes) of a file the connector will download from OpenCTI "
+            "and submit to WildFire."
+        ),
+        default=33554432,
+    )
+    submission_timeout: int = Field(
+        description=(
+            "Maximum time (in seconds) to wait for a submitted file's verdict before "
+            "giving up."
+        ),
+        default=600,
+    )
     max_tlp: Literal[
         "TLP:CLEAR",
         "TLP:WHITE",

--- a/internal-enrichment/paloalto-wildfire/src/connector/settings.py
+++ b/internal-enrichment/paloalto-wildfire/src/connector/settings.py
@@ -41,10 +41,10 @@ class PaloaltoWildfireConfig(BaseConfigModel):
     submit_unknown: bool = Field(
         description=(
             "Submit unknown files (carried by the observable) to WildFire for analysis "
-            "when no verdict exists yet. Enabled by default so Artifacts uploaded to "
-            "OpenCTI are detonated."
+            "when no verdict exists yet. Disabled by default (opt-in): submission "
+            "uploads the sample to WildFire."
         ),
-        default=True,
+        default=False,
     )
     max_file_size: int = Field(
         description=(

--- a/internal-enrichment/paloalto-wildfire/src/main.py
+++ b/internal-enrichment/paloalto-wildfire/src/main.py
@@ -1,0 +1,28 @@
+import traceback
+
+from connector import ConnectorSettings, PaloaltoWildfireConnector
+from pycti import OpenCTIConnectorHelper
+
+if __name__ == "__main__":
+    """
+    Entry point of the script
+
+    - traceback.print_exc(): This function prints the traceback of the exception to the standard error (stderr).
+    The traceback includes information about the point in the program where the exception occurred,
+    which is very useful for debugging purposes.
+    - exit(1): effective way to terminate a Python program when an error is encountered.
+    It signals to the operating system and any calling processes that the program did not complete successfully.
+    """
+    try:
+        settings = ConnectorSettings()
+
+        helper = OpenCTIConnectorHelper(
+            config=settings.to_helper_config(),
+            playbook_compatible=True,  # ! `playbook_compatible=True` only if a bundle is sent
+        )
+
+        connector = PaloaltoWildfireConnector(config=settings, helper=helper)
+        connector.run()
+    except Exception:
+        traceback.print_exc()
+        exit(1)

--- a/internal-enrichment/paloalto-wildfire/src/paloalto_wildfire_client/__init__.py
+++ b/internal-enrichment/paloalto-wildfire/src/paloalto_wildfire_client/__init__.py
@@ -1,0 +1,9 @@
+from paloalto_wildfire_client.api_client import (
+    PaloaltoWildfireClient,
+    WildfireAPIError,
+)
+
+__all__ = [
+    "PaloaltoWildfireClient",
+    "WildfireAPIError",
+]

--- a/internal-enrichment/paloalto-wildfire/src/paloalto_wildfire_client/api_client.py
+++ b/internal-enrichment/paloalto-wildfire/src/paloalto_wildfire_client/api_client.py
@@ -49,7 +49,7 @@ class PaloaltoWildfireClient:
             allowed_methods=None,
             status_forcelist=[429, 500, 502, 503, 504],
             respect_retry_after_header=True,
-            raise_on_status=True,
+            raise_on_status=False,
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self.session.mount("https://", adapter)
@@ -61,16 +61,25 @@ class PaloaltoWildfireClient:
         payload["apikey"] = self.api_key
         try:
             response = self.session.post(url, data=payload, timeout=self.TIMEOUT)
-            self.helper.connector_logger.debug("[API] WildFire request", {"url": url})
+            self.helper.connector_logger.debug(
+                "[API] WildFire request", meta={"url": url}
+            )
             if response.status_code == 404:
                 # WildFire returns 404 when the sample/report is unknown.
                 return None
             response.raise_for_status()
             return response
         except requests.HTTPError as err:
+            status = err.response.status_code if err.response is not None else "?"
+            reason = err.response.reason if err.response is not None else ""
             raise WildfireAPIError(
-                "WildFire API request error: "
-                f"{err.response.status_code} ({err.response.reason})"
+                f"WildFire API request error: {status} ({reason})"
+            ) from err
+        except requests.RequestException as err:
+            # Retry exhaustion (RetryError), timeouts and connection errors are not
+            # HTTPError; wrap them so callers always see a WildfireAPIError.
+            raise WildfireAPIError(
+                f"WildFire API request failed: {type(err).__name__}"
             ) from err
 
     def get_verdict(self, file_hash: str) -> Optional[int]:
@@ -112,9 +121,14 @@ class PaloaltoWildfireClient:
             )
             response.raise_for_status()
         except requests.HTTPError as err:
+            status = err.response.status_code if err.response is not None else "?"
+            reason = err.response.reason if err.response is not None else ""
             raise WildfireAPIError(
-                "WildFire API request error: "
-                f"{err.response.status_code} ({err.response.reason})"
+                f"WildFire API request error: {status} ({reason})"
+            ) from err
+        except requests.RequestException as err:
+            raise WildfireAPIError(
+                f"WildFire API request failed: {type(err).__name__}"
             ) from err
         return self._parse_sha256(response.text)
 

--- a/internal-enrichment/paloalto-wildfire/src/paloalto_wildfire_client/api_client.py
+++ b/internal-enrichment/paloalto-wildfire/src/paloalto_wildfire_client/api_client.py
@@ -1,0 +1,132 @@
+"""HTTP client for the Palo Alto Networks WildFire public API."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import Optional
+
+import requests
+from pycti import OpenCTIConnectorHelper
+from requests.adapters import HTTPAdapter, Retry
+
+# WildFire returns -102 when a hash is unknown to the cloud.
+VERDICT_NOT_FOUND = -102
+
+
+class WildfireAPIError(Exception):
+    """Custom exception for Palo Alto Networks WildFire API errors."""
+
+
+class PaloaltoWildfireClient:
+    """Thin client around the WildFire ``get/verdict`` and ``get/report`` endpoints."""
+
+    TIMEOUT = 60
+
+    def __init__(
+        self,
+        helper: OpenCTIConnectorHelper,
+        api_key: str,
+        base_url: str = "https://wildfire.paloaltonetworks.com/publicapi",
+    ) -> None:
+        """
+        Initialize the WildFire client.
+
+        :param helper: The OpenCTI connector helper (used for logging).
+        :param api_key: The WildFire API key.
+        :param base_url: The WildFire API base URL (cloud region or appliance).
+        """
+        self.helper = helper
+        self.api_key = api_key
+        self.base_url = str(base_url).rstrip("/")
+
+        self.session = requests.Session()
+        retry_strategy = Retry(
+            total=3,
+            backoff_factor=2,
+            allowed_methods=None,
+            status_forcelist=[429, 500, 502, 503, 504],
+            respect_retry_after_header=True,
+            raise_on_status=True,
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
+
+    def _post(self, endpoint: str, data: dict) -> Optional[requests.Response]:
+        url = self.base_url + endpoint
+        payload = dict(data)
+        payload["apikey"] = self.api_key
+        try:
+            response = self.session.post(url, data=payload, timeout=self.TIMEOUT)
+            self.helper.connector_logger.debug("[API] WildFire request", {"url": url})
+            if response.status_code == 404:
+                # WildFire returns 404 when the sample/report is unknown.
+                return None
+            response.raise_for_status()
+            return response
+        except requests.HTTPError as err:
+            raise WildfireAPIError(
+                "WildFire API request error: "
+                f"{err.response.status_code} ({err.response.reason})"
+            ) from err
+
+    def get_verdict(self, file_hash: str) -> Optional[int]:
+        """
+        Return the WildFire verdict code for a file hash, or ``None`` if unknown.
+
+        Verdict codes: 0=benign, 1=malware, 2=grayware, 4=phishing,
+        5=command-and-control.
+        """
+        response = self._post("/get/verdict", {"hash": file_hash})
+        if response is None:
+            return None
+        verdict = self._parse_verdict(response.text)
+        if verdict is None or verdict == VERDICT_NOT_FOUND or verdict < 0:
+            return None
+        return verdict
+
+    def get_report(self, file_hash: str) -> Optional[dict]:
+        """Return the WildFire report fields for a file hash, or ``None``."""
+        response = self._post("/get/report", {"hash": file_hash, "format": "xml"})
+        if response is None:
+            return None
+        return self._parse_report(response.text)
+
+    @staticmethod
+    def _parse_verdict(xml_text: str) -> Optional[int]:
+        try:
+            root = ET.fromstring(xml_text)
+        except ET.ParseError:
+            return None
+        node = root.find(".//verdict")
+        if node is None or node.text is None:
+            return None
+        try:
+            return int(node.text.strip())
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _parse_report(xml_text: str) -> Optional[dict]:
+        try:
+            root = ET.fromstring(xml_text)
+        except ET.ParseError:
+            return None
+        file_info = root.find(".//file_info")
+        if file_info is None:
+            return None
+
+        def _text(tag: str) -> Optional[str]:
+            element = file_info.find(tag)
+            if element is not None and element.text:
+                return element.text.strip()
+            return None
+
+        return {
+            "md5": _text("md5"),
+            "sha1": _text("sha1"),
+            "sha256": _text("sha256"),
+            "filetype": _text("filetype"),
+            "size": _text("size"),
+            "malware": _text("malware"),
+        }

--- a/internal-enrichment/paloalto-wildfire/src/paloalto_wildfire_client/api_client.py
+++ b/internal-enrichment/paloalto-wildfire/src/paloalto_wildfire_client/api_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import xml.etree.ElementTree as ET
 from typing import Optional
 
@@ -11,6 +12,8 @@ from requests.adapters import HTTPAdapter, Retry
 
 # WildFire returns -102 when a hash is unknown to the cloud.
 VERDICT_NOT_FOUND = -102
+# WildFire returns -100 while a submitted sample is still being analysed.
+VERDICT_PENDING = -100
 
 
 class WildfireAPIError(Exception):
@@ -85,12 +88,68 @@ class PaloaltoWildfireClient:
             return None
         return verdict
 
+    def get_verdict_code(self, file_hash: str) -> Optional[int]:
+        """Return the raw WildFire verdict code (including negatives), or ``None``."""
+        response = self._post("/get/verdict", {"hash": file_hash})
+        if response is None:
+            return None
+        return self._parse_verdict(response.text)
+
     def get_report(self, file_hash: str) -> Optional[dict]:
         """Return the WildFire report fields for a file hash, or ``None``."""
         response = self._post("/get/report", {"hash": file_hash, "format": "xml"})
         if response is None:
             return None
         return self._parse_report(response.text)
+
+    def submit_file(self, file_name: str, content: bytes) -> Optional[str]:
+        """Submit a file for analysis, returning the sample SHA-256 (or ``None``)."""
+        url = self.base_url + "/submit/file"
+        files = {"file": (file_name, content)}
+        try:
+            response = self.session.post(
+                url, data={"apikey": self.api_key}, files=files, timeout=self.TIMEOUT
+            )
+            response.raise_for_status()
+        except requests.HTTPError as err:
+            raise WildfireAPIError(
+                "WildFire API request error: "
+                f"{err.response.status_code} ({err.response.reason})"
+            ) from err
+        return self._parse_sha256(response.text)
+
+    def poll_verdict(
+        self, file_hash: str, max_wait: int = 600, interval: int = 30
+    ) -> Optional[int]:
+        """
+        Poll the verdict for a submitted sample until it is final (bounded by max_wait).
+
+        Returns the final non-negative verdict code, or ``None`` if it stays pending,
+        errors, or is rejected.
+        """
+        waited = 0
+        while waited <= max_wait:
+            verdict = self.get_verdict_code(file_hash)
+            if verdict is None:
+                return None
+            if verdict >= 0:
+                return verdict
+            if verdict != VERDICT_PENDING:
+                return None
+            time.sleep(interval)
+            waited += interval
+        return None
+
+    @staticmethod
+    def _parse_sha256(xml_text: str) -> Optional[str]:
+        try:
+            root = ET.fromstring(xml_text)
+        except ET.ParseError:
+            return None
+        node = root.find(".//sha256")
+        if node is not None and node.text:
+            return node.text.strip()
+        return None
 
     @staticmethod
     def _parse_verdict(xml_text: str) -> Optional[int]:

--- a/internal-enrichment/paloalto-wildfire/src/requirements.txt
+++ b/internal-enrichment/paloalto-wildfire/src/requirements.txt
@@ -1,4 +1,4 @@
-pycti==7.260615.0
-pydantic~= 2.11.3
+pycti==7.260701.0
+pydantic~=2.11.3
 requests~=2.33.0
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/paloalto-wildfire/src/requirements.txt
+++ b/internal-enrichment/paloalto-wildfire/src/requirements.txt
@@ -1,0 +1,4 @@
+pycti==7.260609.0
+pydantic~= 2.11.3
+requests~=2.33.0
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/paloalto-wildfire/src/requirements.txt
+++ b/internal-enrichment/paloalto-wildfire/src/requirements.txt
@@ -1,4 +1,4 @@
-pycti==7.260609.0
+pycti==7.260615.0
 pydantic~= 2.11.3
 requests~=2.33.0
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/paloalto-wildfire/tests/conftest.py
+++ b/internal-enrichment/paloalto-wildfire/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())

--- a/internal-enrichment/paloalto-wildfire/tests/test-requirements.txt
+++ b/internal-enrichment/paloalto-wildfire/tests/test-requirements.txt
@@ -1,0 +1,3 @@
+# Main dependencies needs to be installed
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/internal-enrichment/paloalto-wildfire/tests/test_main.py
+++ b/internal-enrichment/paloalto-wildfire/tests/test_main.py
@@ -63,7 +63,7 @@ def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper)
     assert helper.connect_name == "Test Connector"
     assert helper.connect_scope == "test,connector"
     assert helper.log_level == "ERROR"
-    assert helper.connect_auto == True
+    assert helper.connect_auto is True
 
 
 def test_connector_is_instantiated(mock_opencti_connector_helper):

--- a/internal-enrichment/paloalto-wildfire/tests/test_main.py
+++ b/internal-enrichment/paloalto-wildfire/tests/test_main.py
@@ -1,0 +1,83 @@
+from typing import Any
+
+from connector import ConnectorSettings, PaloaltoWildfireConnector
+from pycti import OpenCTIConnectorHelper
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+    It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "auto": True,
+                },
+                "paloalto_wildfire": {
+                    "api_base_url": "http://test.com",
+                    "api_key": "test-api-key",
+                    "max_tlp": "TLP:CLEAR",
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that the implementation of `BaseConnectorSettings` (from `connectors-sdk`) can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from `BaseConnectorSettings`)
+        - the method `to_helper_config` MUST return a dict (as in base class)
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that `OpenCTIConnectorHelper` (from `pycti`) can be instantiated successfully:
+        - the value of `settings.to_helper_config` MUST be the expected dict for `OpenCTIConnectorHelper`
+        - the helper MUST be able to get its instance's attributes from the config dict
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "Test Connector"
+    assert helper.connect_scope == "test,connector"
+    assert helper.log_level == "ERROR"
+    assert helper.connect_auto == True
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST be able to access env/config vars through `self.config`
+        - the connector's main class MUST be able to access `pycti` API through `self.helper`
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    connector = PaloaltoWildfireConnector(config=settings, helper=helper)
+
+    assert connector.config == settings
+    assert connector.helper == helper

--- a/internal-enrichment/paloalto-wildfire/tests/tests_connector/data/artifact_message.json
+++ b/internal-enrichment/paloalto-wildfire/tests/tests_connector/data/artifact_message.json
@@ -1,0 +1,34 @@
+{
+  "stix_objects": [
+    {
+      "type": "artifact",
+      "id": "artifact--22222222-2222-4222-8222-222222222222",
+      "hashes": {
+        "SHA-256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    }
+  ],
+  "stix_entity": {
+    "type": "artifact",
+    "id": "artifact--22222222-2222-4222-8222-222222222222",
+    "hashes": {
+      "SHA-256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+  },
+  "enrichment_entity": {
+    "entity_type": "Artifact",
+    "observable_value": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "hashes": [
+      {
+        "algorithm": "SHA-256",
+        "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    ],
+    "objectMarking": [
+      {
+        "definition_type": "TLP",
+        "definition": "TLP:AMBER"
+      }
+    ]
+  }
+}

--- a/internal-enrichment/paloalto-wildfire/tests/tests_connector/data/file_message.json
+++ b/internal-enrichment/paloalto-wildfire/tests/tests_connector/data/file_message.json
@@ -1,0 +1,36 @@
+{
+  "stix_objects": [
+    {
+      "type": "file",
+      "id": "file--11111111-1111-4111-8111-111111111111",
+      "name": "malware.exe",
+      "hashes": {
+        "SHA-256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    }
+  ],
+  "stix_entity": {
+    "type": "file",
+    "id": "file--11111111-1111-4111-8111-111111111111",
+    "name": "malware.exe",
+    "hashes": {
+      "SHA-256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+  },
+  "enrichment_entity": {
+    "entity_type": "StixFile",
+    "observable_value": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "hashes": [
+      {
+        "algorithm": "SHA-256",
+        "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    ],
+    "objectMarking": [
+      {
+        "definition_type": "TLP",
+        "definition": "TLP:AMBER"
+      }
+    ]
+  }
+}

--- a/internal-enrichment/paloalto-wildfire/tests/tests_connector/test_connector.py
+++ b/internal-enrichment/paloalto-wildfire/tests/tests_connector/test_connector.py
@@ -1,0 +1,212 @@
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import stix2
+from connector import ConnectorSettings, PaloaltoWildfireConnector
+from paloalto_wildfire_client import WildfireAPIError
+from pycti import OpenCTIConnectorHelper
+
+DATA_DIR = Path(__file__).parent / "data"
+
+WILDFIRE_RESULT = {
+    "verdict": 1,
+    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "report": {
+        "md5": "d41d8cd98f00b204e9800998ecf8427e",
+        "sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size": "1024",
+        "filetype": "PE32",
+        "malware": "yes",
+    },
+}
+
+
+def _load(name: str) -> dict:
+    with (DATA_DIR / name).open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """Deterministic settings for tests."""
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "StixFile,Artifact",
+                    "log_level": "error",
+                    "auto": True,
+                },
+                "paloalto_wildfire": {"api_key": "test-api-key"},
+            }
+        )
+
+
+@pytest.fixture
+def file_message() -> dict:
+    return _load("file_message.json")
+
+
+@pytest.fixture
+def artifact_message() -> dict:
+    return _load("artifact_message.json")
+
+
+@pytest.fixture
+def dummy_connector(mock_opencti_connector_helper):
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+    helper.send_stix2_bundle = MagicMock()
+
+    connector = PaloaltoWildfireConnector(config=settings, helper=helper)
+    connector.client = MagicMock()
+    connector._search_hash = MagicMock()
+    connector._create_knowledge = MagicMock()
+    connector._send_bundle = MagicMock()
+    return connector
+
+
+@pytest.fixture
+def stub_connector(mock_opencti_connector_helper):
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+    helper.send_stix2_bundle = MagicMock()
+
+    connector = PaloaltoWildfireConnector(config=settings, helper=helper)
+    connector.identity = stix2.Identity(
+        id="identity--4a9e7924-46a1-43f7-962b-e61f53f4b0ca",
+        name="WildFire",
+        identity_class="organization",
+    )
+    connector.tlp = stix2.TLP_WHITE
+    connector.client = MagicMock()
+    return connector
+
+
+def test_process_message_ignores_entity_exceeding_max_tlp(
+    dummy_connector, file_message
+):
+    dummy_connector.max_tlp = "TLP:CLEAR"
+
+    dummy_connector._process_message(file_message)
+
+    dummy_connector._search_hash.assert_not_called()
+    dummy_connector._create_knowledge.assert_not_called()
+    dummy_connector._send_bundle.assert_called_with(file_message["stix_objects"])
+
+
+@pytest.mark.parametrize(
+    "raised",
+    [WildfireAPIError("api error"), Exception("unexpected")],
+    ids=["wildfire-api-error", "unexpected-exception"],
+)
+def test_process_message_handles_exceptions(dummy_connector, file_message, raised):
+    dummy_connector._search_hash = MagicMock(side_effect=raised)
+
+    with pytest.raises(type(raised)):
+        dummy_connector._process_message(file_message)
+
+    dummy_connector._search_hash.assert_called_once()
+    dummy_connector._create_knowledge.assert_not_called()
+    dummy_connector._send_bundle.assert_called_with(file_message["stix_objects"])
+
+
+def test_process_message_routes_file_with_verdict(dummy_connector, file_message):
+    dummy_connector._search_hash.return_value = WILDFIRE_RESULT
+
+    dummy_connector._process_message(file_message)
+
+    dummy_connector._search_hash.assert_called_once()
+    dummy_connector._create_knowledge.assert_called_once()
+    dummy_connector._send_bundle.assert_called_once()
+
+
+def test_process_message_no_verdict_sends_original(dummy_connector, file_message):
+    dummy_connector._search_hash.return_value = None
+
+    dummy_connector._process_message(file_message)
+
+    dummy_connector._create_knowledge.assert_not_called()
+    dummy_connector._send_bundle.assert_called_with(file_message["stix_objects"])
+
+
+def test_create_knowledge_file(stub_connector, file_message):
+    data = file_message
+    stub_connector.stix_objects = data["stix_objects"]
+
+    result = stub_connector._create_knowledge(
+        data["stix_entity"], data["enrichment_entity"], WILDFIRE_RESULT
+    )
+
+    types = {o["type"] if isinstance(o, dict) else o.type for o in result}
+    assert "identity" in types
+    assert "malware-analysis" in types
+
+    enriched = next(
+        o
+        for o in result
+        if isinstance(o, dict) and o.get("id") == data["stix_entity"]["id"]
+    )
+    assert enriched["x_opencti_score"] == 90
+    assert "wildfire:malware" in enriched["labels"]
+    assert enriched["hashes"]["MD5"] == WILDFIRE_RESULT["report"]["md5"]
+    assert enriched["size"] == 1024
+
+
+def test_create_knowledge_artifact(stub_connector, artifact_message):
+    data = artifact_message
+    stub_connector.stix_objects = data["stix_objects"]
+
+    result = stub_connector._create_knowledge(
+        data["stix_entity"], data["enrichment_entity"], WILDFIRE_RESULT
+    )
+
+    enriched = next(
+        o
+        for o in result
+        if isinstance(o, dict) and o.get("id") == data["stix_entity"]["id"]
+    )
+    assert enriched["x_opencti_score"] == 90
+    assert "size" not in enriched
+
+
+def test_extract_hash_priority():
+    entity = {
+        "hashes": [
+            {"algorithm": "MD5", "hash": "m"},
+            {"algorithm": "SHA-256", "hash": "s"},
+        ]
+    }
+    assert PaloaltoWildfireConnector._extract_hash(entity) == "s"
+
+
+def test_search_hash_no_hash_returns_none(stub_connector):
+    assert stub_connector._search_hash({"hashes": []}) is None
+
+
+def test_search_hash_unknown_verdict_returns_none(stub_connector):
+    stub_connector.client.get_verdict.return_value = None
+
+    result = stub_connector._search_hash(
+        {"hashes": [{"algorithm": "SHA-256", "hash": "s"}]}
+    )
+    assert result is None
+
+
+def test_search_hash_with_verdict(stub_connector):
+    stub_connector.client.get_verdict.return_value = 1
+    stub_connector.client.get_report.return_value = {"sha256": "s"}
+
+    result = stub_connector._search_hash(
+        {"hashes": [{"algorithm": "SHA-256", "hash": "s"}]}
+    )
+    assert result["verdict"] == 1
+    assert result["hash"] == "s"

--- a/internal-enrichment/paloalto-wildfire/tests/tests_connector/test_connector.py
+++ b/internal-enrichment/paloalto-wildfire/tests/tests_connector/test_connector.py
@@ -30,24 +30,37 @@ def _load(name: str) -> dict:
         return json.load(f)
 
 
+def _settings_dict(submit_unknown: bool = False) -> dict:
+    return {
+        "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+        "connector": {
+            "id": "connector-id",
+            "name": "Test Connector",
+            "scope": "StixFile,Artifact",
+            "log_level": "error",
+            "auto": True,
+        },
+        "paloalto_wildfire": {
+            "api_key": "test-api-key",
+            "submit_unknown": submit_unknown,
+        },
+    }
+
+
 class StubConnectorSettings(ConnectorSettings):
-    """Deterministic settings for tests."""
+    """Deterministic settings for tests (submission disabled)."""
 
     @classmethod
     def _load_config_dict(cls, _, handler) -> dict[str, Any]:
-        return handler(
-            {
-                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
-                "connector": {
-                    "id": "connector-id",
-                    "name": "Test Connector",
-                    "scope": "StixFile,Artifact",
-                    "log_level": "error",
-                    "auto": True,
-                },
-                "paloalto_wildfire": {"api_key": "test-api-key"},
-            }
-        )
+        return handler(_settings_dict())
+
+
+class StubConnectorSettingsSubmit(ConnectorSettings):
+    """Deterministic settings for tests (submission enabled)."""
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(_settings_dict(submit_unknown=True))
 
 
 @pytest.fixture
@@ -69,7 +82,23 @@ def dummy_connector(mock_opencti_connector_helper):
     connector = PaloaltoWildfireConnector(config=settings, helper=helper)
     connector.client = MagicMock()
     connector._search_hash = MagicMock()
+    connector._submit = MagicMock()
     connector._create_knowledge = MagicMock()
+    connector._send_bundle = MagicMock()
+    return connector
+
+
+@pytest.fixture
+def submit_connector(mock_opencti_connector_helper):
+    settings = StubConnectorSettingsSubmit()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+    helper.send_stix2_bundle = MagicMock()
+
+    connector = PaloaltoWildfireConnector(config=settings, helper=helper)
+    connector.client = MagicMock()
+    connector._search_hash = MagicMock(return_value=None)
+    connector._submit = MagicMock(return_value=WILDFIRE_RESULT)
+    connector._create_knowledge = MagicMock(return_value=["bundle"])
     connector._send_bundle = MagicMock()
     return connector
 
@@ -134,8 +163,17 @@ def test_process_message_no_verdict_sends_original(dummy_connector, file_message
 
     dummy_connector._process_message(file_message)
 
+    dummy_connector._submit.assert_not_called()  # submit_unknown is False
     dummy_connector._create_knowledge.assert_not_called()
     dummy_connector._send_bundle.assert_called_with(file_message["stix_objects"])
+
+
+def test_process_message_submits_when_enabled(submit_connector, file_message):
+    submit_connector._process_message(file_message)
+
+    submit_connector._search_hash.assert_called_once()
+    submit_connector._submit.assert_called_once()
+    submit_connector._create_knowledge.assert_called_once()
 
 
 def test_create_knowledge_file(stub_connector, file_message):
@@ -210,3 +248,77 @@ def test_search_hash_with_verdict(stub_connector):
     )
     assert result["verdict"] == 1
     assert result["hash"] == "s"
+
+
+def test_download_file_no_import_files(stub_connector):
+    name, content, error = stub_connector._download_file({"importFiles": []})
+    assert content is None
+    assert "No file attached" in error
+
+
+def test_download_file_rejects_declared_oversize(stub_connector):
+    entity = {
+        "importFiles": [
+            {"id": "f1", "name": "big.bin", "size": stub_connector.max_file_size + 1}
+        ]
+    }
+    name, content, error = stub_connector._download_file(entity)
+    assert content is None
+    assert "limit" in error
+
+
+def test_download_file_rejects_empty(stub_connector):
+    stub_connector.helper.api.api_url = "http://localhost:8080/graphql"
+    stub_connector.helper.api.fetch_opencti_file = MagicMock(return_value=b"")
+    entity = {"importFiles": [{"id": "f1", "name": "empty.bin"}]}
+
+    name, content, error = stub_connector._download_file(entity)
+    assert content is None
+    assert "empty" in error
+
+
+def test_download_file_success(stub_connector):
+    stub_connector.helper.api.api_url = "http://localhost:8080/graphql"
+    stub_connector.helper.api.fetch_opencti_file = MagicMock(return_value=b"payload")
+    entity = {"importFiles": [{"id": "f1", "name": "malware.exe"}]}
+
+    name, content, error = stub_connector._download_file(entity)
+    assert error is None
+    assert name == "malware.exe"
+    assert content == b"payload"
+
+
+def test_submit_returns_verdict(stub_connector):
+    stub_connector.helper.api.api_url = "http://localhost:8080/graphql"
+    stub_connector.helper.api.fetch_opencti_file = MagicMock(return_value=b"data")
+    stub_connector.client.submit_file = MagicMock(return_value="sha256-1")
+    stub_connector.client.poll_verdict = MagicMock(return_value=1)
+    stub_connector.client.get_report = MagicMock(return_value={"sha256": "sha256-1"})
+
+    entity = {"importFiles": [{"id": "f1", "name": "malware.exe"}]}
+    result = stub_connector._submit(entity)
+    assert result["verdict"] == 1
+    assert result["hash"] == "sha256-1"
+
+
+def test_submit_skips_on_download_error(stub_connector):
+    stub_connector.client.submit_file = MagicMock()
+    stub_connector._download_file = MagicMock(return_value=(None, None, "boom"))
+
+    assert stub_connector._submit({"importFiles": [{"id": "f1"}]}) is None
+    stub_connector.client.submit_file.assert_not_called()
+
+
+def test_submit_unknown_defaults_to_true():
+    class _Settings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler):
+            return handler(
+                {
+                    "opencti": {"url": "http://localhost:8080", "token": "t"},
+                    "connector": {"id": "c", "scope": "StixFile,Artifact"},
+                    "paloalto_wildfire": {"api_key": "k"},
+                }
+            )
+
+    assert _Settings().paloalto_wildfire.submit_unknown is True

--- a/internal-enrichment/paloalto-wildfire/tests/tests_connector/test_connector.py
+++ b/internal-enrichment/paloalto-wildfire/tests/tests_connector/test_connector.py
@@ -197,6 +197,17 @@ def test_create_knowledge_file(stub_connector, file_message):
     assert "wildfire:malware" in enriched["labels"]
     assert enriched["hashes"]["MD5"] == WILDFIRE_RESULT["report"]["md5"]
     assert enriched["size"] == 1024
+    # The WildFire report file type is mapped onto the STIX File mime_type.
+    assert enriched["mime_type"] == WILDFIRE_RESULT["report"]["filetype"]
+
+    # The Malware Analysis object must carry markings (inherited or default) so the
+    # enrichment never produces an unmarked object.
+    malware_analysis = next(
+        o
+        for o in result
+        if not isinstance(o, dict) and getattr(o, "type", None) == "malware-analysis"
+    )
+    assert malware_analysis["object_marking_refs"]
 
 
 def test_create_knowledge_artifact(stub_connector, artifact_message):

--- a/internal-enrichment/paloalto-wildfire/tests/tests_connector/test_connector.py
+++ b/internal-enrichment/paloalto-wildfire/tests/tests_connector/test_connector.py
@@ -200,14 +200,20 @@ def test_create_knowledge_file(stub_connector, file_message):
     # The WildFire report file type is mapped onto the STIX File mime_type.
     assert enriched["mime_type"] == WILDFIRE_RESULT["report"]["filetype"]
 
-    # The Malware Analysis object must carry markings (inherited or default) so the
-    # enrichment never produces an unmarked object.
+    # The Malware Analysis object must carry the SOURCE observable's marking
+    # (TLP:AMBER from the message's objectMarking), and that marking object must be
+    # included in the bundle so the SDO is correctly marked and self-contained -
+    # not silently downgraded to the connector default.
     malware_analysis = next(
         o
         for o in result
         if not isinstance(o, dict) and getattr(o, "type", None) == "malware-analysis"
     )
-    assert malware_analysis["object_marking_refs"]
+    assert stix2.TLP_AMBER.id in malware_analysis["object_marking_refs"]
+    marking_ids = {
+        o.id for o in result if getattr(o, "type", None) == "marking-definition"
+    }
+    assert stix2.TLP_AMBER.id in marking_ids
 
 
 def test_create_knowledge_artifact(stub_connector, artifact_message):
@@ -320,7 +326,10 @@ def test_submit_skips_on_download_error(stub_connector):
     stub_connector.client.submit_file.assert_not_called()
 
 
-def test_submit_unknown_defaults_to_true():
+def test_submit_unknown_defaults_to_false():
+    # File submission/detonation uploads the sample to WildFire, so it is opt-in:
+    # it must stay disabled unless explicitly enabled (issue #6730 scopes the first
+    # version to verdict-by-hash only).
     class _Settings(ConnectorSettings):
         @classmethod
         def _load_config_dict(cls, _, handler):
@@ -332,4 +341,4 @@ def test_submit_unknown_defaults_to_true():
                 }
             )
 
-    assert _Settings().paloalto_wildfire.submit_unknown is True
+    assert _Settings().paloalto_wildfire.submit_unknown is False

--- a/internal-enrichment/paloalto-wildfire/tests/tests_connector/test_connector.py
+++ b/internal-enrichment/paloalto-wildfire/tests/tests_connector/test_connector.py
@@ -176,6 +176,29 @@ def test_process_message_submits_when_enabled(submit_connector, file_message):
     submit_connector._create_knowledge.assert_called_once()
 
 
+def test_process_message_out_of_scope_returns_original_bundle(
+    dummy_connector, file_message
+):
+    # Playbook trigger (no event_type): the original bundle must be returned
+    # unchanged when the entity is not in the connector scope.
+    file_message["enrichment_entity"]["entity_type"] = "Url"
+
+    message = dummy_connector._process_message(file_message)
+
+    assert "not in connector scope" in message
+    dummy_connector._search_hash.assert_not_called()
+    dummy_connector._send_bundle.assert_called_with(file_message["stix_objects"])
+
+
+def test_process_message_out_of_scope_event_raises(dummy_connector, file_message):
+    # Direct enrichment event (event_type set) on an unsupported entity type.
+    file_message["enrichment_entity"]["entity_type"] = "Url"
+    file_message["event_type"] = "INTERNAL_ENRICHMENT"
+
+    with pytest.raises(ValueError, match="not a supported entity type"):
+        dummy_connector._process_message(file_message)
+
+
 def test_create_knowledge_file(stub_connector, file_message):
     data = file_message
     stub_connector.stix_objects = data["stix_objects"]
@@ -285,7 +308,6 @@ def test_download_file_rejects_declared_oversize(stub_connector):
 
 
 def test_download_file_rejects_empty(stub_connector):
-    stub_connector.helper.api.api_url = "http://localhost:8080/graphql"
     stub_connector.helper.api.fetch_opencti_file = MagicMock(return_value=b"")
     entity = {"importFiles": [{"id": "f1", "name": "empty.bin"}]}
 
@@ -295,7 +317,6 @@ def test_download_file_rejects_empty(stub_connector):
 
 
 def test_download_file_success(stub_connector):
-    stub_connector.helper.api.api_url = "http://localhost:8080/graphql"
     stub_connector.helper.api.fetch_opencti_file = MagicMock(return_value=b"payload")
     entity = {"importFiles": [{"id": "f1", "name": "malware.exe"}]}
 
@@ -303,10 +324,11 @@ def test_download_file_success(stub_connector):
     assert error is None
     assert name == "malware.exe"
     assert content == b"payload"
+    file_url = stub_connector.helper.api.fetch_opencti_file.call_args[0][0]
+    assert file_url == "http://localhost:8080/storage/get/f1"
 
 
 def test_submit_returns_verdict(stub_connector):
-    stub_connector.helper.api.api_url = "http://localhost:8080/graphql"
     stub_connector.helper.api.fetch_opencti_file = MagicMock(return_value=b"data")
     stub_connector.client.submit_file = MagicMock(return_value="sha256-1")
     stub_connector.client.poll_verdict = MagicMock(return_value=1)

--- a/internal-enrichment/paloalto-wildfire/tests/tests_connector/test_settings.py
+++ b/internal-enrichment/paloalto-wildfire/tests/tests_connector/test_settings.py
@@ -1,0 +1,154 @@
+from typing import Any
+
+import pytest
+from connector import ConnectorSettings
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "auto": True,
+                },
+                "paloalto_wildfire": {
+                    "api_base_url": "http://test.com",
+                    "api_key": "test-api-key",
+                    "max_tlp": "TLP:CLEAR",
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "test, connector",
+                },
+                "paloalto_wildfire": {
+                    "api_base_url": "http://test.com",
+                    "api_key": "test-api-key",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) accepts valid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake but valid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    # Given: Valid input
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    # When: We create an ConnectorSettings instance with valid input data
+    settings = FakeConnectorSettings()
+
+    # Then: The ConnectorSettings instance should be created successfully
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.paloalto_wildfire, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param(
+            {},
+            "settings",
+            id="empty_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:PORT",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "auto": True,
+                },
+                "paloalto_wildfire": {
+                    "api_base_url": "http://test.com",
+                    "api_key": "test-api-key",
+                    "max_tlp": "TLP:CLEAR",
+                },
+            },
+            "opencti.url",
+            id="invalid_opencti_url",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "auto": True,
+                },
+                "paloalto_wildfire": {
+                    "api_base_url": "http://test.com",
+                    "api_key": "test-api-key",
+                    "max_tlp": "TLP:CLEAR",
+                },
+            },
+            "connector.id",
+            id="missing_connector_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) raises on invalid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake and invalid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert str("Error validating configuration") in str(err)

--- a/internal-enrichment/paloalto-wildfire/tests/tests_paloalto_wildfire_client/test_api_client.py
+++ b/internal-enrichment/paloalto-wildfire/tests/tests_paloalto_wildfire_client/test_api_client.py
@@ -119,6 +119,16 @@ def test_post_raises_on_http_error():
         client.get_verdict("abc")
 
 
+def test_post_wraps_non_http_request_errors():
+    # Connection/timeout/retry errors (not HTTPError) must also be wrapped as
+    # WildfireAPIError so callers see a single, consistent error type.
+    client = _make_client()
+    client.session.post.side_effect = requests.ConnectionError("boom")
+
+    with pytest.raises(WildfireAPIError):
+        client.get_verdict("abc")
+
+
 def test_get_verdict_code_returns_raw_pending():
     client = _make_client()
     client.session.post.return_value = _response(VERDICT_PENDING_XML)

--- a/internal-enrichment/paloalto-wildfire/tests/tests_paloalto_wildfire_client/test_api_client.py
+++ b/internal-enrichment/paloalto-wildfire/tests/tests_paloalto_wildfire_client/test_api_client.py
@@ -1,8 +1,17 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
 from paloalto_wildfire_client import PaloaltoWildfireClient, WildfireAPIError
+
+SUBMIT_XML = (
+    "<wildfire><upload-file-info><sha256>abc123</sha256>"
+    "</upload-file-info></wildfire>"
+)
+VERDICT_PENDING_XML = (
+    "<wildfire><get-verdict-info><verdict>-100</verdict>"
+    "</get-verdict-info></wildfire>"
+)
 
 VERDICT_XML = (
     "<wildfire><get-verdict-info><sha256>abc</sha256>"
@@ -108,3 +117,49 @@ def test_post_raises_on_http_error():
 
     with pytest.raises(WildfireAPIError):
         client.get_verdict("abc")
+
+
+def test_get_verdict_code_returns_raw_pending():
+    client = _make_client()
+    client.session.post.return_value = _response(VERDICT_PENDING_XML)
+    assert client.get_verdict_code("abc") == -100
+
+
+def test_submit_file_returns_sha256():
+    client = _make_client()
+    client.session.post.return_value = _response(SUBMIT_XML)
+    assert client.submit_file("malware.exe", b"data") == "abc123"
+
+
+def test_submit_file_raises_on_http_error():
+    client = _make_client()
+    err_response = MagicMock()
+    err_response.status_code = 403
+    err_response.reason = "Forbidden"
+    bad = MagicMock()
+    bad.raise_for_status.side_effect = requests.HTTPError(response=err_response)
+    client.session.post.return_value = bad
+
+    with pytest.raises(WildfireAPIError):
+        client.submit_file("malware.exe", b"data")
+
+
+def test_poll_verdict_returns_final():
+    client = _make_client()
+    with patch.object(client, "get_verdict_code", side_effect=[-100, 1]), patch(
+        "paloalto_wildfire_client.api_client.time.sleep"
+    ):
+        assert client.poll_verdict("abc") == 1
+
+
+def test_poll_verdict_returns_none_on_error_code():
+    client = _make_client()
+    with patch.object(client, "get_verdict_code", side_effect=[-100, -103]), patch(
+        "paloalto_wildfire_client.api_client.time.sleep"
+    ):
+        assert client.poll_verdict("abc") is None
+
+
+def test_parse_sha256():
+    assert PaloaltoWildfireClient._parse_sha256(SUBMIT_XML) == "abc123"
+    assert PaloaltoWildfireClient._parse_sha256("not-xml") is None

--- a/internal-enrichment/paloalto-wildfire/tests/tests_paloalto_wildfire_client/test_api_client.py
+++ b/internal-enrichment/paloalto-wildfire/tests/tests_paloalto_wildfire_client/test_api_client.py
@@ -1,0 +1,110 @@
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+from paloalto_wildfire_client import PaloaltoWildfireClient, WildfireAPIError
+
+VERDICT_XML = (
+    "<wildfire><get-verdict-info><sha256>abc</sha256>"
+    "<verdict>1</verdict><md5>def</md5></get-verdict-info></wildfire>"
+)
+VERDICT_UNKNOWN_XML = (
+    "<wildfire><get-verdict-info><verdict>-102</verdict>"
+    "</get-verdict-info></wildfire>"
+)
+REPORT_XML = (
+    "<wildfire><file_info><malware>yes</malware><md5>def</md5>"
+    "<sha1>ghi</sha1><sha256>abc</sha256><size>1024</size>"
+    "<filetype>PE32</filetype></file_info></wildfire>"
+)
+
+
+def _make_client() -> PaloaltoWildfireClient:
+    client = PaloaltoWildfireClient(MagicMock(), api_key="key")
+    client.session = MagicMock()
+    return client
+
+
+def _response(text: str, status: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status
+    response.text = text
+    response.raise_for_status.return_value = None
+    return response
+
+
+def test_get_verdict_returns_code():
+    client = _make_client()
+    client.session.post.return_value = _response(VERDICT_XML)
+    assert client.get_verdict("abc") == 1
+
+
+def test_get_verdict_unknown_returns_none():
+    client = _make_client()
+    client.session.post.return_value = _response(VERDICT_UNKNOWN_XML)
+    assert client.get_verdict("abc") is None
+
+
+def test_get_verdict_404_returns_none():
+    client = _make_client()
+    client.session.post.return_value = _response("", status=404)
+    assert client.get_verdict("abc") is None
+
+
+def test_get_report_parses_file_info():
+    client = _make_client()
+    client.session.post.return_value = _response(REPORT_XML)
+
+    report = client.get_report("abc")
+    assert report["sha256"] == "abc"
+    assert report["md5"] == "def"
+    assert report["size"] == "1024"
+    assert report["malware"] == "yes"
+
+
+def test_apikey_injected_in_payload():
+    client = _make_client()
+    client.session.post.return_value = _response(VERDICT_XML)
+
+    client.get_verdict("hashvalue")
+    _, kwargs = client.session.post.call_args
+    assert kwargs["data"]["apikey"] == "key"
+    assert kwargs["data"]["hash"] == "hashvalue"
+
+
+def test_get_report_404_returns_none():
+    client = _make_client()
+    client.session.post.return_value = _response("", status=404)
+    assert client.get_report("abc") is None
+
+
+def test_get_verdict_bad_xml_returns_none():
+    client = _make_client()
+    client.session.post.return_value = _response("not-xml")
+    assert client.get_verdict("abc") is None
+
+
+def test_get_report_bad_xml_returns_none():
+    client = _make_client()
+    client.session.post.return_value = _response("not-xml")
+    assert client.get_report("abc") is None
+
+
+def test_get_report_without_file_info_returns_none():
+    client = _make_client()
+    client.session.post.return_value = _response("<wildfire></wildfire>")
+    assert client.get_report("abc") is None
+
+
+def test_post_raises_on_http_error():
+    client = _make_client()
+    err_response = MagicMock()
+    err_response.status_code = 500
+    err_response.reason = "Server Error"
+    bad = MagicMock()
+    bad.status_code = 500
+    bad.raise_for_status.side_effect = requests.HTTPError(response=err_response)
+    client.session.post.return_value = bad
+
+    with pytest.raises(WildfireAPIError):
+        client.get_verdict("abc")


### PR DESCRIPTION
## Proposed changes

New internal-enrichment connector for Palo Alto Networks WildFire.

When a `StixFile` or `Artifact` observable is enriched, the connector:

- selects the strongest available hash (SHA-256 > SHA-1 > MD5) and queries the WildFire public API (`POST /get/verdict`);
- optionally, when the hash is unknown and the observable carries an uploaded file, submits it to WildFire (`POST /submit/file`) and polls for the verdict (opt-in via `submit_unknown`, disabled by default, bounded by `submission_timeout`, with `max_file_size` enforced on download);
- maps the WildFire verdict (benign / grayware / phishing / malware / command-and-control) to an OpenCTI score and a `wildfire:<verdict>` label;
- fetches the WildFire report (`POST /get/report`) to complete the file hashes and the file type (`mime_type`) when available;
- attaches a STIX Malware Analysis object (`product = WildFire`) referencing the observable, carrying the source observable's markings, with the result mapped to the STIX `malware-result` vocabulary.

The connector is playbook compatible and always returns the (enriched) bundle. It is modeled on the existing `hybrid-analysis-sandbox` connector (connectors-sdk Pydantic settings, retry/backoff client, `_process_message` flow).

## Related issues

Closes #6730

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works (unit tests for the client and the connector; patch coverage > 80% on new code)
- [x] Code formatting (`black`, `isort`) and linting (`flake8`, STIX id pylint) pass
- [x] Generated `__metadata__` config schema and documentation
- [x] I have added/updated the connector `README.md`, `config.yml.sample`, `docker-compose.yml` and `connector_manifest.json`

## Further comments

The API base URL is configurable to support the different WildFire cloud regions and on-premise WildFire appliances. File submission/detonation of unknown samples is disabled by default (`submit_unknown`); set it to `true` to allow the connector to upload unknown samples to WildFire for analysis, otherwise it is restricted to hash-based verdict/report lookups only (the issue scopes the first version to verdict-by-hash).

## Maintainer review and fix pass

A follow-up review hardened the connector and addressed the automated review threads:

- WildFire client: `Retry(raise_on_status=False)` so exhausted retries raise a consistent `HTTPError`, and every `requests.RequestException` (retry exhaustion, timeouts, connection errors) is wrapped as `WildfireAPIError` in `_post` and `submit_file`.
- Enrichment markings: the Malware Analysis object derives its markings from the source observable's OpenCTI markings (`enrichment_entity["objectMarking"]`, resolving each TLP to its stix2 MarkingDefinition) and includes the marking objects in the bundle, so enrichment never downgrades the TLP to the default or emits a marking reference that `cleanup_inconsistent_bundle` would strip; it falls back to the OpenCTI TLP:CLEAR statement marking only when the observable carries none.
- Enrichment: the report file type is mapped onto the STIX File `mime_type`; the connector default marking is the OpenCTI TLP:CLEAR statement marking instead of `stix2.TLP_WHITE`.
- Submission default: `submit_unknown` defaults to `false` (opt-in). Submission uploads the sample to a third-party service and issue #6730 scopes the first version to verdict-by-hash only, so it is an explicit opt-in (the feature stays available via `submit_unknown=true`).
- Logging uses the `meta=` keyword for structured context throughout the client and connector.
- README: fixed the TOC anchor; corrected the base-connector table (`CONNECTOR_TYPE` = `INTERNAL_ENRICHMENT`, the `auto` config key, `CONNECTOR_AUTO` default `false`, and the optional flags to match the generated schema); rewrote the Usage section for an internal-enrichment connector; and fixed the Debugging typo and logger example.
- Tests: added assertions for the `mime_type` completion and the source-derived Malware Analysis markings, the non-HTTP error wrapping, and the `submit_unknown` opt-in default.
- Dependencies: `pycti` is pinned to the latest release `7.260701.0` (matching the `connectors-sdk` pin on `master`) and `connectors-sdk` is installed from `master`.

## Community status and manager compatibility pass

A second follow-up pass aligned the connector with the catalog/manager conventions:

- `connector_manifest.json`: `"verified": false` and `"last_verified_date": null` are INTENTIONAL - this is a community-contributed connector, not officially verified by Filigran (same status as other recently merged community connectors). The Connector Verified Linter job reports the VC201 verified-status findings as expected; that job is advisory (`continue-on-error: true`) and does not block the PR. Do not flip `verified` to `true` to silence it.
- `connector_manifest.json`: `"manager_supported": true` (the connector follows the connectors-sdk settings contract and ships the generated config schema), use cases aligned with the official XTM Hub taxonomy (`Malware Analysis and Sandbox`), and `support_version` aligned with the pinned pycti (`>=7.260701.0`).
- Dockerfile: direct `ENTRYPOINT ["python", "main.py"]`, `entrypoint.sh` removed (linter rule VC402).
- `docker-compose.yml`: exact `ChangeMe` placeholders and all defaulted variables commented out (linter rules VC101/VC104).
- Connector: out-of-scope entities now return the original bundle unchanged for playbook triggers and raise for direct enrichment events (linter rule VC319); the storage download URL is built from the configured OpenCTI URL instead of `helper.api.api_url` (linter rule VC505).
- `__metadata__/connector_config_schema.json` and `CONNECTOR_CONFIG_DOC.md` regenerated with the connectors-sdk tooling (no drift from the settings model).
- Local run of `connector-linter`: score 94.9, only the two intentional VC201 verified-status findings remain; 46 unit tests pass, `black` / `isort` / `flake8` clean.

## Status

The branch is based on the latest `master` (clean linear history, all commits signed). All required CI checks are green and there are 0 unresolved review threads. `mergeStateStatus` is BLOCKED only because `reviewDecision` requires an approving review from a maintainer other than the author.
