### PR TITLE
fix(connector-cve): keep rate-limiter window continuous across backfill chunks (#6797)

### DIFF
--- a/external-import/cve/src/connector/cve_connector.py
+++ b/external-import/cve/src/connector/cve_connector.py
@@ -67,8 +67,11 @@ class CVEConnector:
         CPE resolution starts immediately and runs concurrently
         with further CVE fetching (bounded by cpe_max_concurrency).
         """
-        # Reset rate limiter state to avoid stale asyncio.Lock across runs
-        self.converter._rate_limiter.reset()
+        # Drop the stale asyncio.Lock from the previous asyncio.run() while
+        # keeping the sliding-window request history, so the rate limiter stays
+        # continuous across consecutive runs (e.g. historical-backfill chunks)
+        # instead of allowing a fresh burst at every chunk boundary.
+        self.converter._rate_limiter.invalidate_lock()
         try:
             self.helper.connector_logger.info(
                 "[CONNECTOR] Starting CVE+CPE streaming pipeline"

--- a/external-import/cve/src/services/utils/rate_limiter.py
+++ b/external-import/cve/src/services/utils/rate_limiter.py
@@ -48,7 +48,26 @@ class AsyncRateLimiter:
 
             await asyncio.sleep(wait_time)
 
+    def invalidate_lock(self) -> None:
+        """Drop the cached lock without discarding request history.
+
+        An ``asyncio.Lock`` is bound to the event loop that created it, so a
+        lock from a previous ``asyncio.run()`` call cannot be reused in a new
+        loop.  Setting ``_lock`` to ``None`` forces ``_get_lock()`` to create a
+        fresh lock in the next loop.  The ``time.monotonic()`` timestamps remain
+        valid across loops, so they are preserved here to keep the sliding
+        window continuous (e.g. across consecutive historical-backfill chunks,
+        each of which runs in its own ``asyncio.run()``).
+        """
+        self._lock = None
+
     def reset(self) -> None:
-        """Reset the limiter state (e.g. between asyncio.run() calls)."""
+        """Fully reset the limiter state, clearing both the cached lock and the
+        recorded request history.
+
+        Use this only when the request history should intentionally be
+        forgotten.  To merely cross an ``asyncio.run()`` boundary while keeping
+        the rate window continuous, use :meth:`invalidate_lock` instead.
+        """
         self._timestamps.clear()
         self._lock = None

--- a/external-import/cve/tests/tests_connector/test_rate_limiter.py
+++ b/external-import/cve/tests/tests_connector/test_rate_limiter.py
@@ -4,6 +4,8 @@ Validates that:
 - The sliding-window algorithm enforces the request cap.
 - Concurrent callers are properly serialised by the internal lock.
 - ``reset()`` clears state for cross-asyncio.run() safety.
+- ``invalidate_lock()`` drops the stale lock while keeping the rate window
+  continuous across asyncio.run() boundaries.
 """
 
 import asyncio
@@ -119,6 +121,62 @@ async def test_reset_invalidates_lock():
     # A new acquire should create a new lock
     await limiter.acquire()
     assert limiter._lock is not old_lock
+
+
+async def test_invalidate_lock_drops_lock_but_keeps_history():
+    """invalidate_lock() must clear the cached lock (so a fresh one is created
+    in the next event loop) while preserving the recorded request timestamps,
+    keeping the sliding window continuous across asyncio.run() boundaries."""
+    limiter = AsyncRateLimiter()
+    await limiter.acquire()
+    await limiter.acquire()
+
+    old_lock = limiter._lock
+    timestamps_before = list(limiter._timestamps)
+
+    limiter.invalidate_lock()
+
+    assert limiter._lock is None
+    # History is preserved, unlike reset().
+    assert list(limiter._timestamps) == timestamps_before
+
+    # A new acquire still creates a fresh lock for the new loop.
+    await limiter.acquire()
+    assert limiter._lock is not old_lock
+
+
+async def test_invalidate_lock_preserves_rate_window_across_runs():
+    """Filling the window then calling invalidate_lock() (as the connector does
+    between historical-backfill chunks) must NOT free the budget: the next
+    acquire still blocks until the window slides, preventing a burst at the
+    chunk boundary."""
+    limiter = AsyncRateLimiter()
+
+    for _ in range(NVD_MAX_REQUESTS):
+        await limiter.acquire()
+
+    # Simulate crossing an asyncio.run() boundary between two chunks.
+    limiter.invalidate_lock()
+
+    # The window is still full, so the next acquire must block.
+    acquired = asyncio.Event()
+
+    async def try_acquire():
+        await limiter.acquire()
+        acquired.set()
+
+    task = asyncio.create_task(try_acquire())
+
+    await asyncio.sleep(0.15)
+    assert (
+        not acquired.is_set()
+    ), "invalidate_lock() must not reset the window and allow a burst"
+
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
 
 
 async def test_sliding_window_releases_slots():


### PR DESCRIPTION
### Proposed changes

* During a historical backfill (`CVE_PULL_HISTORY=true`), the CVE connector walks the NVD dataset in 120-day chunks, and each chunk runs in its own `asyncio.run()`. At the start of every run, `_async_ingest()` called `self.converter._rate_limiter.reset()`, which clears **both** the cached `asyncio.Lock` **and** the sliding-window request-timestamp history.
* Wiping the timestamp history at every chunk boundary meant the limiter started each new chunk with no recent request history, so up to `CVE_CVE_MAX_CONCURRENCY` (default 50) requests could fire as a burst before the limiter re-engaged — exceeding the intended 50 requests / 30 seconds pacing right at the transition and risking HTTP 503 (Cloudflare challenge) responses.
* Root cause: `reset()` was being used for two different purposes. The only thing that *must* be discarded across an `asyncio.run()` boundary is the stale event-loop-bound `Lock`; the timestamps use `time.monotonic()` and remain valid across loops (the limiter's own docstring already notes this).
* Fix: add `AsyncRateLimiter.invalidate_lock()`, which drops only the cached lock and **preserves** the request history, and call it instead of `reset()` between chunks. The sliding window now stays continuous for the entire backfill, so no burst can occur at a chunk boundary. `reset()` is kept unchanged for callers that intentionally want to forget the history.

### Related issues

* Fixes #6797

### Checklist

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The change is intentionally minimal and backward-compatible:

- `external-import/cve/src/services/utils/rate_limiter.py`: new `invalidate_lock()` (drops the lock, keeps timestamps); `reset()` docstring clarified, behaviour unchanged.
- `external-import/cve/src/connector/cve_connector.py`: `_async_ingest()` now calls `invalidate_lock()` instead of `reset()`.
- `external-import/cve/tests/tests_connector/test_rate_limiter.py`: two new tests — one asserting `invalidate_lock()` keeps the history while dropping the lock, and one asserting that after filling the window and calling `invalidate_lock()` (the connector's between-chunk path) the next `acquire()` still blocks, i.e. no burst. Reverting the source change makes the second test fail, confirming it exercises the fix.