### PR TITLE
ci: skip manually crafted schemas when CONNECTOR_CONFIG_DOC.md is absent (#6752)

### DIFF
--- a/shared/tools/composer/generate_connectors_config_schemas/generate_connector_config_json_schema.sh
+++ b/shared/tools/composer/generate_connectors_config_schemas/generate_connector_config_json_schema.sh
@@ -256,6 +256,14 @@ else
     exit 1
 fi
 
+# Skip connectors with manually crafted JSON schema:
+# a schema already exists but CONNECTOR_CONFIG_DOC.md is absent → manual schema, skip update
+if [ -f "$metadata_path/connector_config_schema.json" ] && \
+   [ ! -f "$metadata_path/CONNECTOR_CONFIG_DOC.md" ]; then
+    echo -e "\033[33m⚠️  Warning: connector_config_schema.json exists but CONNECTOR_CONFIG_DOC.md is absent in $metadata_path. Schema was likely created manually, skipping update.\033[0m"
+    exit 0
+fi
+
 echo -e "\033[32mFound pydantic-settings and/or connectors-sdk in dependencies. Proceeding with schema generation...\033[0m"
 
 (

--- a/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.ps1
+++ b/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.ps1
@@ -169,6 +169,15 @@ foreach ($connector_directory in $connector_directories) {
                 continue
             }
             
+            # Skip connectors with manually crafted JSON schema:
+            # a schema already exists but CONNECTOR_CONFIG_DOC.md is absent → manual schema, skip update
+            $schemaPath = Join-Path $connector_path "$CONNECTOR_METADATA_DIRECTORY\connector_config_schema.json"
+            $configDocPath = Join-Path $connector_path "$CONNECTOR_METADATA_DIRECTORY\CONNECTOR_CONFIG_DOC.md"
+            if ((Test-Path $schemaPath) -and (-not (Test-Path $configDocPath))) {
+                Write-Host "⚠️  Warning: connector_config_schema.json exists but CONNECTOR_CONFIG_DOC.md is absent in $connector_path\$CONNECTOR_METADATA_DIRECTORY. Schema was likely created manually, skipping update." -ForegroundColor Yellow
+                continue
+            }
+
             # Create a new PowerShell session to isolate the virtual environment
             $scriptBlock = {
                 param($ConnectorPath, $VENV_NAME)

--- a/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.sh
+++ b/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.sh
@@ -133,6 +133,14 @@ do
           continue
       fi
 
+      # Skip connectors with manually crafted JSON schema:
+      # a schema already exists but CONNECTOR_CONFIG_DOC.md is absent → manual schema, skip update
+      if [ -f "$connector_directory_path/$CONNECTOR_METADATA_DIRECTORY/connector_config_schema.json" ] && \
+         [ ! -f "$connector_directory_path/$CONNECTOR_METADATA_DIRECTORY/CONNECTOR_CONFIG_DOC.md" ]; then
+        echo -e "\033[33m⚠️  Warning: connector_config_schema.json exists but CONNECTOR_CONFIG_DOC.md is absent in $connector_directory_path/$CONNECTOR_METADATA_DIRECTORY. Schema was likely created manually, skipping update.\033[0m"
+        continue
+      fi
+
       (
         echo -e "\033[32mFound pydantic-settings and/or connectors-sdk in dependencies. Proceeding with schema generation...\033[0m"
 


### PR DESCRIPTION
### Proposed changes

* Add a guard in all three schema generation scripts (bash, PowerShell, and single-connector shell) to skip overwriting a `connector_config_schema.json` that was crafted manually — detected by the presence of the schema file without an accompanying `CONNECTOR_CONFIG_DOC.md`.
* Emits a yellow warning message so the skip is visible in CI/local output.

### Related issues

* Closes #6752

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The heuristic used: if `connector_config_schema.json` exists **and** `CONNECTOR_CONFIG_DOC.md` is absent, the schema was written by hand (not generated). The generator skips it with a warning rather than silently overwriting it.