### PR TITLE
feat(fortisandbox): add FortiSandbox enrichment connector (#6415)

### DIFF
--- a/internal-enrichment/fortisandbox/Dockerfile
+++ b/internal-enrichment/fortisandbox/Dockerfile
@@ -3,17 +3,13 @@ ENV CONNECTOR_TYPE=INTERNAL_ENRICHMENT
 
 # Copy the connector
 COPY src /opt/opencti-connector-fortisandbox
+WORKDIR /opt/opencti-connector-fortisandbox
 
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apk update && apk upgrade && \
-    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
-
-RUN cd /opt/opencti-connector-fortisandbox && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["python", "main.py"]

--- a/internal-enrichment/fortisandbox/Dockerfile
+++ b/internal-enrichment/fortisandbox/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-alpine
+ENV CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+
+# Copy the connector
+COPY src /opt/opencti-connector-fortisandbox
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk update && apk upgrade && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN cd /opt/opencti-connector-fortisandbox && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/internal-enrichment/fortisandbox/README.md
+++ b/internal-enrichment/fortisandbox/README.md
@@ -1,0 +1,193 @@
+# OpenCTI FortiSandbox Connector
+
+The FortiSandbox connector is an **internal-enrichment** connector that enriches
+`StixFile` and `Artifact` observables with Fortinet FortiSandbox verdicts.
+
+For each observable, the connector queries the FortiSandbox JSON-RPC API by hash
+(SHA-256 / SHA-1 / MD5). When FortiSandbox has a rating, the connector:
+
+- maps the FortiSandbox rating (clean, low/medium/high risk, suspicious, malicious) to an
+  OpenCTI score and a `fortisandbox:<rating>` label,
+- adds a `malware:<name>` label when FortiSandbox returns a malware name,
+- completes the file hashes,
+- attaches a STIX Malware Analysis object carrying the FortiSandbox result and an external
+  reference (the FortiSandbox detail URL when available).
+
+Optionally (`submit_unknown`), files carried by the observable can be submitted for
+on-demand analysis and polled for a verdict. The connector is playbook compatible and
+always returns the (enriched) bundle.
+
+Table of Contents
+
+- [OpenCTI FortiSandbox Connector](#opencti-internal-enrichment-connector-fortisandbox)
+  - [Introduction](#introduction)
+  - [Installation](#installation)
+    - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenCTI environment variables](#opencti-environment-variables)
+    - [Base connector environment variables](#base-connector-environment-variables)
+    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
+
+## Introduction
+
+[Fortinet FortiSandbox](https://www.fortinet.com/products/sandbox/fortisandbox) is a
+malware-analysis appliance/VM/cloud that returns verdicts and ratings for files. This
+connector uses the FortiSandbox JSON-RPC API to retrieve the rating for a file observable
+and turns it into OpenCTI knowledge.
+
+## Installation
+
+### Requirements
+
+- Python >= 3.11
+- OpenCTI Platform >= 6.8.13
+- A FortiSandbox instance reachable from the connector, and API credentials
+- [`pycti`](https://pypi.org/project/pycti/) library matching your OpenCTI version
+- [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk) library matching your OpenCTI version
+
+## Configuration variables
+
+There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
+in `config.yml` (for manual deployment).
+
+### OpenCTI environment variables
+
+Below are the parameters you'll need to set for OpenCTI:
+
+| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
+| ------------- | ---------- | --------------------------- | --------- | ---------------------------------------------------- |
+| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
+| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+
+### Base connector environment variables
+
+Below are the parameters you'll need to set for running the connector properly:
+
+| Parameter       | config.yml     | Docker environment variable | Default         | Mandatory | Description                                                                              |
+| --------------- | -------------- | --------------------------- | --------------- | --------- | ---------------------------------------------------------------------------------------- |
+| Connector ID    | id             | `CONNECTOR_ID`              | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
+| Connector Type  | type           | `CONNECTOR_TYPE`            | EXTERNAL_IMPORT | Yes       | Should always be set to `INTERNAL_ENRICHMENT` for this connector.                        |
+| Connector Name  | name           | `CONNECTOR_NAME`            |                 | Yes       | Name of the connector.                                                                   |
+| Connector Scope | scope          | `CONNECTOR_SCOPE`           |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
+| Log Level       | log_level      | `CONNECTOR_LOG_LEVEL`       | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
+| Connector Auto  | connector_auto | `CONNECTOR_AUTO`            | True            | Yes       | Must be `true` or `false` to enable or disable auto-enrichment of observables            |
+
+### Connector extra parameters environment variables
+
+Below are the parameters you'll need to set for the connector:
+
+| Parameter      | config.yml     | Docker environment variable     | Default   | Mandatory | Description                                                                          |
+| -------------- | -------------- | ------------------------------- | --------- | --------- | ----------------------------------------------------------------------------------- |
+| API base URL   | api_base_url   | `FORTISANDBOX_API_BASE_URL`     |           | Yes       | FortiSandbox base URL (appliance/VM/cloud), without the `/jsonrpc` suffix.           |
+| Username       | username       | `FORTISANDBOX_USERNAME`         |           | Yes       | FortiSandbox API username.                                                           |
+| Password       | password       | `FORTISANDBOX_PASSWORD`         |           | Yes       | FortiSandbox API password.                                                           |
+| API version    | api_version    | `FORTISANDBOX_API_VERSION`      | `4.2.4`   | No        | JSON-RPC API version sent with each request.                                         |
+| SSL verify     | ssl_verify     | `FORTISANDBOX_SSL_VERIFY`       | `true`    | No        | Whether to verify the FortiSandbox TLS certificate.                                  |
+| Submit unknown | submit_unknown | `FORTISANDBOX_SUBMIT_UNKNOWN`   | `false`   | No        | Submit unknown files (carried by the observable) for on-demand analysis.             |
+| Max TLP        | max_tlp        | `FORTISANDBOX_MAX_TLP`          | `TLP:AMBER` | No      | Maximum TLP of the observable the connector is allowed to enrich.                    |
+
+## Deployment
+
+### Docker Deployment
+
+Before building the Docker container, you need to set the version of pycti in `requirements.txt` equal to whatever
+version of OpenCTI you're running. Example, `pycti==5.12.20`. If you don't, it will take the latest version, but
+sometimes the OpenCTI SDK fails to initialize.
+
+Build a Docker Image using the provided `Dockerfile`.
+
+Example:
+
+```shell
+# Replace the IMAGE NAME with the appropriate value
+docker build . -t [IMAGE NAME]:latest
+```
+
+Make sure to replace the environment variables in `docker-compose.yml` with the appropriate configurations for your
+environment. Then, start the docker container with the provided docker-compose.yml
+
+```shell
+docker compose up -d
+# -d for detached
+```
+
+### Manual Deployment
+
+Create a file `config.yml` based on the provided `config.yml.sample`.
+
+Replace the configuration variables (especially the "**ChangeMe**" variables) with the appropriate configurations for
+you environment.
+
+Install the required python dependencies (preferably in a virtual environment):
+
+```shell
+pip3 install -r requirements.txt
+```
+
+Then, start the connector from `src` directory:
+
+```shell
+python3 main.py
+```
+
+## Usage
+
+After Installation, the connector should require minimal interaction to use, and should update automatically at a regular interval specified in your `docker-compose.yml` or `config.yml` in `duration_period`.
+
+However, if you would like to force an immediate download of a new batch of entities, navigate to:
+
+`Data management` -> `Ingestion` -> `Connectors` in the OpenCTI platform.
+
+Find the connector, and click on the refresh button to reset the connector's state and force a new
+download of data by re-running the connector.
+
+## Behavior
+
+On each enrichment request the connector:
+
+1. Selects the strongest available hash on the observable (SHA-256 > SHA-1 > MD5) and the
+   matching `ctype`.
+2. Authenticates against the FortiSandbox JSON-RPC API (`/sys/login/user`) and queries
+   `/scan/result/filerating`. If FortiSandbox has no rating (or `Unknown`) and
+   `submit_unknown` is disabled, the original bundle is returned unchanged.
+3. When `submit_unknown` is enabled and the observable carries an uploaded file, the file
+   is submitted (`/alert/ondemand/submit-file`) and the submission is polled
+   (`/scan/result/get-jobs-of-submission`, `/scan/result/job`) for a verdict.
+4. Enriches the observable with an `x_opencti_score`, a `fortisandbox:<rating>` label, a
+   `malware:<name>` label (when available), and the resolved hashes.
+5. Creates a STIX Malware Analysis object (`product = FortiSandbox`) referencing the
+   observable, with the rating mapped to the STIX `malware-result` vocabulary.
+
+FortiSandbox rating mapping:
+
+| FortiSandbox rating       | Label                       | Score | Malware Analysis result |
+| ------------------------- | --------------------------- | ----- | ----------------------- |
+| Clean                     | fortisandbox:clean          | 10    | benign                  |
+| Low Risk                  | fortisandbox:low risk       | 40    | suspicious              |
+| Suspicious / Medium Risk  | fortisandbox:suspicious     | 60    | suspicious              |
+| High Risk                 | fortisandbox:high risk      | 80    | malicious               |
+| Malicious                 | fortisandbox:malicious      | 90    | malicious               |
+
+## Debugging
+
+The connector can be debugged by setting the appropiate log level.
+Note that logging messages can be added using `self.helper.connector_logger,{LOG_LEVEL}("Sample message")`, i.
+e., `self.helper.connector_logger.error("An error message")`.
+
+<!-- Any additional information to help future users debug and report detailed issues concerning this connector -->
+
+## Additional information
+
+<!--
+Any additional information about this connector
+* What information is ingested/updated/changed
+* What should the user take into account when using this connector
+* ...
+-->

--- a/internal-enrichment/fortisandbox/README.md
+++ b/internal-enrichment/fortisandbox/README.md
@@ -21,7 +21,7 @@ always returns the (enriched) bundle.
 
 Table of Contents
 
-- [OpenCTI FortiSandbox Connector](#opencti-internal-enrichment-connector-fortisandbox)
+- [OpenCTI FortiSandbox Connector](#opencti-fortisandbox-connector)
   - [Introduction](#introduction)
   - [Installation](#installation)
     - [Requirements](#requirements)
@@ -49,7 +49,7 @@ and turns it into OpenCTI knowledge.
 ### Requirements
 
 - Python >= 3.11
-- OpenCTI Platform >= 6.8.13
+- OpenCTI Platform >= 6.8.12
 - A FortiSandbox instance reachable from the connector, and API credentials
 - [`pycti`](https://pypi.org/project/pycti/) library matching your OpenCTI version
 - [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk) library matching your OpenCTI version
@@ -185,8 +185,7 @@ FortiSandbox rating mapping:
 ## Debugging
 
 The connector can be debugged by setting the appropriate log level.
-Note that logging messages can be added using `self.helper.connector_logger,{LOG_LEVEL}("Sample message")`, i.
-e., `self.helper.connector_logger.error("An error message")`.
+Note that logging messages can be added using `self.helper.connector_logger.{LOG_LEVEL}("Sample message")`, i.e., `self.helper.connector_logger.error("An error message")`.
 
 <!-- Any additional information to help future users debug and report detailed issues concerning this connector -->
 

--- a/internal-enrichment/fortisandbox/README.md
+++ b/internal-enrichment/fortisandbox/README.md
@@ -49,7 +49,7 @@ and turns it into OpenCTI knowledge.
 ### Requirements
 
 - Python >= 3.11
-- OpenCTI Platform >= 6.8.12
+- OpenCTI Platform >= 7.260701.0
 - A FortiSandbox instance reachable from the connector, and API credentials
 - [`pycti`](https://pypi.org/project/pycti/) library matching your OpenCTI version
 - [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk) library matching your OpenCTI version
@@ -102,7 +102,7 @@ Below are the parameters you'll need to set for the connector:
 ### Docker Deployment
 
 Before building the Docker container, you need to set the version of pycti in `requirements.txt` equal to whatever
-version of OpenCTI you're running. Example, `pycti==5.12.20`. If you don't, it will take the latest version, but
+version of OpenCTI you're running. Example, `pycti==7.260701.0`. If you don't, it will take the latest version, but
 sometimes the OpenCTI SDK fails to initialize.
 
 Build a Docker Image using the provided `Dockerfile`.
@@ -143,14 +143,10 @@ python3 main.py
 
 ## Usage
 
-After Installation, the connector should require minimal interaction to use, and should update automatically at a regular interval specified in your `docker-compose.yml` or `config.yml` in `duration_period`.
-
-However, if you would like to force an immediate download of a new batch of entities, navigate to:
-
-`Data management` -> `Ingestion` -> `Connectors` in the OpenCTI platform.
-
-Find the connector, and click on the refresh button to reset the connector's state and force a new
-download of data by re-running the connector.
+The connector is an internal-enrichment connector: it runs on demand. Open a `StixFile` or
+`Artifact` observable in the OpenCTI platform and trigger the enrichment from the
+`Enrichment` panel (or let it run automatically when `CONNECTOR_AUTO` is enabled). The
+connector is also playbook compatible and can be used as an enrichment step in playbooks.
 
 ## Behavior
 

--- a/internal-enrichment/fortisandbox/README.md
+++ b/internal-enrichment/fortisandbox/README.md
@@ -13,8 +13,10 @@ For each observable, the connector queries the FortiSandbox JSON-RPC API by hash
 - attaches a STIX Malware Analysis object carrying the FortiSandbox result and an external
   reference (the FortiSandbox detail URL when available).
 
-Optionally (`submit_unknown`), files carried by the observable can be submitted for
-on-demand analysis and polled for a verdict. The connector is playbook compatible and
+When no verdict exists yet, the connector submits the file carried by the observable for
+on-demand analysis and polls for a verdict (enabled by default via `submit_unknown`; file
+downloads enforce `max_file_size` and reject empty files). This is the primary path for
+`Artifact` observables uploaded to OpenCTI. The connector is playbook compatible and
 always returns the (enriched) bundle.
 
 Table of Contents
@@ -90,7 +92,9 @@ Below are the parameters you'll need to set for the connector:
 | Password       | password       | `FORTISANDBOX_PASSWORD`         |           | Yes       | FortiSandbox API password.                                                           |
 | API version    | api_version    | `FORTISANDBOX_API_VERSION`      | `4.2.4`   | No        | JSON-RPC API version sent with each request.                                         |
 | SSL verify     | ssl_verify     | `FORTISANDBOX_SSL_VERIFY`       | `true`    | No        | Whether to verify the FortiSandbox TLS certificate.                                  |
-| Submit unknown | submit_unknown | `FORTISANDBOX_SUBMIT_UNKNOWN`   | `false`   | No        | Submit unknown files (carried by the observable) for on-demand analysis.             |
+| Submit unknown | submit_unknown | `FORTISANDBOX_SUBMIT_UNKNOWN`   | `true`    | No        | Submit unknown files (carried by the observable) for on-demand analysis.             |
+| Max file size  | max_file_size  | `FORTISANDBOX_MAX_FILE_SIZE`    | `33554432` | No       | Max size (bytes) of a file the connector downloads from OpenCTI and submits (32 MiB).|
+| Submission timeout | submission_timeout | `FORTISANDBOX_SUBMISSION_TIMEOUT` | `600` | No   | Max time (seconds) to wait for a submitted file's verdict.                           |
 | Max TLP        | max_tlp        | `FORTISANDBOX_MAX_TLP`          | `TLP:AMBER` | No      | Maximum TLP of the observable the connector is allowed to enrich.                    |
 
 ## Deployment
@@ -157,9 +161,12 @@ On each enrichment request the connector:
 2. Authenticates against the FortiSandbox JSON-RPC API (`/sys/login/user`) and queries
    `/scan/result/filerating`. If FortiSandbox has no rating (or `Unknown`) and
    `submit_unknown` is disabled, the original bundle is returned unchanged.
-3. When `submit_unknown` is enabled and the observable carries an uploaded file, the file
-   is submitted (`/alert/ondemand/submit-file`) and the submission is polled
-   (`/scan/result/get-jobs-of-submission`, `/scan/result/job`) for a verdict.
+3. When `submit_unknown` is enabled (default) and the observable carries an uploaded file,
+   the connector downloads the file from OpenCTI storage (enforcing `max_file_size` and
+   rejecting empty files), submits it (`/alert/ondemand/submit-file`) and polls the
+   submission (`/scan/result/get-jobs-of-submission`, `/scan/result/job`) for a verdict
+   (bounded by `submission_timeout`). This is the primary path for `Artifact` observables
+   uploaded to OpenCTI.
 4. Enriches the observable with an `x_opencti_score`, a `fortisandbox:<rating>` label, a
    `malware:<name>` label (when available), and the resolved hashes.
 5. Creates a STIX Malware Analysis object (`product = FortiSandbox`) referencing the
@@ -177,7 +184,7 @@ FortiSandbox rating mapping:
 
 ## Debugging
 
-The connector can be debugged by setting the appropiate log level.
+The connector can be debugged by setting the appropriate log level.
 Note that logging messages can be added using `self.helper.connector_logger,{LOG_LEVEL}("Sample message")`, i.
 e., `self.helper.connector_logger.error("An error message")`.
 

--- a/internal-enrichment/fortisandbox/README.md
+++ b/internal-enrichment/fortisandbox/README.md
@@ -75,11 +75,11 @@ Below are the parameters you'll need to set for running the connector properly:
 | Parameter       | config.yml     | Docker environment variable | Default         | Mandatory | Description                                                                              |
 | --------------- | -------------- | --------------------------- | --------------- | --------- | ---------------------------------------------------------------------------------------- |
 | Connector ID    | id             | `CONNECTOR_ID`              | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
-| Connector Type  | type           | `CONNECTOR_TYPE`            | EXTERNAL_IMPORT | Yes       | Should always be set to `INTERNAL_ENRICHMENT` for this connector.                        |
+| Connector Type  | type           | `CONNECTOR_TYPE`            | INTERNAL_ENRICHMENT | Yes       | Should always be set to `INTERNAL_ENRICHMENT` for this connector.                        |
 | Connector Name  | name           | `CONNECTOR_NAME`            |                 | Yes       | Name of the connector.                                                                   |
 | Connector Scope | scope          | `CONNECTOR_SCOPE`           |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
-| Log Level       | log_level      | `CONNECTOR_LOG_LEVEL`       | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
-| Connector Auto  | connector_auto | `CONNECTOR_AUTO`            | True            | Yes       | Must be `true` or `false` to enable or disable auto-enrichment of observables            |
+| Log Level       | log_level      | `CONNECTOR_LOG_LEVEL`       | error           | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
+| Connector Auto  | auto           | `CONNECTOR_AUTO`            | false           | Yes       | Must be `true` or `false` to enable or disable auto-enrichment of observables            |
 
 ### Connector extra parameters environment variables
 

--- a/internal-enrichment/fortisandbox/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/fortisandbox/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -18,5 +18,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |
 | FORTISANDBOX_API_VERSION | `string` |  | string | `"4.2.4"` | FortiSandbox JSON-RPC API version sent with every request. |
 | FORTISANDBOX_SSL_VERIFY | `boolean` |  | boolean | `true` | Whether to verify the FortiSandbox TLS certificate. |
-| FORTISANDBOX_SUBMIT_UNKNOWN | `boolean` |  | boolean | `false` | Submit unknown files for on-demand analysis when no verdict exists yet (requires the observable to carry an uploaded file). |
+| FORTISANDBOX_SUBMIT_UNKNOWN | `boolean` |  | boolean | `true` | Submit unknown files for on-demand analysis when no verdict exists yet (requires the observable to carry an uploaded file). Enabled by default so Artifacts uploaded to OpenCTI are detonated in FortiSandbox. |
+| FORTISANDBOX_MAX_FILE_SIZE | `integer` |  | integer | `33554432` | Maximum size (in bytes) of a file the connector will download from OpenCTI and submit to FortiSandbox. |
+| FORTISANDBOX_SUBMISSION_TIMEOUT | `integer` |  | integer | `600` | Maximum time (in seconds) to wait for a submitted file's verdict before giving up. |
 | FORTISANDBOX_MAX_TLP | `string` |  | `TLP:CLEAR` `TLP:WHITE` `TLP:GREEN` `TLP:AMBER` `TLP:AMBER+STRICT` `TLP:RED` | `"TLP:AMBER"` | Maximum TLP of the observable the connector is allowed to enrich. |

--- a/internal-enrichment/fortisandbox/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/fortisandbox/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,22 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| FORTISANDBOX_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | FortiSandbox base URL (appliance, VM or cloud), without the /jsonrpc suffix. |
+| FORTISANDBOX_USERNAME | `string` | ✅ | string |  | FortiSandbox API username. |
+| FORTISANDBOX_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | FortiSandbox API password. |
+| CONNECTOR_NAME | `string` |  | string | `"FortiSandbox"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["StixFile", "Artifact"]` | The scope of the connector (observable types to enrich). |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `INTERNAL_ENRICHMENT` | `"INTERNAL_ENRICHMENT"` |  |
+| CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |
+| FORTISANDBOX_API_VERSION | `string` |  | string | `"4.2.4"` | FortiSandbox JSON-RPC API version sent with every request. |
+| FORTISANDBOX_SSL_VERIFY | `boolean` |  | boolean | `true` | Whether to verify the FortiSandbox TLS certificate. |
+| FORTISANDBOX_SUBMIT_UNKNOWN | `boolean` |  | boolean | `false` | Submit unknown files for on-demand analysis when no verdict exists yet (requires the observable to carry an uploaded file). |
+| FORTISANDBOX_MAX_TLP | `string` |  | `TLP:CLEAR` `TLP:WHITE` `TLP:GREEN` `TLP:AMBER` `TLP:AMBER+STRICT` `TLP:RED` | `"TLP:AMBER"` | Maximum TLP of the observable the connector is allowed to enrich. |

--- a/internal-enrichment/fortisandbox/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/fortisandbox/__metadata__/connector_config_schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/fortisandbox_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "FortiSandbox",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "StixFile",
+        "Artifact"
+      ],
+      "description": "The scope of the connector (observable types to enrich).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Whether the connector should run automatically when an entity is created or updated.",
+      "type": "boolean"
+    },
+    "FORTISANDBOX_API_BASE_URL": {
+      "description": "FortiSandbox base URL (appliance, VM or cloud), without the /jsonrpc suffix.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "FORTISANDBOX_USERNAME": {
+      "description": "FortiSandbox API username.",
+      "type": "string"
+    },
+    "FORTISANDBOX_PASSWORD": {
+      "description": "FortiSandbox API password.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "FORTISANDBOX_API_VERSION": {
+      "default": "4.2.4",
+      "description": "FortiSandbox JSON-RPC API version sent with every request.",
+      "type": "string"
+    },
+    "FORTISANDBOX_SSL_VERIFY": {
+      "default": true,
+      "description": "Whether to verify the FortiSandbox TLS certificate.",
+      "type": "boolean"
+    },
+    "FORTISANDBOX_SUBMIT_UNKNOWN": {
+      "default": false,
+      "description": "Submit unknown files for on-demand analysis when no verdict exists yet (requires the observable to carry an uploaded file).",
+      "type": "boolean"
+    },
+    "FORTISANDBOX_MAX_TLP": {
+      "default": "TLP:AMBER",
+      "description": "Maximum TLP of the observable the connector is allowed to enrich.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "FORTISANDBOX_API_BASE_URL",
+    "FORTISANDBOX_USERNAME",
+    "FORTISANDBOX_PASSWORD"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/fortisandbox/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/fortisandbox/__metadata__/connector_config_schema.json
@@ -80,9 +80,19 @@
       "type": "boolean"
     },
     "FORTISANDBOX_SUBMIT_UNKNOWN": {
-      "default": false,
-      "description": "Submit unknown files for on-demand analysis when no verdict exists yet (requires the observable to carry an uploaded file).",
+      "default": true,
+      "description": "Submit unknown files for on-demand analysis when no verdict exists yet (requires the observable to carry an uploaded file). Enabled by default so Artifacts uploaded to OpenCTI are detonated in FortiSandbox.",
       "type": "boolean"
+    },
+    "FORTISANDBOX_MAX_FILE_SIZE": {
+      "default": 33554432,
+      "description": "Maximum size (in bytes) of a file the connector will download from OpenCTI and submit to FortiSandbox.",
+      "type": "integer"
+    },
+    "FORTISANDBOX_SUBMISSION_TIMEOUT": {
+      "default": 600,
+      "description": "Maximum time (in seconds) to wait for a submitted file's verdict before giving up.",
+      "type": "integer"
     },
     "FORTISANDBOX_MAX_TLP": {
       "default": "TLP:AMBER",

--- a/internal-enrichment/fortisandbox/__metadata__/connector_manifest.json
+++ b/internal-enrichment/fortisandbox/__metadata__/connector_manifest.json
@@ -6,17 +6,16 @@
   "logo": null,
   "use_cases": [
     "Enrichment & Analysis",
-    "Malware Analysis",
-    "Sandbox"
+    "Malware Analysis and Sandbox"
   ],
-  "verified": true,
+  "verified": false,
   "last_verified_date": null,
   "playbook_supported": true,
   "max_confidence_level": 60,
-  "support_version": ">=6.8.12",
+  "support_version": ">=7.260701.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/fortisandbox",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-fortisandbox",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-enrichment/fortisandbox/__metadata__/connector_manifest.json
+++ b/internal-enrichment/fortisandbox/__metadata__/connector_manifest.json
@@ -1,0 +1,23 @@
+{
+  "title": "FortiSandbox",
+  "slug": "fortisandbox",
+  "description": "The OpenCTI FortiSandbox enrichment connector enriches StixFile and Artifact observables with Fortinet FortiSandbox verdicts. For each observable it queries the FortiSandbox JSON-RPC API by hash (SHA-256/SHA-1/MD5), maps the rating (clean, low/medium/high risk, suspicious, malicious) to an OpenCTI score and labels, completes the file hashes, and attaches a STIX Malware Analysis object with the FortiSandbox result. When enabled, unknown files carried by the observable can be submitted for on-demand analysis and polled for a verdict. The connector is playbook compatible and always returns the enriched bundle.",
+  "short_description": "Enrich StixFile and Artifact observables with Fortinet FortiSandbox verdicts.",
+  "logo": null,
+  "use_cases": [
+    "Enrichment & Analysis",
+    "Malware Analysis",
+    "Sandbox"
+  ],
+  "verified": true,
+  "last_verified_date": null,
+  "playbook_supported": true,
+  "max_confidence_level": 60,
+  "support_version": ">=6.8.12",
+  "subscription_link": null,
+  "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/fortisandbox",
+  "manager_supported": false,
+  "container_version": "rolling",
+  "container_image": "opencti/connector-fortisandbox",
+  "container_type": "INTERNAL_ENRICHMENT"
+}

--- a/internal-enrichment/fortisandbox/config.yml.sample
+++ b/internal-enrichment/fortisandbox/config.yml.sample
@@ -11,7 +11,7 @@ connector:
   auto: false # optional, enable/disable auto-enrichment of OpenCTI entities (default: false)
 
 fortisandbox:
-  api_base_url: 'https://fortisandbox.local' # FortiSandbox base URL (without the /jsonrpc suffix)
+  api_base_url: 'ChangeMe' # FortiSandbox base URL (without the /jsonrpc suffix), e.g. 'https://fortisandbox.local'
   username: 'ChangeMe'
   password: 'ChangeMe'
   api_version: '4.2.4' # optional, JSON-RPC API version (default: '4.2.4')

--- a/internal-enrichment/fortisandbox/config.yml.sample
+++ b/internal-enrichment/fortisandbox/config.yml.sample
@@ -1,0 +1,20 @@
+opencti:
+  url: 'http://localhost'
+  token: 'ChangeMe'
+
+connector:
+  type: 'INTERNAL_ENRICHMENT'
+  id: 'ChangeMe'
+  name: 'FortiSandbox' # optional (default: 'FortiSandbox')
+  scope: 'StixFile,Artifact' # optional (default: 'StixFile,Artifact')
+  log_level: 'error' # optional (default: 'error')
+  auto: false # optional, enable/disable auto-enrichment of OpenCTI entities (default: false)
+
+fortisandbox:
+  api_base_url: 'https://fortisandbox.local' # FortiSandbox base URL (without the /jsonrpc suffix)
+  username: 'ChangeMe'
+  password: 'ChangeMe'
+  api_version: '4.2.4' # optional, JSON-RPC API version (default: '4.2.4')
+  ssl_verify: true # optional (default: true)
+  submit_unknown: false # optional, submit unknown files for on-demand analysis (default: false)
+  max_tlp: 'TLP:AMBER' # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')

--- a/internal-enrichment/fortisandbox/config.yml.sample
+++ b/internal-enrichment/fortisandbox/config.yml.sample
@@ -16,5 +16,7 @@ fortisandbox:
   password: 'ChangeMe'
   api_version: '4.2.4' # optional, JSON-RPC API version (default: '4.2.4')
   ssl_verify: true # optional (default: true)
-  submit_unknown: false # optional, submit unknown files for on-demand analysis (default: false)
+  submit_unknown: true # optional, submit unknown files (carried by the observable) for on-demand analysis (default: true)
+  max_file_size: 33554432 # optional, max size in bytes of a file to download/submit (default: 33554432 = 32 MiB)
+  submission_timeout: 600 # optional, max seconds to wait for a submitted file verdict (default: 600)
   max_tlp: 'TLP:AMBER' # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')

--- a/internal-enrichment/fortisandbox/docker-compose.yml
+++ b/internal-enrichment/fortisandbox/docker-compose.yml
@@ -5,21 +5,21 @@ services:
     environment:
       # Generic parameters (connection with OpenCTI)
       - OPENCTI_URL=http://localhost
-      - OPENCTI_TOKEN=CHANGEME
+      - OPENCTI_TOKEN=ChangeMe
       # Common parameters for connectors of type INTERNAL_ENRICHMENT
-      - CONNECTOR_ID=CHANGEME
-      - CONNECTOR_NAME=FortiSandbox # optional (default: 'FortiSandbox')
-      - CONNECTOR_SCOPE=StixFile,Artifact # optional (default: 'StixFile,Artifact')
-      - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
-      - CONNECTOR_AUTO=false # optional (default: false)
+      - CONNECTOR_ID=ChangeMe
+      # - CONNECTOR_NAME=FortiSandbox # optional (default: 'FortiSandbox')
+      # - CONNECTOR_SCOPE=StixFile,Artifact # optional (default: 'StixFile,Artifact')
+      # - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
+      # - CONNECTOR_AUTO=false # optional (default: false)
       # Custom parameters for connector-fortisandbox
-      - FORTISANDBOX_API_BASE_URL=https://fortisandbox.local # FortiSandbox base URL (without /jsonrpc)
-      - FORTISANDBOX_USERNAME=CHANGEME
-      - FORTISANDBOX_PASSWORD=CHANGEME
-      - FORTISANDBOX_API_VERSION=4.2.4 # optional (default: '4.2.4')
-      - FORTISANDBOX_SSL_VERIFY=true # optional (default: true)
-      - FORTISANDBOX_SUBMIT_UNKNOWN=true # optional, submit unknown files for analysis (default: true)
-      - FORTISANDBOX_MAX_FILE_SIZE=33554432 # optional, max bytes to download/submit (default: 33554432 = 32 MiB)
-      - FORTISANDBOX_SUBMISSION_TIMEOUT=600 # optional, max seconds to wait for a submitted file verdict (default: 600)
-      - FORTISANDBOX_MAX_TLP=TLP:AMBER # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')
+      - FORTISANDBOX_API_BASE_URL=ChangeMe # FortiSandbox base URL (without /jsonrpc), e.g. https://fortisandbox.local
+      - FORTISANDBOX_USERNAME=ChangeMe
+      - FORTISANDBOX_PASSWORD=ChangeMe
+      # - FORTISANDBOX_API_VERSION=4.2.4 # optional (default: '4.2.4')
+      # - FORTISANDBOX_SSL_VERIFY=true # optional (default: true)
+      # - FORTISANDBOX_SUBMIT_UNKNOWN=true # optional, submit unknown files for analysis (default: true)
+      # - FORTISANDBOX_MAX_FILE_SIZE=33554432 # optional, max bytes to download/submit (default: 33554432 = 32 MiB)
+      # - FORTISANDBOX_SUBMISSION_TIMEOUT=600 # optional, max seconds to wait for a submitted file verdict (default: 600)
+      # - FORTISANDBOX_MAX_TLP=TLP:AMBER # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')
     restart: always

--- a/internal-enrichment/fortisandbox/docker-compose.yml
+++ b/internal-enrichment/fortisandbox/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  connector-fortisandbox:
+    image: opencti/connector-fortisandbox:latest # 'fortisandbox' being the name of connector's directory
+    environment:
+      # Generic parameters (connection with OpenCTI)
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=CHANGEME
+      # Common parameters for connectors of type INTERNAL_ENRICHMENT
+      - CONNECTOR_ID=CHANGEME
+      - CONNECTOR_NAME=FortiSandbox # optional (default: 'FortiSandbox')
+      - CONNECTOR_SCOPE=StixFile,Artifact # optional (default: 'StixFile,Artifact')
+      - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
+      - CONNECTOR_AUTO=false # optional (default: false)
+      # Custom parameters for connector-fortisandbox
+      - FORTISANDBOX_API_BASE_URL=https://fortisandbox.local # FortiSandbox base URL (without /jsonrpc)
+      - FORTISANDBOX_USERNAME=CHANGEME
+      - FORTISANDBOX_PASSWORD=CHANGEME
+      - FORTISANDBOX_API_VERSION=4.2.4 # optional (default: '4.2.4')
+      - FORTISANDBOX_SSL_VERIFY=true # optional (default: true)
+      - FORTISANDBOX_SUBMIT_UNKNOWN=false # optional, submit unknown files for analysis (default: false)
+      - FORTISANDBOX_MAX_TLP=TLP:AMBER # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')
+    restart: always

--- a/internal-enrichment/fortisandbox/docker-compose.yml
+++ b/internal-enrichment/fortisandbox/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - FORTISANDBOX_PASSWORD=CHANGEME
       - FORTISANDBOX_API_VERSION=4.2.4 # optional (default: '4.2.4')
       - FORTISANDBOX_SSL_VERIFY=true # optional (default: true)
-      - FORTISANDBOX_SUBMIT_UNKNOWN=false # optional, submit unknown files for analysis (default: false)
+      - FORTISANDBOX_SUBMIT_UNKNOWN=true # optional, submit unknown files for analysis (default: true)
+      - FORTISANDBOX_MAX_FILE_SIZE=33554432 # optional, max bytes to download/submit (default: 33554432 = 32 MiB)
+      - FORTISANDBOX_SUBMISSION_TIMEOUT=600 # optional, max seconds to wait for a submitted file verdict (default: 600)
       - FORTISANDBOX_MAX_TLP=TLP:AMBER # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:AMBER')
     restart: always

--- a/internal-enrichment/fortisandbox/entrypoint.sh
+++ b/internal-enrichment/fortisandbox/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-fortisandbox
-
-# Launch the worker
-python3 main.py

--- a/internal-enrichment/fortisandbox/entrypoint.sh
+++ b/internal-enrichment/fortisandbox/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Go to the right directory
+cd /opt/opencti-connector-fortisandbox
+
+# Launch the worker
+python3 main.py

--- a/internal-enrichment/fortisandbox/src/connector/__init__.py
+++ b/internal-enrichment/fortisandbox/src/connector/__init__.py
@@ -1,0 +1,7 @@
+from connector.connector import FortisandboxConnector
+from connector.settings import ConnectorSettings
+
+__all__ = [
+    "FortisandboxConnector",
+    "ConnectorSettings",
+]

--- a/internal-enrichment/fortisandbox/src/connector/connector.py
+++ b/internal-enrichment/fortisandbox/src/connector/connector.py
@@ -1,0 +1,247 @@
+from copy import deepcopy
+from datetime import datetime, timezone
+from urllib.parse import urljoin
+
+import stix2
+from connector.settings import ConnectorSettings
+from fortisandbox_client import FortiSandboxAPIError, FortisandboxClient
+from pycti import Identity, MalwareAnalysis, OpenCTIConnectorHelper
+
+# FortiSandbox rating -> OpenCTI score (0-100).
+_RATING_SCORES = {
+    "malicious": 90,
+    "high risk": 80,
+    "medium risk": 60,
+    "suspicious": 60,
+    "low risk": 40,
+    "clean": 10,
+}
+
+# FortiSandbox rating -> STIX malware-analysis result (malware-result-ov).
+_RATING_RESULTS = {
+    "malicious": "malicious",
+    "high risk": "malicious",
+    "medium risk": "suspicious",
+    "suspicious": "suspicious",
+    "low risk": "suspicious",
+    "clean": "benign",
+}
+
+
+class FortisandboxConnector:
+    """
+    Internal-enrichment connector that enriches file observables with FortiSandbox
+    ratings (and, optionally, submits unknown files for on-demand analysis).
+    """
+
+    def __init__(self, config: ConnectorSettings, helper: OpenCTIConnectorHelper):
+        self.config = config
+        self.helper = helper
+
+        self.client = FortisandboxClient(
+            helper,
+            api_base_url=self.config.fortisandbox.api_base_url,
+            username=self.config.fortisandbox.username,
+            password=self.config.fortisandbox.password.get_secret_value(),
+            api_version=self.config.fortisandbox.api_version,
+            ssl_verify=self.config.fortisandbox.ssl_verify,
+        )
+        self.max_tlp = self.config.fortisandbox.max_tlp
+
+        self.identity = stix2.Identity(
+            id=Identity.generate_id(name="FortiSandbox", identity_class="organization"),
+            name="FortiSandbox",
+            identity_class="organization",
+            description="File verdicts from Fortinet FortiSandbox.",
+        )
+        self.tlp = stix2.TLP_WHITE
+        self.stix_objects: list = []
+
+    @staticmethod
+    def _extract_hash(opencti_entity: dict):
+        by_algo = {}
+        for entry in opencti_entity.get("hashes", []) or []:
+            algo = entry.get("algorithm")
+            if algo:
+                by_algo[algo] = entry.get("hash")
+        if by_algo.get("SHA-256"):
+            return by_algo["SHA-256"], "sha256"
+        if by_algo.get("SHA-1"):
+            return by_algo["SHA-1"], "sha1"
+        if by_algo.get("MD5"):
+            return by_algo["MD5"], "md5"
+        return None, None
+
+    def _search_hash(self, opencti_entity: dict):
+        file_hash, ctype = self._extract_hash(opencti_entity)
+        if not file_hash:
+            self.helper.connector_logger.info("No usable hash on the observable.")
+            return None
+        data = self.client.get_file_rating(file_hash, ctype=ctype)
+        if not data:
+            return None
+        rating = str(data.get("rating") or "").strip()
+        if not rating or rating.lower() == "unknown":
+            return None
+        return data
+
+    def _submit(self, opencti_entity: dict):
+        import_files = opencti_entity.get("importFiles") or []
+        if not import_files:
+            return None
+        file_uri = import_files[0]["id"]
+        file_name = import_files[0].get("name", "artifact")
+        file_url = urljoin(str(self.config.opencti.url), f"storage/get/{file_uri}")
+        content = self.helper.api.fetch_opencti_file(file_url, True)
+        sid = self.client.submit_file(file_name, content)
+        if not sid:
+            return None
+        self.helper.connector_logger.info(
+            "Submitted file to FortiSandbox, waiting for verdict.", {"sid": sid}
+        )
+        return self.client.get_submission_verdict(sid)
+
+    def _create_knowledge(
+        self, stix_entity: dict, opencti_entity: dict, data: dict
+    ) -> list:
+        rating = str(data.get("rating") or "").strip()
+        key = rating.lower()
+        score = _RATING_SCORES.get(key)
+
+        enriched_entity = deepcopy(stix_entity)
+        enriched_objects = [
+            enriched_entity if obj["id"] == enriched_entity["id"] else obj
+            for obj in self.stix_objects
+        ]
+
+        if opencti_entity["entity_type"] in ["StixFile", "Artifact"]:
+            hashes = enriched_entity.get("hashes", {})
+            if data.get("sha256"):
+                hashes["SHA-256"] = data["sha256"]
+            if data.get("sha1"):
+                hashes["SHA-1"] = data["sha1"]
+            if data.get("md5"):
+                hashes["MD5"] = data["md5"]
+            if hashes:
+                enriched_entity["hashes"] = hashes
+
+        if score is not None:
+            enriched_entity["x_opencti_score"] = score
+
+        labels = enriched_entity.get("labels") or []
+        rating_label = f"fortisandbox:{key}" if key else "fortisandbox:unknown"
+        if rating_label not in labels:
+            labels.append(rating_label)
+        if data.get("malware_name"):
+            malware_label = f"malware:{data['malware_name']}"
+            if malware_label not in labels:
+                labels.append(malware_label)
+        enriched_entity["labels"] = labels
+
+        result_name = "FortiSandbox " + (
+            data.get("sha256") or opencti_entity.get("observable_value", "")
+        )
+        if data.get("detail_url"):
+            external_reference = stix2.ExternalReference(
+                source_name="FortiSandbox",
+                url=data["detail_url"],
+                description=f"FortiSandbox rating: {rating}",
+            )
+        elif data.get("sha256"):
+            external_reference = stix2.ExternalReference(
+                source_name="FortiSandbox",
+                external_id=data["sha256"],
+                description=f"FortiSandbox rating: {rating}",
+            )
+        else:
+            external_reference = stix2.ExternalReference(
+                source_name="FortiSandbox",
+                description=f"FortiSandbox rating: {rating}",
+            )
+
+        malware_analysis = stix2.MalwareAnalysis(
+            id=MalwareAnalysis.generate_id(result_name, "FortiSandbox"),
+            product="FortiSandbox",
+            result_name=result_name,
+            analysis_started=datetime.now(tz=timezone.utc),
+            submitted=datetime.now(tz=timezone.utc),
+            result=_RATING_RESULTS.get(key, "unknown"),
+            sample_ref=enriched_entity["id"],
+            created_by_ref=self.identity.id,
+            external_references=[external_reference],
+        )
+        enriched_objects.append(malware_analysis)
+
+        return [self.identity, self.tlp] + enriched_objects
+
+    def _process_observable(self, stix_entity: dict, opencti_entity: dict):
+        self.helper.connector_logger.info(
+            "Processing the observable",
+            {
+                "observable_type": opencti_entity["entity_type"],
+                "observable_value": opencti_entity.get("observable_value"),
+            },
+        )
+        if opencti_entity["entity_type"] not in ["StixFile", "Artifact"]:
+            return None
+
+        data = self._search_hash(opencti_entity)
+        if data is None and self.config.fortisandbox.submit_unknown:
+            data = self._submit(opencti_entity)
+        if not data:
+            return None
+        return self._create_knowledge(stix_entity, opencti_entity, data)
+
+    def _send_bundle(self, stix_objects: list) -> list:
+        if len(stix_objects) == 0:
+            return []
+        bundle = self.helper.stix2_create_bundle(stix_objects)
+        return self.helper.send_stix2_bundle(bundle, cleanup_inconsistent_bundle=True)
+
+    def _process_message(self, data: dict) -> str:
+        stix_objects = data["stix_objects"]
+        stix_entity = data["stix_entity"]
+        opencti_entity = data["enrichment_entity"]
+
+        self.stix_objects = stix_objects
+        original_stix_objects = deepcopy(stix_objects)
+
+        tlp = "TLP:CLEAR"
+        for marking_definition in opencti_entity["objectMarking"]:
+            if marking_definition["definition_type"] == "TLP":
+                tlp = marking_definition["definition"]
+
+        try:
+            if not OpenCTIConnectorHelper.check_max_tlp(tlp, self.max_tlp):
+                self._send_bundle(original_stix_objects)
+                message = "Do not send any data, TLP of the observable is greater than MAX TLP"
+                self.helper.connector_logger.info(f"[CONNECTOR] {message}")
+                return message
+
+            enriched_objects = self._process_observable(stix_entity, opencti_entity)
+            if enriched_objects:
+                bundles_sent = self._send_bundle(enriched_objects)
+                message = f"Sent {len(bundles_sent)} stix bundle(s) for worker import"
+                self.helper.connector_logger.info(message)
+                return message
+
+            message = "No FortiSandbox verdict found for the observable"
+            self.helper.connector_logger.info(message)
+            self._send_bundle(original_stix_objects)
+            return message
+
+        except FortiSandboxAPIError as err:
+            self.helper.connector_logger.error(
+                f"[CONNECTOR] {err.__class__.__name__}: {str(err)}"
+            )
+            self._send_bundle(original_stix_objects)
+            raise
+        except Exception as err:
+            self.helper.connector_logger.error(
+                "[CONNECTOR] An unexpected error occurred", {"error": str(err)}
+            )
+            self._send_bundle(original_stix_objects)
+            raise
+
+    def run(self) -> None:
+        self.helper.listen(message_callback=self._process_message)

--- a/internal-enrichment/fortisandbox/src/connector/connector.py
+++ b/internal-enrichment/fortisandbox/src/connector/connector.py
@@ -32,18 +32,31 @@ _RATING_RESULTS = {
 }
 
 
-def _tlp_clear() -> stix2.MarkingDefinition:
-    # OpenCTI models TLP:CLEAR as a custom statement marking, not as the legacy STIX
-    # TLP:WHITE; using TLP_WHITE would emit the wrong marking in the bundle.
+def _custom_tlp(definition: str) -> stix2.MarkingDefinition:
+    # OpenCTI models TLP:CLEAR and TLP:AMBER+STRICT as custom statement markings,
+    # not as the legacy STIX markings. The x_opencti_* fields require
+    # allow_custom=True (matching connectors-sdk's TLPMarking.to_stix2_object).
     return stix2.MarkingDefinition(
-        id=MarkingDefinition.generate_id("TLP", "TLP:CLEAR"),
+        id=MarkingDefinition.generate_id("TLP", definition),
         definition_type="statement",
         definition={"statement": "custom"},
-        custom_properties={
-            "x_opencti_definition_type": "TLP",
-            "x_opencti_definition": "TLP:CLEAR",
-        },
+        allow_custom=True,
+        x_opencti_definition_type="TLP",
+        x_opencti_definition=definition,
     )
+
+
+def _tlp_clear() -> stix2.MarkingDefinition:
+    return _custom_tlp("TLP:CLEAR")
+
+
+# Plain STIX markings cover these levels; CLEAR / AMBER+STRICT are custom (above).
+_STIX_TLP_MARKINGS = {
+    "TLP:WHITE": stix2.TLP_WHITE,
+    "TLP:GREEN": stix2.TLP_GREEN,
+    "TLP:AMBER": stix2.TLP_AMBER,
+    "TLP:RED": stix2.TLP_RED,
+}
 
 
 class FortisandboxConnector:
@@ -75,6 +88,28 @@ class FortisandboxConnector:
         )
         self.tlp = _tlp_clear()
         self.stix_objects: list = []
+
+    def _marking_for(self, definition: str) -> stix2.MarkingDefinition:
+        """Resolve a TLP definition string to its STIX marking object."""
+        if definition == "TLP:CLEAR":
+            return self.tlp
+        if definition == "TLP:AMBER+STRICT":
+            return _custom_tlp("TLP:AMBER+STRICT")
+        return _STIX_TLP_MARKINGS.get(definition, self.tlp)
+
+    def _observable_markings(self, opencti_entity: dict) -> list:
+        """
+        Return the source observable's markings so the enrichment inherits them
+        instead of downgrading to the connector default. OpenCTI enrichment
+        payloads expose markings on ``objectMarking`` (not always on the STIX
+        ``object_marking_refs``); fall back to the connector default when none.
+        """
+        markings = [
+            self._marking_for(md["definition"])
+            for md in opencti_entity.get("objectMarking") or []
+            if md.get("definition_type") == "TLP" and md.get("definition")
+        ]
+        return markings or [self.tlp]
 
     @staticmethod
     def _extract_hash(opencti_entity: dict):
@@ -217,9 +252,9 @@ class FortisandboxConnector:
             )
 
         # Inherit the source observable's markings so the enrichment never produces
-        # an unmarked (TLP-downgraded) Malware Analysis object; fall back to the
+        # an unmarked / TLP-downgraded Malware Analysis object; fall back to the
         # connector default marking when the observable carries none.
-        markings = enriched_entity.get("object_marking_refs") or [self.tlp]
+        markings = self._observable_markings(opencti_entity)
         malware_analysis = stix2.MalwareAnalysis(
             id=MalwareAnalysis.generate_id(result_name, "FortiSandbox"),
             product="FortiSandbox",
@@ -234,7 +269,8 @@ class FortisandboxConnector:
         )
         enriched_objects.append(malware_analysis)
 
-        return [self.identity, self.tlp] + enriched_objects
+        # Include the marking objects themselves so the refs resolve in the bundle.
+        return [self.identity] + markings + enriched_objects
 
     def _process_observable(self, stix_entity: dict, opencti_entity: dict):
         self.helper.connector_logger.info(

--- a/internal-enrichment/fortisandbox/src/connector/connector.py
+++ b/internal-enrichment/fortisandbox/src/connector/connector.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from datetime import datetime, timezone
-from urllib.parse import urljoin
 
 import stix2
 from connector.settings import ConnectorSettings
@@ -47,6 +46,7 @@ class FortisandboxConnector:
             ssl_verify=self.config.fortisandbox.ssl_verify,
         )
         self.max_tlp = self.config.fortisandbox.max_tlp
+        self.max_file_size = self.config.fortisandbox.max_file_size
 
         self.identity = stix2.Identity(
             id=Identity.generate_id(name="FortiSandbox", identity_class="organization"),
@@ -85,21 +85,59 @@ class FortisandboxConnector:
             return None
         return data
 
-    def _submit(self, opencti_entity: dict):
+    def _download_file(self, opencti_entity: dict):
+        """
+        Download the file attached to an observable from OpenCTI storage.
+
+        Returns a ``(filename, content, error)`` tuple. On success ``error`` is
+        ``None``; on failure ``content`` is ``None`` and ``error`` is a
+        human-readable reason (enforces ``max_file_size`` and rejects empty files).
+        """
         import_files = opencti_entity.get("importFiles") or []
         if not import_files:
+            return None, None, "No file attached to the observable."
+        file_entry = import_files[0]
+        file_id = file_entry.get("id")
+        if not file_id:
+            return None, None, "Attached file has no id."
+
+        file_name = file_entry.get("name", "artifact")
+        max_mb = round(self.max_file_size / (1024 * 1024), 1)
+
+        declared_size = file_entry.get("size")
+        if declared_size is not None and int(declared_size) > self.max_file_size:
+            return None, None, f"File '{file_name}' exceeds the {max_mb} MB limit."
+
+        api_url = self.helper.api.api_url.replace("/graphql", "")
+        file_uri = f"{api_url}/storage/get/{file_id}"
+        content = self.helper.api.fetch_opencti_file(file_uri, True)
+        if content is None:
+            return None, None, f"Failed to download file '{file_name}' from OpenCTI."
+        if len(content) == 0:
+            return None, None, f"File '{file_name}' is empty (0 bytes)."
+        if len(content) > self.max_file_size:
+            return None, None, f"File '{file_name}' exceeds the {max_mb} MB limit."
+        return file_name, content, None
+
+    def _submit(self, opencti_entity: dict):
+        file_name, content, error = self._download_file(opencti_entity)
+        if error:
+            self.helper.connector_logger.info(
+                "Skipping FortiSandbox submission.", {"reason": error}
+            )
             return None
-        file_uri = import_files[0]["id"]
-        file_name = import_files[0].get("name", "artifact")
-        file_url = urljoin(str(self.config.opencti.url), f"storage/get/{file_uri}")
-        content = self.helper.api.fetch_opencti_file(file_url, True)
         sid = self.client.submit_file(file_name, content)
         if not sid:
+            self.helper.connector_logger.warning(
+                "FortiSandbox did not return a submission id."
+            )
             return None
         self.helper.connector_logger.info(
             "Submitted file to FortiSandbox, waiting for verdict.", {"sid": sid}
         )
-        return self.client.get_submission_verdict(sid)
+        return self.client.get_submission_verdict(
+            sid, max_wait=self.config.fortisandbox.submission_timeout
+        )
 
     def _create_knowledge(
         self, stix_entity: dict, opencti_entity: dict, data: dict

--- a/internal-enrichment/fortisandbox/src/connector/connector.py
+++ b/internal-enrichment/fortisandbox/src/connector/connector.py
@@ -304,6 +304,22 @@ class FortisandboxConnector:
         self.stix_objects = stix_objects
         original_stix_objects = deepcopy(stix_objects)
 
+        if opencti_entity["entity_type"] not in ["StixFile", "Artifact"]:
+            # A missing event_type means the enrichment was triggered by a playbook:
+            # return the original bundle unchanged so the playbook can continue.
+            if not data.get("event_type"):
+                self._send_bundle(original_stix_objects)
+                message = (
+                    "Entity type is out of the connector scope, "
+                    "original bundle returned unchanged"
+                )
+                self.helper.connector_logger.info(f"[CONNECTOR] {message}")
+                return message
+            raise ValueError(
+                f"Failed to process observable, "
+                f"{opencti_entity['entity_type']} is not a supported entity type."
+            )
+
         tlp = "TLP:CLEAR"
         for marking_definition in opencti_entity["objectMarking"]:
             if marking_definition["definition_type"] == "TLP":

--- a/internal-enrichment/fortisandbox/src/connector/connector.py
+++ b/internal-enrichment/fortisandbox/src/connector/connector.py
@@ -4,7 +4,12 @@ from datetime import datetime, timezone
 import stix2
 from connector.settings import ConnectorSettings
 from fortisandbox_client import FortiSandboxAPIError, FortisandboxClient
-from pycti import Identity, MalwareAnalysis, OpenCTIConnectorHelper
+from pycti import (
+    Identity,
+    MalwareAnalysis,
+    MarkingDefinition,
+    OpenCTIConnectorHelper,
+)
 
 # FortiSandbox rating -> OpenCTI score (0-100).
 _RATING_SCORES = {
@@ -25,6 +30,20 @@ _RATING_RESULTS = {
     "low risk": "suspicious",
     "clean": "benign",
 }
+
+
+def _tlp_clear() -> stix2.MarkingDefinition:
+    # OpenCTI models TLP:CLEAR as a custom statement marking, not as the legacy STIX
+    # TLP:WHITE; using TLP_WHITE would emit the wrong marking in the bundle.
+    return stix2.MarkingDefinition(
+        id=MarkingDefinition.generate_id("TLP", "TLP:CLEAR"),
+        definition_type="statement",
+        definition={"statement": "custom"},
+        custom_properties={
+            "x_opencti_definition_type": "TLP",
+            "x_opencti_definition": "TLP:CLEAR",
+        },
+    )
 
 
 class FortisandboxConnector:
@@ -54,7 +73,7 @@ class FortisandboxConnector:
             identity_class="organization",
             description="File verdicts from Fortinet FortiSandbox.",
         )
-        self.tlp = stix2.TLP_WHITE
+        self.tlp = _tlp_clear()
         self.stix_objects: list = []
 
     @staticmethod
@@ -123,7 +142,7 @@ class FortisandboxConnector:
         file_name, content, error = self._download_file(opencti_entity)
         if error:
             self.helper.connector_logger.info(
-                "Skipping FortiSandbox submission.", {"reason": error}
+                "Skipping FortiSandbox submission.", meta={"reason": error}
             )
             return None
         sid = self.client.submit_file(file_name, content)
@@ -133,7 +152,7 @@ class FortisandboxConnector:
             )
             return None
         self.helper.connector_logger.info(
-            "Submitted file to FortiSandbox, waiting for verdict.", {"sid": sid}
+            "Submitted file to FortiSandbox, waiting for verdict.", meta={"sid": sid}
         )
         return self.client.get_submission_verdict(
             sid, max_wait=self.config.fortisandbox.submission_timeout
@@ -197,6 +216,10 @@ class FortisandboxConnector:
                 description=f"FortiSandbox rating: {rating}",
             )
 
+        # Inherit the source observable's markings so the enrichment never produces
+        # an unmarked (TLP-downgraded) Malware Analysis object; fall back to the
+        # connector default marking when the observable carries none.
+        markings = enriched_entity.get("object_marking_refs") or [self.tlp]
         malware_analysis = stix2.MalwareAnalysis(
             id=MalwareAnalysis.generate_id(result_name, "FortiSandbox"),
             product="FortiSandbox",
@@ -206,6 +229,7 @@ class FortisandboxConnector:
             result=_RATING_RESULTS.get(key, "unknown"),
             sample_ref=enriched_entity["id"],
             created_by_ref=self.identity.id,
+            object_marking_refs=markings,
             external_references=[external_reference],
         )
         enriched_objects.append(malware_analysis)
@@ -215,7 +239,7 @@ class FortisandboxConnector:
     def _process_observable(self, stix_entity: dict, opencti_entity: dict):
         self.helper.connector_logger.info(
             "Processing the observable",
-            {
+            meta={
                 "observable_type": opencti_entity["entity_type"],
                 "observable_value": opencti_entity.get("observable_value"),
             },
@@ -276,7 +300,7 @@ class FortisandboxConnector:
             raise
         except Exception as err:
             self.helper.connector_logger.error(
-                "[CONNECTOR] An unexpected error occurred", {"error": str(err)}
+                "[CONNECTOR] An unexpected error occurred", meta={"error": str(err)}
             )
             self._send_bundle(original_stix_objects)
             raise

--- a/internal-enrichment/fortisandbox/src/connector/settings.py
+++ b/internal-enrichment/fortisandbox/src/connector/settings.py
@@ -51,9 +51,24 @@ class FortisandboxConfig(BaseConfigModel):
     submit_unknown: bool = Field(
         description=(
             "Submit unknown files for on-demand analysis when no verdict exists yet "
-            "(requires the observable to carry an uploaded file)."
+            "(requires the observable to carry an uploaded file). Enabled by default so "
+            "Artifacts uploaded to OpenCTI are detonated in FortiSandbox."
         ),
-        default=False,
+        default=True,
+    )
+    max_file_size: int = Field(
+        description=(
+            "Maximum size (in bytes) of a file the connector will download from OpenCTI "
+            "and submit to FortiSandbox."
+        ),
+        default=33554432,
+    )
+    submission_timeout: int = Field(
+        description=(
+            "Maximum time (in seconds) to wait for a submitted file's verdict before "
+            "giving up."
+        ),
+        default=600,
     )
     max_tlp: Literal[
         "TLP:CLEAR",

--- a/internal-enrichment/fortisandbox/src/connector/settings.py
+++ b/internal-enrichment/fortisandbox/src/connector/settings.py
@@ -1,0 +1,80 @@
+from typing import Literal
+
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseInternalEnrichmentConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field, HttpUrl, SecretStr
+
+
+class InternalEnrichmentConnectorConfig(BaseInternalEnrichmentConnectorConfig):
+    """
+    Override the `BaseInternalEnrichmentConnectorConfig` to add parameters and/or defaults
+    to the configuration for connectors of type `INTERNAL_ENRICHMENT`.
+    """
+
+    name: str = Field(
+        description="The name of the connector.",
+        default="FortiSandbox",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector (observable types to enrich).",
+        default=["StixFile", "Artifact"],
+    )
+
+
+class FortisandboxConfig(BaseConfigModel):
+    """
+    Define parameters and/or defaults for the configuration specific to the
+    `FortisandboxConnector`.
+    """
+
+    api_base_url: HttpUrl = Field(
+        description="FortiSandbox base URL (appliance, VM or cloud), without the /jsonrpc suffix.",
+    )
+    username: str = Field(
+        description="FortiSandbox API username.",
+    )
+    password: SecretStr = Field(
+        description="FortiSandbox API password.",
+    )
+    api_version: str = Field(
+        description="FortiSandbox JSON-RPC API version sent with every request.",
+        default="4.2.4",
+    )
+    ssl_verify: bool = Field(
+        description="Whether to verify the FortiSandbox TLS certificate.",
+        default=True,
+    )
+    submit_unknown: bool = Field(
+        description=(
+            "Submit unknown files for on-demand analysis when no verdict exists yet "
+            "(requires the observable to carry an uploaded file)."
+        ),
+        default=False,
+    )
+    max_tlp: Literal[
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED",
+    ] = Field(
+        description="Maximum TLP of the observable the connector is allowed to enrich.",
+        default="TLP:AMBER",
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """
+    Override `BaseConnectorSettings` to include `InternalEnrichmentConnectorConfig` and
+    `FortisandboxConfig`.
+    """
+
+    connector: InternalEnrichmentConnectorConfig = Field(
+        default_factory=InternalEnrichmentConnectorConfig
+    )
+    fortisandbox: FortisandboxConfig = Field(default_factory=FortisandboxConfig)

--- a/internal-enrichment/fortisandbox/src/fortisandbox_client/__init__.py
+++ b/internal-enrichment/fortisandbox/src/fortisandbox_client/__init__.py
@@ -1,0 +1,6 @@
+from fortisandbox_client.api_client import FortiSandboxAPIError, FortisandboxClient
+
+__all__ = [
+    "FortisandboxClient",
+    "FortiSandboxAPIError",
+]

--- a/internal-enrichment/fortisandbox/src/fortisandbox_client/api_client.py
+++ b/internal-enrichment/fortisandbox/src/fortisandbox_client/api_client.py
@@ -1,0 +1,219 @@
+"""JSON-RPC client for the FortiSandbox API."""
+
+from __future__ import annotations
+
+import base64
+import time
+from typing import Optional
+
+import requests
+from pycti import OpenCTIConnectorHelper
+from requests.adapters import HTTPAdapter, Retry
+
+
+class FortiSandboxAPIError(Exception):
+    """Custom exception for FortiSandbox API errors."""
+
+
+class FortisandboxClient:
+    """Thin client around the FortiSandbox JSON-RPC API."""
+
+    TIMEOUT = 60
+
+    def __init__(
+        self,
+        helper: OpenCTIConnectorHelper,
+        api_base_url: str,
+        username: str,
+        password: str,
+        api_version: str = "4.2.4",
+        ssl_verify: bool = True,
+    ) -> None:
+        """
+        Initialize the FortiSandbox client.
+
+        :param helper: The OpenCTI connector helper (used for logging).
+        :param api_base_url: The FortiSandbox base URL (without /jsonrpc).
+        :param username: The FortiSandbox API username.
+        :param password: The FortiSandbox API password.
+        :param api_version: The JSON-RPC API version to send with each request.
+        :param ssl_verify: Whether to verify the TLS certificate.
+        """
+        self.helper = helper
+        self.base_url = str(api_base_url).rstrip("/")
+        self.jsonrpc_url = self.base_url + "/jsonrpc"
+        self.username = username
+        self.password = password
+        self.api_version = api_version
+        self.session_token: Optional[str] = None
+
+        self.session = requests.Session()
+        self.session.verify = ssl_verify
+        retry_strategy = Retry(
+            total=3,
+            backoff_factor=2,
+            allowed_methods=None,
+            status_forcelist=[429, 500, 502, 503, 504],
+            respect_retry_after_header=True,
+            raise_on_status=True,
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
+
+    def _call(self, method: str, params: list, with_session: bool = True) -> dict:
+        payload = {
+            "method": method,
+            "params": params,
+            "id": 1,
+            "version": self.api_version,
+        }
+        if with_session and self.session_token:
+            payload["session"] = self.session_token
+        try:
+            response = self.session.post(
+                self.jsonrpc_url, json=payload, timeout=self.TIMEOUT
+            )
+            response.raise_for_status()
+        except requests.HTTPError as err:
+            raise FortiSandboxAPIError(
+                "FortiSandbox API request error: "
+                f"{err.response.status_code} ({err.response.reason})"
+            ) from err
+        try:
+            return response.json()
+        except ValueError as err:
+            raise FortiSandboxAPIError(
+                "FortiSandbox returned a non-JSON response"
+            ) from err
+
+    def login(self) -> str:
+        """Authenticate and cache the session token."""
+        data = self._call(
+            "exec",
+            [
+                {
+                    "url": "/sys/login/user",
+                    "name": self.username,
+                    "passwd": self.password,
+                }
+            ],
+            with_session=False,
+        )
+        token = data.get("session")
+        if not token:
+            raise FortiSandboxAPIError("FortiSandbox login failed (no session token)")
+        self.session_token = token
+        return token
+
+    def logout(self) -> None:
+        """Best-effort logout to release the session."""
+        if self.session_token:
+            try:
+                self._call("exec", [{"url": "/sys/logout"}])
+            except FortiSandboxAPIError:
+                pass
+            self.session_token = None
+
+    def _ensure_session(self) -> None:
+        if not self.session_token:
+            self.login()
+
+    def get_file_rating(self, checksum: str, ctype: str = "sha256") -> Optional[dict]:
+        """Return the FortiSandbox rating record for a file hash, or ``None``."""
+        self._ensure_session()
+        data = self._call(
+            "get",
+            [{"url": "/scan/result/filerating", "checksum": checksum, "ctype": ctype}],
+        )
+        return self._extract_data(data)
+
+    def submit_file(self, filename: str, content: bytes) -> Optional[str]:
+        """Submit a file for on-demand analysis, returning its submission id."""
+        self._ensure_session()
+        encoded = base64.b64encode(content).decode("ascii")
+        data = self._call(
+            "set",
+            [
+                {
+                    "url": "/alert/ondemand/submit-file",
+                    "file": encoded,
+                    "filename": filename,
+                }
+            ],
+        )
+        result = self._extract_result(data)
+        if isinstance(result, dict):
+            return (
+                result.get("sid")
+                or result.get("submit_id")
+                or (result.get("data") or {}).get("sid")
+            )
+        return None
+
+    def get_submission_verdict(
+        self, sid: str, max_wait: int = 300, interval: int = 30
+    ) -> Optional[dict]:
+        """Poll a submission until its first job has a rating (bounded by max_wait)."""
+        self._ensure_session()
+        waited = 0
+        while waited <= max_wait:
+            data = self._call(
+                "get",
+                [{"url": "/scan/result/get-jobs-of-submission", "sid": sid}],
+            )
+            jobs = self._extract_jobs(data)
+            if jobs:
+                job = jobs[0]
+                jid = (
+                    job.get("jid") or job.get("job_id")
+                    if isinstance(job, dict)
+                    else job
+                )
+                rating = self._get_job(jid)
+                if rating is not None:
+                    return rating
+            time.sleep(interval)
+            waited += interval
+        return None
+
+    def _get_job(self, jid) -> Optional[dict]:
+        data = self._call("get", [{"url": "/scan/result/job", "jid": jid}])
+        return self._extract_data(data)
+
+    @staticmethod
+    def _extract_result(payload) -> Optional[dict]:
+        if not isinstance(payload, dict):
+            return None
+        result = payload.get("result")
+        if isinstance(result, list):
+            result = result[0] if result else None
+        return result if isinstance(result, dict) else None
+
+    @classmethod
+    def _extract_data(cls, payload) -> Optional[dict]:
+        result = cls._extract_result(payload)
+        if not isinstance(result, dict):
+            return None
+        data = result.get("data")
+        if isinstance(data, dict):
+            return data
+        if isinstance(data, list):
+            return data[0] if data else None
+        if "rating" in result:
+            return result
+        return None
+
+    @classmethod
+    def _extract_jobs(cls, payload) -> list:
+        result = cls._extract_result(payload)
+        if not isinstance(result, dict):
+            return []
+        data = result.get("data")
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            jobs = data.get("jobs")
+            if isinstance(jobs, list):
+                return jobs
+        return []

--- a/internal-enrichment/fortisandbox/src/fortisandbox_client/api_client.py
+++ b/internal-enrichment/fortisandbox/src/fortisandbox_client/api_client.py
@@ -55,7 +55,7 @@ class FortisandboxClient:
             allowed_methods=None,
             status_forcelist=[429, 500, 502, 503, 504],
             respect_retry_after_header=True,
-            raise_on_status=True,
+            raise_on_status=False,
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self.session.mount("https://", adapter)
@@ -76,9 +76,16 @@ class FortisandboxClient:
             )
             response.raise_for_status()
         except requests.HTTPError as err:
+            status = err.response.status_code if err.response is not None else "?"
+            reason = err.response.reason if err.response is not None else ""
             raise FortiSandboxAPIError(
-                "FortiSandbox API request error: "
-                f"{err.response.status_code} ({err.response.reason})"
+                f"FortiSandbox API request error: {status} ({reason})"
+            ) from err
+        except requests.RequestException as err:
+            # Retry exhaustion (RetryError), timeouts and connection errors are not
+            # HTTPError; wrap them so callers always see a FortiSandboxAPIError.
+            raise FortiSandboxAPIError(
+                f"FortiSandbox API request failed: {type(err).__name__}"
             ) from err
         try:
             return response.json()
@@ -157,7 +164,7 @@ class FortisandboxClient:
         """Poll a submission until any of its jobs has a rating (bounded by max_wait)."""
         self._ensure_session()
         waited = 0
-        while waited <= max_wait:
+        while True:
             data = self._call(
                 "get",
                 [{"url": "/scan/result/get-jobs-of-submission", "sid": sid}],
@@ -166,9 +173,11 @@ class FortisandboxClient:
                 rating = self._get_job(self._job_id(job))
                 if rating is not None:
                     return rating
-            time.sleep(interval)
+            # Stop once the budget is spent; do not sleep one extra interval past it.
             waited += interval
-        return None
+            if waited > max_wait:
+                return None
+            time.sleep(interval)
 
     @staticmethod
     def _job_id(job):

--- a/internal-enrichment/fortisandbox/src/fortisandbox_client/api_client.py
+++ b/internal-enrichment/fortisandbox/src/fortisandbox_client/api_client.py
@@ -154,7 +154,7 @@ class FortisandboxClient:
     def get_submission_verdict(
         self, sid: str, max_wait: int = 300, interval: int = 30
     ) -> Optional[dict]:
-        """Poll a submission until its first job has a rating (bounded by max_wait)."""
+        """Poll a submission until any of its jobs has a rating (bounded by max_wait)."""
         self._ensure_session()
         waited = 0
         while waited <= max_wait:
@@ -162,20 +162,19 @@ class FortisandboxClient:
                 "get",
                 [{"url": "/scan/result/get-jobs-of-submission", "sid": sid}],
             )
-            jobs = self._extract_jobs(data)
-            if jobs:
-                job = jobs[0]
-                jid = (
-                    job.get("jid") or job.get("job_id")
-                    if isinstance(job, dict)
-                    else job
-                )
-                rating = self._get_job(jid)
+            for job in self._extract_jobs(data):
+                rating = self._get_job(self._job_id(job))
                 if rating is not None:
                     return rating
             time.sleep(interval)
             waited += interval
         return None
+
+    @staticmethod
+    def _job_id(job):
+        if isinstance(job, dict):
+            return job.get("jid") or job.get("job_id")
+        return job
 
     def _get_job(self, jid) -> Optional[dict]:
         data = self._call("get", [{"url": "/scan/result/job", "jid": jid}])

--- a/internal-enrichment/fortisandbox/src/fortisandbox_client/api_client.py
+++ b/internal-enrichment/fortisandbox/src/fortisandbox_client/api_client.py
@@ -173,9 +173,10 @@ class FortisandboxClient:
                 rating = self._get_job(self._job_id(job))
                 if rating is not None:
                     return rating
-            # Stop once the budget is spent; do not sleep one extra interval past it.
+            # Stop once the budget is spent (>=, not >): when the accumulated wait
+            # reaches max_wait we must return without sleeping one more interval.
             waited += interval
-            if waited > max_wait:
+            if waited >= max_wait:
                 return None
             time.sleep(interval)
 

--- a/internal-enrichment/fortisandbox/src/main.py
+++ b/internal-enrichment/fortisandbox/src/main.py
@@ -1,0 +1,28 @@
+import traceback
+
+from connector import ConnectorSettings, FortisandboxConnector
+from pycti import OpenCTIConnectorHelper
+
+if __name__ == "__main__":
+    """
+    Entry point of the script
+
+    - traceback.print_exc(): This function prints the traceback of the exception to the standard error (stderr).
+    The traceback includes information about the point in the program where the exception occurred,
+    which is very useful for debugging purposes.
+    - exit(1): effective way to terminate a Python program when an error is encountered.
+    It signals to the operating system and any calling processes that the program did not complete successfully.
+    """
+    try:
+        settings = ConnectorSettings()
+
+        helper = OpenCTIConnectorHelper(
+            config=settings.to_helper_config(),
+            playbook_compatible=True,  # ! `playbook_compatible=True` only if a bundle is sent
+        )
+
+        connector = FortisandboxConnector(config=settings, helper=helper)
+        connector.run()
+    except Exception:
+        traceback.print_exc()
+        exit(1)

--- a/internal-enrichment/fortisandbox/src/requirements.txt
+++ b/internal-enrichment/fortisandbox/src/requirements.txt
@@ -1,0 +1,4 @@
+pycti==7.260609.0
+pydantic~= 2.11.3
+requests~=2.33.0
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/fortisandbox/src/requirements.txt
+++ b/internal-enrichment/fortisandbox/src/requirements.txt
@@ -1,4 +1,4 @@
-pycti==7.260609.0
+pycti==7.260701.0
 pydantic~= 2.11.3
 requests~=2.33.0
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/fortisandbox/src/requirements.txt
+++ b/internal-enrichment/fortisandbox/src/requirements.txt
@@ -1,4 +1,4 @@
 pycti==7.260701.0
-pydantic~= 2.11.3
+pydantic~=2.11.3
 requests~=2.33.0
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/fortisandbox/tests/conftest.py
+++ b/internal-enrichment/fortisandbox/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())

--- a/internal-enrichment/fortisandbox/tests/test-requirements.txt
+++ b/internal-enrichment/fortisandbox/tests/test-requirements.txt
@@ -1,0 +1,3 @@
+# Main dependencies needs to be installed
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/internal-enrichment/fortisandbox/tests/test-requirements.txt
+++ b/internal-enrichment/fortisandbox/tests/test-requirements.txt
@@ -1,3 +1,3 @@
-# Main dependencies needs to be installed
+# Main dependencies need to be installed
 -r ../src/requirements.txt
 pytest==9.0.3

--- a/internal-enrichment/fortisandbox/tests/test_main.py
+++ b/internal-enrichment/fortisandbox/tests/test_main.py
@@ -64,7 +64,7 @@ def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper)
     assert helper.connect_name == "Test Connector"
     assert helper.connect_scope == "test,connector"
     assert helper.log_level == "ERROR"
-    assert helper.connect_auto == True
+    assert helper.connect_auto is True
 
 
 def test_connector_is_instantiated(mock_opencti_connector_helper):

--- a/internal-enrichment/fortisandbox/tests/test_main.py
+++ b/internal-enrichment/fortisandbox/tests/test_main.py
@@ -1,0 +1,84 @@
+from typing import Any
+
+from connector import ConnectorSettings, FortisandboxConnector
+from pycti import OpenCTIConnectorHelper
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+    It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "auto": True,
+                },
+                "fortisandbox": {
+                    "api_base_url": "http://test.com",
+                    "username": "api-user",
+                    "password": "api-pass",
+                    "max_tlp": "TLP:CLEAR",
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that the implementation of `BaseConnectorSettings` (from `connectors-sdk`) can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from `BaseConnectorSettings`)
+        - the method `to_helper_config` MUST return a dict (as in base class)
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that `OpenCTIConnectorHelper` (from `pycti`) can be instantiated successfully:
+        - the value of `settings.to_helper_config` MUST be the expected dict for `OpenCTIConnectorHelper`
+        - the helper MUST be able to get its instance's attributes from the config dict
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "Test Connector"
+    assert helper.connect_scope == "test,connector"
+    assert helper.log_level == "ERROR"
+    assert helper.connect_auto == True
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST be able to access env/config vars through `self.config`
+        - the connector's main class MUST be able to access `pycti` API through `self.helper`
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    connector = FortisandboxConnector(config=settings, helper=helper)
+
+    assert connector.config == settings
+    assert connector.helper == helper

--- a/internal-enrichment/fortisandbox/tests/tests_connector/data/artifact_message.json
+++ b/internal-enrichment/fortisandbox/tests/tests_connector/data/artifact_message.json
@@ -1,0 +1,34 @@
+{
+  "stix_objects": [
+    {
+      "type": "artifact",
+      "id": "artifact--22222222-2222-4222-8222-222222222222",
+      "hashes": {
+        "SHA-256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    }
+  ],
+  "stix_entity": {
+    "type": "artifact",
+    "id": "artifact--22222222-2222-4222-8222-222222222222",
+    "hashes": {
+      "SHA-256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+  },
+  "enrichment_entity": {
+    "entity_type": "Artifact",
+    "observable_value": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "hashes": [
+      {
+        "algorithm": "SHA-256",
+        "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    ],
+    "objectMarking": [
+      {
+        "definition_type": "TLP",
+        "definition": "TLP:AMBER"
+      }
+    ]
+  }
+}

--- a/internal-enrichment/fortisandbox/tests/tests_connector/data/file_message.json
+++ b/internal-enrichment/fortisandbox/tests/tests_connector/data/file_message.json
@@ -1,0 +1,42 @@
+{
+  "stix_objects": [
+    {
+      "type": "file",
+      "id": "file--11111111-1111-4111-8111-111111111111",
+      "name": "malware.exe",
+      "hashes": {
+        "SHA-256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    }
+  ],
+  "stix_entity": {
+    "type": "file",
+    "id": "file--11111111-1111-4111-8111-111111111111",
+    "name": "malware.exe",
+    "hashes": {
+      "SHA-256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+  },
+  "enrichment_entity": {
+    "entity_type": "StixFile",
+    "observable_value": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "hashes": [
+      {
+        "algorithm": "SHA-256",
+        "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    ],
+    "importFiles": [
+      {
+        "id": "storage-file-id",
+        "name": "malware.exe"
+      }
+    ],
+    "objectMarking": [
+      {
+        "definition_type": "TLP",
+        "definition": "TLP:AMBER"
+      }
+    ]
+  }
+}

--- a/internal-enrichment/fortisandbox/tests/tests_connector/test_connector.py
+++ b/internal-enrichment/fortisandbox/tests/tests_connector/test_connector.py
@@ -1,0 +1,281 @@
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import stix2
+from connector import ConnectorSettings, FortisandboxConnector
+from fortisandbox_client import FortiSandboxAPIError
+from pycti import OpenCTIConnectorHelper
+
+DATA_DIR = Path(__file__).parent / "data"
+
+FORTI_RESULT = {
+    "rating": "Malicious",
+    "score": 90,
+    "malware_name": "W32/Agent",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+    "md5": "d41d8cd98f00b204e9800998ecf8427e",
+    "detail_url": "https://fsa.example.com/job/1",
+    "category": "trojan",
+}
+
+
+def _load(name: str) -> dict:
+    with (DATA_DIR / name).open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _settings_dict(submit_unknown: bool = False) -> dict:
+    return {
+        "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+        "connector": {
+            "id": "connector-id",
+            "name": "Test Connector",
+            "scope": "StixFile,Artifact",
+            "log_level": "error",
+            "auto": True,
+        },
+        "fortisandbox": {
+            "api_base_url": "https://fsa.example.com",
+            "username": "api-user",
+            "password": "api-pass",
+            "submit_unknown": submit_unknown,
+        },
+    }
+
+
+class StubConnectorSettings(ConnectorSettings):
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(_settings_dict())
+
+
+class StubConnectorSettingsSubmit(ConnectorSettings):
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(_settings_dict(submit_unknown=True))
+
+
+@pytest.fixture
+def file_message() -> dict:
+    return _load("file_message.json")
+
+
+@pytest.fixture
+def artifact_message() -> dict:
+    return _load("artifact_message.json")
+
+
+@pytest.fixture
+def dummy_connector(mock_opencti_connector_helper):
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+    helper.send_stix2_bundle = MagicMock()
+
+    connector = FortisandboxConnector(config=settings, helper=helper)
+    connector.client = MagicMock()
+    connector._search_hash = MagicMock()
+    connector._submit = MagicMock()
+    connector._create_knowledge = MagicMock()
+    connector._send_bundle = MagicMock()
+    return connector
+
+
+@pytest.fixture
+def submit_connector(mock_opencti_connector_helper):
+    settings = StubConnectorSettingsSubmit()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+    helper.send_stix2_bundle = MagicMock()
+
+    connector = FortisandboxConnector(config=settings, helper=helper)
+    connector.client = MagicMock()
+    connector._search_hash = MagicMock(return_value=None)
+    connector._submit = MagicMock(return_value=FORTI_RESULT)
+    connector._create_knowledge = MagicMock(return_value=["bundle"])
+    connector._send_bundle = MagicMock()
+    return connector
+
+
+@pytest.fixture
+def stub_connector(mock_opencti_connector_helper):
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+    helper.send_stix2_bundle = MagicMock()
+
+    connector = FortisandboxConnector(config=settings, helper=helper)
+    connector.identity = stix2.Identity(
+        id="identity--4a9e7924-46a1-43f7-962b-e61f53f4b0ca",
+        name="FortiSandbox",
+        identity_class="organization",
+    )
+    connector.tlp = stix2.TLP_WHITE
+    connector.client = MagicMock()
+    return connector
+
+
+def test_process_message_ignores_entity_exceeding_max_tlp(
+    dummy_connector, file_message
+):
+    dummy_connector.max_tlp = "TLP:CLEAR"
+
+    dummy_connector._process_message(file_message)
+
+    dummy_connector._search_hash.assert_not_called()
+    dummy_connector._create_knowledge.assert_not_called()
+    dummy_connector._send_bundle.assert_called_with(file_message["stix_objects"])
+
+
+@pytest.mark.parametrize(
+    "raised",
+    [FortiSandboxAPIError("api error"), Exception("unexpected")],
+    ids=["fortisandbox-api-error", "unexpected-exception"],
+)
+def test_process_message_handles_exceptions(dummy_connector, file_message, raised):
+    dummy_connector._search_hash = MagicMock(side_effect=raised)
+
+    with pytest.raises(type(raised)):
+        dummy_connector._process_message(file_message)
+
+    dummy_connector._search_hash.assert_called_once()
+    dummy_connector._create_knowledge.assert_not_called()
+    dummy_connector._send_bundle.assert_called_with(file_message["stix_objects"])
+
+
+def test_process_message_routes_file_with_rating(dummy_connector, file_message):
+    dummy_connector._search_hash.return_value = FORTI_RESULT
+
+    dummy_connector._process_message(file_message)
+
+    dummy_connector._search_hash.assert_called_once()
+    dummy_connector._create_knowledge.assert_called_once()
+    dummy_connector._send_bundle.assert_called_once()
+
+
+def test_process_message_no_rating_sends_original(dummy_connector, file_message):
+    dummy_connector._search_hash.return_value = None
+
+    dummy_connector._process_message(file_message)
+
+    dummy_connector._submit.assert_not_called()  # submit_unknown is False
+    dummy_connector._create_knowledge.assert_not_called()
+    dummy_connector._send_bundle.assert_called_with(file_message["stix_objects"])
+
+
+def test_process_message_submits_when_enabled(submit_connector, file_message):
+    submit_connector._process_message(file_message)
+
+    submit_connector._search_hash.assert_called_once()
+    submit_connector._submit.assert_called_once()
+    submit_connector._create_knowledge.assert_called_once()
+
+
+def test_create_knowledge_file(stub_connector, file_message):
+    data = file_message
+    stub_connector.stix_objects = data["stix_objects"]
+
+    result = stub_connector._create_knowledge(
+        data["stix_entity"], data["enrichment_entity"], FORTI_RESULT
+    )
+
+    types = {o["type"] if isinstance(o, dict) else o.type for o in result}
+    assert "identity" in types
+    assert "malware-analysis" in types
+
+    enriched = next(
+        o
+        for o in result
+        if isinstance(o, dict) and o.get("id") == data["stix_entity"]["id"]
+    )
+    assert enriched["x_opencti_score"] == 90
+    assert "fortisandbox:malicious" in enriched["labels"]
+    assert "malware:W32/Agent" in enriched["labels"]
+    assert enriched["hashes"]["MD5"] == FORTI_RESULT["md5"]
+
+
+def test_extract_hash_priority():
+    entity = {
+        "hashes": [
+            {"algorithm": "MD5", "hash": "m"},
+            {"algorithm": "SHA-256", "hash": "s"},
+        ]
+    }
+    assert FortisandboxConnector._extract_hash(entity) == ("s", "sha256")
+
+
+def test_extract_hash_sha1_fallback():
+    entity = {"hashes": [{"algorithm": "SHA-1", "hash": "h1"}]}
+    assert FortisandboxConnector._extract_hash(entity) == ("h1", "sha1")
+
+
+def test_extract_hash_md5_fallback():
+    entity = {"hashes": [{"algorithm": "MD5", "hash": "m1"}]}
+    assert FortisandboxConnector._extract_hash(entity) == ("m1", "md5")
+
+
+def test_extract_hash_none():
+    assert FortisandboxConnector._extract_hash({"hashes": []}) == (None, None)
+
+
+def test_process_observable_non_file_returns_none(stub_connector):
+    result = stub_connector._process_observable(
+        {"id": "url--1"}, {"entity_type": "Url", "observable_value": "http://x"}
+    )
+    assert result is None
+
+
+def test_create_knowledge_artifact_without_detail_url(stub_connector, artifact_message):
+    data = artifact_message
+    stub_connector.stix_objects = data["stix_objects"]
+    forti = dict(FORTI_RESULT)
+    forti.pop("detail_url")
+
+    result = stub_connector._create_knowledge(
+        data["stix_entity"], data["enrichment_entity"], forti
+    )
+
+    enriched = next(
+        o
+        for o in result
+        if isinstance(o, dict) and o.get("id") == data["stix_entity"]["id"]
+    )
+    assert enriched["x_opencti_score"] == 90
+    malware_analysis = next(
+        o for o in result if getattr(o, "type", None) == "malware-analysis"
+    )
+    assert malware_analysis["external_references"][0]["external_id"] == forti["sha256"]
+
+
+def test_submit_returns_verdict(stub_connector):
+    stub_connector.helper.api.fetch_opencti_file = MagicMock(return_value=b"data")
+    stub_connector.client.submit_file = MagicMock(return_value="sid-1")
+    stub_connector.client.get_submission_verdict = MagicMock(return_value=FORTI_RESULT)
+
+    opencti_entity = {"importFiles": [{"id": "storage-id", "name": "malware.exe"}]}
+    result = stub_connector._submit(opencti_entity)
+    assert result == FORTI_RESULT
+    stub_connector.client.submit_file.assert_called_once()
+
+
+def test_submit_no_import_files_returns_none(stub_connector):
+    assert stub_connector._submit({"importFiles": []}) is None
+
+
+def test_search_hash_unknown_rating_returns_none(stub_connector):
+    stub_connector.client.get_file_rating.return_value = {"rating": "Unknown"}
+
+    result = stub_connector._search_hash(
+        {"hashes": [{"algorithm": "SHA-256", "hash": "s"}]}
+    )
+    assert result is None
+
+
+def test_search_hash_with_rating(stub_connector):
+    stub_connector.client.get_file_rating.return_value = FORTI_RESULT
+
+    result = stub_connector._search_hash(
+        {"hashes": [{"algorithm": "SHA-256", "hash": "s"}]}
+    )
+    assert result["rating"] == "Malicious"

--- a/internal-enrichment/fortisandbox/tests/tests_connector/test_connector.py
+++ b/internal-enrichment/fortisandbox/tests/tests_connector/test_connector.py
@@ -7,7 +7,7 @@ import pytest
 import stix2
 from connector import ConnectorSettings, FortisandboxConnector
 from fortisandbox_client import FortiSandboxAPIError
-from pycti import OpenCTIConnectorHelper
+from pycti import MarkingDefinition, OpenCTIConnectorHelper
 
 DATA_DIR = Path(__file__).parent / "data"
 
@@ -111,7 +111,8 @@ def stub_connector(mock_opencti_connector_helper):
         name="FortiSandbox",
         identity_class="organization",
     )
-    connector.tlp = stix2.TLP_WHITE
+    # Keep the connector's real default marking (OpenCTI's custom TLP:CLEAR
+    # statement marking) so tests exercise the runtime TLP handling.
     connector.client = MagicMock()
     return connector
 
@@ -220,6 +221,27 @@ def test_create_knowledge_inherits_observable_marking(stub_connector, file_messa
     assert stix2.TLP_AMBER.id in malware_analysis["object_marking_refs"]
     # The marking object is included in the bundle so the ref resolves.
     assert any(getattr(o, "id", None) == stix2.TLP_AMBER.id for o in result)
+
+
+def test_create_knowledge_falls_back_to_custom_tlp_clear(stub_connector, file_message):
+    # Without markings on the observable, the Malware Analysis must carry the
+    # connector default: OpenCTI's custom TLP:CLEAR statement marking (generated
+    # via pycti's deterministic id), not the legacy stix2.TLP_WHITE.
+    data = file_message
+    data["enrichment_entity"]["objectMarking"] = []
+    stub_connector.stix_objects = data["stix_objects"]
+
+    result = stub_connector._create_knowledge(
+        data["stix_entity"], data["enrichment_entity"], FORTI_RESULT
+    )
+
+    expected_id = MarkingDefinition.generate_id("TLP", "TLP:CLEAR")
+    malware_analysis = next(
+        o for o in result if getattr(o, "type", None) == "malware-analysis"
+    )
+    assert malware_analysis["object_marking_refs"] == [expected_id]
+    tlp_clear = next(o for o in result if getattr(o, "id", None) == expected_id)
+    assert tlp_clear["x_opencti_definition"] == "TLP:CLEAR"
 
 
 def test_extract_hash_priority():

--- a/internal-enrichment/fortisandbox/tests/tests_connector/test_connector.py
+++ b/internal-enrichment/fortisandbox/tests/tests_connector/test_connector.py
@@ -117,6 +117,31 @@ def stub_connector(mock_opencti_connector_helper):
     return connector
 
 
+def test_process_message_out_of_scope_playbook_returns_original(
+    dummy_connector, file_message
+):
+    # No event_type in the message: the enrichment was triggered by a playbook,
+    # so an out-of-scope entity must get the original bundle back unchanged.
+    file_message["enrichment_entity"]["entity_type"] = "Url"
+
+    dummy_connector._process_message(file_message)
+
+    dummy_connector._search_hash.assert_not_called()
+    dummy_connector._create_knowledge.assert_not_called()
+    dummy_connector._send_bundle.assert_called_with(file_message["stix_objects"])
+
+
+def test_process_message_out_of_scope_manual_raises(dummy_connector, file_message):
+    # event_type present: manual enrichment of an unsupported entity type must fail.
+    file_message["enrichment_entity"]["entity_type"] = "Url"
+    file_message["event_type"] = "create"
+
+    with pytest.raises(ValueError, match="not a supported entity type"):
+        dummy_connector._process_message(file_message)
+
+    dummy_connector._send_bundle.assert_not_called()
+
+
 def test_process_message_ignores_entity_exceeding_max_tlp(
     dummy_connector, file_message
 ):

--- a/internal-enrichment/fortisandbox/tests/tests_connector/test_connector.py
+++ b/internal-enrichment/fortisandbox/tests/tests_connector/test_connector.py
@@ -204,6 +204,24 @@ def test_create_knowledge_file(stub_connector, file_message):
     assert malware_analysis["object_marking_refs"]
 
 
+def test_create_knowledge_inherits_observable_marking(stub_connector, file_message):
+    # The observable carries TLP:AMBER; the Malware Analysis must inherit AMBER
+    # rather than be downgraded to the connector default marking.
+    data = file_message
+    stub_connector.stix_objects = data["stix_objects"]
+
+    result = stub_connector._create_knowledge(
+        data["stix_entity"], data["enrichment_entity"], FORTI_RESULT
+    )
+
+    malware_analysis = next(
+        o for o in result if getattr(o, "type", None) == "malware-analysis"
+    )
+    assert stix2.TLP_AMBER.id in malware_analysis["object_marking_refs"]
+    # The marking object is included in the bundle so the ref resolves.
+    assert any(getattr(o, "id", None) == stix2.TLP_AMBER.id for o in result)
+
+
 def test_extract_hash_priority():
     entity = {
         "hashes": [

--- a/internal-enrichment/fortisandbox/tests/tests_connector/test_connector.py
+++ b/internal-enrichment/fortisandbox/tests/tests_connector/test_connector.py
@@ -194,6 +194,15 @@ def test_create_knowledge_file(stub_connector, file_message):
     assert "malware:W32/Agent" in enriched["labels"]
     assert enriched["hashes"]["MD5"] == FORTI_RESULT["md5"]
 
+    # The Malware Analysis object must carry markings (inherited or default) so the
+    # enrichment never produces an unmarked object.
+    malware_analysis = next(
+        o
+        for o in result
+        if not isinstance(o, dict) and getattr(o, "type", None) == "malware-analysis"
+    )
+    assert malware_analysis["object_marking_refs"]
+
 
 def test_extract_hash_priority():
     entity = {

--- a/internal-enrichment/fortisandbox/tests/tests_connector/test_connector.py
+++ b/internal-enrichment/fortisandbox/tests/tests_connector/test_connector.py
@@ -249,6 +249,7 @@ def test_create_knowledge_artifact_without_detail_url(stub_connector, artifact_m
 
 
 def test_submit_returns_verdict(stub_connector):
+    stub_connector.helper.api.api_url = "http://localhost:8080/graphql"
     stub_connector.helper.api.fetch_opencti_file = MagicMock(return_value=b"data")
     stub_connector.client.submit_file = MagicMock(return_value="sid-1")
     stub_connector.client.get_submission_verdict = MagicMock(return_value=FORTI_RESULT)
@@ -261,6 +262,73 @@ def test_submit_returns_verdict(stub_connector):
 
 def test_submit_no_import_files_returns_none(stub_connector):
     assert stub_connector._submit({"importFiles": []}) is None
+
+
+def test_download_file_no_import_files(stub_connector):
+    name, content, error = stub_connector._download_file({"importFiles": []})
+    assert content is None
+    assert "No file attached" in error
+
+
+def test_download_file_rejects_declared_oversize(stub_connector):
+    entity = {
+        "importFiles": [
+            {"id": "f1", "name": "big.bin", "size": stub_connector.max_file_size + 1}
+        ]
+    }
+    name, content, error = stub_connector._download_file(entity)
+    assert content is None
+    assert "limit" in error
+
+
+def test_download_file_rejects_empty(stub_connector):
+    stub_connector.helper.api.api_url = "http://localhost:8080/graphql"
+    stub_connector.helper.api.fetch_opencti_file = MagicMock(return_value=b"")
+    entity = {"importFiles": [{"id": "f1", "name": "empty.bin"}]}
+
+    name, content, error = stub_connector._download_file(entity)
+    assert content is None
+    assert "empty" in error
+
+
+def test_download_file_success(stub_connector):
+    stub_connector.helper.api.api_url = "http://localhost:8080/graphql"
+    stub_connector.helper.api.fetch_opencti_file = MagicMock(return_value=b"payload")
+    entity = {"importFiles": [{"id": "f1", "name": "malware.exe"}]}
+
+    name, content, error = stub_connector._download_file(entity)
+    assert error is None
+    assert name == "malware.exe"
+    assert content == b"payload"
+
+
+def test_submit_skips_on_download_error(stub_connector):
+    stub_connector.client.submit_file = MagicMock()
+    stub_connector._download_file = MagicMock(return_value=(None, None, "boom"))
+
+    assert stub_connector._submit({"importFiles": [{"id": "f1"}]}) is None
+    stub_connector.client.submit_file.assert_not_called()
+
+
+def test_submit_unknown_defaults_to_true():
+    from connector import ConnectorSettings
+
+    class _Settings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler):
+            return handler(
+                {
+                    "opencti": {"url": "http://localhost:8080", "token": "t"},
+                    "connector": {"id": "c", "scope": "StixFile,Artifact"},
+                    "fortisandbox": {
+                        "api_base_url": "https://fsa.example.com",
+                        "username": "u",
+                        "password": "p",
+                    },
+                }
+            )
+
+    assert _Settings().fortisandbox.submit_unknown is True
 
 
 def test_search_hash_unknown_rating_returns_none(stub_connector):

--- a/internal-enrichment/fortisandbox/tests/tests_connector/test_settings.py
+++ b/internal-enrichment/fortisandbox/tests/tests_connector/test_settings.py
@@ -63,9 +63,10 @@ def test_settings_should_accept_valid_input(settings_dict):
 
 
 @pytest.mark.parametrize(
-    "settings_dict, field_name",
+    "settings_dict, expected_loc",
     [
-        pytest.param({}, "settings", id="empty_settings_dict"),
+        # No specific field: the whole config is empty, so just assert it is rejected.
+        pytest.param({}, None, id="empty_settings_dict"),
         pytest.param(
             {
                 "opencti": {"url": "http://localhost:8080", "token": "test-token"},
@@ -79,7 +80,7 @@ def test_settings_should_accept_valid_input(settings_dict):
                     "password": "api-pass",
                 },
             },
-            "fortisandbox.api_base_url",
+            "api_base_url",
             id="missing_api_base_url",
         ),
         pytest.param(
@@ -95,17 +96,23 @@ def test_settings_should_accept_valid_input(settings_dict):
                     "password": "api-pass",
                 },
             },
-            "connector.id",
+            "id",
             id="missing_connector_id",
         ),
     ],
 )
-def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+def test_settings_should_raise_when_invalid_input(settings_dict, expected_loc):
     class FakeConnectorSettings(ConnectorSettings):
         @classmethod
         def _load_config_dict(cls, _, handler) -> dict[str, Any]:
             return handler(settings_dict)
 
-    with pytest.raises(ConfigValidationError) as err:
+    # match= asserts on the real exception message (not the pytest ExceptionInfo repr).
+    with pytest.raises(
+        ConfigValidationError, match="Error validating configuration"
+    ) as err:
         FakeConnectorSettings()
-    assert str("Error validating configuration") in str(err)
+    # For field-specific cases, assert the offending field is named in the wrapped
+    # pydantic validation error so the test verifies the *right* field is rejected.
+    if expected_loc is not None:
+        assert expected_loc in str(err.value.__cause__)

--- a/internal-enrichment/fortisandbox/tests/tests_connector/test_settings.py
+++ b/internal-enrichment/fortisandbox/tests/tests_connector/test_settings.py
@@ -1,0 +1,111 @@
+from typing import Any
+
+import pytest
+from connector import ConnectorSettings
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "StixFile,Artifact",
+                    "log_level": "error",
+                    "auto": True,
+                },
+                "fortisandbox": {
+                    "api_base_url": "https://fsa.example.com",
+                    "username": "api-user",
+                    "password": "api-pass",
+                    "max_tlp": "TLP:CLEAR",
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "StixFile,Artifact",
+                },
+                "fortisandbox": {
+                    "api_base_url": "https://fsa.example.com",
+                    "username": "api-user",
+                    "password": "api-pass",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.fortisandbox, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param({}, "settings", id="empty_settings_dict"),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "StixFile,Artifact",
+                },
+                "fortisandbox": {
+                    "username": "api-user",
+                    "password": "api-pass",
+                },
+            },
+            "fortisandbox.api_base_url",
+            id="missing_api_base_url",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "name": "Test Connector",
+                    "scope": "StixFile,Artifact",
+                },
+                "fortisandbox": {
+                    "api_base_url": "https://fsa.example.com",
+                    "username": "api-user",
+                    "password": "api-pass",
+                },
+            },
+            "connector.id",
+            id="missing_connector_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert str("Error validating configuration") in str(err)

--- a/internal-enrichment/fortisandbox/tests/tests_fortisandbox_client/test_api_client.py
+++ b/internal-enrichment/fortisandbox/tests/tests_fortisandbox_client/test_api_client.py
@@ -150,3 +150,20 @@ def test_get_submission_verdict_does_not_sleep_past_max_wait():
 
     assert verdict is None
     sleep.assert_not_called()
+
+
+def test_get_submission_verdict_stops_at_max_wait_boundary():
+    # When the accumulated wait reaches max_wait exactly, the loop must return
+    # without sleeping again (the budget is already spent).
+    client = _make_client()
+    client.session_token = "TOKEN"
+    client.session.post.side_effect = [
+        _response({"result": {"data": [{"jid": "5"}]}}),  # get-jobs-of-submission
+        _response({"result": {"data": None}}),  # job: no rating yet
+    ]
+
+    with patch("fortisandbox_client.api_client.time.sleep") as sleep:
+        verdict = client.get_submission_verdict("sub-1", max_wait=30, interval=30)
+
+    assert verdict is None
+    sleep.assert_not_called()

--- a/internal-enrichment/fortisandbox/tests/tests_fortisandbox_client/test_api_client.py
+++ b/internal-enrichment/fortisandbox/tests/tests_fortisandbox_client/test_api_client.py
@@ -1,0 +1,124 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from fortisandbox_client import FortiSandboxAPIError, FortisandboxClient
+
+
+def _make_client() -> FortisandboxClient:
+    client = FortisandboxClient(
+        MagicMock(),
+        api_base_url="https://fsa.example.com",
+        username="api-user",
+        password="api-pass",
+    )
+    client.session = MagicMock()
+    return client
+
+
+def _response(payload, status: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+def test_login_sets_session_token():
+    client = _make_client()
+    client.session.post.return_value = _response({"session": "TOKEN"})
+
+    token = client.login()
+    assert token == "TOKEN"
+    assert client.session_token == "TOKEN"
+
+
+def test_login_without_token_raises():
+    client = _make_client()
+    client.session.post.return_value = _response({"result": {"status": {"code": -1}}})
+
+    with pytest.raises(FortiSandboxAPIError):
+        client.login()
+
+
+def test_get_file_rating_returns_data():
+    client = _make_client()
+    client.session_token = "TOKEN"
+    client.session.post.return_value = _response(
+        {"result": {"data": {"rating": "Malicious", "sha256": "abc"}}}
+    )
+
+    data = client.get_file_rating("abc")
+    assert data["rating"] == "Malicious"
+
+
+def test_get_file_rating_logs_in_when_no_session():
+    client = _make_client()
+    client.session.post.side_effect = [
+        _response({"session": "TOKEN"}),
+        _response({"result": {"data": {"rating": "Clean"}}}),
+    ]
+
+    data = client.get_file_rating("abc")
+    assert data["rating"] == "Clean"
+    assert client.session_token == "TOKEN"
+
+
+def test_extract_data_inline_rating():
+    payload = {"result": {"rating": "Suspicious"}}
+    assert FortisandboxClient._extract_data(payload) == {"rating": "Suspicious"}
+
+
+def test_extract_data_result_list():
+    payload = {"result": [{"data": {"rating": "Clean"}}]}
+    assert FortisandboxClient._extract_data(payload) == {"rating": "Clean"}
+
+
+def test_extract_data_unexpected_returns_none():
+    assert FortisandboxClient._extract_data({"unexpected": 1}) is None
+
+
+def test_extract_jobs_variants():
+    assert FortisandboxClient._extract_jobs({"result": {"data": [{"jid": "1"}]}}) == [
+        {"jid": "1"}
+    ]
+    assert FortisandboxClient._extract_jobs(
+        {"result": {"data": {"jobs": [{"jid": "2"}]}}}
+    ) == [{"jid": "2"}]
+    assert FortisandboxClient._extract_jobs({"result": {}}) == []
+
+
+def test_submit_file_returns_sid():
+    client = _make_client()
+    client.session_token = "TOKEN"
+    client.session.post.return_value = _response({"result": {"sid": "sub-1"}})
+
+    sid = client.submit_file("malware.exe", b"data")
+    assert sid == "sub-1"
+
+
+def test_get_submission_verdict_polls_jobs():
+    client = _make_client()
+    client.session_token = "TOKEN"
+    client.session.post.side_effect = [
+        _response({"result": {"data": [{"jid": "5"}]}}),
+        _response({"result": {"data": {"rating": "Malicious"}}}),
+    ]
+
+    with patch("fortisandbox_client.api_client.time.sleep"):
+        verdict = client.get_submission_verdict("sub-1")
+    assert verdict["rating"] == "Malicious"
+
+
+def test_call_raises_on_http_error():
+    client = _make_client()
+    client.session_token = "TOKEN"
+    err_response = MagicMock()
+    err_response.status_code = 500
+    err_response.reason = "Server Error"
+    bad = MagicMock()
+    bad.raise_for_status.side_effect = requests.HTTPError(response=err_response)
+    client.session.post.return_value = bad
+
+    with pytest.raises(FortiSandboxAPIError):
+        client.get_file_rating("abc")

--- a/internal-enrichment/fortisandbox/tests/tests_fortisandbox_client/test_api_client.py
+++ b/internal-enrichment/fortisandbox/tests/tests_fortisandbox_client/test_api_client.py
@@ -122,3 +122,31 @@ def test_call_raises_on_http_error():
 
     with pytest.raises(FortiSandboxAPIError):
         client.get_file_rating("abc")
+
+
+def test_call_wraps_non_http_request_errors():
+    # Connection/timeout/retry errors (not HTTPError) must also be wrapped as
+    # FortiSandboxAPIError so callers see a single, consistent error type.
+    client = _make_client()
+    client.session_token = "TOKEN"
+    client.session.post.side_effect = requests.ConnectionError("boom")
+
+    with pytest.raises(FortiSandboxAPIError):
+        client.get_file_rating("abc")
+
+
+def test_get_submission_verdict_does_not_sleep_past_max_wait():
+    # With the budget already spent, the poll loop must return without sleeping
+    # one extra interval beyond max_wait.
+    client = _make_client()
+    client.session_token = "TOKEN"
+    client.session.post.side_effect = [
+        _response({"result": {"data": [{"jid": "5"}]}}),  # get-jobs-of-submission
+        _response({"result": {"data": None}}),  # job: no rating yet
+    ]
+
+    with patch("fortisandbox_client.api_client.time.sleep") as sleep:
+        verdict = client.get_submission_verdict("sub-1", max_wait=0, interval=30)
+
+    assert verdict is None
+    sleep.assert_not_called()


### PR DESCRIPTION
## Proposed changes

New internal-enrichment connector for Fortinet FortiSandbox.

When a `StixFile` or `Artifact` observable is enriched, the connector:

- selects the strongest available hash (SHA-256 > SHA-1 > MD5) and queries the FortiSandbox JSON-RPC API (`/scan/result/filerating`);
- maps the FortiSandbox rating (clean / low / medium / high risk / suspicious / malicious) to an OpenCTI score and a `fortisandbox:<rating>` label, plus a `malware:<name>` label when a malware name is returned;
- completes the file hashes and attaches a STIX Malware Analysis object (`product = FortiSandbox`) referencing the observable, inheriting the source observable's markings, with the rating mapped to the STIX `malware-result` vocabulary;
- when no verdict exists yet and the observable carries an uploaded file, submits it for on-demand analysis (`/alert/ondemand/submit-file`) and polls the submission for a verdict (enabled by default via `submit_unknown`, bounded by `submission_timeout`, with `max_file_size` enforced on download).

The connector handles the JSON-RPC session lifecycle (login/logout, session token) and is playbook compatible (it always returns the bundle). It is modeled on the existing `hybrid-analysis-sandbox` connector (connectors-sdk Pydantic settings, retry/backoff client).

## Related issues

Closes #6415

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Unit tests for the client and the connector (patch coverage > 80% on new code)
- [x] Code formatting (`black`, `isort`) and linting (`flake8`, STIX id pylint) pass
- [x] Generated `__metadata__` config schema and documentation
- [x] Added/updated the connector `README.md`, `config.yml.sample`, `docker-compose.yml` and `connector_manifest.json`

## Further comments

FortiSandbox JSON-RPC responses vary slightly across firmware versions, so the client parses results defensively (handles `result` as object or list, inline `rating`, and `data` as object or list). The API base URL and API version are configurable to support appliances, VMs and the cloud service.

## Maintainer review (independent review-and-fix)

Independent senior review of the full connector across several passes, on top of the automated review threads. Substantive fixes:

- JSON-RPC client: `Retry(raise_on_status=False)` so exhausted retries raise a consistent `HTTPError`, and every `requests.RequestException` (retry exhaustion, timeouts, connection errors) is wrapped as `FortiSandboxAPIError` in `_call`. The submission poll is bounded with `waited >= max_wait`, so it no longer sleeps one extra interval past `submission_timeout`.
- Enrichment markings: the Malware Analysis object inherits the source observable's markings, derived from the enrichment payload's `objectMarking` (which is present even when the STIX `object_marking_refs` is not), so an AMBER / AMBER+STRICT observable is no longer downgraded to TLP:CLEAR; it falls back to the connector default (the OpenCTI TLP:CLEAR statement marking) only when the observable carries none. The custom TLP markings are built with `allow_custom=True` and direct `x_opencti_*` kwargs, matching connectors-sdk's `TLPMarking`. Structured log context uses the `meta=` keyword.
- README: fixed the TOC anchor, aligned the minimum OpenCTI version with the manifest, fixed the Debugging logger example, and corrected the base-connector table defaults (`CONNECTOR_TYPE` = `INTERNAL_ENRICHMENT`, `CONNECTOR_LOG_LEVEL` = `error`, `auto` = `false`).
- Tests: the settings test asserts on the exception message via `pytest.raises(match=...)` and verifies the offending field; added coverage for the non-HTTP error wrapping, the bounded submission poll (including the `waited == max_wait` boundary), the Malware Analysis inheriting the observable's marking, and the fallback to the custom TLP:CLEAR default marking. The `stub_connector` fixture no longer overrides the connector's default marking with `stix2.TLP_WHITE`, so tests exercise the real runtime TLP handling.
- Dependencies: `pycti` pinned to the latest released version (7.260701.0), matching the connectors-sdk pin on master; connectors-sdk installed from master.
- Branch: rebased onto the latest `master` (clean linear history, all commits signed).

## Community status and manager compatibility (follow-up pass)

- The manifest declares `"verified": false` and `"last_verified_date": null` **intentionally**: this is community-contributed work and is not officially verified by Filigran. The two resulting VC201 findings from the advisory Connector Verified Linter job are expected and accepted; that job runs with `continue-on-error` and does not block merge.
- `"manager_supported": true` is set, with `support_version >= 7.260701.0` (matching the pinned pycti) and the standard `use_cases` taxonomy (`Enrichment & Analysis`, `Malware Analysis and Sandbox`).
- Manager-compatibility audit against the repo templates, connectors-sdk and the connector-linter: config is loaded exclusively through connectors-sdk pydantic-settings (env vars + optional `config.yml`, no legacy `get_config_variable`); `__metadata__/connector_config_schema.json` and `CONNECTOR_CONFIG_DOC.md` were regenerated with the SDK tooling and match the settings model exactly; `config.yml.sample` and `docker-compose.yml` follow the sample conventions (exact `ChangeMe` placeholders, defaulted variables commented out, `:latest` image tag); the Dockerfile now uses a direct `ENTRYPOINT ["python", "main.py"]` (entrypoint.sh removed).
- Out-of-scope playbook triggers are now handled explicitly via `event_type`: a playbook trigger for an unsupported entity type gets the original bundle back unchanged, while a manual enrichment raises a clear error (covered by two new tests; 49 tests pass).

## Decisions (Copilot comment intentionally not applied)

- The Dockerfile `apk update && apk upgrade` is kept: it is the current `templates/internal-enrichment/Dockerfile` convention (used by ~100 connectors) and patches base-image CVEs at build time; `apk --no-cache add` keeps the package layer cache-free and `apk del git build-base` drops the build toolchain.

## Status

All blocking CI checks are green on the current head (tests, lint/format, STIX ID linter, codecov). The advisory Connector Verified Linter job reports only the two expected VC201 findings caused by the intentional `verified: false` community status. 0 unresolved review threads.
