### PR TITLE
fix(thehive): remove duplicate connectors-sdk pin from test-requirements

### DIFF
--- a/external-import/thehive/tests/test-requirements.txt
+++ b/external-import/thehive/tests/test-requirements.txt
@@ -1,4 +1,6 @@
-pytest
-pycti==7.260626.0
-connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk
+# Install the connector's pinned runtime dependencies so the test environment
+# mirrors production (run_test.sh then swaps in local connectors-sdk / latest pycti).
+# Do not re-declare connectors-sdk/pycti here: a second pin conflicts with the src
+# requirement when a release pins connectors-sdk to the release tag.
 -r ../src/requirements.txt
+pytest


### PR DESCRIPTION
## Summary

- `external-import/thehive/tests/test-requirements.txt` was the only connector
  test-requirements file that re-declared `connectors-sdk` (and `pycti`) on top of
  `-r ../src/requirements.txt`. Every other connector inherits its runtime deps via
  `-r` (single source of truth) and only adds test deps like `pytest`.
- At release time the release tooling rewrites `connectors-sdk @ ...@master` to
  `@<version>` in `src/requirements.txt` for the release-tag commit, but leaves
  `tests/test-requirements.txt` untouched. thehive's test file kept `@master`, so
  `uv pip install -r test-requirements.txt` resolved two different URLs for
  `connectors-sdk` and failed with
  `Requirements contain conflicting URLs for package connectors-sdk`.
- This broke the tag build for release 7.260626.0 (only thehive failed; every other
  connector was green), and it would recur on every future release until fixed here.
- Fix: make thehive's test-requirements mirror production via `-r` only and keep just
  the test deps (`pytest`), matching every other connector. This removes the
  conflicting second pin and makes the connector robust to release-time SDK pinning.

## Test plan

- [ ] CI `tests / Test external-import/thehive` is green on this PR
- [ ] No `connectors-sdk` URL conflict at the next release tag build
