### PR TITLE
fix(misp): guard attribute label creation with convert_tag_to_label check (#6891)

### DIFF
--- a/external-import/misp/src/connector/use_cases/convert_attribute.py
+++ b/external-import/misp/src/connector/use_cases/convert_attribute.py
@@ -577,9 +577,10 @@ class AttributeConverter:
             if marking:
                 attribute_markings.append(marking)
 
-            label = self.tag_converter.create_label(tag)
-            if label:
-                attribute_labels.append(label)
+            if self.config.convert_tag_to_label:
+                label = self.tag_converter.create_label(tag)
+                if label:
+                    attribute_labels.append(label)
 
         if not attribute_markings:
             attribute_markings = markings


### PR DESCRIPTION
### Proposed changes

* Guard attribute-level tag → label conversion behind the `convert_tag_to_label` configuration flag in `convert_attribute.py`, so labels are only created when the option is explicitly enabled.
* This aligns attribute tag handling with the existing behaviour elsewhere in the connector, where `convert_tag_to_label` is already checked before calling `create_label`.

### Related issues

* Fixes #6891

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

**Bug:** Attribute tags were being converted to labels unconditionally — even when `convert_tag_to_label` was set to `false` in the connector configuration. This caused unwanted labels to appear on imported STIX objects.

**Root cause:** The `convert_attribute` use-case was missing the `self.config.convert_tag_to_label` guard around the `self.tag_converter.create_label(tag)` call. Other code paths in the connector (e.g. event-level tag processing) already perform this check, so this was simply an oversight in the attribute-level path.

**Fix:** Wrap the `create_label` call and the subsequent `attribute_labels.append` inside an `if self.config.convert_tag_to_label:` block, making the behaviour consistent across the connector.