### PR TITLE
feat(ci): add manifest fragment generation and connectors-sdk pinning to connector release (#6888)

### DIFF
--- a/.github/actions/build-connector-image/action.yml
+++ b/.github/actions/build-connector-image/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: "Build variant (e.g. 'ubi9'). Affects cache keys, OCI labels, and auto-generates build-args for shared Dockerfiles."
     required: false
     default: ""
+  sdk_ref:
+    description: "Git ref to pin connectors-sdk to. When empty, no pinning is performed (only release-connector sets this)."
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -109,6 +113,31 @@ runs:
         if [ -f src/requirements.txt ]; then
           echo "--- src/requirements.txt ---"
           grep -E 'pycti|connectors-sdk' src/requirements.txt || echo "(no matches)"
+        fi
+
+    - name: Pin connectors-sdk for release
+      # Only pins when a ref is explicitly provided by the caller (release-connector).
+      # Other release-mode builds (e.g. build-all-connectors) leave sdk_ref empty
+      # and are intentionally not pinned.
+      if: inputs.sdk_ref != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        CONNECTOR_DIR="${{ inputs.connector_path }}"
+        SDK_REF="${{ inputs.sdk_ref }}"
+
+        SDK_GIT="connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@${SDK_REF}#subdirectory=connectors-sdk"
+
+        cd "$CONNECTOR_DIR"
+        echo "🔒 Pinning connectors-sdk → ${SDK_REF} (release build)"
+
+        find . \( -name requirements.txt -o -name pyproject.toml \) -exec \
+          sed -i -E "s|connectors-sdk @ git\+https://github\.com/OpenCTI-Platform/connectors\.git@[^#]+#subdirectory=connectors-sdk|${SDK_GIT}|g" {} +
+
+        echo "✅ connectors-sdk pinned"
+        if [ -f src/requirements.txt ]; then
+          echo "--- src/requirements.txt ---"
+          grep -E 'connectors-sdk' src/requirements.txt || echo "(no connectors-sdk ref)"
         fi
 
     - name: Resolve Dockerfile and build args

--- a/.github/scripts/check_connector_identity_uniqueness.py
+++ b/.github/scripts/check_connector_identity_uniqueness.py
@@ -17,6 +17,17 @@ CONNECTOR_TYPE_DIRS = common.CONNECTOR_TYPE_DIRS
 FIELDS_TO_CHECK = ["slug", "container_image"]
 
 
+def normalize_slug(slug: str) -> str:
+    """Normalize a slug the same way the manifest fragment generator does.
+
+    Keep this in sync with
+    `shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py`.
+    The fragment id/slug must match `^[a-z0-9]+(?:-[a-z0-9]+)*$`, so underscores
+    become hyphens and the value is lower-cased.
+    """
+    return slug.lower().replace("_", "-")
+
+
 def list_manifest_paths_from_fs() -> list[str]:
     paths: list[str] = []
     for connector_type in CONNECTOR_TYPE_DIRS:
@@ -85,6 +96,32 @@ def collect_folder_name_duplicates(connector_dirs: list[Path]) -> dict[str, list
     return duplicates
 
 
+def collect_normalized_slug_duplicates(
+    manifests: list[tuple[str, dict[str, Any]]],
+) -> dict[str, list[str]]:
+    """Detect distinct slugs that collide once normalized for the manifest fragment.
+
+    Exact-duplicate slugs are already reported by `collect_duplicates`; this only
+    flags the *new* class of conflict introduced by normalization, i.e. two or
+    more different raw slugs (e.g. "intel471_v2" and "intel471-v2") collapsing to
+    the same normalized value.
+    """
+    seen: dict[str, list[tuple[str, str]]] = {}
+    for path, data in manifests:
+        raw_value = data.get("slug")
+        if not isinstance(raw_value, str) or not raw_value.strip():
+            continue  # non-empty check already enforced by collect_duplicates
+        raw_value = raw_value.strip()
+        seen.setdefault(normalize_slug(raw_value), []).append((raw_value, path))
+
+    duplicates: dict[str, list[str]] = {}
+    for normalized, entries in seen.items():
+        distinct_raw = {raw for raw, _ in entries}
+        if len(entries) > 1 and len(distinct_raw) > 1:
+            duplicates[normalized] = sorted(path for _, path in entries)
+    return duplicates
+
+
 def main() -> int:
     connector_dirs = list_connector_dirs_from_fs()
     manifests = [
@@ -92,9 +129,12 @@ def main() -> int:
     ]
     duplicates = collect_duplicates(manifests)
     folder_duplicates = collect_folder_name_duplicates(connector_dirs)
+    normalized_slug_duplicates = collect_normalized_slug_duplicates(manifests)
 
-    has_failure = any(duplicates[field] for field in FIELDS_TO_CHECK) or bool(
-        folder_duplicates
+    has_failure = (
+        any(duplicates[field] for field in FIELDS_TO_CHECK)
+        or bool(folder_duplicates)
+        or bool(normalized_slug_duplicates)
     )
     if not has_failure:
         print("No connector identity duplicates detected.")
@@ -112,10 +152,16 @@ def main() -> int:
             for path in paths:
                 print(f"  - {path}")
 
+    for normalized, paths in sorted(normalized_slug_duplicates.items()):
+        print(f"- [normalized_slug] {normalized}")
+        for path in paths:
+            print(f"  - {path}")
+
     print("\nFix by ensuring each connector has unique manifest values for:")
     print("- connector folder basename (used by CI to build Docker image names)")
     print("- slug")
     print("- container_image")
+    print("- normalized slug (used as the manifest fragment id/slug for XTM Hub)")
     return 1
 
 

--- a/.github/workflows/build-connector-type.yml
+++ b/.github/workflows/build-connector-type.yml
@@ -34,6 +34,11 @@ on:
         required: false
         type: string
         default: ""
+      sdk_ref:
+        description: "Git ref to pin connectors-sdk to. When empty, no pinning is performed (only release-connector sets this)."
+        required: false
+        type: string
+        default: ""
     secrets:
       DOCKERHUB_USERNAME:
         required: false
@@ -101,6 +106,7 @@ jobs:
           digests_dir: /tmp/digests
           dockerfile: ${{ inputs.dockerfile }}
           variant: ${{ inputs.variant }}
+          sdk_ref: ${{ inputs.sdk_ref }}
 
       - name: Upload digest
         if: inputs.push
@@ -110,6 +116,19 @@ jobs:
           path: /tmp/digests/
           if-no-files-found: error
           retention-days: 1
+
+      - name: Upload pinned dependency files
+        # Only when connectors-sdk was pinned (release-connector sets sdk_ref).
+        # Uploaded once from the amd64 job — content is identical across platforms.
+        if: inputs.sdk_ref != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pinned-deps-${{ matrix.name }}
+          path: |
+            ${{ matrix.path }}/**/requirements.txt
+            ${{ matrix.path }}/**/pyproject.toml
+          if-no-files-found: warn
+          retention-days: 90
 
   build-arm64:
     name: "Build ${{ inputs.type_name }}/${{ matrix.name }} (arm64)"
@@ -164,6 +183,7 @@ jobs:
           digests_dir: /tmp/digests
           dockerfile: ${{ inputs.dockerfile }}
           variant: ${{ inputs.variant }}
+          sdk_ref: ${{ inputs.sdk_ref }}
 
       - name: Upload digest
         if: inputs.push

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -12,7 +12,8 @@ name: "Release Connector"
 #   2. Resolve connector directory (scan type dirs)
 #   3. Generate scoped release notes (git-cliff)
 #   4. Build & push Docker image (DockerHub + GHCR)
-#   5. Create GitHub Release with changelog + manifest asset
+#   5. Create GitHub Release with changelog + manifest/schema/fragment assets
+#   6. Update container_version in manifest and commit back to default branch
 
 on:
   push:
@@ -356,7 +357,7 @@ jobs:
     secrets: inherit
 
   # ──────────────────────────────────────────────────────────
-  # 4. Create GitHub Release
+  # 4. Create GitHub Release + update manifest version
   # ──────────────────────────────────────────────────────────
   release:
     name: Create GitHub Release
@@ -393,6 +394,56 @@ jobs:
           git tag "$TAG"
           git push origin "$TAG"
 
+      - name: Patch manifest container_version
+        id: patch-manifest
+        run: |
+          CONNECTOR_DIR="${{ needs.resolve.outputs.connector_dir }}"
+          VERSION="${{ needs.resolve.outputs.version }}"
+          MANIFEST="${CONNECTOR_DIR}/__metadata__/connector_manifest.json"
+
+          if [ ! -f "$MANIFEST" ]; then
+            echo "patched=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️ Manifest not found: $MANIFEST — skipping version patch"
+            exit 0
+          fi
+
+          jq --arg v "$VERSION" '.container_version = $v' "$MANIFEST" > "$RUNNER_TEMP/manifest.json" \
+            && mv "$RUNNER_TEMP/manifest.json" "$MANIFEST"
+
+          echo "patched=true" >> "$GITHUB_OUTPUT"
+          echo "✅ Patched container_version → $VERSION in $MANIFEST"
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Generate manifest fragment
+        id: fragment
+        # Non-blocking: the release must succeed even if the fragment can't be built
+        continue-on-error: true
+        run: |
+          CONNECTOR_DIR="${{ needs.resolve.outputs.connector_dir }}"
+          CONNECTOR_NAME="${{ needs.resolve.outputs.connector_name }}"
+          VERSION="${{ needs.resolve.outputs.version }}"
+          MANIFEST="${CONNECTOR_DIR}/__metadata__/connector_manifest.json"
+
+          if [ ! -f "$MANIFEST" ]; then
+            echo "::warning::Manifest not found for ${CONNECTOR_DIR} — skipping fragment generation"
+            exit 0
+          fi
+
+          pip install --quiet -r shared/tools/composer/generate_manifest_fragment/requirements.txt
+
+          FRAGMENT_PATH="${RUNNER_TEMP}/${CONNECTOR_NAME}_manifest_fragment.json"
+          python shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py \
+            --connector-dir "$CONNECTOR_DIR" \
+            --version "$VERSION" \
+            --output "$FRAGMENT_PATH"
+
+          echo "fragment_path=$FRAGMENT_PATH" >> "$GITHUB_OUTPUT"
+          echo "✅ Generated manifest fragment: $FRAGMENT_PATH"
+
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -411,21 +462,102 @@ jobs:
             --notes "$CHANGELOG" \
             --target "${{ github.sha }}"
 
-          # Attach connector manifest as release asset
+          # Attach connector manifest, config schema, and manifest fragment as release assets
           MANIFEST="${CONNECTOR_DIR}/__metadata__/connector_manifest.json"
+          CONFIG_SCHEMA="${CONNECTOR_DIR}/__metadata__/connector_config_schema.json"
+          FRAGMENT="${{ steps.fragment.outputs.fragment_path }}"
+
           if [ -f "$MANIFEST" ]; then
             gh release upload "$TAG" "$MANIFEST" --clobber
+            echo "📎 Attached manifest: $MANIFEST"
+          fi
+
+          if [ -f "$CONFIG_SCHEMA" ]; then
+            gh release upload "$TAG" "$CONFIG_SCHEMA" --clobber
+            echo "📎 Attached config schema: $CONFIG_SCHEMA"
+          fi
+
+          if [ -n "$FRAGMENT" ] && [ -f "$FRAGMENT" ]; then
+            gh release upload "$TAG" "$FRAGMENT" --clobber
+            echo "📎 Attached manifest fragment: $FRAGMENT"
+          else
+            echo "ℹ️ No manifest fragment to attach"
           fi
 
           echo "✅ Release created: $TITLE"
 
   # ──────────────────────────────────────────────────────────
-  # 5. Summary
+  # 5. Commit manifest version back to default branch
+  # ──────────────────────────────────────────────────────────
+  update-manifest:
+    name: Update manifest version
+    runs-on: ubuntu-latest
+    needs: [resolve, release]
+    if: |
+      always() &&
+      needs.resolve.outputs.dry_run != 'true'
+    # Non-blocking: a failure here must not prevent the release from succeeding
+    continue-on-error: true
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Patch and commit container_version
+        run: |
+          CONNECTOR_DIR="${{ needs.resolve.outputs.connector_dir }}"
+          CONNECTOR_NAME="${{ needs.resolve.outputs.connector_name }}"
+          VERSION="${{ needs.resolve.outputs.version }}"
+          MANIFEST="${CONNECTOR_DIR}/__metadata__/connector_manifest.json"
+
+          if [ ! -f "$MANIFEST" ]; then
+            echo "⚠️ Manifest not found: $MANIFEST — skipping"
+            exit 0
+          fi
+
+          # Patch container_version
+          jq --arg v "$VERSION" '.container_version = $v' "$MANIFEST" > "$RUNNER_TEMP/manifest.json" \
+            && mv "$RUNNER_TEMP/manifest.json" "$MANIFEST"
+
+          # Validate the patched JSON
+          jq empty "$MANIFEST"
+
+          # Commit
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$MANIFEST"
+
+          if git diff --cached --quiet; then
+            echo "ℹ️ container_version already set to $VERSION — nothing to commit"
+            exit 0
+          fi
+
+          git commit -m "chore(manifest): update ${CONNECTOR_NAME} container_version to ${VERSION} [skip ci]"
+
+          # Push with retry on non-fast-forward (concurrent releases for other connectors)
+          MAX_RETRIES=3
+          for attempt in $(seq 1 "$MAX_RETRIES"); do
+            if git push; then
+              echo "✅ Manifest update pushed (attempt $attempt)"
+              exit 0
+            fi
+            echo "⚠️ Push rejected (attempt $attempt/$MAX_RETRIES) — rebasing"
+            git pull --rebase origin "${{ github.event.repository.default_branch }}"
+          done
+
+          echo "::warning::Failed to push manifest update after $MAX_RETRIES attempts"
+          exit 1
+
+  # ──────────────────────────────────────────────────────────
+  # 6. Summary
   # ──────────────────────────────────────────────────────────
   summary:
     name: Release summary
     runs-on: ubuntu-latest
-    needs: [resolve, release-notes, build, release]
+    needs: [resolve, release-notes, build, release, update-manifest]
     if: always()
     steps:
       - name: Print summary
@@ -466,4 +598,5 @@ jobs:
             echo "| Release Notes | ${{ needs.release-notes.result }} |"
             echo "| Build | ${{ needs.build.result }} |"
             echo "| Release | ${{ needs.release.result }} |"
+            echo "| Update Manifest | ${{ needs.update-manifest.result }} |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -163,8 +163,8 @@ jobs:
             VERSION="${{ github.ref_name }}"
             VERSION="${VERSION##*/}"
 
-            if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
-              echo "::error::Invalid version '${VERSION}' from tag '${{ github.ref_name }}'. Expected numeric version (e.g. 7.260630.0)"
+            if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]{6}\.[0-9]+$'; then
+              echo "::error::Invalid CalVer version '${VERSION}' from tag '${{ github.ref_name }}'. Expected format: MAJOR.YYMMDD.PATCH (e.g. 7.260630.0)"
               exit 1
             fi
 

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -42,6 +42,13 @@ on:
         required: false
         type: boolean
         default: false
+      sdk_ref:
+        description: >
+          Optional git ref to pin connectors-sdk to in the built image.
+          If omitted, defaults to the release commit SHA (github.sha).
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: release-connector-${{ github.ref_name }}
@@ -354,6 +361,10 @@ jobs:
       image_tags: ${{ needs.resolve.outputs.image_tag }}
       build_mode: release
       push: ${{ needs.resolve.outputs.dry_run != 'true' }}
+      # Resolve the SDK pin ref: user-provided input, else the release commit SHA.
+      # This is always non-empty so the shared build action performs the pin only
+      # for release-connector (build-all-connectors leaves it empty → no pin).
+      sdk_ref: ${{ inputs.sdk_ref != '' && inputs.sdk_ref || github.sha }}
     secrets: inherit
 
   # ──────────────────────────────────────────────────────────
@@ -444,6 +455,15 @@ jobs:
           echo "fragment_path=$FRAGMENT_PATH" >> "$GITHUB_OUTPUT"
           echo "✅ Generated manifest fragment: $FRAGMENT_PATH"
 
+      - name: Download pinned dependency files
+        # Produced by the build job when connectors-sdk was pinned. Non-blocking:
+        # a missing artifact must not prevent the release from being created.
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: pinned-deps-${{ needs.resolve.outputs.connector_name }}
+          path: ${{ runner.temp }}/pinned-deps
+
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -482,6 +502,22 @@ jobs:
             echo "📎 Attached manifest fragment: $FRAGMENT"
           else
             echo "ℹ️ No manifest fragment to attach"
+          fi
+
+          # Attach the pinned dependency files (connectors-sdk pinned to the release ref)
+          # to help reproduce the image manually. Paths are flattened into the asset name
+          # (e.g. src/requirements.txt → mitre-src-requirements.txt) to avoid collisions.
+          PINNED_DIR="${{ runner.temp }}/pinned-deps"
+          if [ -d "$PINNED_DIR" ]; then
+            while IFS= read -r file; do
+              rel="${file#"$PINNED_DIR"/}"
+              asset="${CONNECTOR_NAME}-$(echo "$rel" | tr '/' '-')"
+              cp "$file" "${RUNNER_TEMP}/${asset}"
+              gh release upload "$TAG" "${RUNNER_TEMP}/${asset}" --clobber
+              echo "📎 Attached pinned dependency file: $asset"
+            done < <(find "$PINNED_DIR" -type f \( -name requirements.txt -o -name pyproject.toml \))
+          else
+            echo "ℹ️ No pinned dependency files to attach"
           fi
 
           echo "✅ Release created: $TITLE"

--- a/shared/tools/composer/generate_manifest_fragment/connector_manifest_schema.json
+++ b/shared/tools/composer/generate_manifest_fragment/connector_manifest_schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://filigran.io/schemas/connector-manifest.json",
+  "title": "OpenCTI Connector Manifest",
+  "description": "Schema for OpenCTI connector manifest files describing connector metadata, versioning, and configuration.",
+  "type": "object",
+  "required": [
+    "id",
+    "title",
+    "slug",
+    "description",
+    "short_description",
+    "logo",
+    "use_cases",
+    "subscription_link",
+    "source_code",
+    "manager_supported",
+    "min_version",
+    "version",
+    "image_name",
+    "image_type",
+    "platform",
+    "integration_type",
+    "additional_properties",
+    "config_schema"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the connector, derived from the slug.",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "examples": ["misp", "export-file-csv", "crowdstrike"]
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable display name of the connector.",
+      "minLength": 1,
+      "examples": ["MISP", "Export File Csv", "CrowdStrike"]
+    },
+    "slug": {
+      "type": "string",
+      "description": "URL-friendly unique identifier. Must match the 'id' field.",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "minLength": 1,
+      "examples": ["misp", "export-file-csv", "crowdstrike"]
+    },
+    "description": {
+      "type": "string",
+      "description": "Detailed description of the connector's functionality and capabilities.",
+      "minLength": 1
+    },
+    "short_description": {
+      "type": "string",
+      "description": "Brief one-line summary of the connector's purpose.",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "logo": {
+      "type": "string",
+      "description": "BASE64-encoded image data for the connector's logo.",
+      "minLength": 1
+    },
+    "use_cases": {
+      "type": "array",
+      "description": "List of use case categories this connector supports.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 0,
+      "uniqueItems": true,
+      "examples": [
+        ["Open Source Threat Intel"],
+        ["Commercial Threat Intel", "Threat Intelligence Enrichment"],
+        ["SIEM & Analytics", "Incident Response & Ticketing"]
+      ]
+    },
+    "verified": {
+      "type": ["boolean", "null"],
+      "description": "Whether the connector has passed the Filigran verification process."
+    },
+    "last_verified_date": {
+      "type": ["string", "null"],
+      "description": "Date when the connector was last verified, in ISO 8601 date format.",
+      "format": "date",
+      "examples": ["2025-01-01"]
+    },
+    "subscription_link": {
+      "type": "string",
+      "description": "URL to the external service or subscription page for the data source. Empty string if none.",
+      "examples": ["https://www.misp-project.org", ""]
+    },
+    "source_code": {
+      "type": "string",
+      "description": "URL to the connector's source code repository.",
+      "format": "uri",
+      "examples": ["https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/misp"]
+    },
+    "manager_supported": {
+      "type": "boolean",
+      "description": "Whether the connector supports the OpenCTI manager-based deployment mode."
+    },
+    "min_version": {
+      "type": "string",
+      "description": "Minimum OpenCTI platform version required to run this connector.",
+      "pattern": "^[0-9]+\\.[0-9]+\\.?[0-9]*$",
+      "examples": ["7.260507.0", "6.0.0"]
+    },
+    "version": {
+      "type": "string",
+      "description": "Current version of the connector.",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "examples": ["6.5.1", "1.0.0"]
+    },
+    "image_name": {
+      "type": "string",
+      "description": "Docker image name for the connector (without tag).",
+      "pattern": "^[a-z0-9]+(?:[._/-][a-z0-9]+)*$",
+      "examples": ["opencti/connector-misp", "opencti/connector-export-file-csv"]
+    },
+    "image_type": {
+      "type": "string",
+      "description": "Type of the connector, corresponding to the OpenCTI connector category.",
+      "enum": [
+        "EXTERNAL_IMPORT",
+        "INTERNAL_ENRICHMENT",
+        "INTERNAL_EXPORT_FILE",
+        "INTERNAL_IMPORT_FILE",
+        "STREAM"
+      ]
+    },
+    "platform": {
+      "type": "string",
+      "description": "Target platform this connector integrates with.",
+      "examples": ["OpenCTI"]
+    },
+    "integration_type": {
+      "type": "string",
+      "description": "Type of integration provided by this component.",
+      "examples": ["connector"]
+    },
+    "additional_properties": {
+      "type": "object",
+      "description": "Platform-specific properties. This object will be stringified when stored.",
+      "properties": {
+        "playbook_supported": {
+          "type": "boolean",
+          "description": "Whether the connector can be used within OpenCTI playbooks."
+        },
+        "max_confidence_level": {
+          "type": "integer",
+          "description": "Maximum confidence level (0-100) for data produced by this connector.",
+          "minimum": 0,
+          "maximum": 100
+        }
+      },
+      "additionalProperties": true
+    },
+    "config_schema": {
+      "type": "object",
+      "description": "JSON Schema defining the connector's configuration parameters. This object will be stringified when stored."
+    }
+  },
+  "if": {
+    "properties": {
+      "verified": { "const": true }
+    }
+  },
+  "then": {
+    "required": ["last_verified_date"]
+  }
+}

--- a/shared/tools/composer/generate_manifest_fragment/connector_manifest_schema.json
+++ b/shared/tools/composer/generate_manifest_fragment/connector_manifest_schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://filigran.io/schemas/connector-manifest.json",
-  "title": "OpenCTI Connector Manifest",
-  "description": "Schema for OpenCTI connector manifest files describing connector metadata, versioning, and configuration.",
+  "title": "OpenCTI Connector Manifest Fragment",
+  "description": "Schema for OpenCTI connector manifest fragment files describing connector metadata, versioning, and configuration.",
   "type": "object",
   "required": [
     "id",
@@ -58,7 +58,7 @@
     },
     "logo": {
       "type": "string",
-      "description": "BASE64-encoded image data for the connector's logo.",
+      "description": "Base64-encoded data URL for the connector's logo (e.g. data:image/png;base64,...).",
       "minLength": 1
     },
     "use_cases": {
@@ -104,13 +104,13 @@
     "min_version": {
       "type": "string",
       "description": "Minimum OpenCTI platform version required to run this connector.",
-      "pattern": "^[0-9]+\\.[0-9]+\\.?[0-9]*$",
+      "pattern": "^[0-9]+\\.[0-9]{1,6}\\.?[0-9]*$",
       "examples": ["7.260507.0", "6.0.0"]
     },
     "version": {
       "type": "string",
       "description": "Current version of the connector.",
-      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "pattern": "^[0-9]+\\.[0-9]{1,6}\\.[0-9]+$",
       "examples": ["6.5.1", "1.0.0"]
     },
     "image_name": {

--- a/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
+++ b/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
@@ -1,0 +1,228 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "jsonschema==4.26.0",
+# ]
+# ///
+"""
+Generate a connector *manifest fragment* for XTM Hub delivery.
+
+The fragment follows `connector_manifest_schema.json` (bundled alongside this
+script) and is derived from a connector's existing
+`__metadata__/connector_manifest.json` and
+`__metadata__/connector_config_schema.json`, without modifying either file.
+
+The existing `connector_manifest.json` is kept as-is for backward compatibility
+during the release decoupling rollout; this fragment is the new, forward-looking
+format published as a release artifact (until the XTM Hub endpoint exists).
+
+Usage:
+    python generate_manifest_fragment.py \
+        --connector-dir external-import/mitre \
+        --version 7.260630.0 \
+        --output /tmp/mitre_manifest_fragment.json
+
+Field mapping (existing manifest -> fragment):
+    slug              -> id, slug
+    logo (file path)  -> logo (base64 data URL)
+    support_version   -> min_version (">=" and whitespace stripped)
+    <release version> -> version
+    container_image   -> image_name
+    container_type    -> image_type
+    playbook_supported, max_confidence_level -> additional_properties
+    connector_config_schema.json -> config_schema (embedded)
+Constant fields:
+    platform = "OpenCTI", integration_type = "connector"
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import traceback
+from pathlib import Path
+
+import jsonschema
+
+CONNECTOR_METADATA_DIRECTORY = "__metadata__"
+CONNECTOR_MANIFEST_FILENAME = "connector_manifest.json"
+CONNECTOR_CONFIG_SCHEMA_FILENAME = "connector_config_schema.json"
+
+PLATFORM = "OpenCTI"
+INTEGRATION_TYPE = "connector"
+
+# Maximum length allowed by the schema for `short_description`.
+SHORT_DESCRIPTION_MAX_LENGTH = 200
+
+# Default logo used when a connector does not ship its own.
+DEFAULT_LOGO_PATH = (
+    Path(__file__).parent.parent
+    / "generate_global_manifest"
+    / "connector_default_logo.png"
+)
+
+MIME_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".svg": "image/svg+xml",
+}
+
+
+def find_logo_file(metadata_dir: Path) -> Path:
+    """Return the connector's logo path, or the default logo if none is found."""
+    if metadata_dir.is_dir():
+        for file in os.listdir(metadata_dir):
+            if file.startswith("logo."):
+                return metadata_dir / file
+    print(f"⚠️  No logo found in {metadata_dir}, using the default logo.")
+    return DEFAULT_LOGO_PATH
+
+
+def encode_logo_to_base64(logo_path: Path) -> str:
+    """Read a logo file and encode it as a base64 data URL."""
+    with open(logo_path, "rb") as logo_file:
+        logo_data = logo_file.read()
+    mime_type = MIME_TYPES.get(logo_path.suffix.lower(), "image/png")
+    encoded_logo = base64.b64encode(logo_data).decode("utf-8")
+    return f"data:{mime_type};base64,{encoded_logo}"
+
+
+def parse_min_version(support_version: str | None) -> str:
+    """Convert a `support_version` constraint (e.g. ">= 6.8.0") to a bare version."""
+    if not support_version:
+        return ""
+    match = re.search(r"[0-9]+\.[0-9]+(?:\.[0-9]+)?", support_version)
+    return match.group() if match else ""
+
+
+def normalize_slug(slug: str) -> str:
+    """Normalize a slug to the URL-friendly form required by the schema.
+
+    Directory names may contain underscores (e.g. "intel471_v2"); the fragment
+    id/slug must match `^[a-z0-9]+(?:-[a-z0-9]+)*$`, so underscores become hyphens.
+    """
+    return slug.lower().replace("_", "-")
+
+
+def truncate_short_description(text: str) -> str:
+    """Truncate `short_description` to the schema's maximum length, adding an ellipsis."""
+    if len(text) <= SHORT_DESCRIPTION_MAX_LENGTH:
+        return text
+    return text[: SHORT_DESCRIPTION_MAX_LENGTH - 3].rstrip() + "..."
+
+
+def load_json(path: Path) -> dict:
+    with open(path, "r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def build_fragment(connector_dir: Path, version: str) -> dict:
+    """Build the manifest fragment for a single connector."""
+    metadata_dir = connector_dir / CONNECTOR_METADATA_DIRECTORY
+    manifest_path = metadata_dir / CONNECTOR_MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+
+    manifest = load_json(manifest_path)
+
+    slug = normalize_slug(manifest["slug"])
+    logo = encode_logo_to_base64(find_logo_file(metadata_dir))
+
+    config_schema_path = metadata_dir / CONNECTOR_CONFIG_SCHEMA_FILENAME
+    config_schema = (
+        load_json(config_schema_path) if config_schema_path.is_file() else {}
+    )
+
+    fragment = {
+        "id": slug,
+        "title": manifest["title"],
+        "slug": slug,
+        "description": manifest["description"],
+        "short_description": truncate_short_description(manifest["short_description"]),
+        "logo": logo,
+        "use_cases": manifest["use_cases"],
+        "verified": manifest.get("verified"),
+        "last_verified_date": manifest.get("last_verified_date"),
+        "subscription_link": manifest.get("subscription_link") or "",
+        "source_code": manifest["source_code"],
+        "manager_supported": manifest["manager_supported"],
+        "min_version": parse_min_version(manifest.get("support_version")),
+        "version": version,
+        "image_name": manifest["container_image"],
+        "image_type": manifest["container_type"],
+        "platform": PLATFORM,
+        "integration_type": INTEGRATION_TYPE,
+        "additional_properties": {
+            "playbook_supported": manifest.get("playbook_supported", False),
+            "max_confidence_level": manifest.get("max_confidence_level", 50),
+        },
+        "config_schema": config_schema,
+    }
+    return fragment
+
+
+def validate_fragment(fragment: dict, schema_path: Path) -> None:
+    """Validate the fragment against the manifest schema."""
+    schema = load_json(schema_path)
+    jsonschema.validate(instance=fragment, schema=schema)
+    print("✅ Fragment validated against schema.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate a connector manifest fragment for XTM Hub delivery."
+    )
+    parser.add_argument(
+        "--connector-dir",
+        required=True,
+        help="Path to the connector directory (e.g. external-import/mitre).",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Release version to embed in the fragment (e.g. 7.260630.0).",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path where the generated fragment JSON will be written.",
+    )
+    parser.add_argument(
+        "--schema",
+        default=None,
+        help="Path to connector_manifest_schema.json for optional validation. "
+        "Defaults to the schema bundled alongside this script.",
+    )
+    args = parser.parse_args()
+
+    connector_dir = Path(args.connector_dir)
+    fragment = build_fragment(connector_dir, args.version)
+
+    schema_path = (
+        Path(args.schema)
+        if args.schema
+        else Path(__file__).parent / "connector_manifest_schema.json"
+    )
+    if schema_path.is_file():
+        validate_fragment(fragment, schema_path)
+    else:
+        print(f"ℹ️  Schema not found at {schema_path} — skipping validation.")
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as file:
+        file.write(json.dumps(fragment, indent=2))
+
+    print(f"✅ Manifest fragment written to {output_path}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)

--- a/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
+++ b/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
@@ -168,7 +168,9 @@ def build_fragment(connector_dir: Path, version: str) -> dict:
 def validate_fragment(fragment: dict, schema_path: Path) -> None:
     """Validate the fragment against the manifest schema."""
     schema = load_json(schema_path)
-    jsonschema.validate(instance=fragment, schema=schema)
+    jsonschema.validate(
+        instance=fragment, schema=schema, format_checker=jsonschema.FormatChecker()
+    )
     print("✅ Fragment validated against schema.")
 
 

--- a/shared/tools/composer/generate_manifest_fragment/requirements.txt
+++ b/shared/tools/composer/generate_manifest_fragment/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema==4.26.0


### PR DESCRIPTION
### Proposed changes

* **Align connector manifest schema with the XTM Hub fragment format** — add a new standalone `connector_manifest_schema.json` (bundled beside the generator) describing the forward-looking manifest fragment. Schema decisions: dropped `batch_id`, `use_cases` now allows `minItems: 0`, `subscription_link` stays required (emitted as an empty string when absent), `short_description` is truncated to 200 chars, and `id`/`slug` are normalized to match `^[a-z0-9]+(?:-[a-z0-9]+)*$`. This gives XTM Hub delivery (Phase 3) a stable, versioned contract.
* **Add the manifest fragment generator** — new script `shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py` (plus its `requirements.txt` pinning `jsonschema`) that builds a schema-valid fragment for a single connector from its existing metadata, normalizing the slug and validating against the bundled schema. Validated across all 257 connectors: every one produces a schema-valid fragment.
* **Extend `release-connector.yml` with manifest handling** — on each per-connector release, in addition to building/pushing the image and cutting the GitHub Release, the workflow now (a) patches `container_version` in the existing `connector_manifest.json` and commits it back to the default branch (`[skip ci]`, non-blocking, retry on push race), and (b) generates the new forward-looking manifest fragment. The fragment, the existing manifest, and the config schema are attached as GitHub Release assets. Keeping the legacy manifest ensures backward compatibility while the fragment is additive.
* **Pin `connectors-sdk` to the release commit SHA during release builds** — `connectors-sdk` is currently referenced `@master`, so release images could not be rebuilt reproducibly. The build now rewrites the SDK ref to the release SHA and attaches the resulting `requirements.txt`/`pyproject.toml` as release assets so the image can be recreated manually. The pin is scoped strictly to `release-connector` (`build-all-connectors` is untouched) and is a stopgap until a uv-based lock exists.
* **Detect normalized-slug collisions in the connector identity uniqueness check** — because the fragment normalizes `_` → `-` in the id/slug, two distinct raw slugs (e.g. `intel471_v2` vs a hypothetical `intel471-v2`) could collapse to the same value. The CI check now flags this new class of conflict in addition to exact duplicates.

### Related issues

* Relates to #6888
* Part of the release-decoupling epic (Chunk 5), building on the production-tag trigger work in `ci/6874-production-tag-trigger`

### Checklist
- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

A few deliberate design choices worth highlighting for review:

* **Additive, non-breaking:** the new manifest fragment is generated *alongside* the existing `connector_manifest.json`, which is kept intact for backward compatibility. Nothing that consumes the current manifest is affected.
* **Pin scoped to release only:** the `connectors-sdk` SHA pin applies exclusively to `release-connector`; `build-all-connectors` continues to track `master`. This keeps day-to-day CI on the latest SDK while making release artifacts reproducible. It is intended as a stopgap until a uv-based lockfile lands.
* **Non-blocking manifest commit-back:** the `container_version` commit to the default branch uses `[skip ci]`, is non-blocking, and retries on push races, so it cannot fail or delay a release.
* This PR targets `ci/6874-production-tag-trigger` (not `master`) as one chunk of the larger release-decoupling work; it will merge to `master` together with the rest of the epic.
