### PR TITLE
feat(mise): add mise task runner with dev workflow tasks (#6807)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ external-import/loaderinsightagency
 .coverage
 **/*coverage.xml
 **/junit.xml
+
+.mise/config.local.toml
+.mise/tasks/local/**

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,0 +1,35 @@
+[tools]
+poetry = "latest"
+pre-commit = "latest"
+ty = "latest"
+ruff = "latest"
+uv = "latest"
+gh = "latest"
+"aqua:github/copilot-cli" = "latest"
+git-cliff = "latest"
+
+[env]
+_.path = ["{{config_root}}/tasks"]
+# Set DOCKER_REPO_PATH in .mise/config.local.toml for deploy task
+# DOCKER_REPO_PATH = "/path/to/your/docker/repo"
+
+[tasks.global_manifest]
+description = "Update the global manifest file for all connectors"
+depends = ["generate_config_schema"]
+run = [
+    'sh ./shared/tools/composer/generate_global_manifest/generate_global_manifest.sh'
+]
+
+[tasks.deploy_to_catalog]
+description = "Deploy the connector to the catalog for testing (requires DOCKER_REPO_PATH)"
+# depends = ["push_docker", "global_manifest"]
+alias = "deploy"
+run = [
+    """
+    if [ -z "${DOCKER_REPO_PATH:-}" ]; then
+        echo "Error: DOCKER_REPO_PATH is not set. Define it in .mise/config.local.toml" >&2
+        exit 1
+    fi
+    cd "$DOCKER_REPO_PATH" && if command -v podman >/dev/null 2>&1; then RUNTIME=podman; else RUNTIME=docker; fi && $RUNTIME compose restart opencti
+    """
+]

--- a/.mise/tasks/_helpers.sh
+++ b/.mise/tasks/_helpers.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# _helpers.sh — Shared utilities for mise tasks
+#
+# Usage: source this file from any task script via:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/_helpers.sh"
+#
+# This file intentionally has NO #MISE directives so mise won't register it
+# as a task.
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+RED='\033[31m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+CYAN='\033[36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+log_info()  { printf "${GREEN}%s${RESET}\n" "$*"; }
+log_warn()  { printf "${YELLOW}%s${RESET}\n" "$*"; }
+log_error() { printf "${RED}%s${RESET}\n" "$*" >&2; }
+log_step()  { printf "${CYAN}> %s${RESET}\n" "$*"; }
+
+# ---------------------------------------------------------------------------
+# Dependency checks
+# ---------------------------------------------------------------------------
+require_cmd() {
+    # Verify that a command is available on PATH.
+    #   $1 — command name
+    #   $2 — (optional) install hint shown on failure
+    local cmd="$1"
+    local install_hint="${2:-}"
+
+    if ! command -v "$cmd" &>/dev/null; then
+        if [[ -n "$install_hint" ]]; then
+            log_error "Error: $cmd is required. Install with: $install_hint"
+        else
+            log_error "Error: $cmd is required but was not found on PATH."
+        fi
+        exit 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# File discovery
+# ---------------------------------------------------------------------------
+find_shallowest_file() {
+    # Find the shallowest (closest to root) file matching a given name
+    # inside a directory tree.
+    #   $1 — base directory to search
+    #   $2 — filename to look for (e.g. "requirements.txt")
+    find "$1" -type f -name "$2" \
+        | awk -F/ '{print NF, $0}' \
+        | sort -n \
+        | head -n1 \
+        | cut -d' ' -f2-
+}
+
+# ---------------------------------------------------------------------------
+# Connector manifest helpers
+# ---------------------------------------------------------------------------
+load_manifest() {
+    # Parse the connector manifest and export CONTAINER_VERSION and
+    # CONTAINER_IMAGE.  Exits with an error if anything is missing.
+    #   $1 — (optional) path to manifest; defaults to
+    #         $PWD/__metadata__/connector_manifest.json
+    local manifest_path="${1:-${PWD}/__metadata__/connector_manifest.json}"
+
+    if [[ ! -f "$manifest_path" ]]; then
+        log_error "Error: manifest not found at $manifest_path"
+        exit 1
+    fi
+
+    require_cmd jq "brew install jq"
+
+    CONTAINER_VERSION=$(jq -r '.container_version // empty' "$manifest_path")
+    CONTAINER_IMAGE=$(jq -r '.container_image // empty' "$manifest_path")
+
+    if [[ -z "${CONTAINER_VERSION:-}" ]]; then
+        log_error "Error: 'container_version' is missing or empty in $manifest_path"
+        exit 1
+    fi
+    if [[ -z "${CONTAINER_IMAGE:-}" ]]; then
+        log_error "Error: 'container_image' is missing or empty in $manifest_path"
+        exit 1
+    fi
+
+    export CONTAINER_VERSION CONTAINER_IMAGE
+}
+
+docker_image_tag() {
+    # Print the fully-qualified local-registry image tag.
+    # Requires CONTAINER_IMAGE and CONTAINER_VERSION to be set (via
+    # load_manifest).
+    local registry="${DOCKER_REGISTRY:-registry:5000}"
+    printf "%s/%s:%s" "$registry" "$CONTAINER_IMAGE" "$CONTAINER_VERSION"
+}

--- a/.mise/tasks/build_docker.sh
+++ b/.mise/tasks/build_docker.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#MISE description="Build Connector docker image then the Global Manifest and restart OpenCTI"
+#MISE alias=["build", "b"]
+#MISE dir="{{cwd}}"
+#USAGE flag "--no-cache" help="Disable Docker layer caching"
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Bootstrap
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_helpers.sh"
+
+# ---------------------------------------------------------------------------
+# Load manifest & build
+# ---------------------------------------------------------------------------
+load_manifest
+
+IMAGE_TAG="$(docker_image_tag)"
+
+log_step "Building Docker image for connector"
+log_info "  CONTAINER_IMAGE   = $CONTAINER_IMAGE"
+log_info "  CONTAINER_VERSION = $CONTAINER_VERSION"
+log_info "  IMAGE_TAG         = $IMAGE_TAG"
+
+NO_CACHE_FLAG=""
+[[ "${usage_no_cache:-}" == "true" ]] && NO_CACHE_FLAG="--no-cache"
+
+if command -v podman >/dev/null 2>&1; then
+    RUNTIME=podman
+else
+    RUNTIME=docker
+fi
+
+$RUNTIME buildx build $NO_CACHE_FLAG -t "$IMAGE_TAG" .
+
+log_info "✅ Docker image built successfully: $IMAGE_TAG"

--- a/.mise/tasks/generate_config_schema.sh
+++ b/.mise/tasks/generate_config_schema.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#MISE description="Generate JSON schema for Connector configuration based on the manifest and configuration definition"
+#MISE alias=["generate_schema", "gs"]
+#MISE arg "[connector_directory]" help="Path to the connector directory (defaults to current working directory)"
+#MISE dir="{{cwd}}"
+
+set -euox pipefail
+
+# ---------------------------------------------------------------------------
+# Bootstrap
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_helpers.sh"
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+REPO_ROOT=$(jj root 2>/dev/null || git rev-parse --show-toplevel)
+CONNECTOR_METADATA_DIRECTORY="__metadata__"
+VENV_NAME=".temp_venv"
+
+CONNECTOR_DIRECTORY="${1:-$(pwd)}"
+CONNECTOR_NAME=$(basename "$CONNECTOR_DIRECTORY")
+VENV_PATH="$CONNECTOR_DIRECTORY/$VENV_NAME"
+
+# ---------------------------------------------------------------------------
+# Virtual-environment lifecycle
+# ---------------------------------------------------------------------------
+activate_venv() {
+    # Create an isolated virtual environment inside the connector directory,
+    # activate it, and install the connector's dependencies.
+    local connector_dir="$1"
+
+    uv venv -c "$VENV_PATH"
+
+    # Activate — support both Unix and Windows layouts
+    if [ -f "$VENV_PATH/bin/activate" ]; then
+        # shellcheck disable=SC1091
+        . "$VENV_PATH/bin/activate"
+    elif [ -f "$VENV_PATH/Scripts/activate" ]; then
+        # shellcheck disable=SC1091
+        . "$VENV_PATH/Scripts/activate"
+    else
+        log_error "❌ Could not locate venv activate script in $VENV_PATH"
+        return 1
+    fi
+
+    pushd "$connector_dir" > /dev/null
+    log_step "Installing dependencies in: $connector_dir"
+
+    local requirements_file
+    requirements_file=$(find_shallowest_file "." "requirements.txt")
+
+    if [ -n "$requirements_file" ]; then
+        uv pip install -r "$requirements_file"
+    else
+        # Fall back to installing the package itself (assumes pyproject.toml)
+        uv pip install .
+    fi
+
+    # Ensure connectors-sdk is available for script generation
+    echo "🔄 Installing connectors-sdk for schema generation..."
+    uv pip install "connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk"
+
+    popd > /dev/null
+
+    if [ -d "$VENV_PATH" ]; then
+        log_info "✅ Dependencies installed for: $connector_dir"
+    else
+        log_error "❌ Dependencies not installed for: $connector_dir"
+        return 1
+    fi
+}
+
+cleanup() {
+    log_step "Cleaning up environment..."
+    # Remove any temp copies of generator scripts
+    rm -f "$CONNECTOR_DIRECTORY/generate_connector_config_json_schema_tmp.py"
+    rm -f "$CONNECTOR_DIRECTORY/generate_connector_config_doc_tmp.py"
+    # deactivate is a shell function sourced from the venv — guard against it
+    # not being available (e.g. if activation failed).
+    if command -v deactivate &> /dev/null; then
+        deactivate
+    fi
+    rm -rf "$VENV_PATH"
+}
+
+# Always clean up, even on error / Ctrl-C
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+
+# Ensure the metadata directory exists
+metadata_path="$CONNECTOR_DIRECTORY/$CONNECTOR_METADATA_DIRECTORY"
+if [ ! -d "$metadata_path" ]; then
+    log_warn "Warning: No $CONNECTOR_METADATA_DIRECTORY directory found in $CONNECTOR_DIRECTORY"
+    log_warn "Creating metadata directory..."
+    mkdir -p "$metadata_path"
+fi
+
+# Check if connector is verified
+manifest_path="$metadata_path/connector_manifest.json"
+if [ -f "$manifest_path" ]; then
+    if ! grep -q '"manager_supported": true' "$manifest_path"; then
+        log_warn "Warning: Connector is not manager supported in manifest (requires \"manager_supported\": true)."
+        log_warn "This connector may not support config schema generation."
+        exit 1
+    fi
+else
+    log_warn "Warning: No connector_manifest.json found in $metadata_path"
+    log_warn "This connector may not support config schema generation."
+    exit 1
+fi
+
+echo ""
+log_info "Processing connector: $CONNECTOR_NAME"
+log_step "Looking for a config model in $CONNECTOR_DIRECTORY"
+
+requirements_file=$(find_shallowest_file "$CONNECTOR_DIRECTORY" "requirements.txt")
+pyproject_toml=$(find_shallowest_file "$CONNECTOR_DIRECTORY" "pyproject.toml")
+
+# Verify that the connector actually depends on pydantic-settings / connectors-sdk
+if [[ -n "$requirements_file" ]] && grep -qE 'pydantic-settings|connectors-sdk' "$requirements_file"; then
+    log_step "Found dependency source: $requirements_file"
+elif [[ -n "$pyproject_toml" ]] && grep -q 'connectors-sdk' "$pyproject_toml"; then
+    log_step "Found dependency source: $pyproject_toml"
+else
+    log_warn "Warning: pydantic-settings and connectors-sdk not found in connector's dependencies"
+    log_warn "This connector may not support config schema generation."
+    exit 1
+fi
+
+# Locate generator scripts before doing any heavy work (fail fast)
+schema_generator_path=$(find "$REPO_ROOT" -type f -name "generate_connector_config_json_schema.py.sample" | head -n1)
+doc_generator_path=$(find "$REPO_ROOT" -type f -name "generate_connector_config_doc.py.sample" | head -n1)
+
+if [ -z "$schema_generator_path" ]; then
+    log_error "❌ Could not find generate_connector_config_json_schema.py.sample in $REPO_ROOT"
+    exit 1
+fi
+if [ -z "$doc_generator_path" ]; then
+    log_error "❌ Could not find generate_connector_config_doc.py.sample in $REPO_ROOT"
+    exit 1
+fi
+
+log_info "Found pydantic-settings and/or connectors-sdk in dependencies. Proceeding with schema generation..."
+
+# ---------------------------------------------------------------------------
+# Main work
+# ---------------------------------------------------------------------------
+
+activate_venv "$CONNECTOR_DIRECTORY"
+
+# --- JSON schema -----------------------------------------------------------
+log_step "Generating connector JSON schema..."
+
+# The generator script uses relative imports (e.g. "from src import ...",
+# "from connector import ...") that rely on the script living inside the
+# connector directory.  Copy it in, run it, then remove it (the EXIT trap
+# guarantees removal even on failure).
+
+cp "$schema_generator_path" "$CONNECTOR_DIRECTORY/generate_connector_config_json_schema_tmp.py"
+(cd "$CONNECTOR_DIRECTORY" && python generate_connector_config_json_schema_tmp.py)
+rm -f "$CONNECTOR_DIRECTORY/generate_connector_config_json_schema_tmp.py"
+log_info "✅ JSON schema generated successfully"
+
+# --- Configuration documentation -------------------------------------------
+log_step "Generating configurations table..."
+
+uv pip install -qq jsonschema_markdown
+
+cp "$doc_generator_path" "$CONNECTOR_DIRECTORY/generate_connector_config_doc_tmp.py"
+(cd "$CONNECTOR_DIRECTORY" && python generate_connector_config_doc_tmp.py)
+rm -f "$CONNECTOR_DIRECTORY/generate_connector_config_doc_tmp.py"
+log_info "✅ Configuration documentation generated successfully"
+
+# ---------------------------------------------------------------------------
+# Done  (cleanup_venv runs automatically via the EXIT trap)
+# ---------------------------------------------------------------------------
+echo ""
+log_info "✅ Schema generation completed for connector: $CONNECTOR_NAME"
+echo ""
+log_info "Done!"

--- a/.mise/tasks/push_docker.sh
+++ b/.mise/tasks/push_docker.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#MISE description="Push Connector docker image to local registry"
+#MISE depends=["build_docker"]
+#MISE alias=["push", "p"]
+#MISE dir="{{cwd}}"
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Bootstrap
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_helpers.sh"
+
+# ---------------------------------------------------------------------------
+# Load manifest & push
+# ---------------------------------------------------------------------------
+load_manifest
+
+IMAGE_TAG="$(docker_image_tag)"
+
+log_step "Pushing Docker image to local registry"
+log_info "  IMAGE_TAG = $IMAGE_TAG"
+
+if command -v podman >/dev/null 2>&1; then
+    RUNTIME=podman
+else
+    RUNTIME=docker
+fi
+
+$RUNTIME push "$IMAGE_TAG"
+
+log_info "✅ Docker image pushed successfully: $IMAGE_TAG"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ status: Accepted
     - [Technical Requirements](#technical-requirements)
     - [Knowledge Requirements](#knowledge-requirements)
     - [Development Environment](#development-environment)
+    - [Mise (Development Tooling \& Task Runner)](#mise-development-tooling--task-runner)
   - [Getting Started](#getting-started)
     - [Quick Start](#quick-start)
     - [Initial Setup](#initial-setup)
@@ -123,6 +124,101 @@ You can develop connectors using either:
     - Faster iteration cycle
     - Easier debugging
     - See [Local Setup Guide](./docs/01-common-implementation.md#local-environment)
+
+### Mise (Development Tooling & Task Runner)
+
+This repository uses [mise](https://mise.jdx.dev/) as a polyglot tool version manager and task runner. Mise
+automatically installs the required development tools (Python, uv, ruff, pre-commit, etc.) and provides shared tasks
+for common workflows like building Docker images and generating config schemas.
+
+#### Installation
+
+```bash
+# macOS
+brew install mise
+
+# or via the official installer (Linux/macOS)
+curl https://mise.run | sh
+```
+
+Then activate mise in your shell (add to `~/.zshrc` or `~/.bashrc`):
+
+```bash
+eval "$(mise activate zsh)"  # or bash/fish
+```
+
+#### Setup
+
+Once installed, navigate to the repository root and let mise install all required tools:
+
+```bash
+cd connectors
+mise install
+```
+
+This reads `.mise/config.toml` and installs the declared tools (uv, ruff, pre-commit, gh, etc.) at the correct
+versions.
+
+#### Available Tasks
+
+List all available tasks:
+
+```bash
+mise tasks
+```
+
+Key tasks included:
+
+| Task | Alias | Description |
+|------|-------|-------------|
+| `build_docker` | `build`, `b` | Build the connector Docker image |
+| `push_docker` | `push`, `p` | Push the image to the local registry |
+| `generate_config_schema` | `gs` | Generate JSON schema from connector settings |
+| `global_manifest` | — | Regenerate the global manifest file |
+| `deploy_to_catalog` | `deploy` | Build the connector, push to local registry, and restart OpenCTI |
+
+Run a task from inside a connector directory:
+
+```bash
+cd external-import/misp
+mise run build        # or: mise run b
+mise run gs
+```
+
+> **Note:** Docker-related tasks (`build_docker`, `push_docker`, `deploy_to_catalog`) are designed for a local
+> development setup based on [OpenCTI-Platform/docker](https://github.com/OpenCTI-Platform/docker) (Docker Compose)
+> with a **local registry service** included in the stack (default: `registry:5000`). The build task tags images for
+> this registry, push sends them there, and deploy restarts the OpenCTI container so it pulls the updated image.
+> If your registry address differs, override it via the `DOCKER_REGISTRY` environment variable.
+
+#### Local Configuration
+
+User-specific settings (paths, registries, env vars) should go in `.mise/config.local.toml`, which is git-ignored:
+
+```toml
+# .mise/config.local.toml (not committed)
+[env]
+DOCKER_REPO_PATH = "/path/to/your/opencti-docker-compose"  # path to your OpenCTI-Platform/docker clone
+DOCKER_REGISTRY = "localhost:5000"                          # override if your registry differs
+```
+
+You can also add personal tasks in `.mise/tasks/local/` (also git-ignored).
+
+#### Adding New Tasks
+
+Shared tasks live in `.mise/tasks/` as shell scripts with `#MISE` directives at the top:
+
+```bash
+#!/usr/bin/env bash
+#MISE description="My new task"
+#MISE alias=["mytask"]
+#MISE dir="{{cwd}}"
+
+set -euo pipefail
+# task logic here
+```
+
+See the [mise task documentation](https://mise.jdx.dev/tasks/) for the full directive reference.
 
 ## Getting Started
 


### PR DESCRIPTION
### Proposed changes

* Add mise configuration (`.mise/config.toml`) declaring shared dev tooling (poetry, pre-commit, ty, ruff, uv, gh, copilot-cli, git-cliff) so contributors get a reproducible, single-command tool setup via `mise install`
* Add shared helper library (`.mise/tasks/_helpers.sh`) providing reusable logging, dependency checking, file discovery, and connector manifest loading utilities for all task scripts
* Add `build_docker` task to build connector Docker images from the connector manifest, with `--no-cache` flag and podman/docker auto-detection
* Add `push_docker` task to push built connector images to a local registry, chained as a dependency of the build step
* Add `generate_config_schema` task to generate JSON config schemas and configuration documentation for manager-supported connectors using an isolated venv
* Add `global_manifest` and `deploy_to_catalog` inline tasks in `config.toml` for manifest regeneration and local OpenCTI restart workflows
* Update `.gitignore` to ignore mise local config (`.mise/config.local.toml`) and local tasks directory (`.mise/tasks/local/`), keeping user-specific settings out of version control
* Update `CONTRIBUTING.md` with a dedicated "Mise" section documenting installation, setup, available tasks, local configuration, and how to add new tasks

### Related issues

* Closes #6807

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

[mise](https://mise.jdx.dev/) is a polyglot tool version manager and task runner (think asdf + make in one tool). It reads `.mise/config.toml` to declaratively manage CLI tool versions and exposes project-level tasks as simple shell scripts with `#MISE` directives.

**Why mise?**
- **Reproducible environments** — `mise install` ensures every contributor has the exact same tooling without manually installing each tool.
- **Discoverable tasks** — `mise tasks` lists all available dev workflows; no need to hunt for scattered shell scripts or remember ad-hoc commands.
- **Local-first design** — User-specific overrides (registry URLs, Docker compose paths) go in `.mise/config.local.toml` which is git-ignored. Contributors can also add personal tasks under `.mise/tasks/local/`.
- **Container runtime agnostic** — All Docker tasks auto-detect podman vs docker, supporting both setups without configuration.

The task scripts share a common helper library (`_helpers.sh`) for consistent logging, error handling, and manifest parsing across all tasks.