### PR TITLE
fix(import-document-ai): surface XTM One agent errors and robustly parse the STIX bundle (#6776)

### DIFF
--- a/internal-import-file/import-document-ai/pyproject.toml
+++ b/internal-import-file/import-document-ai/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = ["--cov=import_doc_ai"]

--- a/internal-import-file/import-document-ai/src/import_doc_ai/client_api.py
+++ b/internal-import-file/import-document-ai/src/import_doc_ai/client_api.py
@@ -141,29 +141,70 @@ class ImportDocumentAIClient:
 
         try:
             result = response.json()
-            self.helper.connector_logger.info(
-                "[API] Chatbot agent response received",
-                {"keys": list(result.keys())},
-            )
-            # The OpenCTI proxy relays the XTM One SendMessageResponse:
-            # { "user_message": {...}, "assistant_message": { "content": "..." }, "conversation_id": "..." }
-            # The assistant_message.content contains the STIX bundle as JSON text
-            assistant_content = None
-            if "assistant_message" in result:
-                assistant_content = result["assistant_message"].get("content", "")
-            elif "content" in result:
-                # Fallback: direct content field
-                assistant_content = result["content"]
+        except ValueError as err:
+            raise ValueError(
+                "XTM One agent returned a non-JSON response "
+                f"(HTTP {response.status_code}): {response.text[:500]!r}"
+            ) from err
 
-            if assistant_content and isinstance(assistant_content, str):
-                bundle_data = json.loads(assistant_content)
-            elif isinstance(assistant_content, dict):
-                bundle_data = assistant_content
-            else:
-                raise ValueError(
-                    f"Unexpected response format from XTM One agent: {list(result.keys())}"
+        self.helper.connector_logger.info(
+            "[API] Chatbot agent response received",
+            {
+                "keys": (
+                    list(result.keys())
+                    if isinstance(result, dict)
+                    else type(result).__name__
                 )
+            },
+        )
 
+        # The OpenCTI ``/chatbot/agent`` proxy answers HTTP 200 even when the
+        # upstream XTM One call fails, signalling the failure through an error
+        # envelope:
+        #   {"content": "", "status": "error", "error": "<detail>", "code": <int>}
+        # Surface the real upstream error (timeout, unreachable, LLM failure,
+        # ...) instead of the misleading generic "unexpected response format",
+        # so the failure is actionable in the OpenCTI work status and the
+        # connector logs.
+        if isinstance(result, dict) and result.get("status") == "error":
+            upstream_error = result.get("error") or "unknown error"
+            upstream_code = result.get("code")
+            self.helper.connector_logger.error(
+                "[API] XTM One agent reported an error",
+                {
+                    "agent_slug": agent_slug,
+                    "code": upstream_code,
+                    "error": upstream_error,
+                },
+            )
+            raise ValueError(
+                f"XTM One agent '{agent_slug}' returned an error "
+                f"(code={upstream_code}): {upstream_error}"
+            )
+
+        # Locate the STIX bundle content. Multipart (file) calls relay the XTM
+        # One SendMessageResponse ({"assistant_message": {"content": ...}});
+        # text-mode calls return {"content": ...} directly.
+        assistant_content = None
+        if isinstance(result, dict):
+            assistant_message = result.get("assistant_message")
+            if isinstance(assistant_message, dict):
+                assistant_content = assistant_message.get("content")
+            elif "content" in result:
+                assistant_content = result.get("content")
+
+        if assistant_content is None or (
+            isinstance(assistant_content, str) and not assistant_content.strip()
+        ):
+            raise ValueError(
+                f"XTM One agent '{agent_slug}' returned an empty response "
+                f"(keys: "
+                f"{list(result.keys()) if isinstance(result, dict) else type(result).__name__})"
+            )
+
+        bundle_data = self._parse_agent_bundle_content(assistant_content, agent_slug)
+
+        try:
             bundle = stix2.Bundle(**bundle_data, allow_custom=True)
             bundle = deduplicate_bundle_objects(bundle)
             bundle = filter_relationship_triplets(bundle, allowed_relationship_triplets)
@@ -174,3 +215,66 @@ class ImportDocumentAIClient:
                 {"error": str(e)},
             )
             raise e
+
+    @staticmethod
+    def _strip_json_code_fence(text: str) -> str:
+        """Strip a single surrounding Markdown code fence from *text*.
+
+        LLM-backed agents frequently wrap their JSON answer in a
+        ```` ```json ... ``` ```` fence even when instructed to return raw
+        JSON. Returns the inner content, or the stripped text unchanged when
+        no fence is present.
+        """
+        stripped = text.strip()
+        if not stripped.startswith("```"):
+            return stripped
+        lines = stripped.splitlines()
+        # Drop the opening fence line (``` or ```json).
+        lines = lines[1:]
+        # Drop the closing fence line when present.
+        if lines and lines[-1].strip().startswith("```"):
+            lines = lines[:-1]
+        return "\n".join(lines).strip()
+
+    def _parse_agent_bundle_content(self, content, agent_slug: str) -> dict:
+        """Parse the agent's response content into a STIX bundle dict.
+
+        Handles the shapes an XTM One agent may legitimately produce:
+        - a JSON object already decoded to a dict;
+        - a JSON string, optionally wrapped in a Markdown code fence;
+        - an ``output_format=json`` envelope nesting the bundle under a
+          top-level ``response`` key.
+        """
+        if isinstance(content, dict):
+            data = content
+        elif isinstance(content, str):
+            cleaned = self._strip_json_code_fence(content)
+            try:
+                data = json.loads(cleaned)
+            except json.JSONDecodeError as err:
+                raise ValueError(
+                    f"XTM One agent '{agent_slug}' returned content that is not "
+                    f"valid JSON: {err}. First 500 chars: {cleaned[:500]!r}"
+                ) from err
+        else:
+            raise ValueError(
+                f"XTM One agent '{agent_slug}' returned an unexpected content "
+                f"type: {type(content).__name__}"
+            )
+
+        # ``output_format=json`` can nest the payload under a top-level
+        # "response" key. Unwrap it only when the wrapper is not itself a
+        # bundle and the nested value holds the actual bundle object.
+        if (
+            isinstance(data, dict)
+            and data.get("type") != "bundle"
+            and isinstance(data.get("response"), dict)
+        ):
+            data = data["response"]
+
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"XTM One agent '{agent_slug}' returned a JSON "
+                f"{type(data).__name__}, expected a STIX bundle object"
+            )
+        return data

