### PR TITLE
feat: add Anthropic AI enrichment connector (#7209)

### DIFF
--- a/internal-enrichment/anthropic-ai-enrichment/.dockerignore
+++ b/internal-enrichment/anthropic-ai-enrichment/.dockerignore
@@ -1,0 +1,7 @@
+Dockerfile
+docker-compose.yml
+.git
+.gitignore
+README.md
+__pycache__/
+*.pyc

--- a/internal-enrichment/anthropic-ai-enrichment/Dockerfile
+++ b/internal-enrichment/anthropic-ai-enrichment/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /opt/opencti-connector-anthropic-ai-enrichment
+
+COPY src/requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY src .
+
+CMD ["python", "main.py"]

--- a/internal-enrichment/anthropic-ai-enrichment/Dockerfile
+++ b/internal-enrichment/anthropic-ai-enrichment/Dockerfile
@@ -1,11 +1,17 @@
-FROM python:3.12-slim
+FROM python:3.12-alpine
+ENV CONNECTOR_TYPE=INTERNAL_ENRICHMENT
 
-ENV PYTHONUNBUFFERED=1
-WORKDIR /opt/opencti-connector-anthropic-ai-enrichment
+# Copy the worker
+COPY src /opt/opencti-connector-anthropic-ai-enrichment
 
-COPY src/requirements.txt .
-RUN pip3 install --no-cache-dir -r requirements.txt
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk --no-cache add git build-base libmagic libffi-dev && \
+    cd /opt/opencti-connector-anthropic-ai-enrichment && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
 
-COPY src .
-
-CMD ["python", "main.py"]
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/internal-enrichment/anthropic-ai-enrichment/README.md
+++ b/internal-enrichment/anthropic-ai-enrichment/README.md
@@ -1,0 +1,42 @@
+# Anthropic AI Enrichment
+
+The Anthropic AI Enrichment connector enriches OpenCTI reports, intrusion sets, threat actor groups, and malware objects with analyst-reviewable summaries and structured relationships.
+
+The connector sends selected object text to the configured Anthropic model and asks for structured JSON containing:
+
+- executive summary
+- named threat actors
+- malware and tool names
+- MITRE ATT&CK technique identifiers
+- target sectors
+- target countries
+- confidence score
+
+The connector can create OpenCTI notes, link existing threat actors and malware, create or link attack patterns by ATT&CK ID, and update the OpenCTI score from the returned confidence value.
+
+## Analyst Validation
+
+AI output is an enrichment aid, not authoritative intelligence. Operators should review every generated note, relationship, ATT&CK mapping, and score before using it for detection engineering, reporting, or attribution.
+
+## Configuration
+
+| Parameter | Description | Required |
+| --- | --- | --- |
+| `OPENCTI_URL` | OpenCTI platform URL. | Yes |
+| `OPENCTI_TOKEN` | OpenCTI API token. | Yes |
+| `CONNECTOR_ID` | Connector UUID. | Yes |
+| `CONNECTOR_NAME` | Connector display name. | No |
+| `CONNECTOR_SCOPE` | OpenCTI entity scope. | No |
+| `CONNECTOR_LOG_LEVEL` | Connector log level. | No |
+| `ANTHROPIC_API_KEY` | Anthropic API key. | Yes |
+| `AI_MODEL` | Anthropic model name. | No |
+
+## Deployment
+
+Copy `docker-compose.yml` into your OpenCTI deployment, set the required environment variables, and start the connector service.
+
+```bash
+docker compose up -d connector-anthropic-ai-enrichment
+```
+
+The connector is configured as an internal enrichment connector with `auto` disabled. Analysts can run it on selected entities from the OpenCTI interface.

--- a/internal-enrichment/anthropic-ai-enrichment/README.md
+++ b/internal-enrichment/anthropic-ai-enrichment/README.md
@@ -29,7 +29,7 @@ AI output is an enrichment aid, not authoritative intelligence. Operators should
 | `CONNECTOR_SCOPE` | OpenCTI entity scope. | No |
 | `CONNECTOR_LOG_LEVEL` | Connector log level. | No |
 | `ANTHROPIC_API_KEY` | Anthropic API key. | Yes |
-| `AI_MODEL` | Anthropic model name. | No |
+| `ANTHROPIC_MODEL` | Anthropic model name. | No |
 
 ## Deployment
 

--- a/internal-enrichment/anthropic-ai-enrichment/__metadata__/connector_manifest.json
+++ b/internal-enrichment/anthropic-ai-enrichment/__metadata__/connector_manifest.json
@@ -1,0 +1,21 @@
+{
+  "title": "Anthropic AI Enrichment",
+  "slug": "anthropic-ai-enrichment",
+  "description": "The Anthropic AI Enrichment connector helps analysts enrich OpenCTI reports, intrusion sets, threat actor groups, and malware objects with analyst-reviewable AI summaries and structured CTI relationships. It sends selected object text to the configured Anthropic model and asks for a strict JSON response containing a summary, threat actors, malware families, ATT&CK technique IDs, target sectors, target countries, and confidence.\n\nThe connector can create OpenCTI notes, link existing threat actors and malware, create or link ATT&CK attack patterns by technique ID, and update the OpenCTI score from the returned confidence value. AI output is intended to accelerate triage and enrichment, not to replace human validation; operators should review generated notes, relationships, ATT&CK mappings, and scores before using them for reporting, detection engineering, or attribution.",
+  "short_description": "Enriches OpenCTI reports, intrusion sets, threat actor groups, and malware objects with Anthropic-generated analyst-reviewable summaries, ATT&CK mappings, malware links, actor links, and confidence scores.",
+  "logo": null,
+  "use_cases": [
+    "Enrichment & Analysis"
+  ],
+  "verified": false,
+  "last_verified_date": null,
+  "playbook_supported": false,
+  "max_confidence_level": 50,
+  "support_version": ">=6.2.0",
+  "subscription_link": "https://www.anthropic.com/api",
+  "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/anthropic-ai-enrichment",
+  "manager_supported": false,
+  "container_version": "rolling",
+  "container_image": "opencti/connector-anthropic-ai-enrichment",
+  "container_type": "INTERNAL_ENRICHMENT"
+}

--- a/internal-enrichment/anthropic-ai-enrichment/docker-compose.yml
+++ b/internal-enrichment/anthropic-ai-enrichment/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  connector-anthropic-ai-enrichment:
+    image: opencti/connector-anthropic-ai-enrichment:rolling
+    environment:
+      OPENCTI_URL: ${OPENCTI_URL}
+      OPENCTI_TOKEN: ${OPENCTI_TOKEN}
+      CONNECTOR_ID: ${CONNECTOR_ID}
+      CONNECTOR_NAME: "Anthropic AI Enrichment"
+      CONNECTOR_SCOPE: "Report,Intrusion-Set,Threat-Actor-Group,Malware"
+      CONNECTOR_LOG_LEVEL: "info"
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      AI_MODEL: ${AI_MODEL:-claude-3-5-haiku-latest}
+    restart: always

--- a/internal-enrichment/anthropic-ai-enrichment/docker-compose.yml
+++ b/internal-enrichment/anthropic-ai-enrichment/docker-compose.yml
@@ -9,5 +9,5 @@ services:
       CONNECTOR_SCOPE: "Report,Intrusion-Set,Threat-Actor-Group,Malware"
       CONNECTOR_LOG_LEVEL: "info"
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
-      AI_MODEL: ${AI_MODEL:-claude-3-5-haiku-latest}
+      ANTHROPIC_MODEL: ${ANTHROPIC_MODEL:-claude-3-5-haiku-latest}
     restart: always

--- a/internal-enrichment/anthropic-ai-enrichment/entrypoint.sh
+++ b/internal-enrichment/anthropic-ai-enrichment/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Go to the right directory
+cd /opt/opencti-connector-anthropic-ai-enrichment
+
+# Launch the worker
+python3 main.py

--- a/internal-enrichment/anthropic-ai-enrichment/src/main.py
+++ b/internal-enrichment/anthropic-ai-enrichment/src/main.py
@@ -1,0 +1,225 @@
+import json
+import os
+import time
+
+import anthropic
+from pycti import OpenCTIConnectorHelper
+
+
+SYSTEM_PROMPT = """You are a senior cyber threat intelligence analyst.
+Analyze threat intelligence content and return structured JSON only.
+No prose, no markdown fences, no explanation; return raw JSON."""
+
+REPORT_PROMPT = """Analyze this threat intelligence report. Return JSON with exactly these keys:
+- summary: string, 2-3 sentence executive brief
+- threat_actors: list of strings containing actor names, aliases, or groups mentioned
+- malware_families: list of strings containing malware or tool names
+- attack_techniques: list of strings containing MITRE ATT&CK IDs only, for example ["T1059.001", "T1003"]
+- targeted_sectors: list of strings
+- targeted_countries: list of ISO 3166-1 alpha-2 country codes
+- confidence: integer from 0 to 100
+
+Report:
+{content}"""
+
+INTRUSION_SET_PROMPT = """Analyze this threat actor or intrusion set profile. Return JSON with exactly these keys:
+- summary: string, 2-3 sentence executive brief
+- aliases: list of strings
+- malware_families: list of strings containing malware or tool names
+- attack_techniques: list of strings containing MITRE ATT&CK IDs only, for example ["T1059.001", "T1003"]
+- targeted_sectors: list of strings
+- targeted_countries: list of ISO 3166-1 alpha-2 country codes
+- motivation: string, one of "espionage", "financial", "hacktivism", "destruction", "unknown"
+- sophistication: string, one of "minimal", "intermediate", "advanced", "expert", "unknown"
+- confidence: integer from 0 to 100
+
+Profile:
+{content}"""
+
+
+class AnthropicAIEnrichmentConnector:
+    def __init__(self):
+        config = {
+            "opencti": {
+                "url": os.environ.get("OPENCTI_URL", "http://opencti:8080"),
+                "token": os.environ["OPENCTI_TOKEN"],
+            },
+            "connector": {
+                "id": os.environ["CONNECTOR_ID"],
+                "type": "INTERNAL_ENRICHMENT",
+                "name": os.environ.get("CONNECTOR_NAME", "Anthropic AI Enrichment"),
+                "scope": os.environ.get(
+                    "CONNECTOR_SCOPE",
+                    "Report,Intrusion-Set,Threat-Actor-Group,Malware",
+                ),
+                "log_level": os.environ.get("CONNECTOR_LOG_LEVEL", "info"),
+                "auto": False,
+            },
+        }
+        self.helper = OpenCTIConnectorHelper(config)
+        self.client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+        self.model = os.environ.get("AI_MODEL", "claude-3-5-haiku-latest")
+
+    def _call_anthropic(self, prompt_template: str, content: str) -> dict | None:
+        prompt = prompt_template.format(content=content[:8000])
+        for attempt in range(3):
+            try:
+                msg = self.client.messages.create(
+                    model=self.model,
+                    max_tokens=2048,
+                    system=SYSTEM_PROMPT,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                return json.loads(msg.content[0].text)
+            except anthropic.RateLimitError:
+                wait_seconds = 60 * (attempt + 1)
+                self.helper.log_warning(f"Rate limited; waiting {wait_seconds}s")
+                time.sleep(wait_seconds)
+            except (json.JSONDecodeError, anthropic.APIError) as exc:
+                self.helper.log_error(f"AI enrichment failed: {exc}")
+                return None
+        return None
+
+    def _add_note(self, entity_id: str, summary: str, confidence: int) -> None:
+        self.helper.api.note.create(
+            abstract="AI Summary",
+            content=summary,
+            confidence=confidence,
+            object_ids=[entity_id],
+        )
+
+    def _read_by_name(self, api_client, name: str) -> dict | None:
+        return api_client.read(
+            filters={
+                "mode": "and",
+                "filters": [{"key": "name", "values": [name]}],
+                "filterGroups": [],
+            }
+        )
+
+    def _link_threat_actors(self, entity_id: str, names: list[str], confidence: int) -> None:
+        for name in names:
+            actor = self._read_by_name(self.helper.api.threat_actor_group, name)
+            if actor:
+                self.helper.api.stix_core_relationship.create(
+                    fromId=entity_id,
+                    toId=actor["id"],
+                    relationship_type="related-to",
+                    confidence=confidence,
+                )
+
+    def _link_malware(self, entity_id: str, names: list[str], confidence: int) -> None:
+        for name in names:
+            malware = self._read_by_name(self.helper.api.malware, name)
+            if malware:
+                self.helper.api.stix_core_relationship.create(
+                    fromId=entity_id,
+                    toId=malware["id"],
+                    relationship_type="uses",
+                    confidence=confidence,
+                )
+
+    def _link_attack_patterns(self, entity_id: str, technique_ids: list[str], confidence: int) -> None:
+        for technique_id in technique_ids:
+            pattern = self.helper.api.attack_pattern.read(
+                filters={
+                    "mode": "and",
+                    "filters": [{"key": "x_mitre_id", "values": [technique_id]}],
+                    "filterGroups": [],
+                }
+            )
+            if not pattern:
+                pattern = self.helper.api.attack_pattern.create(
+                    name=technique_id,
+                    x_mitre_id=technique_id,
+                    confidence=50,
+                )
+            if pattern:
+                self.helper.api.stix_core_relationship.create(
+                    fromId=entity_id,
+                    toId=pattern["id"],
+                    relationship_type="uses",
+                    confidence=confidence,
+                )
+
+    def _update_score(self, entity_id: str, confidence: int) -> None:
+        self.helper.api.stix_domain_object.update_field(
+            id=entity_id,
+            input={"key": "x_opencti_score", "value": str(confidence)},
+        )
+
+    def _enrich_report(self, report: dict) -> str:
+        content = report.get("description") or report.get("name") or ""
+        if len(content) < 10:
+            return "Skipped: content too short"
+
+        result = self._call_anthropic(REPORT_PROMPT, content)
+        if not result:
+            return "Skipped: AI error"
+
+        confidence = int(result.get("confidence", 50))
+        entity_id = report["id"]
+
+        if result.get("summary"):
+            self._add_note(entity_id, result["summary"], confidence)
+        self._link_threat_actors(entity_id, result.get("threat_actors", []), confidence)
+        self._link_malware(entity_id, result.get("malware_families", []), confidence)
+        self._link_attack_patterns(entity_id, result.get("attack_techniques", []), confidence)
+        self._update_score(entity_id, confidence)
+        return "Enriched"
+
+    def _enrich_intrusion_set(self, entity: dict) -> str:
+        content = entity.get("description") or entity.get("name") or ""
+        if len(content) < 10:
+            return "Skipped: content too short"
+
+        result = self._call_anthropic(INTRUSION_SET_PROMPT, content)
+        if not result:
+            return "Skipped: AI error"
+
+        confidence = int(result.get("confidence", 50))
+        entity_id = entity["id"]
+
+        if result.get("summary"):
+            self._add_note(entity_id, result["summary"], confidence)
+        self._link_malware(entity_id, result.get("malware_families", []), confidence)
+        self._link_attack_patterns(entity_id, result.get("attack_techniques", []), confidence)
+        self._update_score(entity_id, confidence)
+        return "Enriched"
+
+    def _read_entity(self, entity_type: str, entity_id: str) -> dict:
+        if entity_type == "report":
+            return self.helper.api.report.read(id=entity_id) or {}
+        if entity_type == "malware":
+            return self.helper.api.malware.read(id=entity_id) or {}
+        if entity_type in ("intrusion-set", "threat-actor-group"):
+            return self.helper.api.intrusion_set.read(id=entity_id) or {}
+        return {}
+
+    def process_message(self, data: dict) -> str:
+        entity_type = data.get("entity_type", "").lower()
+        entity_id = data.get("entity_id")
+        entity = data.get("enrichment_entity") or {}
+
+        self.helper.log_info(f"Received enrichment request for {entity_type} {entity_id}")
+        if not entity_id:
+            return "Skipped: missing entity id"
+
+        if not entity:
+            entity = self._read_entity(entity_type, entity_id)
+        if not entity:
+            return "Skipped: entity not found"
+
+        if entity_type == "report":
+            return self._enrich_report(entity)
+        if entity_type in ("intrusion-set", "threat-actor-group", "malware"):
+            return self._enrich_intrusion_set(entity)
+        return "Skipped: unsupported entity type"
+
+    def start(self):
+        self.helper.log_info("Anthropic AI Enrichment connector starting")
+        self.helper.listen(self.process_message)
+
+
+if __name__ == "__main__":
+    AnthropicAIEnrichmentConnector().start()

--- a/internal-enrichment/anthropic-ai-enrichment/src/main.py
+++ b/internal-enrichment/anthropic-ai-enrichment/src/main.py
@@ -1,10 +1,10 @@
 import json
-import os
 import re
 import time
 
 import anthropic
 from pycti import OpenCTIConnectorHelper
+from settings import ConnectorSettings
 
 SYSTEM_PROMPT = """You are a senior cyber threat intelligence analyst.
 Analyze threat intelligence content and return structured JSON only.
@@ -76,27 +76,11 @@ def normalize_attack_ids(value) -> list[str]:
 
 
 class AnthropicAIEnrichmentConnector:
-    def __init__(self):
-        config = {
-            "opencti": {
-                "url": os.environ.get("OPENCTI_URL", "http://opencti:8080"),
-                "token": os.environ["OPENCTI_TOKEN"],
-            },
-            "connector": {
-                "id": os.environ["CONNECTOR_ID"],
-                "type": "INTERNAL_ENRICHMENT",
-                "name": os.environ.get("CONNECTOR_NAME", "Anthropic AI Enrichment"),
-                "scope": os.environ.get(
-                    "CONNECTOR_SCOPE",
-                    "Report,Intrusion-Set,Threat-Actor-Group,Malware",
-                ),
-                "log_level": os.environ.get("CONNECTOR_LOG_LEVEL", "info"),
-                "auto": False,
-            },
-        }
-        self.helper = OpenCTIConnectorHelper(config)
-        self.client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
-        self.model = os.environ.get("AI_MODEL", "claude-3-5-haiku-latest")
+    def __init__(self, config: ConnectorSettings, helper: OpenCTIConnectorHelper):
+        self.config = config
+        self.helper = helper
+        self.client = anthropic.Anthropic(api_key=config.anthropic.api_key)
+        self.model = config.anthropic.model
 
     def _call_anthropic(self, prompt_template: str, content: str) -> dict | None:
         prompt = prompt_template.format(content=content[:8000])
@@ -109,7 +93,19 @@ class AnthropicAIEnrichmentConnector:
                     system=SYSTEM_PROMPT,
                     messages=[{"role": "user", "content": prompt}],
                 )
-                return json.loads(msg.content[0].text)
+                text = msg.content[0].text
+                parsed = json.loads(text)
+                if not isinstance(parsed, dict):
+                    # Valid JSON but not an object (e.g. a bare list or
+                    # number) - every caller does result.get(...), so treat
+                    # this the same as a parse failure rather than letting
+                    # it raise AttributeError deeper in the enrichment code.
+                    raise json.JSONDecodeError(
+                        f"Expected a JSON object, got {type(parsed).__name__}",
+                        text,
+                        0,
+                    )
+                return parsed
             except anthropic.RateLimitError as exc:
                 last_error = exc
                 wait_seconds = 60 * (attempt + 1)
@@ -303,4 +299,6 @@ class AnthropicAIEnrichmentConnector:
 
 
 if __name__ == "__main__":
-    AnthropicAIEnrichmentConnector().start()
+    settings = ConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+    AnthropicAIEnrichmentConnector(config=settings, helper=helper).start()

--- a/internal-enrichment/anthropic-ai-enrichment/src/main.py
+++ b/internal-enrichment/anthropic-ai-enrichment/src/main.py
@@ -1,10 +1,10 @@
 import json
 import os
+import re
 import time
 
 import anthropic
 from pycti import OpenCTIConnectorHelper
-
 
 SYSTEM_PROMPT = """You are a senior cyber threat intelligence analyst.
 Analyze threat intelligence content and return structured JSON only.
@@ -36,6 +36,44 @@ INTRUSION_SET_PROMPT = """Analyze this threat actor or intrusion set profile. Re
 Profile:
 {content}"""
 
+# MITRE ATT&CK technique/sub-technique identifiers, e.g. "T1059" or "T1059.001".
+ATTACK_ID_RE = re.compile(r"^T\d{4}(\.\d{3})?$")
+
+# Anthropic API errors that are worth retrying: transport-level failures and the
+# server's own transient 5xx errors. Client errors (bad request, auth, permission,
+# not found, etc.) will never succeed on retry, so they are not included here.
+RETRYABLE_API_ERRORS = (
+    anthropic.APIConnectionError,
+    anthropic.APITimeoutError,
+    anthropic.InternalServerError,
+)
+
+
+def normalize_string_list(value) -> list[str]:
+    """Coerce AI-provided output into a list of non-empty strings.
+
+    The model is asked for a JSON list, but nothing stops it from returning a
+    bare string, null, or a list containing non-string/empty items. Iterating
+    over an unvalidated string would loop over its characters instead of
+    treating it as a single value.
+    """
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def normalize_attack_ids(value) -> list[str]:
+    """Like normalize_string_list, but also drops anything that isn't a
+    well-formed MITRE ATT&CK technique ID, so malformed model output can't
+    create bogus Attack Pattern objects."""
+    return [
+        item.upper()
+        for item in normalize_string_list(value)
+        if ATTACK_ID_RE.match(item.upper())
+    ]
+
 
 class AnthropicAIEnrichmentConnector:
     def __init__(self):
@@ -62,6 +100,7 @@ class AnthropicAIEnrichmentConnector:
 
     def _call_anthropic(self, prompt_template: str, content: str) -> dict | None:
         prompt = prompt_template.format(content=content[:8000])
+        last_error: Exception | None = None
         for attempt in range(3):
             try:
                 msg = self.client.messages.create(
@@ -71,14 +110,46 @@ class AnthropicAIEnrichmentConnector:
                     messages=[{"role": "user", "content": prompt}],
                 )
                 return json.loads(msg.content[0].text)
-            except anthropic.RateLimitError:
+            except anthropic.RateLimitError as exc:
+                last_error = exc
                 wait_seconds = 60 * (attempt + 1)
                 self.helper.log_warning(f"Rate limited; waiting {wait_seconds}s")
                 time.sleep(wait_seconds)
-            except (json.JSONDecodeError, anthropic.APIError) as exc:
-                self.helper.log_error(f"AI enrichment failed: {exc}")
+            except json.JSONDecodeError as exc:
+                last_error = exc
+                self.helper.log_warning(
+                    f"AI response was not valid JSON (attempt {attempt + 1}/3): {exc}"
+                )
+            except RETRYABLE_API_ERRORS as exc:
+                last_error = exc
+                wait_seconds = 5 * (attempt + 1)
+                self.helper.log_warning(
+                    f"Anthropic API transient error (attempt {attempt + 1}/3): "
+                    f"{exc}; waiting {wait_seconds}s"
+                )
+                time.sleep(wait_seconds)
+            except anthropic.APIError as exc:
+                # Non-retryable (bad request, auth, permission, not found, ...).
+                self.helper.log_error(
+                    f"AI enrichment failed with a non-retryable error: {exc}"
+                )
                 return None
+        self.helper.log_error(f"AI enrichment failed after 3 attempts: {last_error}")
         return None
+
+    def _safe_confidence(self, raw_confidence, default: int = 50) -> int:
+        """Parse the AI-provided confidence defensively and cap it at the
+        connector's own configured confidence level, matching the convention
+        used by other internal-enrichment connectors in this repo."""
+        try:
+            confidence = int(float(raw_confidence))
+        except (TypeError, ValueError):
+            confidence = default
+        confidence = max(0, min(100, confidence))
+        max_confidence = self.helper.connect_confidence_level
+        if isinstance(max_confidence, int):
+            confidence = min(confidence, max_confidence)
+        return confidence
 
     def _add_note(self, entity_id: str, summary: str, confidence: int) -> None:
         self.helper.api.note.create(
@@ -97,8 +168,8 @@ class AnthropicAIEnrichmentConnector:
             }
         )
 
-    def _link_threat_actors(self, entity_id: str, names: list[str], confidence: int) -> None:
-        for name in names:
+    def _link_threat_actors(self, entity_id: str, names: list, confidence: int) -> None:
+        for name in normalize_string_list(names):
             actor = self._read_by_name(self.helper.api.threat_actor_group, name)
             if actor:
                 self.helper.api.stix_core_relationship.create(
@@ -108,8 +179,8 @@ class AnthropicAIEnrichmentConnector:
                     confidence=confidence,
                 )
 
-    def _link_malware(self, entity_id: str, names: list[str], confidence: int) -> None:
-        for name in names:
+    def _link_malware(self, entity_id: str, names: list, confidence: int) -> None:
+        for name in normalize_string_list(names):
             malware = self._read_by_name(self.helper.api.malware, name)
             if malware:
                 self.helper.api.stix_core_relationship.create(
@@ -119,8 +190,10 @@ class AnthropicAIEnrichmentConnector:
                     confidence=confidence,
                 )
 
-    def _link_attack_patterns(self, entity_id: str, technique_ids: list[str], confidence: int) -> None:
-        for technique_id in technique_ids:
+    def _link_attack_patterns(
+        self, entity_id: str, technique_ids: list, confidence: int
+    ) -> None:
+        for technique_id in normalize_attack_ids(technique_ids):
             pattern = self.helper.api.attack_pattern.read(
                 filters={
                     "mode": "and",
@@ -157,14 +230,16 @@ class AnthropicAIEnrichmentConnector:
         if not result:
             return "Skipped: AI error"
 
-        confidence = int(result.get("confidence", 50))
+        confidence = self._safe_confidence(result.get("confidence"))
         entity_id = report["id"]
 
         if result.get("summary"):
             self._add_note(entity_id, result["summary"], confidence)
         self._link_threat_actors(entity_id, result.get("threat_actors", []), confidence)
         self._link_malware(entity_id, result.get("malware_families", []), confidence)
-        self._link_attack_patterns(entity_id, result.get("attack_techniques", []), confidence)
+        self._link_attack_patterns(
+            entity_id, result.get("attack_techniques", []), confidence
+        )
         self._update_score(entity_id, confidence)
         return "Enriched"
 
@@ -177,13 +252,15 @@ class AnthropicAIEnrichmentConnector:
         if not result:
             return "Skipped: AI error"
 
-        confidence = int(result.get("confidence", 50))
+        confidence = self._safe_confidence(result.get("confidence"))
         entity_id = entity["id"]
 
         if result.get("summary"):
             self._add_note(entity_id, result["summary"], confidence)
         self._link_malware(entity_id, result.get("malware_families", []), confidence)
-        self._link_attack_patterns(entity_id, result.get("attack_techniques", []), confidence)
+        self._link_attack_patterns(
+            entity_id, result.get("attack_techniques", []), confidence
+        )
         self._update_score(entity_id, confidence)
         return "Enriched"
 
@@ -192,8 +269,10 @@ class AnthropicAIEnrichmentConnector:
             return self.helper.api.report.read(id=entity_id) or {}
         if entity_type == "malware":
             return self.helper.api.malware.read(id=entity_id) or {}
-        if entity_type in ("intrusion-set", "threat-actor-group"):
+        if entity_type == "intrusion-set":
             return self.helper.api.intrusion_set.read(id=entity_id) or {}
+        if entity_type == "threat-actor-group":
+            return self.helper.api.threat_actor_group.read(id=entity_id) or {}
         return {}
 
     def process_message(self, data: dict) -> str:
@@ -201,7 +280,9 @@ class AnthropicAIEnrichmentConnector:
         entity_id = data.get("entity_id")
         entity = data.get("enrichment_entity") or {}
 
-        self.helper.log_info(f"Received enrichment request for {entity_type} {entity_id}")
+        self.helper.log_info(
+            f"Received enrichment request for {entity_type} {entity_id}"
+        )
         if not entity_id:
             return "Skipped: missing entity id"
 

--- a/internal-enrichment/anthropic-ai-enrichment/src/requirements.txt
+++ b/internal-enrichment/anthropic-ai-enrichment/src/requirements.txt
@@ -1,0 +1,2 @@
+pycti>=6.2.0
+anthropic>=0.40.0

--- a/internal-enrichment/anthropic-ai-enrichment/src/requirements.txt
+++ b/internal-enrichment/anthropic-ai-enrichment/src/requirements.txt
@@ -1,2 +1,2 @@
-pycti>=6.2.0
-anthropic>=0.40.0
+pycti==7.260626.0
+anthropic==0.120.2

--- a/internal-enrichment/anthropic-ai-enrichment/src/requirements.txt
+++ b/internal-enrichment/anthropic-ai-enrichment/src/requirements.txt
@@ -1,2 +1,7 @@
-pycti==7.260626.0
 anthropic==0.120.2
+pydantic>=2.8.2,<3
+# connectors-sdk pins an exact pycti version of its own (and that pin moves
+# frequently); pinning pycti here too just races it and breaks installs
+# whenever the two drift apart, so pycti's version is left to be resolved
+# transitively through connectors-sdk instead of fixed independently.
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/anthropic-ai-enrichment/src/settings.py
+++ b/internal-enrichment/anthropic-ai-enrichment/src/settings.py
@@ -1,0 +1,52 @@
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseInternalEnrichmentConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field
+
+
+class InternalEnrichmentConnectorConfig(BaseInternalEnrichmentConnectorConfig):
+    """
+    Override `BaseInternalEnrichmentConnectorConfig` to add parameters and/or defaults
+    to the configuration for connectors of type `INTERNAL_ENRICHMENT`.
+    """
+
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="2382f232-2b6e-4057-b922-b39c2d325784",
+    )
+    name: str = Field(
+        description="The name of the connector.",
+        default="Anthropic AI Enrichment",
+    )
+    scope: ListFromString = Field(
+        description="The scope of observables the connector will enrich.",
+        default=["Report", "Intrusion-Set", "Threat-Actor-Group", "Malware"],
+    )
+
+
+class AnthropicConfig(BaseConfigModel):
+    """
+    Define parameters and/or defaults for the configuration specific to the
+    Anthropic API integration.
+    """
+
+    api_key: str = Field(description="Anthropic API key.")
+    model: str = Field(
+        description="Anthropic model to use for enrichment.",
+        default="claude-3-5-haiku-latest",
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """
+    Override `BaseConnectorSettings` to include `InternalEnrichmentConnectorConfig`
+    and `AnthropicConfig`.
+    """
+
+    connector: InternalEnrichmentConnectorConfig = Field(
+        default_factory=InternalEnrichmentConnectorConfig
+    )
+    anthropic: AnthropicConfig = Field(default_factory=AnthropicConfig)

--- a/internal-enrichment/anthropic-ai-enrichment/tests/conftest.py
+++ b/internal-enrichment/anthropic-ai-enrichment/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest configuration for the Anthropic AI Enrichment connector tests.
+
+The connector ships at ``src/main.py``. Adding ``src`` to ``sys.path`` lets
+the test modules ``import main`` directly, without the connector's container
+entrypoint scaffolding.
+"""
+
+import sys
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/internal-enrichment/anthropic-ai-enrichment/tests/test-requirements.txt
+++ b/internal-enrichment/anthropic-ai-enrichment/tests/test-requirements.txt
@@ -1,0 +1,2 @@
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/internal-enrichment/anthropic-ai-enrichment/tests/test_main.py
+++ b/internal-enrichment/anthropic-ai-enrichment/tests/test_main.py
@@ -1,0 +1,192 @@
+"""Unit tests for the Anthropic AI Enrichment connector.
+
+These cover the defects raised in review: an unsafe/unclamped confidence
+cast, unvalidated AI list output being iterated directly, the
+threat-actor-group entity lookup using the wrong API endpoint, and a retry
+loop that gave up instead of retrying on JSON/API errors.
+"""
+
+from unittest.mock import MagicMock
+
+import anthropic
+import main as connector_module
+import pytest
+from main import (
+    AnthropicAIEnrichmentConnector,
+    normalize_attack_ids,
+    normalize_string_list,
+)
+
+REQUIRED_ENV = {
+    "OPENCTI_TOKEN": "test-token",
+    "CONNECTOR_ID": "test-connector-id",
+    "ANTHROPIC_API_KEY": "test-api-key",
+}
+
+
+class _NonRetryableAPIError(anthropic.APIError):
+    """A minimal stand-in for a real non-retryable error (bad request, auth,
+    permission, ...). We avoid constructing the real SDK exception classes
+    directly since their __init__ signatures require a live httpx response
+    object that isn't relevant to what this test is checking."""
+
+    def __init__(self, message: str):
+        self.message = message
+
+    def __str__(self) -> str:
+        return self.message
+
+
+@pytest.fixture
+def connector(monkeypatch):
+    """A connector instance with OpenCTIConnectorHelper and the Anthropic
+    client replaced by mocks, so no real network or OpenCTI connection is
+    made."""
+    for key, value in REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(connector_module, "OpenCTIConnectorHelper", MagicMock())
+    monkeypatch.setattr(connector_module.anthropic, "Anthropic", MagicMock())
+    monkeypatch.setattr(connector_module.time, "sleep", MagicMock())
+
+    instance = AnthropicAIEnrichmentConnector()
+    instance.helper.connect_confidence_level = 100
+    return instance
+
+
+class TestNormalizeStringList:
+    def test_accepts_a_list_of_strings(self):
+        assert normalize_string_list(["APT28", " Sandworm "]) == ["APT28", "Sandworm"]
+
+    def test_wraps_a_bare_string_instead_of_iterating_characters(self):
+        assert normalize_string_list("APT28") == ["APT28"]
+
+    def test_drops_empty_and_non_string_items(self):
+        assert normalize_string_list(["APT28", "", None, 42, "  "]) == ["APT28"]
+
+    def test_non_list_non_string_input_returns_empty(self):
+        assert normalize_string_list(None) == []
+        assert normalize_string_list(123) == []
+
+
+class TestNormalizeAttackIds:
+    def test_accepts_well_formed_ids_and_uppercases_them(self):
+        assert normalize_attack_ids(["t1059.001", "T1003"]) == ["T1059.001", "T1003"]
+
+    def test_drops_malformed_ids(self):
+        assert normalize_attack_ids(["T1059.001", "not-an-id", "T99", ""]) == [
+            "T1059.001"
+        ]
+
+    def test_wraps_a_bare_string(self):
+        assert normalize_attack_ids("T1059.001") == ["T1059.001"]
+
+
+class TestSafeConfidence:
+    def test_valid_integer_passes_through(self, connector):
+        assert connector._safe_confidence(72) == 72
+
+    def test_string_number_is_parsed(self, connector):
+        assert connector._safe_confidence("85") == 85
+
+    def test_invalid_value_falls_back_to_default(self, connector):
+        assert connector._safe_confidence("not-a-number", default=40) == 40
+        assert connector._safe_confidence(None, default=40) == 40
+
+    def test_out_of_range_values_are_clamped_to_0_100(self, connector):
+        assert connector._safe_confidence(150) == 100
+        assert connector._safe_confidence(-10) == 0
+
+    def test_result_is_capped_at_the_connector_confidence_level(self, connector):
+        connector.helper.connect_confidence_level = 50
+        assert connector._safe_confidence(95) == 50
+        assert connector._safe_confidence(30) == 30
+
+
+class TestReadEntityRouting:
+    def test_threat_actor_group_uses_the_threat_actor_group_endpoint(self, connector):
+        connector.helper.api.threat_actor_group.read.return_value = {"id": "actor--1"}
+        connector.helper.api.intrusion_set.read.return_value = {"id": "wrong-type"}
+
+        result = connector._read_entity("threat-actor-group", "actor--1")
+
+        assert result == {"id": "actor--1"}
+        connector.helper.api.threat_actor_group.read.assert_called_once_with(
+            id="actor--1"
+        )
+        connector.helper.api.intrusion_set.read.assert_not_called()
+
+    def test_intrusion_set_uses_the_intrusion_set_endpoint(self, connector):
+        connector.helper.api.intrusion_set.read.return_value = {"id": "is--1"}
+
+        result = connector._read_entity("intrusion-set", "is--1")
+
+        assert result == {"id": "is--1"}
+        connector.helper.api.intrusion_set.read.assert_called_once_with(id="is--1")
+
+    def test_unknown_entity_type_returns_empty_dict(self, connector):
+        assert connector._read_entity("identity", "identity--1") == {}
+
+
+class TestLinkingNormalizesUntrustedAiOutput:
+    def test_link_threat_actors_ignores_a_bare_string_instead_of_looping_chars(
+        self, connector
+    ):
+        connector.helper.api.threat_actor_group.read.return_value = None
+
+        connector._link_threat_actors("report--1", "APT28", confidence=50)
+
+        connector.helper.api.threat_actor_group.read.assert_called_once()
+        called_filters = connector.helper.api.threat_actor_group.read.call_args.kwargs[
+            "filters"
+        ]
+        assert called_filters["filters"][0]["values"] == ["APT28"]
+
+    def test_link_attack_patterns_drops_malformed_technique_ids(self, connector):
+        connector.helper.api.attack_pattern.read.return_value = None
+        connector.helper.api.attack_pattern.create.return_value = {"id": "pattern--1"}
+
+        connector._link_attack_patterns(
+            "report--1", ["T1059.001", "not-a-technique"], confidence=50
+        )
+
+        assert connector.helper.api.attack_pattern.create.call_count == 1
+        assert (
+            connector.helper.api.attack_pattern.create.call_args.kwargs["x_mitre_id"]
+            == "T1059.001"
+        )
+
+
+class TestCallAnthropicRetries:
+    def _message(self, text: str):
+        message = MagicMock()
+        message.content = [MagicMock(text=text)]
+        return message
+
+    def test_retries_on_invalid_json_and_eventually_succeeds(self, connector):
+        connector.client.messages.create.side_effect = [
+            self._message("not json"),
+            self._message('{"confidence": 80}'),
+        ]
+
+        result = connector._call_anthropic("{content}", "some content")
+
+        assert result == {"confidence": 80}
+        assert connector.client.messages.create.call_count == 2
+
+    def test_gives_up_after_three_failed_attempts(self, connector):
+        connector.client.messages.create.return_value = self._message("not json")
+
+        result = connector._call_anthropic("{content}", "some content")
+
+        assert result is None
+        assert connector.client.messages.create.call_count == 3
+
+    def test_does_not_retry_a_non_retryable_api_error(self, connector):
+        connector.client.messages.create.side_effect = _NonRetryableAPIError(
+            "bad api key"
+        )
+
+        result = connector._call_anthropic("{content}", "some content")
+
+        assert result is None
+        assert connector.client.messages.create.call_count == 1

--- a/internal-enrichment/anthropic-ai-enrichment/tests/test_main.py
+++ b/internal-enrichment/anthropic-ai-enrichment/tests/test_main.py
@@ -2,8 +2,9 @@
 
 These cover the defects raised in review: an unsafe/unclamped confidence
 cast, unvalidated AI list output being iterated directly, the
-threat-actor-group entity lookup using the wrong API endpoint, and a retry
-loop that gave up instead of retrying on JSON/API errors.
+threat-actor-group entity lookup using the wrong API endpoint, a retry
+loop that gave up instead of retrying on JSON/API errors, and a parsed
+JSON value that isn't a dict.
 """
 
 from unittest.mock import MagicMock
@@ -16,12 +17,6 @@ from main import (
     normalize_attack_ids,
     normalize_string_list,
 )
-
-REQUIRED_ENV = {
-    "OPENCTI_TOKEN": "test-token",
-    "CONNECTOR_ID": "test-connector-id",
-    "ANTHROPIC_API_KEY": "test-api-key",
-}
 
 
 class _NonRetryableAPIError(anthropic.APIError):
@@ -39,18 +34,20 @@ class _NonRetryableAPIError(anthropic.APIError):
 
 @pytest.fixture
 def connector(monkeypatch):
-    """A connector instance with OpenCTIConnectorHelper and the Anthropic
-    client replaced by mocks, so no real network or OpenCTI connection is
-    made."""
-    for key, value in REQUIRED_ENV.items():
-        monkeypatch.setenv(key, value)
-    monkeypatch.setattr(connector_module, "OpenCTIConnectorHelper", MagicMock())
+    """A connector instance built from a fake ConnectorSettings and a mocked
+    OpenCTIConnectorHelper, with the Anthropic client itself also mocked so
+    no real network call is made."""
     monkeypatch.setattr(connector_module.anthropic, "Anthropic", MagicMock())
     monkeypatch.setattr(connector_module.time, "sleep", MagicMock())
 
-    instance = AnthropicAIEnrichmentConnector()
-    instance.helper.connect_confidence_level = 100
-    return instance
+    config = MagicMock()
+    config.anthropic.api_key = "test-api-key"
+    config.anthropic.model = "claude-3-5-haiku-latest"
+
+    helper = MagicMock()
+    helper.connect_confidence_level = 100
+
+    return AnthropicAIEnrichmentConnector(config=config, helper=helper)
 
 
 class TestNormalizeStringList:
@@ -190,3 +187,16 @@ class TestCallAnthropicRetries:
 
         assert result is None
         assert connector.client.messages.create.call_count == 1
+
+    def test_retries_when_the_model_returns_a_json_list_instead_of_an_object(
+        self, connector
+    ):
+        connector.client.messages.create.side_effect = [
+            self._message("[1, 2, 3]"),
+            self._message('{"confidence": 80}'),
+        ]
+
+        result = connector._call_anthropic("{content}", "some content")
+
+        assert result == {"confidence": 80}
+        assert connector.client.messages.create.call_count == 2


### PR DESCRIPTION
Closes #7209

## Proposed changes

Adds an internal enrichment connector that uses Anthropic models to generate analyst-reviewable CTI enrichment for OpenCTI reports, intrusion sets, threat actor groups, and malware objects.

The connector can:
- create AI summary notes
- link existing threat actor groups and malware by name
- create or link ATT&CK attack patterns by technique ID
- update the OpenCTI score from the model confidence

## Validation

- `pytest` (21/21 passing), `isort --profile black`, `black`, `flake8 --ignore=E,W`, and the repo's `check_stix_plugin` pylint check (10.00/10) all pass locally
- `connector-linter check internal-enrichment/anthropic-ai-enrichment --select VC305` passes locally (migrated to `connectors_sdk.BaseConnectorSettings`)
- Verified the console entry point actually starts against a real `pip install` of the built dependencies (not just `pip install -e .`)

## Safety note

AI output is documented as analyst-assistance only. Generated summaries, relationships, ATT&CK mappings, and scores should be reviewed before operational use.
