### PR TITLE
fix(flare): add deterministic ID to stix identity in tests (#5657)

### DIFF
--- a/external-import/flare/src/connector/tests/test_converter_to_stix.py
+++ b/external-import/flare/src/connector/tests/test_converter_to_stix.py
@@ -11,6 +11,7 @@ from connector.events import (
     RansomleakEvent,
     StealerLogEvent,
 )
+from pycti import Identity as PyctiIdentity
 
 _APPROX_NOW = object()  # sentinel: assert result is approximately datetime.now(utc)
 
@@ -51,7 +52,11 @@ def mock_config() -> MagicMock:
 
 @pytest.fixture
 def author() -> stix2.Identity:
-    return stix2.Identity(name="Flare", identity_class="organization")
+    return stix2.Identity(
+        id=PyctiIdentity.generate_id("Flare", "organization"),
+        name="Flare",
+        identity_class="organization",
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
### Proposed changes

* Add deterministic STIX identity ID generation using `PyctiIdentity.generate_id()` in the test fixture, replacing the auto-generated ID that violated the repository's STIX ID policy.

### Related issues

* Closes #5657

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The test `author` fixture was creating a `stix2.Identity` without a deterministic ID, which would fail the custom pylint STIX ID checker. This fix uses `pycti.Identity.generate_id("Flare", "organization")` to produce a reproducible ID.