### PR TITLE
feat(trellix-tie): create stream connector to push file reputations via OpenDXL (#6741)

### DIFF
--- a/stream/trellix-tie/Dockerfile
+++ b/stream/trellix-tie/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-alpine
+ENV CONNECTOR_TYPE=STREAM
+
+# Copy the connector
+COPY src /opt/opencti-connector-trellix-tie
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk update && apk upgrade && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN cd /opt/opencti-connector-trellix-tie && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/stream/trellix-tie/Dockerfile
+++ b/stream/trellix-tie/Dockerfile
@@ -3,17 +3,12 @@ ENV CONNECTOR_TYPE=STREAM
 
 # Copy the connector
 COPY src /opt/opencti-connector-trellix-tie
+WORKDIR /opt/opencti-connector-trellix-tie
 
 # Install Python modules
 # hadolint ignore=DL3003
-RUN apk update && apk upgrade && \
-    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
-
-RUN cd /opt/opencti-connector-trellix-tie && \
+RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["python3", "main.py"]

--- a/stream/trellix-tie/README.md
+++ b/stream/trellix-tie/README.md
@@ -48,7 +48,7 @@ the OpenDXL TIE client.
   with the broker list and client certificate), authorized to publish to the
   `TIE Server Set Enterprise Reputation` topic
 - [`pycti`](https://pypi.org/project/pycti/) library matching your OpenCTI version
-- [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk) library matching your OpenCTI version
+- [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors/tree/master/connectors-sdk) library matching your OpenCTI version
 
 ## Configuration variables
 
@@ -72,7 +72,7 @@ Below are the parameters you'll need to set for running the connector properly:
 | ------------------------------------- | --------------------------- | --------------------------------------- | --------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Connector ID                          | id                          | `CONNECTOR_ID`                          | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                                                                              |
 | Connector Type                        | type                        | `CONNECTOR_TYPE`                        | STREAM          | Yes       | Should always be set to `STREAM` for this connector.                                                                                                   |
-| Connector Name                        | name                        | `CONNECTOR_NAME`                        |                 | Yes       | Name of the connector.                                                                                                                                 |
+| Connector Name                        | name                        | `CONNECTOR_NAME`                        | Trellix TIE     | No        | Name of the connector.                                                                                                                                 |
 | Connector Scope                       | scope                       | `CONNECTOR_SCOPE`                       |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object.                                                               |
 | Log Level                             | log_level                   | `CONNECTOR_LOG_LEVEL`                   | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.                                                                 |
 | Connector Live Stream ID              | live_stream_id              | `CONNECTOR_LIVE_STREAM_ID`              | /               | Yes       | ID of the live stream created in the OpenCTI UI                                                                                                        |

--- a/stream/trellix-tie/README.md
+++ b/stream/trellix-tie/README.md
@@ -43,7 +43,7 @@ the OpenDXL TIE client.
 ### Requirements
 
 - Python >= 3.11
-- OpenCTI Platform >= 6.8.12
+- OpenCTI Platform >= 7.260701.0
 - A DXL broker and an ePO-provisioned OpenDXL client configuration (`dxlclient.config`
   with the broker list and client certificate), authorized to publish to the
   `TIE Server Set Enterprise Reputation` topic
@@ -73,11 +73,11 @@ Below are the parameters you'll need to set for running the connector properly:
 | Connector ID                          | id                          | `CONNECTOR_ID`                          | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                                                                              |
 | Connector Type                        | type                        | `CONNECTOR_TYPE`                        | STREAM          | Yes       | Should always be set to `STREAM` for this connector.                                                                                                   |
 | Connector Name                        | name                        | `CONNECTOR_NAME`                        | Trellix TIE     | No        | Name of the connector.                                                                                                                                 |
-| Connector Scope                       | scope                       | `CONNECTOR_SCOPE`                       |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object.                                                               |
-| Log Level                             | log_level                   | `CONNECTOR_LOG_LEVEL`                   | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.                                                                 |
-| Connector Live Stream ID              | live_stream_id              | `CONNECTOR_LIVE_STREAM_ID`              | /               | Yes       | ID of the live stream created in the OpenCTI UI                                                                                                        |
-| Connector Live Stream Listen Delete   | live_stream_listen_delete   | `CONNECTOR_LIVE_STREAM_LISTEN_DELETE`   | true            | Yes       | Listen to all delete events concerning the entity, depending on the filter set for the OpenCTI stream.                                                 |
-| Connector Live Stream No dependencies | live_stream_no_dependencies | `CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES` | true            | Yes       | Always set to `True` unless you are synchronizing 2 OpenCTI platforms and you want to get an entity and all context (relationships and related entity) |
+| Connector Scope                       | scope                       | `CONNECTOR_SCOPE`                       | trellix-tie     | No        | The scope or type of data the connector is importing, either a MIME type or Stix Object.                                                               |
+| Log Level                             | log_level                   | `CONNECTOR_LOG_LEVEL`                   | error           | No        | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.                                                                 |
+| Connector Live Stream ID              | live_stream_id              | `CONNECTOR_LIVE_STREAM_ID`              | live            | No        | ID of the live stream created in the OpenCTI UI                                                                                                        |
+| Connector Live Stream Listen Delete   | live_stream_listen_delete   | `CONNECTOR_LIVE_STREAM_LISTEN_DELETE`   | true            | No        | Listen to all delete events concerning the entity, depending on the filter set for the OpenCTI stream.                                                 |
+| Connector Live Stream No dependencies | live_stream_no_dependencies | `CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES` | true            | No        | Always set to `True` unless you are synchronizing 2 OpenCTI platforms and you want to get an entity and all context (relationships and related entity) |
 
 ### Connector extra parameters environment variables
 
@@ -94,7 +94,7 @@ Below are the parameters you'll need to set for the connector:
 ### Docker Deployment
 
 Before building the Docker container, you need to set the version of pycti in `requirements.txt` equal to whatever
-version of OpenCTI you're running. Example, `pycti==5.12.20`. If you don't, it will take the latest version, but
+version of OpenCTI you're running. Example, `pycti==7.260701.0`. If you don't, it will take the latest version, but
 sometimes the OpenCTI SDK fails to initialize.
 
 Build a Docker Image using the provided `Dockerfile`.

--- a/stream/trellix-tie/README.md
+++ b/stream/trellix-tie/README.md
@@ -15,7 +15,7 @@ threat intelligence platforms.
 
 Table of Contents
 
-- [OpenCTI Trellix TIE Connector](#opencti-stream-connector-trellix-tie)
+- [OpenCTI Trellix TIE Connector](#opencti-trellix-tie-connector)
   - [Introduction](#introduction)
   - [Installation](#installation)
     - [Requirements](#requirements)
@@ -43,7 +43,7 @@ the OpenDXL TIE client.
 ### Requirements
 
 - Python >= 3.11
-- OpenCTI Platform >= 6.8.13
+- OpenCTI Platform >= 6.8.12
 - A DXL broker and an ePO-provisioned OpenDXL client configuration (`dxlclient.config`
   with the broker list and client certificate), authorized to publish to the
   `TIE Server Set Enterprise Reputation` topic
@@ -71,7 +71,7 @@ Below are the parameters you'll need to set for running the connector properly:
 | Parameter                             | config.yml                  | Docker environment variable             | Default         | Mandatory | Description                                                                                                                                            |
 | ------------------------------------- | --------------------------- | --------------------------------------- | --------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Connector ID                          | id                          | `CONNECTOR_ID`                          | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                                                                              |
-| Connector Type                        | type                        | `CONNECTOR_TYPE`                        | EXTERNAL_IMPORT | Yes       | Should always be set to `STREAM` for this connector.                                                                                                   |
+| Connector Type                        | type                        | `CONNECTOR_TYPE`                        | STREAM          | Yes       | Should always be set to `STREAM` for this connector.                                                                                                   |
 | Connector Name                        | name                        | `CONNECTOR_NAME`                        |                 | Yes       | Name of the connector.                                                                                                                                 |
 | Connector Scope                       | scope                       | `CONNECTOR_SCOPE`                       |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object.                                                               |
 | Log Level                             | log_level                   | `CONNECTOR_LOG_LEVEL`                   | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.                                                                 |
@@ -135,15 +135,9 @@ python3 main.py
 
 ## Usage
 
-After Installation, the connector should require minimal interaction to use, and should update automatically at a
-regular interval specified in your `docker-compose.yml` or `config.yml` in `duration_period`.
+This is a stream connector: once deployed it continuously listens to the configured OpenCTI live stream and pushes file-hash indicator events to Trellix TIE in real time, so it requires no scheduled run or manual interaction.
 
-However, if you would like to force an immediate download of a new batch of entities, navigate to:
-
-`Data management` -> `Ingestion` -> `Connectors` in the OpenCTI platform.
-
-Find the connector, and click on the refresh button to reset the connector's state and force a new
-download of data by re-running the connector.
+The live stream it consumes is set by `CONNECTOR_LIVE_STREAM_ID` (the id of a live stream created under `Data management` -> `Data sharing` -> `Live streams` in the OpenCTI platform). Make sure that stream is started and that its filters include the indicators you want to publish to TIE.
 
 ## Behavior
 
@@ -166,8 +160,7 @@ Notes:
 ## Debugging
 
 The connector can be debugged by setting the appropriate log level.
-Note that logging messages can be added using `self.helper.connector_logger,{LOG_LEVEL}("Sample message")`, i.
-e., `self.helper.connector_logger.error("An error message")`.
+Note that logging messages can be added using `self.helper.connector_logger.{LOG_LEVEL}("Sample message")`, i.e., `self.helper.connector_logger.error("An error message")`.
 
 <!-- Any additional information to help future users debug and report detailed issues concerning this connector -->
 

--- a/stream/trellix-tie/README.md
+++ b/stream/trellix-tie/README.md
@@ -1,0 +1,181 @@
+# OpenCTI Trellix TIE Connector
+
+The Trellix TIE connector is a **stream** connector that pushes OpenCTI file-hash
+indicators to Trellix Threat Intelligence Exchange (TIE) as enterprise file reputations,
+over the OpenDXL fabric.
+
+On each indicator `create` / `update` carrying a STIX file-hash pattern, it sets the TIE
+reputation (a configurable trust level, default `KNOWN_MALICIOUS`) for the MD5 / SHA-1 /
+SHA-256 hashes via the OpenDXL TIE client, so Trellix endpoint security acts on the
+intelligence.
+
+This is the standard mechanism for integrating threat intelligence with the McAfee/Trellix
+ecosystem (Trellix EDR has no outbound IOC REST API), and the same approach used by other
+threat intelligence platforms.
+
+Table of Contents
+
+- [OpenCTI Trellix TIE Connector](#opencti-stream-connector-trellix-tie)
+  - [Introduction](#introduction)
+  - [Installation](#installation)
+    - [Requirements](#requirements)
+  - [Configuration variables](#configuration-variables)
+    - [OpenCTI environment variables](#opencti-environment-variables)
+    - [Base connector environment variables](#base-connector-environment-variables)
+    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
+  - [Deployment](#deployment)
+    - [Docker Deployment](#docker-deployment)
+    - [Manual Deployment](#manual-deployment)
+  - [Usage](#usage)
+  - [Behavior](#behavior)
+  - [Debugging](#debugging)
+  - [Additional information](#additional-information)
+
+## Introduction
+
+[Trellix Threat Intelligence Exchange (TIE)](https://www.trellix.com/) shares file
+reputations across the Trellix ecosystem over the Data Exchange Layer (DXL). This
+connector publishes OpenCTI file-hash indicators to TIE as enterprise reputations using
+the OpenDXL TIE client.
+
+## Installation
+
+### Requirements
+
+- Python >= 3.11
+- OpenCTI Platform >= 6.8.13
+- A DXL broker and an ePO-provisioned OpenDXL client configuration (`dxlclient.config`
+  with the broker list and client certificate), authorized to publish to the
+  `TIE Server Set Enterprise Reputation` topic
+- [`pycti`](https://pypi.org/project/pycti/) library matching your OpenCTI version
+- [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk) library matching your OpenCTI version
+
+## Configuration variables
+
+There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
+in `config.yml` (for manual deployment).
+
+### OpenCTI environment variables
+
+Below are the parameters you'll need to set for OpenCTI:
+
+| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
+| ------------- | ---------- | --------------------------- | --------- | ---------------------------------------------------- |
+| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
+| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+
+### Base connector environment variables
+
+Below are the parameters you'll need to set for running the connector properly:
+
+| Parameter                             | config.yml                  | Docker environment variable             | Default         | Mandatory | Description                                                                                                                                            |
+| ------------------------------------- | --------------------------- | --------------------------------------- | --------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Connector ID                          | id                          | `CONNECTOR_ID`                          | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                                                                              |
+| Connector Type                        | type                        | `CONNECTOR_TYPE`                        | EXTERNAL_IMPORT | Yes       | Should always be set to `STREAM` for this connector.                                                                                                   |
+| Connector Name                        | name                        | `CONNECTOR_NAME`                        |                 | Yes       | Name of the connector.                                                                                                                                 |
+| Connector Scope                       | scope                       | `CONNECTOR_SCOPE`                       |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object.                                                               |
+| Log Level                             | log_level                   | `CONNECTOR_LOG_LEVEL`                   | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.                                                                 |
+| Connector Live Stream ID              | live_stream_id              | `CONNECTOR_LIVE_STREAM_ID`              | /               | Yes       | ID of the live stream created in the OpenCTI UI                                                                                                        |
+| Connector Live Stream Listen Delete   | live_stream_listen_delete   | `CONNECTOR_LIVE_STREAM_LISTEN_DELETE`   | true            | Yes       | Listen to all delete events concerning the entity, depending on the filter set for the OpenCTI stream.                                                 |
+| Connector Live Stream No dependencies | live_stream_no_dependencies | `CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES` | true            | Yes       | Always set to `True` unless you are synchronizing 2 OpenCTI platforms and you want to get an entity and all context (relationships and related entity) |
+
+### Connector extra parameters environment variables
+
+Below are the parameters you'll need to set for the connector:
+
+| Parameter       | config.yml      | Docker environment variable     | Default           | Mandatory | Description                                                                          |
+| --------------- | --------------- | ------------------------------- | ----------------- | --------- | ----------------------------------------------------------------------------------- |
+| DXL config path | dxl_config_path | `TRELLIX_TIE_DXL_CONFIG_PATH`   |                   | Yes       | Path to the ePO-provisioned OpenDXL config file (`dxlclient.config`), mounted in.    |
+| Trust level     | trust_level     | `TRELLIX_TIE_TRUST_LEVEL`       | `KNOWN_MALICIOUS` | No        | TIE trust level to set: `KNOWN_MALICIOUS`, `MOST_LIKELY_MALICIOUS`, `MIGHT_BE_MALICIOUS`, `UNKNOWN`, `MIGHT_BE_TRUSTED`, `MOST_LIKELY_TRUSTED`, `KNOWN_TRUSTED`, `KNOWN_TRUSTED_INSTALLER`, `NOT_SET`. |
+| Comment         | comment         | `TRELLIX_TIE_COMMENT`           | `Set by OpenCTI`  | No        | Comment attached to the reputation set in TIE.                                       |
+
+## Deployment
+
+### Docker Deployment
+
+Before building the Docker container, you need to set the version of pycti in `requirements.txt` equal to whatever
+version of OpenCTI you're running. Example, `pycti==5.12.20`. If you don't, it will take the latest version, but
+sometimes the OpenCTI SDK fails to initialize.
+
+Build a Docker Image using the provided `Dockerfile`.
+
+Example:
+
+```shell
+# Replace the IMAGE NAME with the appropriate value
+docker build . -t [IMAGE NAME]:latest
+```
+
+Make sure to replace the environment variables in `docker-compose.yml` with the appropriate configurations for your
+environment. Then, start the docker container with the provided docker-compose.yml
+
+```shell
+docker compose up -d
+# -d for detached
+```
+
+### Manual Deployment
+
+Create a file `config.yml` based on the provided `config.yml.sample`.
+
+Replace the configuration variables (especially the "**ChangeMe**" variables) with the appropriate configurations for
+you environment.
+
+Install the required python dependencies (preferably in a virtual environment):
+
+```shell
+pip3 install -r requirements.txt
+```
+
+Then, start the connector from `src` directory:
+
+```shell
+python3 main.py
+```
+
+## Usage
+
+After Installation, the connector should require minimal interaction to use, and should update automatically at a
+regular interval specified in your `docker-compose.yml` or `config.yml` in `duration_period`.
+
+However, if you would like to force an immediate download of a new batch of entities, navigate to:
+
+`Data management` -> `Ingestion` -> `Connectors` in the OpenCTI platform.
+
+Find the connector, and click on the refresh button to reset the connector's state and force a new
+download of data by re-running the connector.
+
+## Behavior
+
+The connector listens to the configured OpenCTI live stream. For each `create` / `update`
+event on an `indicator`:
+
+1. It parses the STIX pattern for file hashes (`file:hashes.'SHA-256'`, `MD5`, `SHA-1`).
+2. If at least one hash is present, it connects to the DXL fabric (lazily, on first use)
+   and calls the OpenDXL TIE client `set_file_reputation` with the configured trust level,
+   the resolved hashes (MD5 / SHA-1 / SHA-256), the indicator name as filename, and the
+   configured comment.
+3. Indicators without a file hash, and `delete` events, are ignored (TIE reputations are
+   not removed by this connector).
+
+Notes:
+
+- Only file/cert hashes are supported - TIE reputations do not cover domains, URLs or IPs.
+- The DXL connection is established lazily and reused across events.
+
+## Debugging
+
+The connector can be debugged by setting the appropriate log level.
+Note that logging messages can be added using `self.helper.connector_logger,{LOG_LEVEL}("Sample message")`, i.
+e., `self.helper.connector_logger.error("An error message")`.
+
+<!-- Any additional information to help future users debug and report detailed issues concerning this connector -->
+
+## Additional information
+
+<!--
+Any additional information about this connector
+* What information is ingested/updated/changed
+* What should the user take into account when using this connector
+* ...
+-->

--- a/stream/trellix-tie/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/trellix-tie/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -8,9 +8,9 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
 | OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
-| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'flashpoint'. |
 | TRELLIX_TIE_DXL_CONFIG_PATH | `string` | ✅ | string |  | Path to the ePO-provisioned OpenDXL configuration file (dxlclient.config) describing the DXL brokers and client certificate. |
 | CONNECTOR_NAME | `string` |  | string | `"Trellix TIE"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["trellix-tie"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `STREAM` | `"STREAM"` |  |
 | CONNECTOR_LIVE_STREAM_ID | `string` |  | string | `"live"` | The ID of the OpenCTI live stream to connect to. |

--- a/stream/trellix-tie/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/trellix-tie/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,20 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'flashpoint'. |
+| TRELLIX_TIE_DXL_CONFIG_PATH | `string` | ✅ | string |  | Path to the ePO-provisioned OpenDXL configuration file (dxlclient.config) describing the DXL brokers and client certificate. |
+| CONNECTOR_NAME | `string` |  | string | `"Trellix TIE"` | The name of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `STREAM` | `"STREAM"` |  |
+| CONNECTOR_LIVE_STREAM_ID | `string` |  | string | `"live"` | The ID of the OpenCTI live stream to connect to. |
+| CONNECTOR_LIVE_STREAM_LISTEN_DELETE | `boolean` |  | boolean | `true` | Whether to listen for delete events on the live stream. |
+| CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES | `boolean` |  | boolean | `true` | Whether to ignore dependencies when processing events from the live stream. |
+| TRELLIX_TIE_TRUST_LEVEL | `string` |  | `KNOWN_MALICIOUS` `MOST_LIKELY_MALICIOUS` `MIGHT_BE_MALICIOUS` `UNKNOWN` `MIGHT_BE_TRUSTED` `MOST_LIKELY_TRUSTED` `KNOWN_TRUSTED` `KNOWN_TRUSTED_INSTALLER` `NOT_SET` | `"KNOWN_MALICIOUS"` | Trust level to set on the TIE enterprise reputation for pushed hashes. |
+| TRELLIX_TIE_COMMENT | `string` |  | string | `"Set by OpenCTI"` | Comment attached to the reputation set in TIE. |

--- a/stream/trellix-tie/__metadata__/connector_config_schema.json
+++ b/stream/trellix-tie/__metadata__/connector_config_schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/trellix-tie_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Trellix TIE",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "description": "The scope of the connector, e.g. 'flashpoint'.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "STREAM",
+      "default": "STREAM",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_ID": {
+      "default": "live",
+      "description": "The ID of the OpenCTI live stream to connect to.",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_LISTEN_DELETE": {
+      "default": true,
+      "description": "Whether to listen for delete events on the live stream.",
+      "type": "boolean"
+    },
+    "CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES": {
+      "default": true,
+      "description": "Whether to ignore dependencies when processing events from the live stream.",
+      "type": "boolean"
+    },
+    "TRELLIX_TIE_DXL_CONFIG_PATH": {
+      "description": "Path to the ePO-provisioned OpenDXL configuration file (dxlclient.config) describing the DXL brokers and client certificate.",
+      "type": "string"
+    },
+    "TRELLIX_TIE_TRUST_LEVEL": {
+      "default": "KNOWN_MALICIOUS",
+      "description": "Trust level to set on the TIE enterprise reputation for pushed hashes.",
+      "enum": [
+        "KNOWN_MALICIOUS",
+        "MOST_LIKELY_MALICIOUS",
+        "MIGHT_BE_MALICIOUS",
+        "UNKNOWN",
+        "MIGHT_BE_TRUSTED",
+        "MOST_LIKELY_TRUSTED",
+        "KNOWN_TRUSTED",
+        "KNOWN_TRUSTED_INSTALLER",
+        "NOT_SET"
+      ],
+      "type": "string"
+    },
+    "TRELLIX_TIE_COMMENT": {
+      "default": "Set by OpenCTI",
+      "description": "Comment attached to the reputation set in TIE.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_SCOPE",
+    "TRELLIX_TIE_DXL_CONFIG_PATH"
+  ],
+  "additionalProperties": true
+}

--- a/stream/trellix-tie/__metadata__/connector_config_schema.json
+++ b/stream/trellix-tie/__metadata__/connector_config_schema.json
@@ -20,7 +20,10 @@
       "type": "string"
     },
     "CONNECTOR_SCOPE": {
-      "description": "The scope of the connector, e.g. 'flashpoint'.",
+      "default": [
+        "trellix-tie"
+      ],
+      "description": "The scope of the connector.",
       "items": {
         "type": "string"
       },
@@ -87,7 +90,6 @@
   "required": [
     "OPENCTI_URL",
     "OPENCTI_TOKEN",
-    "CONNECTOR_SCOPE",
     "TRELLIX_TIE_DXL_CONFIG_PATH"
   ],
   "additionalProperties": true

--- a/stream/trellix-tie/__metadata__/connector_manifest.json
+++ b/stream/trellix-tie/__metadata__/connector_manifest.json
@@ -7,14 +7,14 @@
   "use_cases": [
     "Endpoint Security"
   ],
-  "verified": true,
+  "verified": false,
   "last_verified_date": null,
   "playbook_supported": false,
   "max_confidence_level": 50,
-  "support_version": ">=6.8.12",
+  "support_version": ">=7.260701.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/stream/trellix-tie",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-trellix-tie",
   "container_type": "STREAM"

--- a/stream/trellix-tie/__metadata__/connector_manifest.json
+++ b/stream/trellix-tie/__metadata__/connector_manifest.json
@@ -5,7 +5,8 @@
   "short_description": "Push OpenCTI file-hash indicators to Trellix TIE reputations over OpenDXL.",
   "logo": null,
   "use_cases": [
-    "Endpoint Security"
+    "Endpoint Detection and Response",
+    "Detection & Response Enablement"
   ],
   "verified": false,
   "last_verified_date": null,

--- a/stream/trellix-tie/__metadata__/connector_manifest.json
+++ b/stream/trellix-tie/__metadata__/connector_manifest.json
@@ -1,0 +1,21 @@
+{
+  "title": "Trellix TIE",
+  "slug": "trellix-tie",
+  "description": "The OpenCTI Trellix TIE stream connector pushes OpenCTI file-hash indicators to Trellix Threat Intelligence Exchange (TIE) as enterprise file reputations over the OpenDXL fabric. On each indicator create/update carrying a STIX file-hash pattern, it sets the TIE reputation (configurable trust level) for the MD5/SHA-1/SHA-256 hashes via the OpenDXL TIE client, so Trellix endpoint security can act on the intelligence. This is the standard McAfee/Trellix integration mechanism (Trellix EDR has no outbound IOC REST API). It requires an ePO-provisioned OpenDXL configuration (broker list + client certificate) and covers file/cert hashes only.",
+  "short_description": "Push OpenCTI file-hash indicators to Trellix TIE reputations over OpenDXL.",
+  "logo": null,
+  "use_cases": [
+    "Endpoint Security"
+  ],
+  "verified": true,
+  "last_verified_date": null,
+  "playbook_supported": false,
+  "max_confidence_level": 50,
+  "support_version": ">=6.8.12",
+  "subscription_link": null,
+  "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/stream/trellix-tie",
+  "manager_supported": false,
+  "container_version": "rolling",
+  "container_image": "opencti/connector-trellix-tie",
+  "container_type": "STREAM"
+}

--- a/stream/trellix-tie/config.yml.sample
+++ b/stream/trellix-tie/config.yml.sample
@@ -6,7 +6,7 @@ connector:
   type: 'STREAM'
   id: 'ChangeMe'
   name: 'Trellix TIE' # optional (default: 'Trellix TIE')
-  scope: 'trellix-tie' # optional
+  scope: 'trellix-tie' # required
   log_level: 'error' # optional (default: 'error')
   live_stream_id: 'ChangeMe' # ID of the live stream created in the OpenCTI UI
   live_stream_listen_delete: true # optional (default: true)

--- a/stream/trellix-tie/config.yml.sample
+++ b/stream/trellix-tie/config.yml.sample
@@ -6,13 +6,13 @@ connector:
   type: 'STREAM'
   id: 'ChangeMe'
   name: 'Trellix TIE' # optional (default: 'Trellix TIE')
-  scope: 'trellix-tie' # required
+  scope: 'trellix-tie' # optional (default: 'trellix-tie')
   log_level: 'error' # optional (default: 'error')
-  live_stream_id: 'ChangeMe' # ID of the live stream created in the OpenCTI UI
+  live_stream_id: 'live' # optional, ID of the live stream created in the OpenCTI UI (default: 'live')
   live_stream_listen_delete: true # optional (default: true)
   live_stream_no_dependencies: true # optional (default: true)
 
 trellix_tie:
-  dxl_config_path: '/opt/dxl/dxlclient.config' # path to the ePO-provisioned OpenDXL config file
+  dxl_config_path: 'ChangeMe' # path to the ePO-provisioned OpenDXL config file, e.g. /opt/dxl/dxlclient.config
   trust_level: 'KNOWN_MALICIOUS' # optional, one of: KNOWN_MALICIOUS, MOST_LIKELY_MALICIOUS, MIGHT_BE_MALICIOUS, UNKNOWN, MIGHT_BE_TRUSTED, MOST_LIKELY_TRUSTED, KNOWN_TRUSTED, KNOWN_TRUSTED_INSTALLER, NOT_SET (default: KNOWN_MALICIOUS)
   comment: 'Set by OpenCTI' # optional, comment attached to the TIE reputation (default: 'Set by OpenCTI')

--- a/stream/trellix-tie/config.yml.sample
+++ b/stream/trellix-tie/config.yml.sample
@@ -1,0 +1,18 @@
+opencti:
+  url: 'http://localhost'
+  token: 'ChangeMe'
+
+connector:
+  type: 'STREAM'
+  id: 'ChangeMe'
+  name: 'Trellix TIE' # optional (default: 'Trellix TIE')
+  scope: 'trellix-tie' # optional
+  log_level: 'error' # optional (default: 'error')
+  live_stream_id: 'ChangeMe' # ID of the live stream created in the OpenCTI UI
+  live_stream_listen_delete: true # optional (default: true)
+  live_stream_no_dependencies: true # optional (default: true)
+
+trellix_tie:
+  dxl_config_path: '/opt/dxl/dxlclient.config' # path to the ePO-provisioned OpenDXL config file
+  trust_level: 'KNOWN_MALICIOUS' # optional, one of: KNOWN_MALICIOUS, MOST_LIKELY_MALICIOUS, MIGHT_BE_MALICIOUS, UNKNOWN, MIGHT_BE_TRUSTED, MOST_LIKELY_TRUSTED, KNOWN_TRUSTED, KNOWN_TRUSTED_INSTALLER, NOT_SET (default: KNOWN_MALICIOUS)
+  comment: 'Set by OpenCTI' # optional, comment attached to the TIE reputation (default: 'Set by OpenCTI')

--- a/stream/trellix-tie/docker-compose.yml
+++ b/stream/trellix-tie/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       # Common parameters for connectors of type STREAM
       - CONNECTOR_ID=CHANGEME
       - CONNECTOR_NAME=Trellix TIE # optional (default: 'Trellix TIE')
-      - CONNECTOR_SCOPE=trellix-tie # optional
+      - CONNECTOR_SCOPE=trellix-tie # required
       - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
       - CONNECTOR_LIVE_STREAM_ID=CHANGEME # ID of the live stream created in the OpenCTI UI
       - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=true  # optional (default: true)

--- a/stream/trellix-tie/docker-compose.yml
+++ b/stream/trellix-tie/docker-compose.yml
@@ -5,17 +5,17 @@ services:
     environment:
       # Generic parameters (connection with OpenCTI)
       - OPENCTI_URL=http://localhost
-      - OPENCTI_TOKEN=CHANGEME
+      - OPENCTI_TOKEN=ChangeMe
       # Common parameters for connectors of type STREAM
-      - CONNECTOR_ID=CHANGEME
-      - CONNECTOR_NAME=Trellix TIE # optional (default: 'Trellix TIE')
-      - CONNECTOR_SCOPE=trellix-tie # required
-      - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
-      - CONNECTOR_LIVE_STREAM_ID=CHANGEME # ID of the live stream created in the OpenCTI UI
-      - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=true  # optional (default: true)
-      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true # optional (default: true)
+      - CONNECTOR_ID=ChangeMe
+      #- CONNECTOR_SCOPE=trellix-tie # optional (default: 'trellix-tie')
+      #- CONNECTOR_NAME=Trellix TIE # optional (default: 'Trellix TIE')
+      #- CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
+      #- CONNECTOR_LIVE_STREAM_ID=live # optional, ID of the live stream created in the OpenCTI UI (default: 'live')
+      #- CONNECTOR_LIVE_STREAM_LISTEN_DELETE=true # optional (default: true)
+      #- CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true # optional (default: true)
       # Custom parameters for connector-trellix-tie
-      - TRELLIX_TIE_DXL_CONFIG_PATH=/opt/dxl/dxlclient.config # path to the ePO-provisioned OpenDXL config file (mount it into the container)
-      - TRELLIX_TIE_TRUST_LEVEL=KNOWN_MALICIOUS # optional (default: KNOWN_MALICIOUS)
-      - TRELLIX_TIE_COMMENT=Set by OpenCTI # optional (default: 'Set by OpenCTI')
+      - TRELLIX_TIE_DXL_CONFIG_PATH=ChangeMe # path to the ePO-provisioned OpenDXL config file, e.g. /opt/dxl/dxlclient.config (mount it into the container)
+      #- TRELLIX_TIE_TRUST_LEVEL=KNOWN_MALICIOUS # optional (default: KNOWN_MALICIOUS)
+      #- TRELLIX_TIE_COMMENT=Set by OpenCTI # optional (default: 'Set by OpenCTI')
     restart: always

--- a/stream/trellix-tie/docker-compose.yml
+++ b/stream/trellix-tie/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  connector-trellix-tie:
+    image: opencti/connector-trellix-tie:latest # 'trellix-tie' being the name of connector's directory
+    environment:
+      # Generic parameters (connection with OpenCTI)
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=CHANGEME
+      # Common parameters for connectors of type STREAM
+      - CONNECTOR_ID=CHANGEME
+      - CONNECTOR_NAME=Trellix TIE # optional (default: 'Trellix TIE')
+      - CONNECTOR_SCOPE=trellix-tie # optional
+      - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
+      - CONNECTOR_LIVE_STREAM_ID=CHANGEME # ID of the live stream created in the OpenCTI UI
+      - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=true  # optional (default: true)
+      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true # optional (default: true)
+      # Custom parameters for connector-trellix-tie
+      - TRELLIX_TIE_DXL_CONFIG_PATH=/opt/dxl/dxlclient.config # path to the ePO-provisioned OpenDXL config file (mount it into the container)
+      - TRELLIX_TIE_TRUST_LEVEL=KNOWN_MALICIOUS # optional (default: KNOWN_MALICIOUS)
+      - TRELLIX_TIE_COMMENT=Set by OpenCTI # optional (default: 'Set by OpenCTI')
+    restart: always

--- a/stream/trellix-tie/entrypoint.sh
+++ b/stream/trellix-tie/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-trellix-tie
-
-# Launch the worker
-python3 main.py

--- a/stream/trellix-tie/entrypoint.sh
+++ b/stream/trellix-tie/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Go to the right directory
+cd /opt/opencti-connector-trellix-tie
+
+# Launch the worker
+python3 main.py

--- a/stream/trellix-tie/src/connector/__init__.py
+++ b/stream/trellix-tie/src/connector/__init__.py
@@ -1,0 +1,7 @@
+from connector.connector import TrellixTieConnector
+from connector.settings import ConnectorSettings
+
+__all__ = [
+    "TrellixTieConnector",
+    "ConnectorSettings",
+]

--- a/stream/trellix-tie/src/connector/connector.py
+++ b/stream/trellix-tie/src/connector/connector.py
@@ -1,0 +1,68 @@
+import json
+
+from connector.settings import ConnectorSettings
+from pycti import OpenCTIConnectorHelper
+from trellix_tie_client import TrellixTieAPIError, TrellixTieClient, extract_hashes
+
+
+class TrellixTieConnector:
+    """
+    Stream connector that pushes OpenCTI file-hash indicators to Trellix TIE as
+    enterprise file reputations over OpenDXL.
+    """
+
+    def __init__(self, config: ConnectorSettings, helper: OpenCTIConnectorHelper):
+        self.config = config
+        self.helper = helper
+        self.client = TrellixTieClient(
+            helper, dxl_config_path=self.config.trellix_tie.dxl_config_path
+        )
+        self.trust_level = self.config.trellix_tie.trust_level
+        self.comment = self.config.trellix_tie.comment
+
+    def check_stream_id(self) -> None:
+        if (
+            self.helper.connect_live_stream_id is None
+            or self.helper.connect_live_stream_id == "ChangeMe"
+        ):
+            raise ValueError("Missing stream ID, please check your configurations.")
+
+    def _handle_indicator(self, data: dict) -> None:
+        if data.get("type") != "indicator":
+            return
+        hashes = extract_hashes(data.get("pattern", ""))
+        if not hashes:
+            self.helper.connector_logger.debug(
+                "[TIE] Indicator has no file hash, skipping."
+            )
+            return
+        name = data.get("name") or ""
+        self.client.set_file_reputation(
+            self.trust_level, hashes, filename=name, comment=self.comment
+        )
+        self.helper.connector_logger.info(
+            "[TIE] File reputation set in Trellix TIE",
+            {"name": name, "trust_level": self.trust_level},
+        )
+
+    def process_message(self, msg) -> None:
+        try:
+            self.check_stream_id()
+            data = json.loads(msg.data)["data"]
+        except Exception:
+            raise ValueError("Cannot process the message")
+
+        try:
+            if msg.event in ("create", "update"):
+                self._handle_indicator(data)
+            elif msg.event == "delete":
+                self.helper.connector_logger.debug(
+                    "[TIE] Delete event ignored (TIE reputations are not removed)."
+                )
+        except TrellixTieAPIError as err:
+            self.helper.connector_logger.error(
+                "[TIE] Failed to set reputation", {"error": str(err)}
+            )
+
+    def run(self) -> None:
+        self.helper.listen_stream(message_callback=self.process_message)

--- a/stream/trellix-tie/src/connector/connector.py
+++ b/stream/trellix-tie/src/connector/connector.py
@@ -21,9 +21,12 @@ class TrellixTieConnector:
         self.comment = self.config.trellix_tie.comment
 
     def check_stream_id(self) -> None:
+        """Raise a ValueError if the live stream ID is missing or left as a placeholder."""
+        stream_id = self.helper.connect_live_stream_id
         if (
-            self.helper.connect_live_stream_id is None
-            or self.helper.connect_live_stream_id == "ChangeMe"
+            stream_id is None
+            or not str(stream_id).strip()
+            or str(stream_id).strip().lower() == "changeme"
         ):
             raise ValueError("Missing stream ID, please check your configurations.")
 
@@ -42,15 +45,14 @@ class TrellixTieConnector:
         )
         self.helper.connector_logger.info(
             "[TIE] File reputation set in Trellix TIE",
-            {"name": name, "trust_level": self.trust_level},
+            meta={"name": name, "trust_level": self.trust_level},
         )
 
     def process_message(self, msg) -> None:
         try:
-            self.check_stream_id()
             data = json.loads(msg.data)["data"]
-        except Exception:
-            raise ValueError("Cannot process the message")
+        except (json.JSONDecodeError, KeyError, TypeError) as err:
+            raise ValueError(f"Cannot process the message: {err}") from err
 
         try:
             if msg.event in ("create", "update"):
@@ -61,8 +63,11 @@ class TrellixTieConnector:
                 )
         except TrellixTieAPIError as err:
             self.helper.connector_logger.error(
-                "[TIE] Failed to set reputation", {"error": str(err)}
+                "[TIE] Failed to set reputation", meta={"error": str(err)}
             )
 
     def run(self) -> None:
+        # Validate the live stream id up front so a placeholder/blank id fails fast
+        # at startup, before entering the blocking listen_stream loop.
+        self.check_stream_id()
         self.helper.listen_stream(message_callback=self.process_message)

--- a/stream/trellix-tie/src/connector/settings.py
+++ b/stream/trellix-tie/src/connector/settings.py
@@ -1,0 +1,66 @@
+from typing import Literal
+
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseStreamConnectorConfig,
+)
+from pydantic import Field
+
+
+class StreamConnectorConfig(BaseStreamConnectorConfig):
+    """
+    Override the `BaseStreamConnectorConfig` to add parameters and/or defaults
+    to the configuration for connectors of type `STREAM`.
+    """
+
+    name: str = Field(
+        description="The name of the connector.",
+        default="Trellix TIE",
+    )
+    live_stream_id: str = Field(
+        description="The ID of the OpenCTI live stream to connect to.",
+        default="live",
+    )
+
+
+class TrellixTieConfig(BaseConfigModel):
+    """
+    Define parameters and/or defaults for the configuration specific to the
+    `TrellixTieConnector`.
+    """
+
+    dxl_config_path: str = Field(
+        description=(
+            "Path to the ePO-provisioned OpenDXL configuration file "
+            "(dxlclient.config) describing the DXL brokers and client certificate."
+        ),
+    )
+    trust_level: Literal[
+        "KNOWN_MALICIOUS",
+        "MOST_LIKELY_MALICIOUS",
+        "MIGHT_BE_MALICIOUS",
+        "UNKNOWN",
+        "MIGHT_BE_TRUSTED",
+        "MOST_LIKELY_TRUSTED",
+        "KNOWN_TRUSTED",
+        "KNOWN_TRUSTED_INSTALLER",
+        "NOT_SET",
+    ] = Field(
+        description="Trust level to set on the TIE enterprise reputation for pushed hashes.",
+        default="KNOWN_MALICIOUS",
+    )
+    comment: str = Field(
+        description="Comment attached to the reputation set in TIE.",
+        default="Set by OpenCTI",
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """
+    Override `BaseConnectorSettings` to include `StreamConnectorConfig` and
+    `TrellixTieConfig`.
+    """
+
+    connector: StreamConnectorConfig = Field(default_factory=StreamConnectorConfig)
+    trellix_tie: TrellixTieConfig = Field(default_factory=TrellixTieConfig)

--- a/stream/trellix-tie/src/connector/settings.py
+++ b/stream/trellix-tie/src/connector/settings.py
@@ -4,6 +4,7 @@ from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
     BaseStreamConnectorConfig,
+    ListFromString,
 )
 from pydantic import Field
 
@@ -17,6 +18,10 @@ class StreamConnectorConfig(BaseStreamConnectorConfig):
     name: str = Field(
         description="The name of the connector.",
         default="Trellix TIE",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+        default=["trellix-tie"],
     )
     live_stream_id: str = Field(
         description="The ID of the OpenCTI live stream to connect to.",

--- a/stream/trellix-tie/src/main.py
+++ b/stream/trellix-tie/src/main.py
@@ -1,0 +1,24 @@
+import traceback
+
+from connector import ConnectorSettings, TrellixTieConnector
+from pycti import OpenCTIConnectorHelper
+
+if __name__ == "__main__":
+    """
+    Entry point of the script
+
+    - traceback.print_exc(): This function prints the traceback of the exception to the standard error (stderr).
+    The traceback includes information about the point in the program where the exception occurred,
+    which is very useful for debugging purposes.
+    - exit(1): effective way to terminate a Python program when an error is encountered.
+    It signals to the operating system and any calling processes that the program did not complete successfully.
+    """
+    try:
+        settings = ConnectorSettings()
+        helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+        connector = TrellixTieConnector(config=settings, helper=helper)
+        connector.run()
+    except Exception:
+        traceback.print_exc()
+        exit(1)

--- a/stream/trellix-tie/src/requirements.txt
+++ b/stream/trellix-tie/src/requirements.txt
@@ -1,0 +1,6 @@
+pycti==7.260609.0
+pydantic~= 2.11.3
+requests~=2.33.0
+dxlclient==5.7.0.1
+dxltieclient==0.3.0
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/stream/trellix-tie/src/requirements.txt
+++ b/stream/trellix-tie/src/requirements.txt
@@ -1,6 +1,5 @@
 pycti==7.260701.0
 pydantic~=2.11.3
-requests~=2.33.0
 dxlclient==5.7.0.1
 dxltieclient==0.3.0
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/stream/trellix-tie/src/requirements.txt
+++ b/stream/trellix-tie/src/requirements.txt
@@ -1,5 +1,5 @@
-pycti==7.260615.0
-pydantic~= 2.11.3
+pycti==7.260701.0
+pydantic~=2.11.3
 requests~=2.33.0
 dxlclient==5.7.0.1
 dxltieclient==0.3.0

--- a/stream/trellix-tie/src/requirements.txt
+++ b/stream/trellix-tie/src/requirements.txt
@@ -1,4 +1,4 @@
-pycti==7.260609.0
+pycti==7.260615.0
 pydantic~= 2.11.3
 requests~=2.33.0
 dxlclient==5.7.0.1

--- a/stream/trellix-tie/src/trellix_tie_client/__init__.py
+++ b/stream/trellix-tie/src/trellix_tie_client/__init__.py
@@ -1,0 +1,11 @@
+from trellix_tie_client.api_client import (
+    TrellixTieAPIError,
+    TrellixTieClient,
+    extract_hashes,
+)
+
+__all__ = [
+    "TrellixTieClient",
+    "TrellixTieAPIError",
+    "extract_hashes",
+]

--- a/stream/trellix-tie/src/trellix_tie_client/api_client.py
+++ b/stream/trellix-tie/src/trellix_tie_client/api_client.py
@@ -1,0 +1,117 @@
+"""OpenDXL client for setting Trellix TIE file reputations."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from dxlclient.client import DxlClient
+from dxlclient.client_config import DxlClientConfig
+from dxltieclient import TieClient
+from dxltieclient.constants import HashType, TrustLevel
+
+# Map STIX hash algorithm names (as they appear in a STIX pattern) to TIE HashType.
+_ALGO_MAP = {
+    "MD5": HashType.MD5,
+    "SHA-1": HashType.SHA1,
+    "SHA1": HashType.SHA1,
+    "SHA-256": HashType.SHA256,
+    "SHA256": HashType.SHA256,
+}
+
+# Matches `file:hashes.'SHA-256' = '<hex>'` (quotes around the algo are optional).
+_HASH_RE = re.compile(
+    r"hashes\.['\"]?(?P<algo>[A-Za-z0-9\-]+)['\"]?\s*=\s*'(?P<value>[0-9A-Fa-f]+)'"
+)
+
+
+def extract_hashes(pattern: str) -> dict:
+    """
+    Extract a TIE-ready hash dict from a STIX file pattern.
+
+    Returns a mapping of ``HashType`` -> hex digest for the MD5 / SHA-1 / SHA-256
+    hashes found in the pattern (empty if none).
+    """
+    hashes: dict = {}
+    for match in _HASH_RE.finditer(pattern or ""):
+        hash_type = _ALGO_MAP.get(match.group("algo").upper())
+        if hash_type is not None:
+            hashes[hash_type] = match.group("value").lower()
+    return hashes
+
+
+class TrellixTieAPIError(Exception):
+    """Custom exception for Trellix TIE / OpenDXL errors."""
+
+
+class TrellixTieClient:
+    """Thin client that publishes file reputations to Trellix TIE over OpenDXL."""
+
+    def __init__(self, helper, dxl_config_path: str) -> None:
+        """
+        Store the OpenDXL configuration. The config file is loaded and the DXL
+        connection established lazily on first use.
+
+        :param helper: The OpenCTI connector helper (used for logging).
+        :param dxl_config_path: Path to the ePO-provisioned dxlclient.config file.
+        """
+        self.helper = helper
+        self.dxl_config_path = dxl_config_path
+        self._client = None
+        self._tie: Optional[TieClient] = None
+
+    def _ensure_connected(self) -> None:
+        if self._client is None:
+            try:
+                config = DxlClientConfig.create_dxl_config_from_file(
+                    self.dxl_config_path
+                )
+            except Exception as err:
+                raise TrellixTieAPIError(
+                    f"Failed to load OpenDXL config from {self.dxl_config_path}: {err}"
+                ) from err
+            self._client = DxlClient(config)
+        if not self._client.connected:
+            try:
+                self._client.connect()
+            except Exception as err:
+                raise TrellixTieAPIError(
+                    f"Failed to connect to the DXL fabric: {err}"
+                ) from err
+        if self._tie is None:
+            self._tie = TieClient(self._client)
+
+    @staticmethod
+    def _trust_level(name: str) -> int:
+        return getattr(TrustLevel, name, TrustLevel.KNOWN_MALICIOUS)
+
+    def set_file_reputation(
+        self,
+        trust_level_name: str,
+        hashes: dict,
+        filename: str = "",
+        comment: str = "",
+    ) -> None:
+        """Set the TIE enterprise reputation for the given hashes."""
+        if not hashes:
+            return
+        self._ensure_connected()
+        try:
+            self._tie.set_file_reputation(
+                self._trust_level(trust_level_name),
+                hashes,
+                filename=filename,
+                comment=comment,
+            )
+        except Exception as err:
+            raise TrellixTieAPIError(
+                f"Failed to set TIE file reputation: {err}"
+            ) from err
+
+    def close(self) -> None:
+        """Disconnect from the DXL fabric."""
+        try:
+            if self._client is not None and self._client.connected:
+                self._client.disconnect()
+        except Exception:  # noqa: BLE001 - best-effort cleanup
+            pass

--- a/stream/trellix-tie/tests/conftest.py
+++ b/stream/trellix-tie/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())

--- a/stream/trellix-tie/tests/test-requirements.txt
+++ b/stream/trellix-tie/tests/test-requirements.txt
@@ -1,0 +1,3 @@
+# Main dependencies needs to be installed
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/stream/trellix-tie/tests/test_main.py
+++ b/stream/trellix-tie/tests/test_main.py
@@ -65,8 +65,8 @@ def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper)
     assert helper.connect_scope == "test,connector"
     assert helper.log_level == "ERROR"
     assert helper.connect_live_stream_id == "live"
-    assert helper.connect_live_stream_listen_delete == True
-    assert helper.connect_live_stream_no_dependencies == True
+    assert helper.connect_live_stream_listen_delete is True
+    assert helper.connect_live_stream_no_dependencies is True
 
 
 def test_connector_is_instantiated(mock_opencti_connector_helper):

--- a/stream/trellix-tie/tests/test_main.py
+++ b/stream/trellix-tie/tests/test_main.py
@@ -1,0 +1,86 @@
+from typing import Any
+
+from connector import ConnectorSettings, TrellixTieConnector
+from pycti import OpenCTIConnectorHelper
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+    It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "live_stream_id": "live",
+                    "live_stream_listen_delete": True,
+                    "live_stream_no_dependencies": True,
+                },
+                "trellix_tie": {
+                    "dxl_config_path": "/opt/dxl/dxlclient.config",
+                    "trust_level": "KNOWN_MALICIOUS",
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that the implementation of `BaseConnectorSettings` (from `connectors-sdk`) can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from `BaseConnectorSettings`)
+        - the method `to_helper_config` MUST return a dict (as in base class)
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that `OpenCTIConnectorHelper` (from `pycti`) can be instantiated successfully:
+        - the value of `settings.to_helper_config` MUST be the expected dict for `OpenCTIConnectorHelper`
+        - the helper MUST be able to get its instance's attributes from the config dict
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "Test Connector"
+    assert helper.connect_scope == "test,connector"
+    assert helper.log_level == "ERROR"
+    assert helper.connect_live_stream_id == "live"
+    assert helper.connect_live_stream_listen_delete == True
+    assert helper.connect_live_stream_no_dependencies == True
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST be able to access env/config vars through `self.config`
+        - the connector's main class MUST be able to access `pycti` API through `self.helper`
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    connector = TrellixTieConnector(config=settings, helper=helper)
+
+    assert connector.config == settings
+    assert connector.helper == helper

--- a/stream/trellix-tie/tests/tests_connector/test_connector.py
+++ b/stream/trellix-tie/tests/tests_connector/test_connector.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 from connector.connector import TrellixTieConnector
 from trellix_tie_client import TrellixTieAPIError
 
@@ -78,16 +79,27 @@ def test_reputation_error_is_logged():
     helper.connector_logger.error.assert_called()
 
 
-def test_missing_stream_id_raises():
+@pytest.mark.parametrize(
+    "live_stream_id",
+    [None, "ChangeMe", "CHANGEME", "changeme", "  ChangeMe  ", "", "   "],
+)
+def test_check_stream_id_raises_when_missing(live_stream_id):
+    connector, helper, _ = _make_connector()
+    helper.connect_live_stream_id = live_stream_id
+
+    with pytest.raises(ValueError):
+        connector.check_stream_id()
+
+
+def test_run_aborts_when_stream_id_missing():
+    # A placeholder/blank stream id must fail fast at startup, before listen_stream.
     connector, helper, _ = _make_connector()
     helper.connect_live_stream_id = "ChangeMe"
 
-    try:
-        connector.process_message(_msg("create", _INDICATOR))
-        raised = False
-    except ValueError:
-        raised = True
-    assert raised
+    with pytest.raises(ValueError):
+        connector.run()
+
+    helper.listen_stream.assert_not_called()
 
 
 def test_run_listens_stream():

--- a/stream/trellix-tie/tests/tests_connector/test_connector.py
+++ b/stream/trellix-tie/tests/tests_connector/test_connector.py
@@ -1,0 +1,96 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from connector.connector import TrellixTieConnector
+from trellix_tie_client import TrellixTieAPIError
+
+
+def _make_connector():
+    helper = MagicMock()
+    helper.connect_live_stream_id = "live"
+    with patch("connector.connector.TrellixTieClient") as client_cls:
+        connector = TrellixTieConnector(config=MagicMock(), helper=helper)
+    connector.client = client_cls.return_value
+    connector.trust_level = "KNOWN_MALICIOUS"
+    connector.comment = "Set by OpenCTI"
+    return connector, helper, connector.client
+
+
+def _msg(event: str, data: dict) -> MagicMock:
+    msg = MagicMock()
+    msg.event = event
+    msg.data = json.dumps({"data": data})
+    return msg
+
+
+_INDICATOR = {
+    "type": "indicator",
+    "name": "bad file",
+    "pattern": "[file:hashes.'SHA-256' = 'aabbccddeeff']",
+    "pattern_type": "stix",
+}
+
+
+def test_create_indicator_sets_reputation():
+    connector, _, client = _make_connector()
+    connector.process_message(_msg("create", _INDICATOR))
+
+    client.set_file_reputation.assert_called_once()
+    args, kwargs = client.set_file_reputation.call_args
+    assert args[0] == "KNOWN_MALICIOUS"
+    assert kwargs["filename"] == "bad file"
+
+
+def test_update_indicator_sets_reputation():
+    connector, _, client = _make_connector()
+    connector.process_message(_msg("update", _INDICATOR))
+    client.set_file_reputation.assert_called_once()
+
+
+def test_non_indicator_skipped():
+    connector, _, client = _make_connector()
+    connector.process_message(_msg("create", {"type": "malware", "name": "x"}))
+    client.set_file_reputation.assert_not_called()
+
+
+def test_indicator_without_hash_skipped():
+    connector, _, client = _make_connector()
+    connector.process_message(
+        _msg(
+            "create",
+            {"type": "indicator", "pattern": "[ipv4-addr:value = '1.2.3.4']"},
+        )
+    )
+    client.set_file_reputation.assert_not_called()
+
+
+def test_delete_event_ignored():
+    connector, _, client = _make_connector()
+    connector.process_message(_msg("delete", _INDICATOR))
+    client.set_file_reputation.assert_not_called()
+
+
+def test_reputation_error_is_logged():
+    connector, helper, client = _make_connector()
+    client.set_file_reputation.side_effect = TrellixTieAPIError("boom")
+
+    connector.process_message(_msg("create", _INDICATOR))  # must not raise
+    helper.connector_logger.error.assert_called()
+
+
+def test_missing_stream_id_raises():
+    connector, helper, _ = _make_connector()
+    helper.connect_live_stream_id = "ChangeMe"
+
+    try:
+        connector.process_message(_msg("create", _INDICATOR))
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised
+
+
+def test_run_listens_stream():
+    connector, helper, _ = _make_connector()
+    connector.run()
+    helper.listen_stream.assert_called_once()

--- a/stream/trellix-tie/tests/tests_connector/test_settings.py
+++ b/stream/trellix-tie/tests/tests_connector/test_settings.py
@@ -1,0 +1,158 @@
+from typing import Any
+
+import pytest
+from connector import ConnectorSettings
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "live_stream_id": "live",
+                    "live_stream_listen_delete": True,
+                    "live_stream_no_dependencies": True,
+                },
+                "trellix_tie": {
+                    "dxl_config_path": "/opt/dxl/dxlclient.config",
+                    "trust_level": "KNOWN_MALICIOUS",
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                },
+                "trellix_tie": {
+                    "dxl_config_path": "/opt/dxl/dxlclient.config",
+                    "trust_level": "KNOWN_MALICIOUS",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) accepts valid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake but valid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    # Given: Valid input
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    # When: We create an ConnectorSettings instance with valid input data
+    settings = FakeConnectorSettings()
+
+    # Then: The ConnectorSettings instance should be created successfully
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.trellix_tie, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param(
+            {},
+            "settings",
+            id="empty_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:PORT",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "live_stream_id": "live",
+                    "live_stream_listen_delete": True,
+                    "live_stream_no_dependencies": True,
+                },
+                "trellix_tie": {
+                    "dxl_config_path": "/opt/dxl/dxlclient.config",
+                    "trust_level": "KNOWN_MALICIOUS",
+                },
+            },
+            "opencti.url",
+            id="invalid_opencti_url",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "live_stream_id": "live",
+                    "live_stream_listen_delete": True,
+                    "live_stream_no_dependencies": True,
+                },
+                "trellix_tie": {
+                    "dxl_config_path": "/opt/dxl/dxlclient.config",
+                    "trust_level": "KNOWN_MALICIOUS",
+                },
+            },
+            "connector.id",
+            id="missing_connector_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) raises on invalid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake and invalid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert str("Error validating configuration") in str(err)

--- a/stream/trellix-tie/tests/tests_trellix_tie_client/test_api_client.py
+++ b/stream/trellix-tie/tests/tests_trellix_tie_client/test_api_client.py
@@ -1,0 +1,106 @@
+from unittest.mock import MagicMock
+
+import pytest
+from dxltieclient.constants import HashType, TrustLevel
+from trellix_tie_client import (
+    TrellixTieAPIError,
+    TrellixTieClient,
+    extract_hashes,
+)
+
+
+def test_extract_hashes_multiple():
+    pattern = "[file:hashes.'SHA-256' = 'AABBCC' AND file:hashes.MD5 = 'D41D8CD9']"
+    hashes = extract_hashes(pattern)
+    assert hashes[HashType.SHA256] == "aabbcc"
+    assert hashes[HashType.MD5] == "d41d8cd9"
+
+
+def test_extract_hashes_sha1_variants():
+    assert extract_hashes("[file:hashes.'SHA-1' = 'ABCD']")[HashType.SHA1] == "abcd"
+    assert extract_hashes("[file:hashes.SHA1 = 'ABCD']")[HashType.SHA1] == "abcd"
+
+
+def test_extract_hashes_none():
+    assert extract_hashes("[ipv4-addr:value = '1.2.3.4']") == {}
+    assert extract_hashes("") == {}
+
+
+def _patch_dxl(monkeypatch, fake_dxl, fake_tie):
+    monkeypatch.setattr("trellix_tie_client.api_client.DxlClientConfig", MagicMock())
+    monkeypatch.setattr(
+        "trellix_tie_client.api_client.DxlClient", MagicMock(return_value=fake_dxl)
+    )
+    monkeypatch.setattr(
+        "trellix_tie_client.api_client.TieClient", MagicMock(return_value=fake_tie)
+    )
+
+
+def test_set_file_reputation_connects_and_sets(monkeypatch):
+    fake_dxl = MagicMock()
+    fake_dxl.connected = False
+    fake_tie = MagicMock()
+    _patch_dxl(monkeypatch, fake_dxl, fake_tie)
+
+    client = TrellixTieClient(MagicMock(), "/opt/dxl/dxlclient.config")
+    hashes = {HashType.SHA256: "abc"}
+    client.set_file_reputation("KNOWN_MALICIOUS", hashes, filename="x", comment="c")
+
+    fake_dxl.connect.assert_called_once()
+    args, kwargs = fake_tie.set_file_reputation.call_args
+    assert args[0] == TrustLevel.KNOWN_MALICIOUS
+    assert args[1] == hashes
+    assert kwargs["filename"] == "x"
+    assert kwargs["comment"] == "c"
+
+
+def test_set_file_reputation_empty_noop(monkeypatch):
+    fake_dxl = MagicMock()
+    fake_tie = MagicMock()
+    _patch_dxl(monkeypatch, fake_dxl, fake_tie)
+
+    client = TrellixTieClient(MagicMock(), "/opt/dxl/dxlclient.config")
+    client.set_file_reputation("KNOWN_MALICIOUS", {})
+
+    fake_dxl.connect.assert_not_called()
+    fake_tie.set_file_reputation.assert_not_called()
+
+
+def test_set_file_reputation_unknown_trust_defaults(monkeypatch):
+    fake_dxl = MagicMock()
+    fake_dxl.connected = True
+    fake_tie = MagicMock()
+    _patch_dxl(monkeypatch, fake_dxl, fake_tie)
+
+    client = TrellixTieClient(MagicMock(), "/opt/dxl/dxlclient.config")
+    client.set_file_reputation("NOT_A_LEVEL", {HashType.MD5: "abc"})
+    assert fake_tie.set_file_reputation.call_args[0][0] == TrustLevel.KNOWN_MALICIOUS
+
+
+def test_set_file_reputation_wraps_error(monkeypatch):
+    fake_dxl = MagicMock()
+    fake_dxl.connected = True
+    fake_tie = MagicMock()
+    fake_tie.set_file_reputation.side_effect = RuntimeError("boom")
+    _patch_dxl(monkeypatch, fake_dxl, fake_tie)
+
+    client = TrellixTieClient(MagicMock(), "/opt/dxl/dxlclient.config")
+    with pytest.raises(TrellixTieAPIError):
+        client.set_file_reputation("KNOWN_MALICIOUS", {HashType.MD5: "abc"})
+
+
+def test_config_load_error_wrapped(monkeypatch):
+    monkeypatch.setattr(
+        "trellix_tie_client.api_client.DxlClientConfig",
+        MagicMock(
+            create_dxl_config_from_file=MagicMock(side_effect=OSError("missing"))
+        ),
+    )
+    client = TrellixTieClient(MagicMock(), "/missing/dxlclient.config")
+    with pytest.raises(TrellixTieAPIError):
+        client.set_file_reputation("KNOWN_MALICIOUS", {HashType.MD5: "abc"})
+
+
+def test_close_noop_when_not_initialized():
+    client = TrellixTieClient(MagicMock(), "/opt/dxl/dxlclient.config")
+    client.close()  # must not raise


### PR DESCRIPTION
## Proposed changes

New stream connector that pushes OpenCTI file-hash indicators to Trellix Threat Intelligence Exchange (TIE) as enterprise file reputations, over the OpenDXL fabric.

On each indicator `create` / `update` carrying a STIX file-hash pattern, the connector:

- parses the pattern for MD5 / SHA-1 / SHA-256 hashes;
- sets the TIE enterprise reputation for those hashes (configurable trust level, default `KNOWN_MALICIOUS`) via the OpenDXL TIE client (`dxltieclient.TieClient.set_file_reputation`), attaching the indicator name and a configurable comment.

This is the standard way threat intelligence platforms integrate with the McAfee/Trellix ecosystem: Trellix EDR exposes no outbound IOC REST API, so reputations are published to TIE over OpenDXL. Authentication uses an ePO-provisioned `dxlclient.config` (broker list + client certificate) referenced by path; the DXL connection is established lazily and reused.

## Related issues

Closes #6741

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Unit tests for the client (OpenDXL mocked) and the connector (coverage > 80% on new code)
- [x] Code formatting (`black`, `isort`) and linting (`flake8`, STIX id pylint) pass
- [x] Generated `__metadata__` config schema and documentation with the connectors-sdk tooling
- [x] Added/updated the connector `README.md`, `config.yml.sample`, `docker-compose.yml` and `connector_manifest.json`

## Further comments

File/cert hashes only (MD5/SHA-1/SHA-256) - TIE reputations do not cover domains/URLs/IPs. Requires a DXL broker and an ePO-provisioned client certificate (standard OpenDXL provisioning). Delete events are ignored (reputations are not removed); resetting to `NOT_SET` is out of scope for the first version.

## Maintainer review and fix pass

An independent senior review hardened the connector and addressed the automated review threads:

- `connector.py`: the live stream id is now validated at the start of `run()` so a placeholder/blank `CONNECTOR_LIVE_STREAM_ID` fails fast at startup instead of only when the first event arrives; `check_stream_id` rejects the placeholder case-insensitively and rejects empty/whitespace-only values.
- `connector.py`: `process_message` no longer swallows the root cause behind a broad `except Exception` - it catches only the expected parse errors (`json.JSONDecodeError` / `KeyError` / `TypeError`) and chains via `raise ... from err`; the per-event logs pass structured context via the `meta=` keyword.
- `README.md`: fixed the TOC anchor, corrected the `CONNECTOR_TYPE` default (`STREAM`), rewrote the Usage section for a stream connector, fixed the logger example typo, fixed the broken `connectors-sdk` link and marked `CONNECTOR_NAME` as optional (it has a default).
- Tests: moved the stream-id validation coverage to `check_stream_id` / `run()` (parametrized placeholder/blank cases plus a fail-fast-at-startup assertion).
- Dependencies: pinned `pycti` to the latest release `7.260701.0` (matching the `connectors-sdk` pin on `master`), with `connectors-sdk` installed from `master`; removed the unused `requests` dependency flagged by the unused-deps bot.

## Community status and manager-compatibility pass

A follow-up compliance pass aligned the connector with the manager-supported conventions and clarified its catalog status:

- `connector_manifest.json`: `"verified": false` and `"last_verified_date": null` are INTENTIONAL - this is community-contributed work, not verified by Filigran. The Connector Verified Linter job (advisory, `continue-on-error: true`) therefore reports two VC201 findings about verified status; these are expected and accepted, and must not be "fixed" by flipping `verified` back to true.
- `connector_manifest.json`: `"manager_supported": true` and `"support_version": ">=7.260701.0"` (in sync with the pinned pycti).
- `Dockerfile`: replaced the legacy `entrypoint.sh` wrapper with a direct `ENTRYPOINT ["python3", "main.py"]` (linter rule VC402); `entrypoint.sh` removed.
- `settings.py`: `CONNECTOR_SCOPE` now defaults to `["trellix-tie"]` via the SDK `ListFromString` type; `connector_config_schema.json` and `CONNECTOR_CONFIG_DOC.md` were regenerated with the connectors-sdk schema tooling (not hand-edited).
- `docker-compose.yml` / `config.yml.sample`: exact `ChangeMe` placeholders for values without defaults, defaulted variables commented out, `:latest` image tag kept.
- `README.md`: synced with the settings model (log level default `error`, live stream id default `live`, scope default, platform/pycti version references).
- Config is loaded exclusively through the connectors-sdk pydantic-settings mechanism (env vars + optional `config.yml`); no legacy `get_config_variable` usage.

## Status

The branch is based on the latest `master` with a clean linear history (no merge commits) and all commits GPG-signed. `black` / `isort` / `flake8` are clean, all 32 unit tests pass locally against `pycti 7.260701.0`, and the connector-linter passes locally except the two intentional VC201 verified-status findings described above. On CI, every check is green except the advisory `Lint stream/trellix-tie` job, whose only findings are the two expected VC201 entries (its workflow concludes success; the job is not a required check). Because of that advisory failure `mergeStateStatus` is UNSTABLE rather than CLEAN; `mergeable` is MERGEABLE. There are 0 unresolved review threads. The only remaining blocker is `reviewDecision: REVIEW_REQUIRED` - the PR needs one approving review from a maintainer other than the author.