--- a/internal-import-file/import-document-ai/src/import_doc_ai/client_api.py
+++ b/internal-import-file/import-document-ai/src/import_doc_ai/client_api.py
@@ -143,19 +143,22 @@ class ImportDocumentAIClient:
             result = response.json()
         except ValueError as err:
             raise ValueError(
-                "XTM One agent returned a non-JSON response "
+                f"XTM One agent '{agent_slug}' returned a non-JSON response "
                 f"(HTTP {response.status_code}): {response.text[:500]!r}"
             ) from err
 
+        # Fail fast on a non-object JSON payload (e.g. a bare list or string).
+        # Everything below assumes a JSON object; without this guard such a
+        # response would misleadingly surface as an "empty response" error.
+        if not isinstance(result, dict):
+            raise ValueError(
+                f"XTM One agent '{agent_slug}' returned an unexpected response "
+                f"type: {type(result).__name__} (expected a JSON object)"
+            )
+
         self.helper.connector_logger.info(
             "[API] Chatbot agent response received",
-            {
-                "keys": (
-                    list(result.keys())
-                    if isinstance(result, dict)
-                    else type(result).__name__
-                )
-            },
+            {"keys": list(result.keys())},
         )
 
         # The OpenCTI ``/chatbot/agent`` proxy answers HTTP 200 even when the
@@ -166,7 +169,7 @@ class ImportDocumentAIClient:
         # ...) instead of the misleading generic "unexpected response format",
         # so the failure is actionable in the OpenCTI work status and the
         # connector logs.
