### PR TITLE
fix(elastic-security-intel): correct reference URLs (#6760)

### DIFF
--- a/stream/elastic-security-intel/src/elastic_security_intel_connector/api_handler.py
+++ b/stream/elastic-security-intel/src/elastic_security_intel_connector/api_handler.py
@@ -175,7 +175,7 @@ class ElasticApiHandler:
                 "from": "now-6m",
                 "enabled": True,
                 "tags": ["opencti", "threat-intel"],
-                "references": [f"{self.opencti_url}/id/{opencti_id}"],
+                "references": [f"{self.opencti_url}/dashboard/id/{opencti_id}"],
                 "meta": {
                     "opencti_id": opencti_id,
                     "pattern_type": pattern_type,
@@ -488,7 +488,7 @@ class ElasticApiHandler:
             threat_indicator["sightings"] = observable_data["x_opencti_score"]
 
         # Reference (OpenCTI source) - use proper URL format with /id/{ID}
-        threat_indicator["reference"] = f"{self.opencti_url}/id/{opencti_id}"
+        threat_indicator["reference"] = f"{self.opencti_url}/dashboard/id/{opencti_id}"
         threat_indicator["provider"] = ["OpenCTI"]  # ECS expects array
 
         # Feed information


### PR DESCRIPTION
### Proposed changes

  * Reference URLs emitted by the `elastic-security-intel` connector now follow OpenCTI's standard `/dashboard/id/{uuid}` format instead of `/id/{uuid}`.
  * Affects both Elastic Detection Rule `references` (api_handler.py:178) and ECS `threat.indicator.reference` (api_handler.py:491).

  ### Related issues

  * Closes #6760

  ### Checklist

  - [x] I consider the submitted work as finished
  - [x] I have signed my commits using GPG key.
  - [x] I tested the code for its functionality using different use cases
  - [x] I added/update the relevant documentation (either on github or on notion)
  - [x] Where necessary I refactored code to improve the overall quality

  ### Further comments
