### PR TITLE
fix(shodan): skip all Shodan API errors instead of crashing (#6806)

### DIFF
--- a/internal-enrichment/shodan/src/connector/connector.py
+++ b/internal-enrichment/shodan/src/connector/connector.py
@@ -399,8 +399,11 @@ class ShodanConnector:
                 bundles_sent = self.helper.send_stix2_bundle(bundle)
                 return "Sent " + str(len(bundles_sent)) + " STIX bundle(s) for import"
             except shodan.APIError as e:
-                # Handling specific errors for Shodan API
-                raise ValueError(f"Shodan API Error : {e}") from e
+                self.helper.connector_logger.error(
+                    "Shodan API error, skipping enrichment",
+                    {"query": ip_value, "error": str(e)},
+                )
+                return f"Skipped: {e}"
         elif (
             stix_entity["type"] == "indicator"
             and stix_entity["pattern_type"] == "shodan"
@@ -504,8 +507,11 @@ class ShodanConnector:
                 )
                 return f"Sent {len(bundles_sent)} STIX bundle(s) for import"
             except shodan.APIError as e:
-                # Handling specific errors for Shodan API
-                raise ValueError(f"Shodan API Error : {e}") from e
+                self.helper.connector_logger.error(
+                    "Shodan API error, skipping enrichment",
+                    {"query": pattern_value, "error": str(e)},
+                )
+                return f"Skipped: {e}"
 
         elif stix_entity["type"] == "indicator":
             raise ValueError(f"Unsupported pattern type: {stix_entity['pattern_type']}")

--- a/internal-enrichment/shodan/tests/test_main.py
+++ b/internal-enrichment/shodan/tests/test_main.py
@@ -1,7 +1,8 @@
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+import shodan
 from connector import ConnectorSettings, ShodanConnector
 from pycti import OpenCTIConnectorHelper
 
@@ -100,3 +101,129 @@ def test_connector_is_instantiated(mock_opencti_connector_helper):
 
     assert connector.config == settings
     assert connector.helper == helper
+
+
+def _make_connector():
+    """Helper to build a ShodanConnector with mocked dependencies."""
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+    helper.connector_logger = MagicMock()
+    helper.send_stix2_bundle = MagicMock(return_value=["bundle-1"])
+    helper.stix2_create_bundle = MagicMock(return_value='{"type":"bundle"}')
+    connector = ShodanConnector(config=settings, helper=helper)
+    return connector
+
+
+def _make_enrichment_data():
+    """Minimal enrichment data payload for an IPv4 observable."""
+    return {
+        "stix_objects": [],
+        "stix_entity": {
+            "type": "ipv4-addr",
+            "value": "1.2.3.4",
+            "id": "ipv4-addr--test",
+        },
+        "enrichment_entity": {
+            "objectMarking": [{"definition_type": "TLP", "definition": "TLP:CLEAR"}]
+        },
+    }
+
+
+class TestProcessMessageErrorHandling:
+    """Integration tests: process_message gracefully skips all Shodan API errors."""
+
+    def test_unknown_ip_does_not_crash_consumer(self, mock_opencti_connector_helper):
+        connector = _make_connector()
+        data = _make_enrichment_data()
+
+        with patch.object(
+            connector.shodanAPI,
+            "host",
+            side_effect=shodan.APIError("No information available for that IP."),
+        ):
+            connector.process_message(data)
+
+        connector.helper.connector_logger.error.assert_called_once()
+        connector.helper.send_stix2_bundle.assert_not_called()
+
+    def test_access_denied_does_not_crash_consumer(self, mock_opencti_connector_helper):
+        connector = _make_connector()
+        data = _make_enrichment_data()
+
+        with patch.object(
+            connector.shodanAPI,
+            "host",
+            side_effect=shodan.APIError("Access denied"),
+        ):
+            connector.process_message(data)
+
+        connector.helper.connector_logger.error.assert_called_once()
+        connector.helper.send_stix2_bundle.assert_not_called()
+
+    def test_any_api_error_is_skipped_with_message(self, mock_opencti_connector_helper):
+        connector = _make_connector()
+        data = _make_enrichment_data()
+
+        with patch.object(
+            connector.shodanAPI,
+            "host",
+            side_effect=shodan.APIError("Rate limit reached"),
+        ):
+            connector.process_message(data)
+
+        connector.helper.connector_logger.error.assert_called_once()
+
+
+def _make_indicator_enrichment_data():
+    """Minimal enrichment data payload for a Shodan indicator."""
+    return {
+        "stix_objects": [],
+        "stix_entity": {
+            "type": "indicator",
+            "pattern_type": "shodan",
+            "pattern": "apache port:443",
+            "id": "indicator--test",
+        },
+        "enrichment_entity": {
+            "id": "enrichment--test",
+            "objectMarking": [{"definition_type": "TLP", "definition": "TLP:CLEAR"}],
+        },
+    }
+
+
+class TestProcessMessageIndicatorErrorHandling:
+    """Integration tests: process_message gracefully skips Shodan API errors on indicator/shodan path."""
+
+    def test_count_api_error_does_not_crash_consumer(
+        self, mock_opencti_connector_helper
+    ):
+        connector = _make_connector()
+        connector.helper.api = MagicMock()
+        data = _make_indicator_enrichment_data()
+
+        with patch.object(
+            connector.shodanAPI,
+            "count",
+            side_effect=shodan.APIError("Access denied"),
+        ):
+            connector.process_message(data)
+
+        connector.helper.connector_logger.error.assert_called_once()
+        connector.helper.send_stix2_bundle.assert_not_called()
+
+    def test_rate_limit_on_indicator_does_not_crash_consumer(
+        self, mock_opencti_connector_helper
+    ):
+        connector = _make_connector()
+        connector.helper.api = MagicMock()
+        data = _make_indicator_enrichment_data()
+
+        with patch.object(
+            connector.shodanAPI,
+            "count",
+            side_effect=shodan.APIError("Rate limit reached"),
+        ):
+            connector.process_message(data)
+
+        connector.helper.connector_logger.error.assert_called_once()
+        connector.helper.send_stix2_bundle.assert_not_called()


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.

PR TITLE FORMAT (enforced by CI):
  type(scope?)!?: description (#123)
  - type: feat | fix | chore | docs | style | refactor | perf | test | build | ci | revert
  - scope: optional, e.g. connector name
  - description: must start with a lowercase letter
  - (#123): required linked issue number
  Example: feat(alienvault): add pagination support (#42)
-->

### Proposed changes

* Skip error instead of crash.


### Related issues

* Closes: #6806 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
