### PR TITLE
fix(greynoise): handle missing bot key in scanner intelligence (#6803)

### DIFF
--- a/internal-enrichment/greynoise/src/main.py
+++ b/internal-enrichment/greynoise/src/main.py
@@ -217,7 +217,7 @@ class GreyNoiseConnector:
                 "#57B9FF",
             )
 
-        if data["internet_scanner_intelligence"]["bot"] is True:
+        if data["internet_scanner_intelligence"].get("bot") is True:
             # Create label for "Known Bot Activity"
             self._create_custom_label("Known BOT Activity", "#7e4ec2")
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.

PR TITLE FORMAT (enforced by CI):
  type(scope?)!?: description (#123)
  - type: feat | fix | chore | docs | style | refactor | perf | test | build | ci | revert
  - scope: optional, e.g. connector name
  - description: must start with a lowercase letter
  - (#123): required linked issue number
  Example: feat(alienvault): add pagination support (#42)
-->

### Proposed changes

* GreyNoise's `internet_scanner_intelligence` payload doesn't always include the `bot` field. The connector accessed it with direct dict indexing (`["bot"]`), which raised a `KeyError` whenever the field was absent.
* Changed `data["internet_scanner_intelligence"]["bot"]` to `data["internet_scanner_intelligence"].get("bot")` so the check safely evaluates to `None`/falsy instead of crashing.

### Related issues

* Close #6803

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x ] I consider the submitted work as finished
- [ x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
