### PR TITLE
fix(taxii-post): skip identity object when delete_created_by_ref is enabled (#6762)

### DIFF
--- a/stream/taxii-post/src/taxii_post_connector/connector.py
+++ b/stream/taxii-post/src/taxii_post_connector/connector.py
@@ -50,6 +50,43 @@ class TaxiiPostConnector:
         ):
             raise ValueError("Missing stream ID, please check your configurations.")
 
+    def _prepare_object(self, data):
+        """
+        Apply the configured transformations to a single STIX object before it
+        is posted to the TAXII server.
+
+        Returns the transformed object, or ``None`` when the object must not be
+        posted at all. When ``delete_created_by_ref`` is enabled the author
+        identity referenced by ``created_by_ref`` is stripped from every object;
+        the identity object itself would otherwise still reach the server as its
+        own stream event, so it is dropped here to honor the configuration.
+        """
+        data_object = data
+        if self.config.delete_created_by_ref and data_object.get("type") == "identity":
+            return None
+        data_object["spec_version"] = self.config.stix_version
+        if (
+            self.config.delete_marking_definition
+            and "object_marking_refs" in data_object
+        ):
+            del data_object["object_marking_refs"]
+        if self.config.delete_created_by_ref and "created_by_ref" in data_object:
+            del data_object["created_by_ref"]
+        if self.config.stix_version != "2.1":
+            del data_object["extensions"]
+            for key in (
+                "spec_version",
+                "revoked",
+                "confidence",
+                "lang",
+                "pattern_type",
+                "pattern_version",
+                "is_family",
+            ):
+                if key in data_object:
+                    del data_object[key]
+        return data_object
+
     def _process_message(self, msg):
         try:
             data = json.loads(msg.data)["data"]
@@ -70,28 +107,14 @@ class TaxiiPostConnector:
             "Accept": accept_header_by_taxii_version(self.config.version),
         }
         try:
-            data_object = data
-            data_object["spec_version"] = self.config.stix_version
-            if (
-                self.config.delete_marking_definition
-                and "object_marking_refs" in data_object
-            ):
-                del data_object["object_marking_refs"]
-            if self.config.delete_created_by_ref and "created_by_ref" in data_object:
-                del data_object["created_by_ref"]
-            if self.config.stix_version != "2.1":
-                del data_object["extensions"]
-                for key in (
-                    "spec_version",
-                    "revoked",
-                    "confidence",
-                    "lang",
-                    "pattern_type",
-                    "pattern_version",
-                    "is_family",
-                ):
-                    if key in data_object:
-                        del data_object[key]
+            data_object = self._prepare_object(data)
+            if data_object is None:
+                self.helper.log_info(
+                    "Skipping identity object "
+                    + data["id"]
+                    + " (delete_created_by_ref is enabled)"
+                )
+                return
             bundle = {
                 "type": "bundle",
                 "spec_version": self.config.stix_version,

--- a/stream/taxii-post/tests/test_connector.py
+++ b/stream/taxii-post/tests/test_connector.py
@@ -1,8 +1,29 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 from taxii_post_connector.connector import (
+    TaxiiPostConnector,
     accept_header_by_taxii_version,
     content_type_by_stix_version,
 )
+from taxii_post_connector.settings import TaxiiConfig
+
+
+def make_connector(**taxii_overrides):
+    """
+    Build a `TaxiiPostConnector` with a real `TaxiiConfig` (so configuration
+    behaves exactly like in production) and a mocked helper, for unit testing
+    the object transformation logic without any network or OpenCTI access.
+    """
+    taxii_config = {
+        "url": "http://test.com",
+        "collection_id": "collection-id",
+        **taxii_overrides,
+    }
+    config = SimpleNamespace(taxii=TaxiiConfig(**taxii_config))
+    return TaxiiPostConnector(config=config, helper=MagicMock())
+
 
 # --------------------------
 # --- Scenario Functions ---
@@ -39,3 +60,43 @@ def test_content_type_by_stix_version(stix_version, expected_result):
     result = content_type_by_stix_version(stix_version)
     # Then the custom properties are correctly formatted
     assert result == expected_result
+
+
+# Scenario: identity objects must not be posted when created_by_ref is stripped
+def test_prepare_object_skips_identity_when_delete_created_by_ref_enabled():
+    # Given a connector configured to strip created_by_ref
+    connector = make_connector(delete_created_by_ref=True)
+    identity = {"id": "identity--1", "type": "identity", "name": "ACME"}
+    # When we prepare an identity object
+    result = connector._prepare_object(identity)
+    # Then it is skipped (not posted) since its created_by_ref attribution is removed
+    assert result is None
+
+
+# Scenario: identity objects are kept when created_by_ref is not stripped
+def test_prepare_object_keeps_identity_when_delete_created_by_ref_disabled():
+    # Given a connector configured to keep created_by_ref
+    connector = make_connector(delete_created_by_ref=False)
+    identity = {"id": "identity--1", "type": "identity", "name": "ACME"}
+    # When we prepare an identity object
+    result = connector._prepare_object(identity)
+    # Then it is still posted
+    assert result is not None
+    assert result["id"] == "identity--1"
+
+
+# Scenario: non-identity objects are always posted, with created_by_ref stripped
+def test_prepare_object_keeps_non_identity_and_strips_created_by_ref():
+    # Given a connector configured to strip created_by_ref
+    connector = make_connector(delete_created_by_ref=True)
+    indicator = {
+        "id": "indicator--1",
+        "type": "indicator",
+        "created_by_ref": "identity--1",
+    }
+    # When we prepare a non-identity object
+    result = connector._prepare_object(indicator)
+    # Then it is posted with the created_by_ref attribution removed
+    assert result is not None
+    assert result["id"] == "indicator--1"
+    assert "created_by_ref" not in result


### PR DESCRIPTION
### Proposed changes

* When `delete_created_by_ref` is enabled, the taxii-post stream connector stripped `created_by_ref` from every object but still posted the author **identity** object (which arrives as its own stream event), so the attribution the user asked to remove still reached the TAXII server.
* Extracted the per-object transformation in `stream/taxii-post/src/taxii_post_connector/connector.py` into a new `_prepare_object` method. It returns `None` for `identity` objects while `delete_created_by_ref` is enabled, so `_process_message` skips posting them. All other objects keep the exact same transformation (marking refs / created_by_ref stripping, STIX version downgrade) and behaviour.

### Related issues

* Close https://github.com/OpenCTI-Platform/connectors/issues/6762

### Checklist

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The identity object referenced by `created_by_ref` is exactly the author attribution that `delete_created_by_ref` is meant to remove, so dropping `identity` objects under that flag is consistent with the configuration's intent. The skip is gated on `delete_created_by_ref` being enabled, so default behaviour for users who keep attribution is unchanged.

Added three unit tests in `tests/test_connector.py` covering `_prepare_object`: identity skipped when the flag is on, identity kept when the flag is off, and non-identity objects still posted with `created_by_ref` stripped. The full suite (26 tests) passes; `black`, `isort --profile black`, and `flake8 --ignore=E,W` are clean.