### PR TITLE
fix(phishunt): add User-Agent header to public feed request to fix HTTP 403 (#6177)

### DIFF
--- a/external-import/phishunt/src/connector/connector.py
+++ b/external-import/phishunt/src/connector/connector.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import re
 import ssl
 import sys
@@ -44,8 +45,14 @@ class Phishunt:
         url = "https://phishunt.io/feed.txt"
         try:
             bundle_objects = []
+            req = urllib.request.Request(
+                url=url,
+                headers={
+                    "User-Agent": f"OpenCTI-Phishunt-Connector/{importlib.metadata.version('pycti')}"
+                },
+            )
             with urllib.request.urlopen(
-                url=url, context=ssl.create_default_context()
+                req, context=ssl.create_default_context()
             ) as fp:
                 for count, line in enumerate(fp, 1):
                     count += 1
@@ -123,7 +130,7 @@ class Phishunt:
             resp.raise_for_status()
             data = resp.json()
             bundle_objects = []
-            for url in data:
+            for url in data.get("results", data) if isinstance(data, dict) else data:
                 stix_url = stix2.URL(
                     value=url["url"],
                     object_marking_refs=[stix2.TLP_WHITE],

--- a/external-import/phishunt/tests/tests_connector/test_connector_feeds.py
+++ b/external-import/phishunt/tests/tests_connector/test_connector_feeds.py
@@ -1,0 +1,154 @@
+import importlib.metadata
+import ssl
+import urllib.request
+from io import BytesIO
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from connector import ConnectorSettings, Phishunt
+from pycti import OpenCTIConnectorHelper
+
+
+class StubConnectorSettings(ConnectorSettings):
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "phishunt": {
+                    "api_key": None,
+                    "create_indicators": False,
+                    "default_x_opencti_score": 40,
+                    "x_opencti_score_domain": 40,
+                    "x_opencti_score_ip": 40,
+                    "x_opencti_score_url": 40,
+                },
+            }
+        )
+
+
+@pytest.fixture
+def phishunt_connector():
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    with (
+        patch(f"{module_import_path}.killProgramHook"),
+        patch(f"{module_import_path}.sched.scheduler"),
+        patch(f"{module_import_path}.ConnectorInfo"),
+        patch(f"{module_import_path}.OpenCTIApiClient"),
+        patch(f"{module_import_path}.OpenCTIConnector"),
+        patch(f"{module_import_path}.OpenCTIMetricHandler"),
+        patch(f"{module_import_path}.PingAlive"),
+    ):
+        settings = StubConnectorSettings()
+        helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+        return Phishunt(config=settings, helper=helper)
+
+
+class TestProcessPublicFeed:
+    def test_user_agent_uses_pycti_version(self, phishunt_connector):
+        """_process_public_feed must send the pycti version in the User-Agent header (fix #6177)."""
+        expected_version = importlib.metadata.version("pycti")
+        expected_user_agent = f"OpenCTI-Phishunt-Connector/{expected_version}"
+
+        feed_content = b"# comment\n# comment\n# comment\nhttp://phishing.example.com\n"
+        captured_requests = []
+
+        def fake_urlopen(req, context=None):
+            captured_requests.append(req)
+            fp = BytesIO(feed_content)
+            fp.__enter__ = lambda s: s
+            fp.__exit__ = MagicMock(return_value=False)
+            return fp
+
+        with (
+            patch("urllib.request.urlopen", side_effect=fake_urlopen),
+            patch.object(
+                phishunt_connector.helper, "send_stix2_bundle", return_value=[]
+            ),
+            patch.object(
+                phishunt_connector.helper,
+                "api",
+                MagicMock(
+                    work=MagicMock(initiate_work=MagicMock(return_value="work_id"))
+                ),
+            ),
+        ):
+            phishunt_connector._process_public_feed("work_id")
+
+        assert len(captured_requests) == 1
+        req = captured_requests[0]
+        assert isinstance(req, urllib.request.Request)
+        assert req.get_header("User-agent") == expected_user_agent
+
+    def test_request_uses_ssl_context(self, phishunt_connector):
+        """_process_public_feed must pass an SSL context to urlopen."""
+        feed_content = b"# comment\n# comment\n# comment\n"
+        captured_kwargs = {}
+
+        def fake_urlopen(req, context=None):
+            captured_kwargs["context"] = context
+            fp = BytesIO(feed_content)
+            fp.__enter__ = lambda s: s
+            fp.__exit__ = MagicMock(return_value=False)
+            return fp
+
+        with (
+            patch("urllib.request.urlopen", side_effect=fake_urlopen),
+            patch.object(
+                phishunt_connector.helper, "send_stix2_bundle", return_value=[]
+            ),
+        ):
+            phishunt_connector._process_public_feed("work_id")
+
+        assert isinstance(captured_kwargs["context"], ssl.SSLContext)
+
+
+class TestProcessPrivateFeed:
+    def test_iterates_over_results_key(self, phishunt_connector):
+        """_process_private_feed must iterate over data['results'] when API returns paginated dict."""
+        api_response = {
+            "count": 1,
+            "offset": 0,
+            "limit": 100,
+            "results": [
+                {"url": "http://phishing.example.com"},
+            ],
+        }
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = api_response
+        mock_resp.raise_for_status = MagicMock()
+
+        with (
+            patch("requests.request", return_value=mock_resp),
+            patch.object(
+                phishunt_connector.helper, "send_stix2_bundle", return_value=[]
+            ),
+        ):
+            # Should not raise TypeError: string indices must be integers
+            phishunt_connector._process_private_feed("work_id")
+
+    def test_iterates_over_list_response(self, phishunt_connector):
+        """_process_private_feed must also handle a plain list response (backward compat)."""
+        api_response = [{"url": "http://phishing.example.com"}]
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = api_response
+        mock_resp.raise_for_status = MagicMock()
+
+        with (
+            patch("requests.request", return_value=mock_resp),
+            patch.object(
+                phishunt_connector.helper, "send_stix2_bundle", return_value=[]
+            ),
+        ):
+            phishunt_connector._process_private_feed("work_id")


### PR DESCRIPTION
### Proposed changes

* Add a `urllib.request.Request` wrapper with a `User-Agent` header in `_process_public_feed()` to fix HTTP 403 returned by phishunt.io when using the default Python-urllib User-Agent
* Fix `_process_private_feed()` to iterate over `data["results"]` as the API now returns a paginated dict `{"count": ..., "results": [...]}` instead of a plain list

### Related issues

* Fixes #6177

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The public feed path (`_process_public_feed()`) was using `urllib.request.urlopen()` with a bare URL string, sending the default `Python-urllib/3.x` User-Agent which phishunt.io blocks with HTTP 403. The fix wraps the request in a `urllib.request.Request` object with a proper User-Agent (using the installed pycti version, consistent with the flashpoint connector pattern).

Additionally, the private feed API (`feed_json`) now returns a paginated response `{"count": int, "results": [...]}` instead of a plain list, causing a `TypeError: string indices must be integers`. The fix handles both response formats for backward compatibility.

Tests added to cover both fixes.