-        if isinstance(result, dict) and result.get("status") == "error":
+        if result.get("status") == "error":
             upstream_error = result.get("error") or "unknown error"
             upstream_code = result.get("code")
             self.helper.connector_logger.error(
@@ -186,20 +189,18 @@ class ImportDocumentAIClient:
         # One SendMessageResponse ({"assistant_message": {"content": ...}});
         # text-mode calls return {"content": ...} directly.
         assistant_content = None
-        if isinstance(result, dict):
-            assistant_message = result.get("assistant_message")
-            if isinstance(assistant_message, dict):
-                assistant_content = assistant_message.get("content")
-            elif "content" in result:
-                assistant_content = result.get("content")
+        assistant_message = result.get("assistant_message")
+        if isinstance(assistant_message, dict):
+            assistant_content = assistant_message.get("content")
+        elif "content" in result:
+            assistant_content = result.get("content")
 
         if assistant_content is None or (
             isinstance(assistant_content, str) and not assistant_content.strip()
         ):
             raise ValueError(
                 f"XTM One agent '{agent_slug}' returned an empty response "
-                f"(keys: "
-                f"{list(result.keys()) if isinstance(result, dict) else type(result).__name__})"
+                f"(keys: {list(result.keys())})"
             )
 
         bundle_data = self._parse_agent_bundle_content(assistant_content, agent_slug)

--- a/internal-import-file/import-document-ai/tests/test_xtm_one_client.py
+++ b/internal-import-file/import-document-ai/tests/test_xtm_one_client.py
@@ -1,0 +1,194 @@
+"""Unit tests for the XTM One mode of ``ImportDocumentAIClient``.
+
+These tests focus on ``get_bundle_via_xtm_one``, which talks to the OpenCTI
+``/chatbot/agent`` proxy. The proxy answers HTTP 200 even on upstream
+failures (it relays them through an error envelope), so the connector must
+both surface those errors and robustly parse the success payload.
+"""
+
+import json
+import sys
+import uuid
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+sys.path.append(str((Path(__file__).resolve().parent.parent / "src")))
+
+from import_doc_ai.client_api import ImportDocumentAIClient
+
+
+class FakeResponse:
+    """Minimal ``requests.Response`` stand-in for the proxy reply."""
+
+    def __init__(self, json_data, status_code: int = 200, text: str | None = None):
+        self._json_data = json_data
+        self.status_code = status_code
+        self.text = text if text is not None else json.dumps(json_data)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+    def json(self):
+        if isinstance(self._json_data, Exception):
+            raise self._json_data
+        return self._json_data
+
+
+@pytest.fixture(name="xtm_client")
+def fixture_xtm_client() -> ImportDocumentAIClient:
+    helper = Mock()
+    helper.api.query.return_value = {"data": {"settings": {"id": "instance-id"}}}
+    helper.opencti_url = "http://opencti.local"
+    helper.api.api_token = "test-token"
+    helper.connector_logger.info = Mock()
+    helper.connector_logger.error = Mock()
+    config = Mock()
+    config.licence_key_base64 = None
+    return ImportDocumentAIClient(helper, config)
+
+
+def _call(xtm_client: ImportDocumentAIClient, agent_slug: str = "cti-stix-harvester"):
+    return xtm_client.get_bundle_via_xtm_one(
+        file_name="report.pdf",
+        file_mime="application/pdf",
+        file_data=BytesIO(b"%PDF-1.4 test"),
+        agent_slug=agent_slug,
+        allowed_relationship_triplets=set(),
+    )
+
+
+def _bundle_dict() -> dict:
+    return {
+        "type": "bundle",
+        "id": f"bundle--{uuid.uuid4()}",
+        "objects": [
+            {
+                "type": "identity",
+                "spec_version": "2.1",
+                "id": f"identity--{uuid.uuid4()}",
+                "name": "ACME Corp",
+                "identity_class": "organization",
+            }
+        ],
+    }
+
+
+def _patch_post(monkeypatch, response: FakeResponse) -> None:
+    monkeypatch.setattr(
+        "import_doc_ai.client_api.requests.post",
+        lambda *args, **kwargs: response,
+    )
+
+
+def test_success_assistant_message_bare_bundle(monkeypatch, xtm_client):
+    # Given the multipart proxy relays a SendMessageResponse with a bare bundle
+    bundle = _bundle_dict()
+    _patch_post(
+        monkeypatch,
+        FakeResponse(
+            {
+                "user_message": {"content": "Extract STIX from the attached files"},
+                "assistant_message": {"content": json.dumps(bundle)},
+                "conversation_id": str(uuid.uuid4()),
+            }
+        ),
+    )
+
+    # When fetching the bundle
+    result = _call(xtm_client)
+
+    # Then the bundle is parsed and returned
+    assert result["type"] == "bundle"
+    assert len(result["objects"]) == 1
+    assert result["objects"][0]["type"] == "identity"
+
+
+def test_success_content_wrapped_in_code_fence_and_response_key(monkeypatch, xtm_client):
+    # Given an LLM agent that fenced its JSON and nested it under "response"
+    bundle = _bundle_dict()
+    fenced = "```json\n" + json.dumps({"response": bundle}) + "\n```"
+    _patch_post(
+        monkeypatch,
+        FakeResponse({"assistant_message": {"content": fenced}}),
+    )
+
+    # When fetching the bundle
+    result = _call(xtm_client)
+
+    # Then the fence is stripped, the wrapper unwrapped and the bundle parsed
+    assert result["type"] == "bundle"
+    assert len(result["objects"]) == 1
+
+
+def test_error_envelope_raises_actionable_error(monkeypatch, xtm_client):
+    # Given the proxy relays an upstream failure via its 200 error envelope
+    _patch_post(
+        monkeypatch,
+        FakeResponse(
+            {
+                "content": "",
+                "status": "error",
+                "error": "XTM One is unreachable",
+                "code": 503,
+            }
+        ),
+    )
+
+    # When fetching the bundle, then a clear error surfaces the real cause
+    with pytest.raises(ValueError) as exc_info:
+        _call(xtm_client)
+
+    message = str(exc_info.value)
+    assert "cti-stix-harvester" in message
+    assert "503" in message
+    assert "unreachable" in message.lower()
+    # And the generic, misleading message is gone
+    assert "Unexpected response format" not in message
+
+
+def test_empty_assistant_content_raises_clear_error(monkeypatch, xtm_client):
+    # Given a success-shaped reply whose assistant content is blank
+    _patch_post(
+        monkeypatch,
+        FakeResponse({"assistant_message": {"content": "   "}}),
+    )
+
+    # When fetching the bundle, then the empty response is reported clearly
+    with pytest.raises(ValueError) as exc_info:
+        _call(xtm_client)
+
+    assert "empty response" in str(exc_info.value)
+
+
+def test_non_json_content_raises_clear_error(monkeypatch, xtm_client):
+    # Given an assistant message that is not valid JSON
+    _patch_post(
+        monkeypatch,
+        FakeResponse({"assistant_message": {"content": "I could not extract anything"}}),
+    )
+
+    # When fetching the bundle, then the JSON decode failure is reported clearly
+    with pytest.raises(ValueError) as exc_info:
+        _call(xtm_client)
+
+    assert "not " in str(exc_info.value)
+    assert "valid JSON" in str(exc_info.value)
+
+
+def test_non_json_http_body_raises_clear_error(monkeypatch, xtm_client):
+    # Given the proxy returns a non-JSON body (e.g. an HTML error page)
+    _patch_post(
+        monkeypatch,
+        FakeResponse(ValueError("no json"), text="<html>502 Bad Gateway</html>"),
+    )
+
+    # When fetching the bundle, then the non-JSON response is reported clearly
+    with pytest.raises(ValueError) as exc_info:
+        _call(xtm_client)
+
+    assert "non-JSON response" in str(exc_info.value)

--- a/internal-import-file/import-document-ai/tests/test_xtm_one_client.py
+++ b/internal-import-file/import-document-ai/tests/test_xtm_one_client.py
@@ -15,6 +15,8 @@ from unittest.mock import Mock
 
 import pytest
 import requests
+import stix2
+import stix2.exceptions
 
 sys.path.append(str((Path(__file__).resolve().parent.parent / "src")))
 
@@ -108,7 +110,9 @@ def test_success_assistant_message_bare_bundle(monkeypatch, xtm_client):
     assert result["objects"][0]["type"] == "identity"
 
 
-def test_success_content_wrapped_in_code_fence_and_response_key(monkeypatch, xtm_client):
+def test_success_content_wrapped_in_code_fence_and_response_key(
+    monkeypatch, xtm_client
+):
     # Given an LLM agent that fenced its JSON and nested it under "response"
     bundle = _bundle_dict()
     fenced = "```json\n" + json.dumps({"response": bundle}) + "\n```"
@@ -169,7 +173,9 @@ def test_non_json_content_raises_clear_error(monkeypatch, xtm_client):
     # Given an assistant message that is not valid JSON
     _patch_post(
         monkeypatch,
-        FakeResponse({"assistant_message": {"content": "I could not extract anything"}}),
+        FakeResponse(
+            {"assistant_message": {"content": "I could not extract anything"}}
+        ),
     )
 
     # When fetching the bundle, then the JSON decode failure is reported clearly
@@ -192,3 +198,119 @@ def test_non_json_http_body_raises_clear_error(monkeypatch, xtm_client):
         _call(xtm_client)
 
     assert "non-JSON response" in str(exc_info.value)
+
+
+def test_non_dict_json_response_raises_clear_error(monkeypatch, xtm_client):
+    # Given the proxy relays a non-object JSON payload (e.g. a bare list)
+    _patch_post(monkeypatch, FakeResponse([1, 2, 3]))
+
+    # When fetching the bundle, then the unexpected type is reported clearly
+    with pytest.raises(ValueError) as exc_info:
+        _call(xtm_client)
+
+    message = str(exc_info.value)
+    assert "unexpected response type" in message
+    assert "list" in message
+
+
+def test_success_text_mode_content(monkeypatch, xtm_client):
+    # Given a text-mode reply returning the bundle under a top-level "content"
+    bundle = _bundle_dict()
+    _patch_post(
+        monkeypatch,
+        FakeResponse({"content": json.dumps(bundle), "status": "success"}),
+    )
+
+    # When fetching the bundle
+    result = _call(xtm_client)
+
+    # Then the top-level content is parsed into the bundle
+    assert result["type"] == "bundle"
+    assert len(result["objects"]) == 1
+
+
+def test_success_assistant_content_already_dict(monkeypatch, xtm_client):
+    # Given an assistant message whose content is an already-decoded bundle dict
+    bundle = _bundle_dict()
+    _patch_post(
+        monkeypatch,
+        FakeResponse({"assistant_message": {"content": bundle}}),
+    )
+
+    # When fetching the bundle
+    result = _call(xtm_client)
+
+    # Then the dict content is used directly
+    assert result["type"] == "bundle"
+    assert len(result["objects"]) == 1
+
+
+def test_json_array_content_raises_clear_error(monkeypatch, xtm_client):
+    # Given assistant content that is valid JSON but not an object (a list)
+    _patch_post(
+        monkeypatch,
+        FakeResponse({"assistant_message": {"content": "[1, 2, 3]"}}),
+    )
+
+    # When fetching the bundle, then the non-object payload is reported clearly
+    with pytest.raises(ValueError) as exc_info:
+        _call(xtm_client)
+
+    assert "expected a STIX bundle object" in str(exc_info.value)
+
+
+def test_non_string_non_dict_content_raises_clear_error(monkeypatch, xtm_client):
+    # Given assistant content that is neither a string nor a dict (e.g. a number)
+    _patch_post(monkeypatch, FakeResponse({"assistant_message": {"content": 123}}))
+
+    # When fetching the bundle, then the unexpected content type is reported
+    with pytest.raises(ValueError) as exc_info:
+        _call(xtm_client)
+
+    assert "unexpected content type" in str(exc_info.value)
+
+
+def test_connection_error_is_reraised(monkeypatch, xtm_client):
+    # Given the chatbot proxy is unreachable
+    def _raise(*args, **kwargs):
+        raise requests.ConnectionError("boom")
+
+    monkeypatch.setattr("import_doc_ai.client_api.requests.post", _raise)
+
+    # When fetching the bundle, then a friendly ConnectionError is raised
+    with pytest.raises(requests.ConnectionError) as exc_info:
+        _call(xtm_client)
+
+    assert "unreachable" in str(exc_info.value).lower()
+
+
+def test_http_error_status_is_reraised(monkeypatch, xtm_client):
+    # Given the proxy answers with a hard HTTP error status
+    _patch_post(monkeypatch, FakeResponse({"detail": "boom"}, status_code=500))
+
+    # When fetching the bundle, then the HTTP error propagates
+    with pytest.raises(requests.RequestException):
+        _call(xtm_client)
+
+
+def test_invalid_stix_bundle_raises_stixerror(monkeypatch, xtm_client):
+    # Given valid JSON that is not a valid STIX bundle (malware missing fields)
+    invalid_bundle = {
+        "type": "bundle",
+        "id": f"bundle--{uuid.uuid4()}",
+        "objects": [
+            {
+                "type": "malware",
+                "spec_version": "2.1",
+                "id": f"malware--{uuid.uuid4()}",
+            }
+        ],
+    }
+    _patch_post(
+        monkeypatch,
+        FakeResponse({"assistant_message": {"content": json.dumps(invalid_bundle)}}),
+    )
+
+    # When fetching the bundle, then the STIX validation error surfaces
+    with pytest.raises(stix2.exceptions.STIXError):
+        _call(xtm_client)


### PR DESCRIPTION
### Proposed changes

Closes #6776

In XTM One mode the Import Document AI connector lets the user choose which agent extracts STIX from an uploaded document (for example "CTI STIX Harvester" or "CTI STIX Harvester (Filigran AI)"). When the selected agent run failed upstream, the connector crashed with a misleading error that hid the real cause: `ValueError: Unexpected response format from XTM One agent: ['content', 'status', 'error', 'code']`.

Root cause: the connector calls `POST {opencti_url}/chatbot/agent` (multipart). The OpenCTI chatbot proxy (`postAgentMessage`) answers HTTP 200 even when the upstream XTM One call fails, relaying the failure through an error envelope `{ "content": "", "status": "error", "error": "<detail>", "code": <int> }`. `get_bundle_via_xtm_one` never inspected `status`, so an upstream failure (seen with the LLM-based "CTI STIX Harvester" agent) fell through to a generic "Unexpected response format" that discarded the real error and code. The keys reported in the crash are exactly that error envelope. The deterministic "(Filigran AI)" agent is unaffected because it returns quickly and succeeds.

What changed in `import_doc_ai/client_api.py` (`get_bundle_via_xtm_one`):

- Detect the `status=error` envelope and raise an actionable error including the upstream `error` detail, `code`, and `agent_slug`, so the real failure (timeout, unreachable, LLM error, ...) is visible in the OpenCTI work status and logs.
- Fail fast with an explicit "unexpected response type" error when the proxy returns a non-object JSON payload (e.g. a bare list), instead of a misleading "empty response".
- Parse the assistant STIX content robustly: strip Markdown code fences, accept a dict or string, and unwrap an `output_format=json` `response` wrapper; report empty / non-JSON / non-object content with precise, agent-tagged errors.

Testing and coverage:

- Adds `tests/test_xtm_one_client.py` (14 tests) covering success (bare bundle, fenced + `response`-wrapped, text-mode `content`, already-decoded dict) and every failure path (error envelope, empty, non-JSON body, non-dict response, JSON-array content, non-string content, connection error, HTTP error status, invalid STIX bundle).
- Adds a connector `pyproject.toml` with `[tool.pytest.ini_options]` (`--cov=import_doc_ai`) so pytest measures the connector's coverage. The connector previously had no `--cov` source, which is why codecov reported 0% patch. `client_api.py` is now 96% covered (patch 100%).

### Related issues

- Closes #6776

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The proxy intentionally returns HTTP 200 with the error envelope so the OpenCTI chatbot UI can render the message instead of crashing; programmatic consumers like this connector must therefore inspect `status`. The fix is kept entirely connector-side to avoid changing that shared proxy contract.

Copilot's two `meta=` logging suggestions were intentionally not applied: pycti's logger signature is `info(self, message, meta=None)`, so the positional dict is already passed as `meta`, matching every other `connector_logger` call in this file - switching only the new lines to `meta=` would make the file inconsistent.
