### PR TITLE
fix(email-intel-imap): normalize offset-naive email date before comparison (#6823)

### DIFF
--- a/external-import/email-intel-imap/src/email_intel_imap/connector.py
+++ b/external-import/email-intel-imap/src/email_intel_imap/connector.py
@@ -36,7 +36,13 @@ class Connector(BaseConnector):
                 since_date.date()
             )
             # As the IMAP library filters by date, we need to add this to filter also by time
-            if email.date > since_date
+            # Normalize naive datetimes to UTC before comparing with the always-aware since_date
+            if (
+                email.date
+                if email.date.tzinfo is not None
+                else email.date.replace(tzinfo=datetime.UTC)
+            )
+            > since_date
             for stix_object in self.converter.to_stix_objects(email)
         ]
 

--- a/external-import/email-intel-imap/tests/email_intel_imap/test_connector.py
+++ b/external-import/email-intel-imap/tests/email_intel_imap/test_connector.py
@@ -168,3 +168,25 @@ def test_connector_unknown_error(connector: Connector) -> None:
     connector.helper.get_state.side_effect = ValueError("Unknown error")
 
     assert connector.process() == "Unexpected error. See connector logs for details."
+
+
+@freezegun.freeze_time("2025-04-22T14:00:00Z")
+def test_connector_process_data_naive_email_date(
+    connector: Connector, mocked_mail_box: Mock
+) -> None:
+    """Regression test: offset-naive email.date must not crash when compared to the
+    always offset-aware since_date (TypeError: can't compare offset-naive and
+    offset-aware datetimes)."""
+    naive_old = datetime.datetime(2025, 2, 1, 12, 0, 0)  # before the 30-day window
+    naive_recent = datetime.datetime(2025, 4, 21, 12, 0, 0)  # within the 30-day window
+
+    email1 = Mock(subject="old", html="body old", attachments=[], date=naive_old)
+    email2 = Mock(
+        subject="recent", html="body recent", attachments=[], date=naive_recent
+    )
+
+    mocked_mail_box.fetch.return_value = [email1, email2]
+    stix_objects = connector.process_data()
+
+    assert len(stix_objects) == 1
+    assert stix_objects[0].name == "recent"


### PR DESCRIPTION
## Proposed changes

Normalize `email.date` to UTC before comparing it with the always offset-aware `since_date`, preventing a `TypeError` crash on every poll cycle when an IMAP server returns emails with a naive `datetime` (no timezone in the `Date` header).

- In `connector.py`: use `.replace(tzinfo=datetime.UTC)` when `email.date.tzinfo is None` before the comparison.
- Add regression test `test_connector_process_data_naive_email_date` covering both a naive date outside and inside the import window.

## Related issues

- Closes: #6823

## Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality