### PR TITLE
feat(corelight-investigator): create external-import connector for alerts and detections (#6736)

### DIFF
--- a/external-import/corelight-investigator/Dockerfile
+++ b/external-import/corelight-investigator/Dockerfile
@@ -13,7 +13,5 @@ RUN cd /opt/opencti-connector-corelight-investigator && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+WORKDIR /opt/opencti-connector-corelight-investigator
+ENTRYPOINT ["python", "main.py"]

--- a/external-import/corelight-investigator/Dockerfile
+++ b/external-import/corelight-investigator/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-alpine
+ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
+
+# Copy the connector
+COPY src /opt/opencti-connector-corelight-investigator
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk update && apk upgrade && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN cd /opt/opencti-connector-corelight-investigator && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/external-import/corelight-investigator/README.md
+++ b/external-import/corelight-investigator/README.md
@@ -13,7 +13,7 @@ state.
 
 Table of Contents
 
-- [OpenCTI Corelight Investigator Connector](#opencti-external-ingestion-connector-corelight-investigator)
+- [OpenCTI Corelight Investigator Connector](#opencti-corelight-investigator-connector)
   - [Introduction](#introduction)
   - [Installation](#installation)
     - [Requirements](#requirements)
@@ -90,7 +90,7 @@ Below are the parameters you'll need to set for the connector:
 ### Docker Deployment
 
 Before building the Docker container, you need to set the version of pycti in `requirements.txt` equal to whatever
-version of OpenCTI you're running. Example, `pycti==5.12.20`. If you don't, it will take the latest version, but
+version of OpenCTI you're running. Example, `pycti==7.260701.0`. If you don't, it will take the latest version, but
 sometimes the OpenCTI SDK fails to initialize.
 
 Build a Docker Image using the provided `Dockerfile`.
@@ -168,7 +168,7 @@ API reference; the endpoint path is configurable via `alerts_path` if your tenan
 ## Debugging
 
 The connector can be debugged by setting the appropriate log level.
-Note that logging messages can be added using `self.helper.connector_logger,{LOG_LEVEL}("Sample message")`, i.
+Note that logging messages can be added using `self.helper.connector_logger.{LOG_LEVEL}("Sample message")`, i.
 e., `self.helper.connector_logger.error("An error message")`.
 
 <!-- Any additional information to help future users debug and report detailed issues concerning this connector -->

--- a/external-import/corelight-investigator/README.md
+++ b/external-import/corelight-investigator/README.md
@@ -40,7 +40,7 @@ detections mapped to MITRE ATT&CK. This connector imports those findings into Op
 ### Requirements
 
 - Python >= 3.11
-- OpenCTI Platform >= 6.8.13
+- OpenCTI Platform >= 6.8.12
 - A Corelight Investigator API key (read access to Detections and Alerts)
 - [`pycti`](https://pypi.org/project/pycti/) library matching your OpenCTI version
 - [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk) library matching your OpenCTI version

--- a/external-import/corelight-investigator/README.md
+++ b/external-import/corelight-investigator/README.md
@@ -40,7 +40,7 @@ detections mapped to MITRE ATT&CK. This connector imports those findings into Op
 ### Requirements
 
 - Python >= 3.11
-- OpenCTI Platform >= 6.8.12
+- OpenCTI Platform >= 7.260701.0
 - A Corelight Investigator API key (read access to Detections and Alerts)
 - [`pycti`](https://pypi.org/project/pycti/) library matching your OpenCTI version
 - [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk) library matching your OpenCTI version
@@ -63,13 +63,14 @@ Below are the parameters you'll need to set for OpenCTI:
 
 Below are the parameters you'll need to set for running the connector properly:
 
-| Parameter       | config.yml | Docker environment variable | Default         | Mandatory | Description                                                                              |
-| --------------- | ---------- | --------------------------- | --------------- | --------- | ---------------------------------------------------------------------------------------- |
-| Connector ID    | id         | `CONNECTOR_ID`              | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
-| Connector Type  | type       | `CONNECTOR_TYPE`            | EXTERNAL_IMPORT | Yes       | Should always be set to `EXTERNAL_IMPORT` for this connector.                            |
-| Connector Name  | name       | `CONNECTOR_NAME`            |                 | Yes       | Name of the connector.                                                                   |
-| Connector Scope | scope      | `CONNECTOR_SCOPE`           |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
-| Log Level       | log_level  | `CONNECTOR_LOG_LEVEL`       | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
+| Parameter       | config.yml      | Docker environment variable | Default                 | Mandatory | Description                                                                              |
+| --------------- | --------------- | --------------------------- | ----------------------- | --------- | ---------------------------------------------------------------------------------------- |
+| Connector ID    | id              | `CONNECTOR_ID`              | /                       | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
+| Connector Type  | type            | `CONNECTOR_TYPE`            | EXTERNAL_IMPORT         | Yes       | Should always be set to `EXTERNAL_IMPORT` for this connector.                            |
+| Connector Name  | name            | `CONNECTOR_NAME`            | Corelight Investigator  | No        | Name of the connector.                                                                   |
+| Connector Scope | scope           | `CONNECTOR_SCOPE`           | corelight-investigator  | No        | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
+| Log Level       | log_level       | `CONNECTOR_LOG_LEVEL`       | error                   | No        | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
+| Duration Period | duration_period | `CONNECTOR_DURATION_PERIOD` | PT1H                    | No        | Interval in ISO-8601 format between two runs of the connector.                           |
 
 ### Connector extra parameters environment variables
 

--- a/external-import/corelight-investigator/README.md
+++ b/external-import/corelight-investigator/README.md
@@ -1,0 +1,183 @@
+# OpenCTI Corelight Investigator Connector
+
+The Corelight Investigator connector is an **external-import** connector that pulls alerts
+and detections from Corelight Investigator (Corelight's SaaS NDR) into OpenCTI as STIX
+Incidents.
+
+On a schedule it queries the Investigator "Detections and Alerts" API, maps each alert /
+detection to a STIX Incident (with the normalized Investigator severity 1-10 mapped to the
+OpenCTI severity), extracts the source / destination IP observables referenced by an alert
+and relates them to the Incident, and attributes everything to a Corelight Investigator
+author identity with a configurable TLP marking. Imports are incremental via connector
+state.
+
+Table of Contents
+
+- [OpenCTI Corelight Investigator Connector](#opencti-external-ingestion-connector-corelight-investigator)
+  - [Introduction](#introduction)
+  - [Installation](#installation)
+    - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenCTI environment variables](#opencti-environment-variables)
+    - [Base connector environment variables](#base-connector-environment-variables)
+    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
+
+## Introduction
+
+[Corelight Investigator](https://corelight.com/products/investigator) is Corelight's
+SaaS NDR platform. It produces ML / behavioral / signature / threat-intel alerts and
+detections mapped to MITRE ATT&CK. This connector imports those findings into OpenCTI.
+
+## Installation
+
+### Requirements
+
+- Python >= 3.11
+- OpenCTI Platform >= 6.8.13
+- A Corelight Investigator API key (read access to Detections and Alerts)
+- [`pycti`](https://pypi.org/project/pycti/) library matching your OpenCTI version
+- [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk) library matching your OpenCTI version
+
+## Configuration variables
+
+There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
+in `config.yml` (for manual deployment).
+
+### OpenCTI environment variables
+
+Below are the parameters you'll need to set for OpenCTI:
+
+| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
+| ------------- | ---------- | --------------------------- | --------- | ---------------------------------------------------- |
+| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
+| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+
+### Base connector environment variables
+
+Below are the parameters you'll need to set for running the connector properly:
+
+| Parameter       | config.yml | Docker environment variable | Default         | Mandatory | Description                                                                              |
+| --------------- | ---------- | --------------------------- | --------------- | --------- | ---------------------------------------------------------------------------------------- |
+| Connector ID    | id         | `CONNECTOR_ID`              | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
+| Connector Type  | type       | `CONNECTOR_TYPE`            | EXTERNAL_IMPORT | Yes       | Should always be set to `EXTERNAL_IMPORT` for this connector.                            |
+| Connector Name  | name       | `CONNECTOR_NAME`            |                 | Yes       | Name of the connector.                                                                   |
+| Connector Scope | scope      | `CONNECTOR_SCOPE`           |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
+| Log Level       | log_level  | `CONNECTOR_LOG_LEVEL`       | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
+
+### Connector extra parameters environment variables
+
+Below are the parameters you'll need to set for the connector:
+
+| Parameter          | config.yml         | Docker environment variable             | Default          | Mandatory | Description                                                                  |
+| ------------------ | ------------------ | --------------------------------------- | ---------------- | --------- | --------------------------------------------------------------------------- |
+| API base URL       | api_base_url       | `CORELIGHT_INVESTIGATOR_API_BASE_URL`   |                  | Yes       | Corelight Investigator API base URL (region specific).                      |
+| API key            | api_key            | `CORELIGHT_INVESTIGATOR_API_KEY`        |                  | Yes       | Corelight Investigator API key (Authorization bearer header).               |
+| Alerts path        | alerts_path        | `CORELIGHT_INVESTIGATOR_ALERTS_PATH`    | `/api/v1/alerts` | No        | Path of the Detections and Alerts API endpoint.                             |
+| Import window days | import_window_days | `CORELIGHT_INVESTIGATOR_IMPORT_WINDOW_DAYS` | `7`          | No        | Look-back window (days) used on the first run.                              |
+| Max alerts         | max_alerts         | `CORELIGHT_INVESTIGATOR_MAX_ALERTS`     | `1000`           | No        | Maximum number of alerts to request per run.                                |
+| TLP level          | tlp_level          | `CORELIGHT_INVESTIGATOR_TLP_LEVEL`      | `amber`          | No        | Default TLP marking applied to imported entities.                           |
+| Verify SSL         | ssl_verify         | `CORELIGHT_INVESTIGATOR_SSL_VERIFY`     | `true`           | No        | Whether to verify the API server TLS certificate.                           |
+
+## Deployment
+
+### Docker Deployment
+
+Before building the Docker container, you need to set the version of pycti in `requirements.txt` equal to whatever
+version of OpenCTI you're running. Example, `pycti==5.12.20`. If you don't, it will take the latest version, but
+sometimes the OpenCTI SDK fails to initialize.
+
+Build a Docker Image using the provided `Dockerfile`.
+
+Example:
+
+```shell
+# Replace the IMAGE NAME with the appropriate value
+docker build . -t [IMAGE NAME]:latest
+```
+
+Make sure to replace the environment variables in `docker-compose.yml` with the appropriate configurations for your
+environment. Then, start the docker container with the provided docker-compose.yml
+
+```shell
+docker compose up -d
+# -d for detached
+```
+
+### Manual Deployment
+
+Create a file `config.yml` based on the provided `config.yml.sample`.
+
+Replace the configuration variables (especially the "**ChangeMe**" variables) with the appropriate configurations for
+you environment.
+
+Install the required python dependencies (preferably in a virtual environment):
+
+```shell
+pip3 install -r requirements.txt
+```
+
+Then, start the connector from `src` directory:
+
+```shell
+python3 main.py
+```
+
+## Usage
+
+After Installation, the connector should require minimal interaction to use, and should update automatically at a regular interval specified in your `docker-compose.yml` or `config.yml` in `duration_period`.
+
+However, if you would like to force an immediate download of a new batch of entities, navigate to:
+
+`Data management` -> `Ingestion` -> `Connectors` in the OpenCTI platform.
+
+Find the connector, and click on the refresh button to reset the connector's state and force a new
+download of data by re-running the connector.
+
+## Behavior
+
+On each run the connector:
+
+1. Determines the lookback start time (`last_run` from state, or now minus
+   `import_window_days` on the first run).
+2. Queries the Investigator Detections and Alerts API for alerts since that time.
+3. Maps each alert / detection to a STIX Incident; the normalized Investigator severity
+   (1-10) is mapped to the OpenCTI severity:
+
+   | Investigator severity | OpenCTI severity |
+   | --------------------- | ---------------- |
+   | 9-10                  | critical         |
+   | 7-8                   | high             |
+   | 4-6                   | medium           |
+   | 1-3                   | low              |
+
+4. Extracts the source / destination IP observables referenced by an alert and creates
+   `related-to` relationships from the Incident to those observables.
+5. Bundles the Incidents, observables, author identity and TLP marking and sends them to
+   OpenCTI, then records the run timestamp.
+
+The exact REST path/parameters of the Investigator API are documented in the in-product
+API reference; the endpoint path is configurable via `alerts_path` if your tenant differs.
+
+## Debugging
+
+The connector can be debugged by setting the appropriate log level.
+Note that logging messages can be added using `self.helper.connector_logger,{LOG_LEVEL}("Sample message")`, i.
+e., `self.helper.connector_logger.error("An error message")`.
+
+<!-- Any additional information to help future users debug and report detailed issues concerning this connector -->
+
+## Additional information
+
+<!--
+Any additional information about this connector
+* What information is ingested/updated/changed
+* What should the user take into account when using this connector
+* ...
+-->

--- a/external-import/corelight-investigator/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/corelight-investigator/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,22 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'flashpoint'. |
+| CORELIGHT_INVESTIGATOR_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Corelight Investigator API base URL (region specific, e.g. https://eu.api.investigator.corelight.com). |
+| CORELIGHT_INVESTIGATOR_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Corelight Investigator API key (sent as an Authorization bearer header). |
+| CONNECTOR_NAME | `string` |  | string | `"Corelight Investigator"` | The name of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
+| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"PT1H"` | The period of time to await between two runs of the connector. |
+| CORELIGHT_INVESTIGATOR_ALERTS_PATH | `string` |  | string | `"/api/v1/alerts"` | Path of the Investigator Detections and Alerts API endpoint. |
+| CORELIGHT_INVESTIGATOR_IMPORT_WINDOW_DAYS | `integer` |  | `0 < x ` | `7` | Number of days to look back on the first run. |
+| CORELIGHT_INVESTIGATOR_MAX_ALERTS | `integer` |  | `0 < x ` | `1000` | Maximum number of alerts to request per run. |
+| CORELIGHT_INVESTIGATOR_TLP_LEVEL | `string` |  | `clear` `white` `green` `amber` `amber+strict` `red` | `"amber"` | Default TLP marking applied to the imported entities. |
+| CORELIGHT_INVESTIGATOR_SSL_VERIFY | `boolean` |  | boolean | `true` | Whether to verify the API server TLS certificate. |

--- a/external-import/corelight-investigator/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/corelight-investigator/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -8,10 +8,10 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
 | OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
-| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'flashpoint'. |
 | CORELIGHT_INVESTIGATOR_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Corelight Investigator API base URL (region specific, e.g. https://eu.api.investigator.corelight.com). |
 | CORELIGHT_INVESTIGATOR_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Corelight Investigator API key (sent as an Authorization bearer header). |
 | CONNECTOR_NAME | `string` |  | string | `"Corelight Investigator"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["corelight-investigator"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
 | CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"PT1H"` | The period of time to await between two runs of the connector. |

--- a/external-import/corelight-investigator/__metadata__/connector_config_schema.json
+++ b/external-import/corelight-investigator/__metadata__/connector_config_schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/corelight-investigator_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Corelight Investigator",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "description": "The scope of the connector, e.g. 'flashpoint'.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT1H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "CORELIGHT_INVESTIGATOR_API_BASE_URL": {
+      "description": "Corelight Investigator API base URL (region specific, e.g. https://eu.api.investigator.corelight.com).",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "CORELIGHT_INVESTIGATOR_API_KEY": {
+      "description": "Corelight Investigator API key (sent as an Authorization bearer header).",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CORELIGHT_INVESTIGATOR_ALERTS_PATH": {
+      "default": "/api/v1/alerts",
+      "description": "Path of the Investigator Detections and Alerts API endpoint.",
+      "type": "string"
+    },
+    "CORELIGHT_INVESTIGATOR_IMPORT_WINDOW_DAYS": {
+      "default": 7,
+      "description": "Number of days to look back on the first run.",
+      "exclusiveMinimum": 0,
+      "type": "integer"
+    },
+    "CORELIGHT_INVESTIGATOR_MAX_ALERTS": {
+      "default": 1000,
+      "description": "Maximum number of alerts to request per run.",
+      "exclusiveMinimum": 0,
+      "type": "integer"
+    },
+    "CORELIGHT_INVESTIGATOR_TLP_LEVEL": {
+      "default": "amber",
+      "description": "Default TLP marking applied to the imported entities.",
+      "enum": [
+        "clear",
+        "white",
+        "green",
+        "amber",
+        "amber+strict",
+        "red"
+      ],
+      "type": "string"
+    },
+    "CORELIGHT_INVESTIGATOR_SSL_VERIFY": {
+      "default": true,
+      "description": "Whether to verify the API server TLS certificate.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_SCOPE",
+    "CORELIGHT_INVESTIGATOR_API_BASE_URL",
+    "CORELIGHT_INVESTIGATOR_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/corelight-investigator/__metadata__/connector_config_schema.json
+++ b/external-import/corelight-investigator/__metadata__/connector_config_schema.json
@@ -20,7 +20,10 @@
       "type": "string"
     },
     "CONNECTOR_SCOPE": {
-      "description": "The scope of the connector, e.g. 'flashpoint'.",
+      "default": [
+        "corelight-investigator"
+      ],
+      "description": "The scope of the connector.",
       "items": {
         "type": "string"
       },
@@ -101,7 +104,6 @@
   "required": [
     "OPENCTI_URL",
     "OPENCTI_TOKEN",
-    "CONNECTOR_SCOPE",
     "CORELIGHT_INVESTIGATOR_API_BASE_URL",
     "CORELIGHT_INVESTIGATOR_API_KEY"
   ],

--- a/external-import/corelight-investigator/__metadata__/connector_manifest.json
+++ b/external-import/corelight-investigator/__metadata__/connector_manifest.json
@@ -1,0 +1,21 @@
+{
+  "title": "Corelight Investigator",
+  "slug": "corelight-investigator",
+  "description": "The OpenCTI Corelight Investigator connector imports alerts and detections from Corelight Investigator (SaaS NDR) into OpenCTI as STIX Incidents. It periodically queries the Investigator Detections and Alerts API (bearer API key), maps the normalized Investigator severity (1-10) to the OpenCTI severity, extracts the source/destination IP observables referenced by an alert, and attributes the imported objects to a Corelight Investigator author identity with a configurable TLP marking. Imports are incremental using the connector state.",
+  "short_description": "Import Corelight Investigator alerts and detections into OpenCTI as STIX Incidents.",
+  "logo": null,
+  "use_cases": [
+    "Threat Detection"
+  ],
+  "verified": true,
+  "last_verified_date": null,
+  "playbook_supported": false,
+  "max_confidence_level": 50,
+  "support_version": ">=6.8.12",
+  "subscription_link": null,
+  "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/corelight-investigator",
+  "manager_supported": false,
+  "container_version": "rolling",
+  "container_image": "opencti/connector-corelight-investigator",
+  "container_type": "EXTERNAL_IMPORT"
+}

--- a/external-import/corelight-investigator/__metadata__/connector_manifest.json
+++ b/external-import/corelight-investigator/__metadata__/connector_manifest.json
@@ -7,14 +7,14 @@
   "use_cases": [
     "Threat Detection"
   ],
-  "verified": true,
+  "verified": false,
   "last_verified_date": null,
   "playbook_supported": false,
   "max_confidence_level": 50,
-  "support_version": ">=6.8.12",
+  "support_version": ">=7.260701.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/corelight-investigator",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-corelight-investigator",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/corelight-investigator/__metadata__/connector_manifest.json
+++ b/external-import/corelight-investigator/__metadata__/connector_manifest.json
@@ -5,7 +5,8 @@
   "short_description": "Import Corelight Investigator alerts and detections into OpenCTI as STIX Incidents.",
   "logo": null,
   "use_cases": [
-    "Threat Detection"
+    "Detection & Response Enablement",
+    "Network Security"
   ],
   "verified": false,
   "last_verified_date": null,

--- a/external-import/corelight-investigator/config.yml.sample
+++ b/external-import/corelight-investigator/config.yml.sample
@@ -1,0 +1,20 @@
+opencti:
+  url: 'http://localhost'
+  token: 'ChangeMe'
+
+connector:
+  type: 'EXTERNAL_IMPORT'
+  id: 'ChangeMe'
+  name: 'Corelight Investigator' # optional (default: 'Corelight Investigator')
+  scope: 'corelight-investigator' # optional
+  log_level: 'error' # optional (default: 'error')
+  duration_period: 'PT1H' # optional, interval in ISO-8601 format between two runs of the connector (default: 'PT1H')
+
+corelight_investigator:
+  api_base_url: 'https://eu.api.investigator.corelight.com' # Corelight Investigator API base URL (region specific)
+  api_key: 'ChangeMe' # Corelight Investigator API key (Authorization bearer header)
+  alerts_path: '/api/v1/alerts' # optional, Detections and Alerts API endpoint path (default: '/api/v1/alerts')
+  import_window_days: 7 # optional, look-back window in days on the first run (default: 7)
+  max_alerts: 1000 # optional, max alerts to request per run (default: 1000)
+  tlp_level: 'amber' # optional, available values: 'clear', 'white', 'green', 'amber', 'amber+strict', 'red' (default: 'amber')
+  ssl_verify: true # optional (default: true)

--- a/external-import/corelight-investigator/config.yml.sample
+++ b/external-import/corelight-investigator/config.yml.sample
@@ -6,7 +6,7 @@ connector:
   type: 'EXTERNAL_IMPORT'
   id: 'ChangeMe'
   name: 'Corelight Investigator' # optional (default: 'Corelight Investigator')
-  scope: 'corelight-investigator' # optional
+  scope: 'corelight-investigator' # mandatory
   log_level: 'error' # optional (default: 'error')
   duration_period: 'PT1H' # optional, interval in ISO-8601 format between two runs of the connector (default: 'PT1H')
 

--- a/external-import/corelight-investigator/config.yml.sample
+++ b/external-import/corelight-investigator/config.yml.sample
@@ -5,16 +5,16 @@ opencti:
 connector:
   type: 'EXTERNAL_IMPORT'
   id: 'ChangeMe'
-  name: 'Corelight Investigator' # optional (default: 'Corelight Investigator')
-  scope: 'corelight-investigator' # mandatory
-  log_level: 'error' # optional (default: 'error')
-  duration_period: 'PT1H' # optional, interval in ISO-8601 format between two runs of the connector (default: 'PT1H')
+  #name: 'Corelight Investigator' # optional (default: 'Corelight Investigator')
+  #scope: 'corelight-investigator' # optional (default: 'corelight-investigator')
+  #log_level: 'error' # optional (default: 'error')
+  #duration_period: 'PT1H' # optional, interval in ISO-8601 format between two runs of the connector (default: 'PT1H')
 
 corelight_investigator:
-  api_base_url: 'https://eu.api.investigator.corelight.com' # Corelight Investigator API base URL (region specific)
+  api_base_url: 'ChangeMe' # Corelight Investigator API base URL, region specific, e.g. 'https://eu.api.investigator.corelight.com'
   api_key: 'ChangeMe' # Corelight Investigator API key (Authorization bearer header)
-  alerts_path: '/api/v1/alerts' # optional, Detections and Alerts API endpoint path (default: '/api/v1/alerts')
-  import_window_days: 7 # optional, look-back window in days on the first run (default: 7)
-  max_alerts: 1000 # optional, max alerts to request per run (default: 1000)
-  tlp_level: 'amber' # optional, available values: 'clear', 'white', 'green', 'amber', 'amber+strict', 'red' (default: 'amber')
-  ssl_verify: true # optional (default: true)
+  #alerts_path: '/api/v1/alerts' # optional, Detections and Alerts API endpoint path (default: '/api/v1/alerts')
+  #import_window_days: 7 # optional, look-back window in days on the first run (default: 7)
+  #max_alerts: 1000 # optional, max alerts to request per run (default: 1000)
+  #tlp_level: 'amber' # optional, available values: 'clear', 'white', 'green', 'amber', 'amber+strict', 'red' (default: 'amber')
+  #ssl_verify: true # optional (default: true)

--- a/external-import/corelight-investigator/docker-compose.yml
+++ b/external-import/corelight-investigator/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       # Common parameters for connectors of type EXTERNAL_IMPORT
       - CONNECTOR_ID=CHANGEME
       - CONNECTOR_NAME=Corelight Investigator # optional (default: 'Corelight Investigator')
-      - CONNECTOR_SCOPE=corelight-investigator # optional
+      - CONNECTOR_SCOPE=corelight-investigator # mandatory
       - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
       - CONNECTOR_DURATION_PERIOD=PT1H # optional, interval in ISO-8601 format between two runs of the connector (default: 'PT1H')
       # Custom parameters for connector-corelight-investigator

--- a/external-import/corelight-investigator/docker-compose.yml
+++ b/external-import/corelight-investigator/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  connector-corelight-investigator:
+    image: opencti/connector-corelight-investigator:latest # 'corelight-investigator' being the name of connector's directory
+    environment:
+      # Generic parameters (connection with OpenCTI)
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=CHANGEME
+      # Common parameters for connectors of type EXTERNAL_IMPORT
+      - CONNECTOR_ID=CHANGEME
+      - CONNECTOR_NAME=Corelight Investigator # optional (default: 'Corelight Investigator')
+      - CONNECTOR_SCOPE=corelight-investigator # optional
+      - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
+      - CONNECTOR_DURATION_PERIOD=PT1H # optional, interval in ISO-8601 format between two runs of the connector (default: 'PT1H')
+      # Custom parameters for connector-corelight-investigator
+      - CORELIGHT_INVESTIGATOR_API_BASE_URL=https://eu.api.investigator.corelight.com # region specific
+      - CORELIGHT_INVESTIGATOR_API_KEY=CHANGEME
+      - CORELIGHT_INVESTIGATOR_ALERTS_PATH=/api/v1/alerts # optional (default: '/api/v1/alerts')
+      - CORELIGHT_INVESTIGATOR_IMPORT_WINDOW_DAYS=7 # optional (default: 7)
+      - CORELIGHT_INVESTIGATOR_MAX_ALERTS=1000 # optional (default: 1000)
+      - CORELIGHT_INVESTIGATOR_TLP_LEVEL=amber # optional, available values: 'clear', 'white', 'green', 'amber', 'amber+strict', 'red' (default: 'amber')
+      - CORELIGHT_INVESTIGATOR_SSL_VERIFY=true # optional (default: true)
+    restart: always

--- a/external-import/corelight-investigator/docker-compose.yml
+++ b/external-import/corelight-investigator/docker-compose.yml
@@ -5,19 +5,19 @@ services:
     environment:
       # Generic parameters (connection with OpenCTI)
       - OPENCTI_URL=http://localhost
-      - OPENCTI_TOKEN=CHANGEME
+      - OPENCTI_TOKEN=ChangeMe
       # Common parameters for connectors of type EXTERNAL_IMPORT
-      - CONNECTOR_ID=CHANGEME
-      - CONNECTOR_NAME=Corelight Investigator # optional (default: 'Corelight Investigator')
-      - CONNECTOR_SCOPE=corelight-investigator # mandatory
-      - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
-      - CONNECTOR_DURATION_PERIOD=PT1H # optional, interval in ISO-8601 format between two runs of the connector (default: 'PT1H')
+      - CONNECTOR_ID=ChangeMe
+      #- CONNECTOR_NAME=Corelight Investigator # optional (default: 'Corelight Investigator')
+      #- CONNECTOR_SCOPE=corelight-investigator # optional (default: 'corelight-investigator')
+      #- CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
+      #- CONNECTOR_DURATION_PERIOD=PT1H # optional, interval in ISO-8601 format between two runs of the connector (default: 'PT1H')
       # Custom parameters for connector-corelight-investigator
-      - CORELIGHT_INVESTIGATOR_API_BASE_URL=https://eu.api.investigator.corelight.com # region specific
-      - CORELIGHT_INVESTIGATOR_API_KEY=CHANGEME
-      - CORELIGHT_INVESTIGATOR_ALERTS_PATH=/api/v1/alerts # optional (default: '/api/v1/alerts')
-      - CORELIGHT_INVESTIGATOR_IMPORT_WINDOW_DAYS=7 # optional (default: 7)
-      - CORELIGHT_INVESTIGATOR_MAX_ALERTS=1000 # optional (default: 1000)
-      - CORELIGHT_INVESTIGATOR_TLP_LEVEL=amber # optional, available values: 'clear', 'white', 'green', 'amber', 'amber+strict', 'red' (default: 'amber')
-      - CORELIGHT_INVESTIGATOR_SSL_VERIFY=true # optional (default: true)
+      - CORELIGHT_INVESTIGATOR_API_BASE_URL=ChangeMe # region specific, e.g. 'https://eu.api.investigator.corelight.com'
+      - CORELIGHT_INVESTIGATOR_API_KEY=ChangeMe
+      #- CORELIGHT_INVESTIGATOR_ALERTS_PATH=/api/v1/alerts # optional (default: '/api/v1/alerts')
+      #- CORELIGHT_INVESTIGATOR_IMPORT_WINDOW_DAYS=7 # optional (default: 7)
+      #- CORELIGHT_INVESTIGATOR_MAX_ALERTS=1000 # optional (default: 1000)
+      #- CORELIGHT_INVESTIGATOR_TLP_LEVEL=amber # optional, available values: 'clear', 'white', 'green', 'amber', 'amber+strict', 'red' (default: 'amber')
+      #- CORELIGHT_INVESTIGATOR_SSL_VERIFY=true # optional (default: true)
     restart: always

--- a/external-import/corelight-investigator/entrypoint.sh
+++ b/external-import/corelight-investigator/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Go to the right directory
+cd /opt/opencti-connector-corelight-investigator
+
+# Launch the worker
+python3 main.py

--- a/external-import/corelight-investigator/entrypoint.sh
+++ b/external-import/corelight-investigator/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-corelight-investigator
-
-# Launch the worker
-python3 main.py

--- a/external-import/corelight-investigator/src/connector/__init__.py
+++ b/external-import/corelight-investigator/src/connector/__init__.py
@@ -1,0 +1,7 @@
+from connector.connector import CorelightInvestigatorConnector
+from connector.settings import ConnectorSettings
+
+__all__ = [
+    "ConnectorSettings",
+    "CorelightInvestigatorConnector",
+]

--- a/external-import/corelight-investigator/src/connector/connector.py
+++ b/external-import/corelight-investigator/src/connector/connector.py
@@ -60,6 +60,7 @@ class CorelightInvestigatorConnector:
         self.helper.connector_logger.info(
             "[CONNECTOR] Starting Corelight Investigator connector..."
         )
+        work_id = None
         try:
             now = datetime.now(timezone.utc)
             since = self._since()
@@ -85,8 +86,12 @@ class CorelightInvestigatorConnector:
             sys.exit(0)
         except CorelightInvestigatorAPIError as err:
             self.helper.connector_logger.error(str(err))
+            if work_id:
+                self.helper.api.work.to_processed(work_id, str(err), in_error=True)
         except Exception as err:
             self.helper.connector_logger.error(str(err))
+            if work_id:
+                self.helper.api.work.to_processed(work_id, str(err), in_error=True)
 
     def run(self) -> None:
         self.helper.schedule_process(

--- a/external-import/corelight-investigator/src/connector/connector.py
+++ b/external-import/corelight-investigator/src/connector/connector.py
@@ -1,0 +1,95 @@
+import sys
+from datetime import datetime, timedelta, timezone
+
+from connector.converter_to_stix import ConverterToStix
+from connector.settings import ConnectorSettings
+from corelight_investigator_client import (
+    CorelightInvestigatorAPIError,
+    CorelightInvestigatorClient,
+)
+from pycti import OpenCTIConnectorHelper
+
+
+class CorelightInvestigatorConnector:
+    """
+    External-import connector that pulls Corelight Investigator alerts/detections into
+    OpenCTI as STIX Incidents.
+    """
+
+    def __init__(self, config: ConnectorSettings, helper: OpenCTIConnectorHelper):
+        self.config = config
+        self.helper = helper
+        self.client = CorelightInvestigatorClient(
+            helper,
+            api_base_url=self.config.corelight_investigator.api_base_url,
+            api_key=self.config.corelight_investigator.api_key.get_secret_value(),
+            alerts_path=self.config.corelight_investigator.alerts_path,
+            max_alerts=self.config.corelight_investigator.max_alerts,
+            ssl_verify=self.config.corelight_investigator.ssl_verify,
+        )
+        self.converter = ConverterToStix(
+            helper, tlp_level=self.config.corelight_investigator.tlp_level
+        )
+
+    def _since(self) -> str:
+        state = self.helper.get_state() or {}
+        last_run = state.get("last_run")
+        if last_run:
+            return last_run
+        window = self.config.corelight_investigator.import_window_days
+        since = datetime.now(timezone.utc) - timedelta(days=window)
+        return since.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+    def _collect_intelligence(self, since: str) -> list:
+        alerts = self.client.get_alerts(since=since)
+        stix_objects: list = []
+        for alert in alerts:
+            incident = self.converter.create_incident(alert)
+            if incident is None:
+                continue
+            stix_objects.append(incident)
+            stix_objects.extend(
+                self.converter.create_observables(alert, incident["id"])
+            )
+        if stix_objects:
+            stix_objects.append(self.converter.author)
+            stix_objects.append(self.converter.tlp_marking)
+        return stix_objects
+
+    def process_message(self) -> None:
+        self.helper.connector_logger.info(
+            "[CONNECTOR] Starting Corelight Investigator connector..."
+        )
+        try:
+            now = datetime.now(timezone.utc)
+            since = self._since()
+            work_id = self.helper.api.work.initiate_work(
+                self.helper.connect_id, "Corelight Investigator run"
+            )
+
+            stix_objects = self._collect_intelligence(since)
+            if stix_objects:
+                bundle = self.helper.stix2_create_bundle(stix_objects)
+                self.helper.send_stix2_bundle(
+                    bundle, work_id=work_id, cleanup_inconsistent_bundle=True
+                )
+
+            current_state = self.helper.get_state() or {}
+            current_state["last_run"] = now.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+            self.helper.set_state(current_state)
+            self.helper.api.work.to_processed(
+                work_id, "Corelight Investigator connector successfully run"
+            )
+        except (KeyboardInterrupt, SystemExit):
+            self.helper.connector_logger.info("[CONNECTOR] Connector stopped...")
+            sys.exit(0)
+        except CorelightInvestigatorAPIError as err:
+            self.helper.connector_logger.error(str(err))
+        except Exception as err:
+            self.helper.connector_logger.error(str(err))
+
+    def run(self) -> None:
+        self.helper.schedule_process(
+            message_callback=self.process_message,
+            duration_period=self.config.connector.duration_period.total_seconds(),
+        )

--- a/external-import/corelight-investigator/src/connector/connector.py
+++ b/external-import/corelight-investigator/src/connector/connector.py
@@ -64,12 +64,14 @@ class CorelightInvestigatorConnector:
         try:
             now = datetime.now(timezone.utc)
             since = self._since()
-            work_id = self.helper.api.work.initiate_work(
-                self.helper.connect_id, "Corelight Investigator run"
-            )
 
+            # Only initiate a work when there is data to ingest, so empty runs
+            # do not clutter the OpenCTI jobs UI with zero-bundle works.
             stix_objects = self._collect_intelligence(since)
             if stix_objects:
+                work_id = self.helper.api.work.initiate_work(
+                    self.helper.connect_id, "Corelight Investigator run"
+                )
                 bundle = self.helper.stix2_create_bundle(stix_objects)
                 self.helper.send_stix2_bundle(
                     bundle, work_id=work_id, cleanup_inconsistent_bundle=True
@@ -78,9 +80,10 @@ class CorelightInvestigatorConnector:
             current_state = self.helper.get_state() or {}
             current_state["last_run"] = now.strftime("%Y-%m-%dT%H:%M:%S.000Z")
             self.helper.set_state(current_state)
-            self.helper.api.work.to_processed(
-                work_id, "Corelight Investigator connector successfully run"
-            )
+            if work_id:
+                self.helper.api.work.to_processed(
+                    work_id, "Corelight Investigator connector successfully run"
+                )
         except (KeyboardInterrupt, SystemExit):
             self.helper.connector_logger.info("[CONNECTOR] Connector stopped...")
             sys.exit(0)

--- a/external-import/corelight-investigator/src/connector/converter_to_stix.py
+++ b/external-import/corelight-investigator/src/connector/converter_to_stix.py
@@ -22,6 +22,12 @@ _SEVERITY_BANDS = [(9, "critical"), (7, "high"), (4, "medium"), (0, "low")]
 _SOURCE_IP_FIELDS = ("src_ip", "source_ip", "src", "id_orig_h")
 _DEST_IP_FIELDS = ("dst_ip", "dest_ip", "destination_ip", "dst", "id_resp_h")
 
+# Fixed sentinel used when an alert provides no usable timestamp. Falling back to
+# this constant (instead of "now") keeps the STIX created/modified - and the
+# deterministic id - constant across runs, so a timestamp-less alert is not
+# re-sent with drifting timestamps and needlessly updated every cycle.
+_FALLBACK_TIMESTAMP = "1970-01-01T00:00:00.000Z"
+
 
 def _statement_marking(definition: str) -> stix2.MarkingDefinition:
     """Build a custom statement MarkingDefinition for a TLP level.
@@ -131,11 +137,18 @@ class ConverterToStix:
             or alert.get("start_time")
             or alert.get("created")
         )
-        # When the alert has no usable timestamp, fall back to "now" for the STIX
-        # created/modified fields but seed generate_id with None, so a re-imported
-        # alert keeps a stable Incident id instead of creating a new one each run.
-        created = self._format_iso(source_dt or datetime.now(timezone.utc))
+        # Deterministic id: seed generate_id with the alert id (so distinct alerts
+        # do not collide when their names repeat) plus the source timestamp. With no
+        # usable timestamp the timestamp seed is None and created/modified fall back
+        # to a fixed sentinel (never "now"), so a re-imported alert keeps a stable id
+        # and is not re-sent with drifting timestamps each run.
+        id_seed_name = f"{name} [{alert_id}]" if alert_id else name
         id_seed = self._format_iso(source_dt) if source_dt is not None else None
+        created = (
+            self._format_iso(source_dt)
+            if source_dt is not None
+            else _FALLBACK_TIMESTAMP
+        )
         severity = self._map_severity(alert.get("severity"))
         description = (
             alert.get("description")
@@ -150,7 +163,7 @@ class ConverterToStix:
             ]
 
         return stix2.Incident(
-            id=Incident.generate_id(name, id_seed),
+            id=Incident.generate_id(id_seed_name, id_seed),
             name=name,
             description=description,
             created=created,

--- a/external-import/corelight-investigator/src/connector/converter_to_stix.py
+++ b/external-import/corelight-investigator/src/connector/converter_to_stix.py
@@ -1,0 +1,193 @@
+"""Converter from Corelight Investigator alerts/detections to STIX 2.1 objects."""
+
+import ipaddress
+from datetime import datetime, timezone
+from typing import Optional
+
+import stix2
+from pycti import Identity, Incident, MarkingDefinition, StixCoreRelationship
+
+_TLP_MAPPING = {
+    "clear": stix2.TLP_WHITE,
+    "white": stix2.TLP_WHITE,
+    "green": stix2.TLP_GREEN,
+    "amber": stix2.TLP_AMBER,
+    "red": stix2.TLP_RED,
+}
+
+# Investigator severity is a normalized 1-10 score (10 = most critical).
+_SEVERITY_BANDS = [(9, "critical"), (7, "high"), (4, "medium"), (0, "low")]
+
+# Candidate fields that may carry source / destination IP addresses.
+_SOURCE_IP_FIELDS = ("src_ip", "source_ip", "src", "id_orig_h")
+_DEST_IP_FIELDS = ("dst_ip", "dest_ip", "destination_ip", "dst", "id_resp_h")
+
+
+def _amber_strict() -> stix2.MarkingDefinition:
+    return stix2.MarkingDefinition(
+        id=MarkingDefinition.generate_id("TLP", "TLP:AMBER+STRICT"),
+        definition_type="statement",
+        definition={"statement": "custom"},
+        custom_properties={
+            "x_opencti_definition_type": "TLP",
+            "x_opencti_definition": "TLP:AMBER+STRICT",
+        },
+    )
+
+
+class ConverterToStix:
+    """Convert Corelight Investigator alert dictionaries into STIX 2.1 objects."""
+
+    def __init__(self, helper, tlp_level: str):
+        self.helper = helper
+        self.author = self._create_author()
+        if tlp_level == "amber+strict":
+            self.tlp_marking = _amber_strict()
+        else:
+            self.tlp_marking = _TLP_MAPPING.get(tlp_level, stix2.TLP_AMBER)
+
+    @staticmethod
+    def _create_author() -> stix2.Identity:
+        return stix2.Identity(
+            id=Identity.generate_id(
+                name="Corelight Investigator", identity_class="organization"
+            ),
+            name="Corelight Investigator",
+            identity_class="organization",
+            description="Alerts and detections imported from Corelight Investigator.",
+        )
+
+    @staticmethod
+    def _to_iso(value) -> str:
+        if value is None or value == "":
+            dt = datetime.now(timezone.utc)
+        elif isinstance(value, (int, float)) or (
+            isinstance(value, str) and value.isdigit()
+        ):
+            epoch = float(value)
+            if epoch > 1e12:  # milliseconds
+                epoch /= 1000.0
+            dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
+        else:
+            try:
+                dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+                dt = (
+                    dt.replace(tzinfo=timezone.utc)
+                    if dt.tzinfo is None
+                    else dt.astimezone(timezone.utc)
+                )
+            except ValueError:
+                dt = datetime.now(timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+    @staticmethod
+    def _map_severity(value) -> str:
+        try:
+            score = int(value)
+        except (TypeError, ValueError):
+            return "low"
+        for threshold, label in _SEVERITY_BANDS:
+            if score >= threshold:
+                return label
+        return "low"
+
+    def create_incident(self, alert: dict) -> Optional[stix2.Incident]:
+        """Create a STIX Incident from a Corelight Investigator alert/detection."""
+        alert_id = str(
+            alert.get("alert_id") or alert.get("id") or alert.get("uid") or ""
+        ).strip()
+        event_type = alert.get("EventType") or alert.get("event_type") or "Alert"
+        name = (
+            alert.get("name")
+            or alert.get("rule_name")
+            or alert.get("title")
+            or (
+                f"Corelight {event_type} {alert_id}"
+                if alert_id
+                else f"Corelight {event_type}"
+            )
+        )
+        created = self._to_iso(
+            alert.get("timestamp")
+            or alert.get("ts")
+            or alert.get("start_time")
+            or alert.get("created")
+        )
+        severity = self._map_severity(alert.get("severity"))
+        description = (
+            alert.get("description")
+            or alert.get("message")
+            or "Alert imported from Corelight Investigator."
+        )
+
+        external_references = None
+        if alert_id:
+            external_references = [
+                {"source_name": "Corelight Investigator", "external_id": alert_id}
+            ]
+
+        return stix2.Incident(
+            id=Incident.generate_id(name, created),
+            name=name,
+            description=description,
+            created=created,
+            modified=created,
+            created_by_ref=self.author["id"],
+            object_marking_refs=[self.tlp_marking],
+            external_references=external_references,
+            custom_properties={
+                "source": "Corelight Investigator",
+                "severity": severity,
+                "incident_type": str(event_type).lower(),
+            },
+        )
+
+    @staticmethod
+    def _ip_version(value: str) -> Optional[str]:
+        try:
+            return f"ipv{ipaddress.ip_address(value).version}"
+        except ValueError:
+            return None
+
+    def create_observables(self, alert: dict, incident_id: str) -> list:
+        """Create IP observables referenced by an alert, linked to the Incident."""
+        objects = []
+        seen = set()
+        fields = _SOURCE_IP_FIELDS + _DEST_IP_FIELDS
+        for field in fields:
+            value = alert.get(field)
+            if not value or not isinstance(value, str):
+                continue
+            value = value.strip()
+            if value in seen:
+                continue
+            version = self._ip_version(value)
+            if version is None:
+                continue
+            seen.add(value)
+
+            if version == "ipv4":
+                observable = stix2.IPv4Address(
+                    value=value,
+                    object_marking_refs=[self.tlp_marking],
+                    custom_properties={"x_opencti_created_by_ref": self.author["id"]},
+                )
+            else:
+                observable = stix2.IPv6Address(
+                    value=value,
+                    object_marking_refs=[self.tlp_marking],
+                    custom_properties={"x_opencti_created_by_ref": self.author["id"]},
+                )
+            relationship = stix2.Relationship(
+                id=StixCoreRelationship.generate_id(
+                    "related-to", incident_id, observable["id"]
+                ),
+                relationship_type="related-to",
+                source_ref=incident_id,
+                target_ref=observable["id"],
+                created_by_ref=self.author["id"],
+                object_marking_refs=[self.tlp_marking],
+            )
+            objects.append(observable)
+            objects.append(relationship)
+        return objects

--- a/external-import/corelight-investigator/src/connector/converter_to_stix.py
+++ b/external-import/corelight-investigator/src/connector/converter_to_stix.py
@@ -7,8 +7,8 @@ from typing import Optional
 import stix2
 from pycti import Identity, Incident, MarkingDefinition, StixCoreRelationship
 
+# TLP levels that map directly to a stix2 built-in MarkingDefinition.
 _TLP_MAPPING = {
-    "clear": stix2.TLP_WHITE,
     "white": stix2.TLP_WHITE,
     "green": stix2.TLP_GREEN,
     "amber": stix2.TLP_AMBER,
@@ -23,16 +23,30 @@ _SOURCE_IP_FIELDS = ("src_ip", "source_ip", "src", "id_orig_h")
 _DEST_IP_FIELDS = ("dst_ip", "dest_ip", "destination_ip", "dst", "id_resp_h")
 
 
-def _amber_strict() -> stix2.MarkingDefinition:
+def _statement_marking(definition: str) -> stix2.MarkingDefinition:
+    """Build a custom statement MarkingDefinition for a TLP level.
+
+    TLP:CLEAR and TLP:AMBER+STRICT are not stix2 built-ins. OpenCTI materializes them
+    as statement markings whose canonical id is derived from the definition, so the UI
+    shows the correct label instead of aliasing TLP:WHITE / TLP:AMBER (matches
+    connectors-sdk ``TLPMarking.to_stix2_object``).
+    """
     return stix2.MarkingDefinition(
-        id=MarkingDefinition.generate_id("TLP", "TLP:AMBER+STRICT"),
+        id=MarkingDefinition.generate_id("TLP", definition),
         definition_type="statement",
         definition={"statement": "custom"},
-        custom_properties={
-            "x_opencti_definition_type": "TLP",
-            "x_opencti_definition": "TLP:AMBER+STRICT",
-        },
+        allow_custom=True,
+        x_opencti_definition_type="TLP",
+        x_opencti_definition=definition,
     )
+
+
+def _resolve_tlp_marking(tlp_level: str) -> stix2.MarkingDefinition:
+    if tlp_level == "clear":
+        return _statement_marking("TLP:CLEAR")
+    if tlp_level == "amber+strict":
+        return _statement_marking("TLP:AMBER+STRICT")
+    return _TLP_MAPPING.get(tlp_level, stix2.TLP_AMBER)
 
 
 class ConverterToStix:
@@ -41,10 +55,7 @@ class ConverterToStix:
     def __init__(self, helper, tlp_level: str):
         self.helper = helper
         self.author = self._create_author()
-        if tlp_level == "amber+strict":
-            self.tlp_marking = _amber_strict()
-        else:
-            self.tlp_marking = _TLP_MAPPING.get(tlp_level, stix2.TLP_AMBER)
+        self.tlp_marking = _resolve_tlp_marking(tlp_level)
 
     @staticmethod
     def _create_author() -> stix2.Identity:
@@ -58,26 +69,33 @@ class ConverterToStix:
         )
 
     @staticmethod
-    def _to_iso(value) -> str:
+    def _parse_timestamp(value) -> Optional[datetime]:
+        """Parse a Corelight timestamp into an aware UTC datetime.
+
+        Returns ``None`` when the value is missing or cannot be parsed, so callers can
+        tell a real source timestamp apart from a "now" fallback.
+        """
         if value is None or value == "":
-            dt = datetime.now(timezone.utc)
-        elif isinstance(value, (int, float)) or (
-            isinstance(value, str) and value.isdigit()
+            return None
+        if isinstance(value, (int, float)) or (
+            isinstance(value, str) and value.strip().isdigit()
         ):
             epoch = float(value)
             if epoch > 1e12:  # milliseconds
                 epoch /= 1000.0
-            dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
-        else:
-            try:
-                dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-                dt = (
-                    dt.replace(tzinfo=timezone.utc)
-                    if dt.tzinfo is None
-                    else dt.astimezone(timezone.utc)
-                )
-            except ValueError:
-                dt = datetime.now(timezone.utc)
+            return datetime.fromtimestamp(epoch, tz=timezone.utc)
+        try:
+            dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return (
+            dt.replace(tzinfo=timezone.utc)
+            if dt.tzinfo is None
+            else dt.astimezone(timezone.utc)
+        )
+
+    @staticmethod
+    def _format_iso(dt: datetime) -> str:
         return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
 
     @staticmethod
@@ -107,12 +125,17 @@ class ConverterToStix:
                 else f"Corelight {event_type}"
             )
         )
-        created = self._to_iso(
+        source_dt = self._parse_timestamp(
             alert.get("timestamp")
             or alert.get("ts")
             or alert.get("start_time")
             or alert.get("created")
         )
+        # When the alert has no usable timestamp, fall back to "now" for the STIX
+        # created/modified fields but seed generate_id with None, so a re-imported
+        # alert keeps a stable Incident id instead of creating a new one each run.
+        created = self._format_iso(source_dt or datetime.now(timezone.utc))
+        id_seed = self._format_iso(source_dt) if source_dt is not None else None
         severity = self._map_severity(alert.get("severity"))
         description = (
             alert.get("description")
@@ -127,7 +150,7 @@ class ConverterToStix:
             ]
 
         return stix2.Incident(
-            id=Incident.generate_id(name, created),
+            id=Incident.generate_id(name, id_seed),
             name=name,
             description=description,
             created=created,

--- a/external-import/corelight-investigator/src/connector/settings.py
+++ b/external-import/corelight-investigator/src/connector/settings.py
@@ -5,6 +5,7 @@ from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
     BaseExternalImportConnectorConfig,
+    ListFromString,
 )
 from pydantic import Field, HttpUrl, SecretStr
 
@@ -18,6 +19,10 @@ class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
     name: str = Field(
         description="The name of the connector.",
         default="Corelight Investigator",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+        default=["corelight-investigator"],
     )
     duration_period: timedelta = Field(
         description="The period of time to await between two runs of the connector.",

--- a/external-import/corelight-investigator/src/connector/settings.py
+++ b/external-import/corelight-investigator/src/connector/settings.py
@@ -1,0 +1,82 @@
+from datetime import timedelta
+from typing import Literal
+
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseExternalImportConnectorConfig,
+)
+from pydantic import Field, HttpUrl, SecretStr
+
+
+class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
+    """
+    Override the `BaseExternalImportConnectorConfig` to add parameters and/or defaults
+    to the configuration for connectors of type `EXTERNAL_IMPORT`.
+    """
+
+    name: str = Field(
+        description="The name of the connector.",
+        default="Corelight Investigator",
+    )
+    duration_period: timedelta = Field(
+        description="The period of time to await between two runs of the connector.",
+        default=timedelta(hours=1),
+    )
+
+
+class CorelightInvestigatorConfig(BaseConfigModel):
+    """
+    Define parameters and/or defaults for the configuration specific to the
+    `CorelightInvestigatorConnector`.
+    """
+
+    api_base_url: HttpUrl = Field(
+        description="Corelight Investigator API base URL (region specific, e.g. https://eu.api.investigator.corelight.com).",
+    )
+    api_key: SecretStr = Field(
+        description="Corelight Investigator API key (sent as an Authorization bearer header).",
+    )
+    alerts_path: str = Field(
+        description="Path of the Investigator Detections and Alerts API endpoint.",
+        default="/api/v1/alerts",
+    )
+    import_window_days: int = Field(
+        description="Number of days to look back on the first run.",
+        default=7,
+        gt=0,
+    )
+    max_alerts: int = Field(
+        description="Maximum number of alerts to request per run.",
+        default=1000,
+        gt=0,
+    )
+    tlp_level: Literal[
+        "clear",
+        "white",
+        "green",
+        "amber",
+        "amber+strict",
+        "red",
+    ] = Field(
+        description="Default TLP marking applied to the imported entities.",
+        default="amber",
+    )
+    ssl_verify: bool = Field(
+        description="Whether to verify the API server TLS certificate.",
+        default=True,
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """
+    Override `BaseConnectorSettings` to include `ExternalImportConnectorConfig` and
+    `CorelightInvestigatorConfig`.
+    """
+
+    connector: ExternalImportConnectorConfig = Field(
+        default_factory=ExternalImportConnectorConfig
+    )
+    corelight_investigator: CorelightInvestigatorConfig = Field(
+        default_factory=CorelightInvestigatorConfig
+    )

--- a/external-import/corelight-investigator/src/corelight_investigator_client/__init__.py
+++ b/external-import/corelight-investigator/src/corelight_investigator_client/__init__.py
@@ -1,0 +1,9 @@
+from corelight_investigator_client.api_client import (
+    CorelightInvestigatorAPIError,
+    CorelightInvestigatorClient,
+)
+
+__all__ = [
+    "CorelightInvestigatorClient",
+    "CorelightInvestigatorAPIError",
+]

--- a/external-import/corelight-investigator/src/corelight_investigator_client/api_client.py
+++ b/external-import/corelight-investigator/src/corelight_investigator_client/api_client.py
@@ -1,0 +1,111 @@
+"""HTTP client for the Corelight Investigator Detections and Alerts API."""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+import requests
+from pycti import OpenCTIConnectorHelper
+
+
+class CorelightInvestigatorAPIError(Exception):
+    """Custom exception for Corelight Investigator API errors."""
+
+
+class CorelightInvestigatorClient:
+    """Thin client around the Corelight Investigator Detections and Alerts API."""
+
+    REQUEST_ATTEMPTS = 3
+    BACKOFF_FACTOR = 5
+    TIMEOUT = 60
+
+    def __init__(
+        self,
+        helper: OpenCTIConnectorHelper,
+        api_base_url: str,
+        api_key: str,
+        alerts_path: str = "/api/v1/alerts",
+        max_alerts: int = 1000,
+        ssl_verify: bool = True,
+    ) -> None:
+        """
+        Initialize the Corelight Investigator client.
+
+        :param helper: The OpenCTI connector helper (used for logging).
+        :param api_base_url: The Investigator API base URL (region specific).
+        :param api_key: The Investigator API key (Authorization bearer).
+        :param alerts_path: The Detections and Alerts API endpoint path.
+        :param max_alerts: Maximum number of alerts to request per run.
+        :param ssl_verify: Whether to verify the TLS certificate.
+        """
+        self.helper = helper
+        self._base_url = str(api_base_url).rstrip("/")
+        self._alerts_path = "/" + alerts_path.lstrip("/")
+        self._max_alerts = max_alerts
+
+        self.session = requests.Session()
+        self.session.verify = ssl_verify
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {api_key}",
+                "Accept": "application/json",
+            }
+        )
+
+    def get_alerts(self, since: Optional[str] = None) -> list:
+        """Fetch alerts/detections, optionally only those after ``since`` (ISO-8601)."""
+        params: dict = {"limit": self._max_alerts}
+        if since:
+            params["start_time"] = since
+        response = self._request("get", self._alerts_path, params=params)
+        if response is None:
+            return []
+        try:
+            return self._extract_alerts(response.json())
+        except ValueError as err:
+            raise CorelightInvestigatorAPIError(
+                "Corelight Investigator returned a non-JSON response"
+            ) from err
+
+    @staticmethod
+    def _extract_alerts(payload) -> list:
+        if isinstance(payload, list):
+            return payload
+        if isinstance(payload, dict):
+            for key in ("data", "alerts", "detections", "results", "items"):
+                value = payload.get(key)
+                if isinstance(value, list):
+                    return value
+        return []
+
+    def _request(
+        self, method: str, path: str, params: dict = None
+    ) -> Optional[requests.Response]:
+        url = f"{self._base_url}{path}"
+        for attempt in range(self.REQUEST_ATTEMPTS):
+            try:
+                response = self.session.request(
+                    method, url, params=params, timeout=self.TIMEOUT
+                )
+                if response.status_code == 429 and attempt < self.REQUEST_ATTEMPTS - 1:
+                    time.sleep(self.BACKOFF_FACTOR * (2**attempt))
+                    continue
+                response.raise_for_status()
+                return response
+            except requests.HTTPError as err:
+                status = err.response.status_code if err.response is not None else 0
+                if status >= 500 and attempt < self.REQUEST_ATTEMPTS - 1:
+                    time.sleep(self.BACKOFF_FACTOR * (2**attempt))
+                    continue
+                raise CorelightInvestigatorAPIError(
+                    f"Corelight Investigator API error: {status} ({err})"
+                ) from err
+            except requests.RequestException as err:
+                if attempt < self.REQUEST_ATTEMPTS - 1:
+                    time.sleep(self.BACKOFF_FACTOR * (2**attempt))
+                    continue
+                raise CorelightInvestigatorAPIError(
+                    f"Corelight Investigator request failed: {err}"
+                ) from err
+        return None

--- a/external-import/corelight-investigator/src/corelight_investigator_client/api_client.py
+++ b/external-import/corelight-investigator/src/corelight_investigator_client/api_client.py
@@ -80,7 +80,7 @@ class CorelightInvestigatorClient:
         return []
 
     def _request(
-        self, method: str, path: str, params: dict = None
+        self, method: str, path: str, params: Optional[dict] = None
     ) -> Optional[requests.Response]:
         url = f"{self._base_url}{path}"
         for attempt in range(self.REQUEST_ATTEMPTS):

--- a/external-import/corelight-investigator/src/main.py
+++ b/external-import/corelight-investigator/src/main.py
@@ -1,0 +1,24 @@
+import traceback
+
+from connector import ConnectorSettings, CorelightInvestigatorConnector
+from pycti import OpenCTIConnectorHelper
+
+if __name__ == "__main__":
+    """
+    Entry point of the script
+
+    - traceback.print_exc(): This function prints the traceback of the exception to the standard error (stderr).
+    The traceback includes information about the point in the program where the exception occurred,
+    which is very useful for debugging purposes.
+    - exit(1): effective way to terminate a Python program when an error is encountered.
+    It signals to the operating system and any calling processes that the program did not complete successfully.
+    """
+    try:
+        settings = ConnectorSettings()
+        helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+        connector = CorelightInvestigatorConnector(config=settings, helper=helper)
+        connector.run()
+    except Exception:
+        traceback.print_exc()
+        exit(1)

--- a/external-import/corelight-investigator/src/requirements.txt
+++ b/external-import/corelight-investigator/src/requirements.txt
@@ -1,0 +1,4 @@
+pycti==7.260609.0
+pydantic~= 2.11.3
+requests~=2.33.0
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/corelight-investigator/src/requirements.txt
+++ b/external-import/corelight-investigator/src/requirements.txt
@@ -1,4 +1,4 @@
-pycti==7.260609.0
+pycti==7.260701.0
 pydantic~=2.11.3
 requests~=2.33.0
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/corelight-investigator/src/requirements.txt
+++ b/external-import/corelight-investigator/src/requirements.txt
@@ -1,4 +1,4 @@
 pycti==7.260609.0
-pydantic~= 2.11.3
+pydantic~=2.11.3
 requests~=2.33.0
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/corelight-investigator/tests/conftest.py
+++ b/external-import/corelight-investigator/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())

--- a/external-import/corelight-investigator/tests/test-requirements.txt
+++ b/external-import/corelight-investigator/tests/test-requirements.txt
@@ -1,0 +1,3 @@
+# Main dependencies needs to be installed
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/external-import/corelight-investigator/tests/test_main.py
+++ b/external-import/corelight-investigator/tests/test_main.py
@@ -1,0 +1,83 @@
+from typing import Any
+
+from connector import ConnectorSettings, CorelightInvestigatorConnector
+from pycti import OpenCTIConnectorHelper
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+    It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "corelight_investigator": {
+                    "api_base_url": "https://eu.api.investigator.corelight.com",
+                    "api_key": "test-api-key",
+                    "tlp_level": "amber",
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that the implementation of `BaseConnectorSettings` (from `connectors-sdk`) can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from `BaseConnectorSettings`)
+        - the method `to_helper_config` MUST return a dict (as in base class)
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that `OpenCTIConnectorHelper` (from `pycti`) can be instantiated successfully:
+        - the value of `settings.to_helper_config` MUST be the expected dict for `OpenCTIConnectorHelper`
+        - the helper MUST be able to get its instance's attributes from the config dict
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "Test Connector"
+    assert helper.connect_scope == "test,connector"
+    assert helper.log_level == "ERROR"
+    assert helper.connect_duration_period == "PT5M"
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST be able to access env/config vars through `self.config`
+        - the connector's main class MUST be able to access `pycti` API through `self.helper`
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    connector = CorelightInvestigatorConnector(config=settings, helper=helper)
+
+    assert connector.config == settings
+    assert connector.helper == helper

--- a/external-import/corelight-investigator/tests/tests_connector/test_connector.py
+++ b/external-import/corelight-investigator/tests/tests_connector/test_connector.py
@@ -76,8 +76,22 @@ def test_process_message_sends_bundle_and_updates_state(connector):
 
     connector.process_message()
 
+    connector.helper.api.work.initiate_work.assert_called_once()
     connector.helper.send_stix2_bundle.assert_called_once()
     connector.helper.api.work.to_processed.assert_called_once()
+    saved_state = connector.helper.set_state.call_args[0][0]
+    assert "last_run" in saved_state
+
+
+def test_process_message_skips_work_when_no_data(connector):
+    connector.client.get_alerts.return_value = []
+
+    connector.process_message()
+
+    # no data -> no work is initiated and no bundle is sent, but state advances
+    connector.helper.api.work.initiate_work.assert_not_called()
+    connector.helper.send_stix2_bundle.assert_not_called()
+    connector.helper.api.work.to_processed.assert_not_called()
     saved_state = connector.helper.set_state.call_args[0][0]
     assert "last_run" in saved_state
 
@@ -89,19 +103,32 @@ def test_process_message_handles_api_error(connector):
 
     connector.helper.connector_logger.error.assert_called()
     connector.helper.send_stix2_bundle.assert_not_called()
-    # the initiated work must be finalized (in error) rather than left dangling
-    connector.helper.api.work.to_processed.assert_called_once()
-    assert connector.helper.api.work.to_processed.call_args.kwargs["in_error"] is True
+    # the error occurs while collecting data, before any work is initiated,
+    # so there is no dangling work to finalize
+    connector.helper.api.work.initiate_work.assert_not_called()
+    connector.helper.api.work.to_processed.assert_not_called()
 
 
-def test_process_message_finalizes_work_on_unexpected_error(connector):
+def test_process_message_handles_unexpected_error(connector):
     connector.client.get_alerts.side_effect = RuntimeError("kaboom")
 
     connector.process_message()  # must not raise
 
     connector.helper.connector_logger.error.assert_called()
     connector.helper.send_stix2_bundle.assert_not_called()
-    # an unexpected error must also finalize the initiated work (in error)
+    connector.helper.api.work.initiate_work.assert_not_called()
+    connector.helper.api.work.to_processed.assert_not_called()
+
+
+def test_process_message_finalizes_work_when_send_fails(connector):
+    connector.client.get_alerts.return_value = [ALERT]
+    connector.helper.send_stix2_bundle.side_effect = RuntimeError("send failed")
+
+    connector.process_message()  # must not raise
+
+    connector.helper.connector_logger.error.assert_called()
+    # a work initiated before the failure must be finalized (in error)
+    connector.helper.api.work.initiate_work.assert_called_once()
     connector.helper.api.work.to_processed.assert_called_once()
     assert connector.helper.api.work.to_processed.call_args.kwargs["in_error"] is True
 

--- a/external-import/corelight-investigator/tests/tests_connector/test_connector.py
+++ b/external-import/corelight-investigator/tests/tests_connector/test_connector.py
@@ -94,6 +94,18 @@ def test_process_message_handles_api_error(connector):
     assert connector.helper.api.work.to_processed.call_args.kwargs["in_error"] is True
 
 
+def test_process_message_finalizes_work_on_unexpected_error(connector):
+    connector.client.get_alerts.side_effect = RuntimeError("kaboom")
+
+    connector.process_message()  # must not raise
+
+    connector.helper.connector_logger.error.assert_called()
+    connector.helper.send_stix2_bundle.assert_not_called()
+    # an unexpected error must also finalize the initiated work (in error)
+    connector.helper.api.work.to_processed.assert_called_once()
+    assert connector.helper.api.work.to_processed.call_args.kwargs["in_error"] is True
+
+
 def test_since_uses_window_when_no_state(connector):
     connector.helper.get_state = MagicMock(return_value={})
     since = connector._since()

--- a/external-import/corelight-investigator/tests/tests_connector/test_connector.py
+++ b/external-import/corelight-investigator/tests/tests_connector/test_connector.py
@@ -1,0 +1,109 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from connector import ConnectorSettings, CorelightInvestigatorConnector
+from corelight_investigator_client import CorelightInvestigatorAPIError
+from pycti import OpenCTIConnectorHelper
+
+ALERT = {
+    "alert_id": "a-1",
+    "name": "Beaconing detected",
+    "EventType": "Detection",
+    "severity": 9,
+    "timestamp": "2024-05-01T00:00:00Z",
+    "src_ip": "1.2.3.4",
+}
+
+
+class StubConnectorSettings(ConnectorSettings):
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "corelight-investigator",
+                    "log_level": "error",
+                    "duration_period": "PT1H",
+                },
+                "corelight_investigator": {
+                    "api_base_url": "https://eu.api.investigator.corelight.com",
+                    "api_key": "test-api-key",
+                    "tlp_level": "amber",
+                },
+            }
+        )
+
+
+@pytest.fixture
+def connector(mock_opencti_connector_helper):
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+    helper.get_state = MagicMock(return_value={})
+    helper.set_state = MagicMock()
+    helper.stix2_create_bundle = MagicMock(return_value="bundle")
+    helper.send_stix2_bundle = MagicMock()
+    helper.api.work.initiate_work = MagicMock(return_value="work-1")
+    helper.api.work.to_processed = MagicMock()
+    helper.schedule_process = MagicMock()
+
+    instance = CorelightInvestigatorConnector(config=settings, helper=helper)
+    instance.client = MagicMock()
+    return instance
+
+
+def test_collect_intelligence_builds_objects(connector):
+    connector.client.get_alerts.return_value = [ALERT]
+
+    objects = connector._collect_intelligence(since="2024-01-01T00:00:00.000Z")
+    types = [o["type"] for o in objects]
+
+    assert "incident" in types
+    assert "ipv4-addr" in types
+    assert "identity" in types
+
+
+def test_collect_intelligence_empty(connector):
+    connector.client.get_alerts.return_value = []
+    assert connector._collect_intelligence(since="2024-01-01T00:00:00.000Z") == []
+
+
+def test_process_message_sends_bundle_and_updates_state(connector):
+    connector.client.get_alerts.return_value = [ALERT]
+
+    connector.process_message()
+
+    connector.helper.send_stix2_bundle.assert_called_once()
+    connector.helper.api.work.to_processed.assert_called_once()
+    saved_state = connector.helper.set_state.call_args[0][0]
+    assert "last_run" in saved_state
+
+
+def test_process_message_handles_api_error(connector):
+    connector.client.get_alerts.side_effect = CorelightInvestigatorAPIError("boom")
+
+    connector.process_message()  # must not raise
+
+    connector.helper.connector_logger.error.assert_called()
+    connector.helper.send_stix2_bundle.assert_not_called()
+
+
+def test_since_uses_window_when_no_state(connector):
+    connector.helper.get_state = MagicMock(return_value={})
+    since = connector._since()
+    assert since.endswith("Z")
+
+
+def test_since_uses_last_run_when_present(connector):
+    connector.helper.get_state = MagicMock(
+        return_value={"last_run": "2024-03-01T00:00:00.000Z"}
+    )
+    assert connector._since() == "2024-03-01T00:00:00.000Z"
+
+
+def test_run_schedules_process(connector):
+    connector.run()
+    connector.helper.schedule_process.assert_called_once()

--- a/external-import/corelight-investigator/tests/tests_connector/test_connector.py
+++ b/external-import/corelight-investigator/tests/tests_connector/test_connector.py
@@ -89,6 +89,9 @@ def test_process_message_handles_api_error(connector):
 
     connector.helper.connector_logger.error.assert_called()
     connector.helper.send_stix2_bundle.assert_not_called()
+    # the initiated work must be finalized (in error) rather than left dangling
+    connector.helper.api.work.to_processed.assert_called_once()
+    assert connector.helper.api.work.to_processed.call_args.kwargs["in_error"] is True
 
 
 def test_since_uses_window_when_no_state(connector):

--- a/external-import/corelight-investigator/tests/tests_connector/test_converter.py
+++ b/external-import/corelight-investigator/tests/tests_connector/test_converter.py
@@ -82,6 +82,24 @@ def test_incident_id_is_stable_without_timestamp():
     )
 
 
+def test_incidents_with_same_name_different_id_have_distinct_ids():
+    # Distinct alerts that happen to share a name must not collapse into one
+    # Incident: the alert id is part of the id seed.
+    converter = _converter()
+    a = converter.create_incident({"alert_id": "a-1", "name": "Same"})
+    b = converter.create_incident({"alert_id": "a-2", "name": "Same"})
+    assert a["id"] != b["id"]
+
+
+def test_incident_timestamps_use_stable_fallback_without_timestamp():
+    # With no source timestamp, created/modified must be a fixed sentinel (not
+    # "now"), so the same Incident is not re-sent with drifting timestamps.
+    converter = _converter()
+    incident = converter.create_incident({"alert_id": "x", "EventType": "Alert"})
+    assert incident["created"] == incident["modified"]
+    assert str(incident["created"]).startswith("1970-01-01")
+
+
 def test_incident_uses_source_timestamp():
     # The STIX created/modified must reflect the source timestamp, not "now".
     converter = _converter()

--- a/external-import/corelight-investigator/tests/tests_connector/test_converter.py
+++ b/external-import/corelight-investigator/tests/tests_connector/test_converter.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -17,6 +18,18 @@ def test_author_is_identity():
 def test_amber_strict_marking():
     converter = _converter("amber+strict")
     assert converter.tlp_marking["definition_type"] == "statement"
+    assert converter.tlp_marking["x_opencti_definition"] == "TLP:AMBER+STRICT"
+
+
+def test_clear_marking_is_statement_not_white():
+    # TLP:CLEAR must be a distinct statement marking, not an alias of TLP:WHITE,
+    # so OpenCTI shows the correct label.
+    clear = _converter("clear").tlp_marking
+    assert clear["definition_type"] == "statement"
+    assert clear["x_opencti_definition"] == "TLP:CLEAR"
+
+    white = _converter("white").tlp_marking
+    assert white["definition_type"] == "tlp"
 
 
 @pytest.mark.parametrize(
@@ -57,6 +70,39 @@ def test_create_incident_default_name():
     converter = _converter()
     incident = converter.create_incident({"alert_id": "x", "EventType": "Alert"})
     assert incident["name"] == "Corelight Alert x"
+
+
+def test_incident_id_is_stable_without_timestamp():
+    # No source timestamp: the id must not depend on "now", so re-importing the same
+    # alert keeps the same Incident id instead of creating duplicates each run.
+    converter = _converter()
+    alert = {"alert_id": "x", "EventType": "Alert"}
+    assert (
+        converter.create_incident(alert)["id"] == converter.create_incident(alert)["id"]
+    )
+
+
+def test_incident_uses_source_timestamp():
+    # The STIX created/modified must reflect the source timestamp, not "now".
+    converter = _converter()
+    incident = converter.create_incident(
+        {"alert_id": "a-1", "name": "n", "timestamp": "2024-05-01T00:00:00Z"}
+    )
+    serialized = json.loads(incident.serialize())
+    assert serialized["created"].startswith("2024-05-01T00:00:00")
+    assert serialized["modified"] == serialized["created"]
+
+
+@pytest.mark.parametrize("value", [None, "", "not-a-date"])
+def test_parse_timestamp_returns_none_for_invalid(value):
+    assert ConverterToStix._parse_timestamp(value) is None
+
+
+def test_parse_timestamp_handles_epoch_seconds_and_millis():
+    assert ConverterToStix._parse_timestamp(0).year == 1970
+    assert ConverterToStix._parse_timestamp(
+        1_700_000_000_000
+    ) == ConverterToStix._parse_timestamp(1_700_000_000)
 
 
 def test_create_observables():

--- a/external-import/corelight-investigator/tests/tests_connector/test_converter.py
+++ b/external-import/corelight-investigator/tests/tests_connector/test_converter.py
@@ -1,0 +1,80 @@
+from unittest.mock import MagicMock
+
+import pytest
+from connector.converter_to_stix import ConverterToStix
+
+
+def _converter(tlp_level: str = "amber") -> ConverterToStix:
+    return ConverterToStix(MagicMock(), tlp_level=tlp_level)
+
+
+def test_author_is_identity():
+    converter = _converter()
+    assert converter.author["type"] == "identity"
+    assert converter.author["name"] == "Corelight Investigator"
+
+
+def test_amber_strict_marking():
+    converter = _converter("amber+strict")
+    assert converter.tlp_marking["definition_type"] == "statement"
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (10, "critical"),
+        (9, "critical"),
+        (7, "high"),
+        (4, "medium"),
+        (1, "low"),
+        (None, "low"),
+    ],
+)
+def test_map_severity(value, expected):
+    assert ConverterToStix._map_severity(value) == expected
+
+
+def test_create_incident():
+    converter = _converter()
+    incident = converter.create_incident(
+        {
+            "alert_id": "a-1",
+            "name": "Beaconing detected",
+            "EventType": "Detection",
+            "severity": 9,
+            "timestamp": "2024-05-01T00:00:00Z",
+            "description": "C2 beaconing",
+        }
+    )
+    assert incident["type"] == "incident"
+    assert incident["name"] == "Beaconing detected"
+    assert incident["external_references"][0]["external_id"] == "a-1"
+    assert incident["incident_type"] == "detection"
+    assert incident["severity"] == "critical"
+
+
+def test_create_incident_default_name():
+    converter = _converter()
+    incident = converter.create_incident({"alert_id": "x", "EventType": "Alert"})
+    assert incident["name"] == "Corelight Alert x"
+
+
+def test_create_observables():
+    converter = _converter()
+    objects = converter.create_observables(
+        {"src_ip": "1.2.3.4", "dest_ip": "2001:db8::1"},
+        "incident--11111111-1111-4111-8111-111111111111",
+    )
+    types = {o["type"] for o in objects}
+    assert "ipv4-addr" in types
+    assert "ipv6-addr" in types
+    assert "relationship" in types
+
+
+def test_create_observables_skips_invalid():
+    converter = _converter()
+    objects = converter.create_observables(
+        {"src_ip": "not-an-ip", "dest_ip": ""},
+        "incident--11111111-1111-4111-8111-111111111111",
+    )
+    assert objects == []

--- a/external-import/corelight-investigator/tests/tests_connector/test_settings.py
+++ b/external-import/corelight-investigator/tests/tests_connector/test_settings.py
@@ -1,0 +1,151 @@
+from typing import Any
+
+import pytest
+from connector import ConnectorSettings
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "corelight_investigator": {
+                    "api_base_url": "http://test.com",
+                    "api_key": "test-api-key",
+                    "tlp_level": "clear",
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "test, connector",
+                },
+                "corelight_investigator": {
+                    "api_base_url": "http://test.com",
+                    "api_key": "test-api-key",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) accepts valid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake but valid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.corelight_investigator, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param(
+            {},
+            "settings",
+            id="empty_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:PORT",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "corelight_investigator": {
+                    "api_base_url": "http://test.com",
+                    "api_key": "test-api-key",
+                    "tlp_level": "clear",
+                },
+            },
+            "opencti.url",
+            id="invalid_opencti_url",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "corelight_investigator": {
+                    "api_base_url": "http://test.com",
+                    "api_key": "test-api-key",
+                    "tlp_level": "clear",
+                },
+            },
+            "connector.id",
+            id="missing_connector_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) raises on invalid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake and invalid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert str("Error validating configuration") in str(err)

--- a/external-import/corelight-investigator/tests/tests_corelight_investigator_client/test_api_client.py
+++ b/external-import/corelight-investigator/tests/tests_corelight_investigator_client/test_api_client.py
@@ -1,0 +1,82 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from corelight_investigator_client import (
+    CorelightInvestigatorAPIError,
+    CorelightInvestigatorClient,
+)
+
+
+def _make_client() -> CorelightInvestigatorClient:
+    client = CorelightInvestigatorClient(
+        MagicMock(),
+        api_base_url="https://eu.api.investigator.corelight.com",
+        api_key="key",
+        alerts_path="/api/v1/alerts",
+    )
+    client.session = MagicMock()
+    return client
+
+
+def _response(payload, status: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+def test_extract_alerts_variants():
+    assert CorelightInvestigatorClient._extract_alerts([{"id": 1}]) == [{"id": 1}]
+    assert CorelightInvestigatorClient._extract_alerts({"data": [{"id": 2}]}) == [
+        {"id": 2}
+    ]
+    assert CorelightInvestigatorClient._extract_alerts({"alerts": [{"id": 3}]}) == [
+        {"id": 3}
+    ]
+    assert CorelightInvestigatorClient._extract_alerts({"unexpected": 1}) == []
+
+
+def test_get_alerts_returns_list():
+    client = _make_client()
+    client.session.request.return_value = _response({"data": [{"alert_id": "a"}]})
+    assert client.get_alerts() == [{"alert_id": "a"}]
+
+
+def test_get_alerts_passes_since():
+    client = _make_client()
+    client.session.request.return_value = _response({"data": []})
+
+    client.get_alerts(since="2024-01-01T00:00:00.000Z")
+    call = client.session.request.call_args
+    assert call.kwargs["params"]["start_time"] == "2024-01-01T00:00:00.000Z"
+    assert call.kwargs["params"]["limit"] == 1000
+
+
+def test_get_alerts_raises_on_http_error():
+    client = _make_client()
+    err_response = MagicMock()
+    err_response.status_code = 401
+    bad = MagicMock()
+    bad.status_code = 401
+    bad.raise_for_status.side_effect = requests.HTTPError(response=err_response)
+    client.session.request.return_value = bad
+
+    with pytest.raises(CorelightInvestigatorAPIError):
+        client.get_alerts()
+
+
+def test_get_alerts_retries_on_rate_limit():
+    client = _make_client()
+    rate_limited = MagicMock()
+    rate_limited.status_code = 429
+    client.session.request.side_effect = [
+        rate_limited,
+        _response({"data": [{"alert_id": "a"}]}),
+    ]
+
+    with patch("corelight_investigator_client.api_client.time.sleep"):
+        result = client.get_alerts()
+    assert result == [{"alert_id": "a"}]
+    assert client.session.request.call_count == 2


### PR DESCRIPTION
## Proposed changes

New external-import connector for Corelight Investigator (SaaS NDR).

On a schedule the connector:

- queries the Investigator "Detections and Alerts" API (bearer API key), incrementally using connector state (configurable initial look-back window);
- maps each alert / detection to a STIX Incident, with the normalized Investigator severity (1-10) mapped to the OpenCTI severity and the `EventType` recorded as the incident type;
- extracts the source / destination IP observables referenced by an alert and creates `related-to` relationships from the Incident to those observables;
- attributes the imported objects to a Corelight Investigator author identity and applies a configurable TLP marking.

## Related issues

Closes #6736

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Unit tests for the client, converter and connector (coverage > 80% on new code)
- [x] Code formatting (`black`, `isort`) and linting (`flake8`, STIX id pylint) pass
- [x] Generated `__metadata__` config schema and documentation (via the SDK schema tooling)
- [x] Added/updated the connector `README.md`, `config.yml.sample`, `docker-compose.yml` and `connector_manifest.json`

## Further comments

The exact REST path/parameters of the Investigator Detections and Alerts API are documented in the in-product API reference (require a tenant account), so the query endpoint path is configurable via `alerts_path` with a documented default, and the response parser accepts the common envelope keys (`data` / `alerts` / `detections` / `results`). This is the import side of a Corelight integration; the Corelight open sensor consumes intel via Zeek/TAXII (e.g. OpenCTI's native TAXII2 live feed) rather than an outbound IOC API.

## Community status and manager support

This connector is community-contributed work and is NOT officially verified by Filigran: the manifest intentionally ships `"verified": false` and `"last_verified_date": null`. Do not flip `verified` back to `true` as part of this PR. Note: the VC201 verified-status check has been removed from the connector-linter on `master`, so the advisory Connector Verified Linter job passes cleanly with this community status.

The connector IS manager-supported (`"manager_supported": true`): configuration is loaded through the connectors-sdk pydantic-settings mechanism (env vars + optional `config.yml`), `__metadata__/connector_config_schema.json` is generated from the settings model with the SDK schema generator and `CONNECTOR_CONFIG_DOC.md` is generated from that schema. Manager-compatibility pass applied on top of the initial review:

- `connector_manifest.json`: `verified: false`, `manager_supported: true`, `support_version: >=7.260701.0` (in sync with the pinned pycti).
- `Dockerfile`: direct `ENTRYPOINT ["python", "main.py"]` instead of the `entrypoint.sh` indirection (VC402); `entrypoint.sh` removed.
- `CONNECTOR_SCOPE` now has a default (`corelight-investigator`), so the only mandatory variables are the OpenCTI URL/token and the Corelight API base URL/key; schema and doc regenerated accordingly.
- `docker-compose.yml` / `config.yml.sample`: exact `ChangeMe` placeholders, defaulted variables commented out (VC104 sample conventions).
- `connector.py`: a work is only initiated when the run actually collected data, so empty runs no longer create zero-bundle works (VC317).
- Local connector-linter run on the rebased branch: 36/36 checks pass (score 100%), zero errors and zero warnings; the CI Connector Verified Linter job on the connector is green as well.

## Maintainer review (independent review-and-fix)

Independent senior review of the full connector, on top of the automated review threads. Substantive fixes:

- `converter_to_stix.py`: TLP:CLEAR and TLP:AMBER+STRICT are built as custom statement MarkingDefinitions via a shared `_statement_marking` helper (matching connectors-sdk `TLPMarking.to_stix2_object`), so OpenCTI shows the correct TLP label instead of aliasing `stix2.TLP_WHITE` / `TLP_AMBER`.
- `converter_to_stix.py` (deterministic ids): `Incident.generate_id` is seeded with the alert id in the name (so distinct alerts that share a name do not collapse into one Incident) plus the source timestamp; when an alert has no usable timestamp, `created`/`modified` fall back to a fixed sentinel instead of "now", so a re-imported alert keeps a stable id and is not re-sent with drifting timestamps each run.
- `connector.py`: works are finalized with `in_error=True` when a failure occurs after the work was initiated; a fetch failure raises (the client raises after retries), so `last_run` is not advanced on error and the next run retries.
- Docs: the README requirements and configuration tables reflect the actual defaults (OpenCTI >= 7.260701.0, `scope` / `log_level` / `duration_period` optional with defaults); the README Table of Contents anchor and logging example fixed.
- Dependencies: `pycti` pinned to the latest release `7.260701.0` (aligned with `connectors-sdk` on `master`, which is installed from `master`, never a pinned tag).

## Tests

Unit tests cover the settings model, the API client (request shaping, retries, error wrapping), the converter (TLP:CLEAR / AMBER+STRICT marking shapes, severity mapping, `_parse_timestamp`, deterministic and collision-free incident ids, stable fallback timestamps, IP observable extraction + relationships) and the connector (no work initiated on empty runs, work finalized `in_error` when the bundle send fails). 44 unit tests pass; `black` / `isort` / `flake8` clean locally.

## Status

The branch is rebased onto the latest `master` (linear history, all commits GPG-signed). All CI checks are green, including the advisory Connector Verified Linter job (36/36 checks on this connector after VC201 removal upstream). 0 unresolved review threads.
