### PR TITLE
chore(sigmahq): add default value for connector scope (#6872)

### DIFF
--- a/external-import/sigmahq/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/sigmahq/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -8,8 +8,8 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
 | OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
-| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'flashpoint'. |
 | CONNECTOR_NAME | `string` |  | string | `"SigmaHQ"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["sigmahq"]` | The scope of the connector |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
 | CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"P1D"` | The period of time to await between two runs of the connector. (Default: 1 day) |

--- a/external-import/sigmahq/__metadata__/connector_config_schema.json
+++ b/external-import/sigmahq/__metadata__/connector_config_schema.json
@@ -20,7 +20,10 @@
       "type": "string"
     },
     "CONNECTOR_SCOPE": {
-      "description": "The scope of the connector, e.g. 'flashpoint'.",
+      "default": [
+        "sigmahq"
+      ],
+      "description": "The scope of the connector",
       "items": {
         "type": "string"
       },
@@ -77,8 +80,7 @@
   },
   "required": [
     "OPENCTI_URL",
-    "OPENCTI_TOKEN",
-    "CONNECTOR_SCOPE"
+    "OPENCTI_TOKEN"
   ],
   "additionalProperties": true
 }

--- a/external-import/sigmahq/src/connector/settings.py
+++ b/external-import/sigmahq/src/connector/settings.py
@@ -5,6 +5,7 @@ from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
     BaseExternalImportConnectorConfig,
+    ListFromString,
 )
 from pydantic import Field
 
@@ -22,6 +23,9 @@ class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
     duration_period: timedelta = Field(
         description="The period of time to await between two runs of the connector. (Default: 1 day)",
         default=timedelta(days=1),
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector", default=["sigmahq"]
     )
 
 


### PR DESCRIPTION
### Proposed changes

* Add a default value (`["sigmahq"]`) for the `scope` field in `SigmaHQConnectorConfig`, using the `ListFromString` type from the connectors SDK.
* Regenerate the JSON schema and config documentation to reflect that `CONNECTOR_SCOPE` is no longer a required field and now carries a sensible default.
* This reduces deployment friction — users no longer need to explicitly set `CONNECTOR_SCOPE` for the most common use case.

### Related issues

* Closes #6872

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This change makes the SigmaHQ connector easier to deploy out-of-the-box by providing a default scope of `["sigmahq"]`. Previously, omitting `CONNECTOR_SCOPE` from the environment/configuration would cause a validation error at startup.