### PR TITLE
ci(connector-linter): enforce blocking VC305 for new connectors and split vclint verified/manager-supported checks (#6882)

### DIFF
--- a/.github/scripts/_matrix_common.py
+++ b/.github/scripts/_matrix_common.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Shared helpers for the GitHub Actions matrix-generation scripts.
+
+Centralizes logic that was duplicated across build_linter_matrix.py,
+build_new_connector_matrix.py, build_test_matrix.py and
+build_alpine_matrix.py: git helpers, connector manifest eligibility rules,
+$GITHUB_OUTPUT writing, and matrix batching (to stay under the GitHub
+Actions 256-job-per-matrix limit).
+
+Not a CI entry point itself — each build_*_matrix.py script keeps its own
+`main()` and script-specific discovery/filtering rules, and imports from
+here (this file lives alongside them, so a plain `import _matrix_common`
+resolves without any packaging).
+"""
+
+import json
+import math
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, TypeVar
+
+GITHUB_ACTIONS_JOB_LIMIT = 256
+
+# Top-level connector-type directories, shared by every script that walks
+# the repo looking for connectors.
+CONNECTOR_TYPE_DIRS = [
+    "external-import",
+    "internal-enrichment",
+    "internal-export-file",
+    "internal-import-file",
+    "stream",
+]
+
+T = TypeVar("T")
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git"] + list(args), capture_output=True, text=True
+    ).stdout.strip()
+
+
+def get_base_commit() -> str | None:
+    """Merge-base commit between origin/$RELEASE_REF and HEAD (default: master)."""
+    release_ref = os.environ.get("RELEASE_REF", "master")
+    commit = git("merge-base", f"origin/{release_ref}", "HEAD")
+    return commit or None
+
+
+def has_changes(base_commit: str, *pathspecs: str) -> bool:
+    """True if any file under *pathspecs* changed between base_commit and HEAD."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", base_commit, "HEAD", "--"] + list(pathspecs),
+        capture_output=True,
+        text=True,
+    )
+    return bool(result.stdout.strip())
+
+
+def existed_at_commit(commit: str, path: Path) -> bool:
+    """True if *path* already existed (as a blob/tree) at *commit*."""
+    result = subprocess.run(
+        ["git", "cat-file", "-e", f"{commit}:{path.as_posix()}"],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Connector manifest helpers
+# ---------------------------------------------------------------------------
+
+
+def load_manifest(connector_root: Path) -> dict[str, Any]:
+    """Load __metadata__/connector_manifest.json, or {} if missing/invalid."""
+    manifest_path = connector_root / "__metadata__" / "connector_manifest.json"
+    if not manifest_path.exists():
+        return {}
+    try:
+        return json.loads(manifest_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def is_verified(manifest: dict[str, Any]) -> bool:
+    """True if verified=true AND last_verified_date is set."""
+    verified = manifest.get("verified", False) is True
+    has_date = manifest.get("last_verified_date") not in (None, "", False)
+    return verified and has_date
+
+
+def is_manager_supported(manifest: dict[str, Any]) -> bool:
+    return manifest.get("manager_supported", False) is True
+
+
+def is_eligible(manifest: dict[str, Any]) -> bool:
+    """True if verified-with-date or manager-supported."""
+    return is_verified(manifest) or is_manager_supported(manifest)
+
+
+# ---------------------------------------------------------------------------
+# Connector discovery
+# ---------------------------------------------------------------------------
+
+_CONNECTOR_ROOT_MARKERS = ("src", "__metadata__", "Dockerfile", "docker-compose.yml")
+
+
+def is_connector_root(path: Path) -> bool:
+    """True if *path* looks like a connector root directory."""
+    return any((path / marker).exists() for marker in _CONNECTOR_ROOT_MARKERS)
+
+
+def discover_connector_roots(
+    connector_dirs: list[str] = CONNECTOR_TYPE_DIRS,
+) -> list[Path]:
+    """All connector root dirs currently on the filesystem, under *connector_dirs*."""
+    roots: list[Path] = []
+    for ctype in connector_dirs:
+        ctype_dir = Path(ctype)
+        if not ctype_dir.is_dir():
+            continue
+        for entry in sorted(ctype_dir.iterdir()):
+            if (
+                entry.is_dir()
+                and not entry.name.startswith(".")
+                and is_connector_root(entry)
+            ):
+                roots.append(entry)
+    return roots
+
+
+# ---------------------------------------------------------------------------
+# Matrix batching
+# ---------------------------------------------------------------------------
+
+
+def build_batched_matrix(
+    items: list[T],
+    make_entry: Callable[[list[T]], dict],
+    type_of: Callable[[T], str],
+    limit: int = GITHUB_ACTIONS_JOB_LIMIT,
+) -> list[dict]:
+    """Build GitHub Actions matrix entries, batching by type if over *limit*.
+
+    Below the limit, each item gets its own matrix entry (maximum
+    granularity/parallelism). At or above the limit, items are grouped by
+    ``type_of(item)`` and packed into batches to stay under the GitHub
+    Actions per-matrix job cap.
+    """
+    if len(items) <= limit:
+        return [make_entry([item]) for item in items]
+
+    groups: dict[str, list[T]] = {}
+    for item in items:
+        groups.setdefault(type_of(item), []).append(item)
+
+    batch_size = math.ceil(len(items) / limit)
+    entries = []
+    for _, group_items in sorted(groups.items()):
+        for i in range(0, len(group_items), batch_size):
+            entries.append(make_entry(group_items[i : i + batch_size]))
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions output
+# ---------------------------------------------------------------------------
+
+
+def write_output(key: str, value: str) -> None:
+    """Write a key=value pair to $GITHUB_OUTPUT (or stdout if not set)."""
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    line = f"{key}={value}\n"
+    if output_file:
+        with Path(output_file).open("a") as f:
+            f.write(line)
+    else:
+        print(line, end="")

--- a/.github/scripts/build_alpine_matrix.py
+++ b/.github/scripts/build_alpine_matrix.py
@@ -27,13 +27,9 @@ import os
 import subprocess
 from pathlib import Path
 
-CONNECTOR_TYPE_DIRS = [
-    "external-import",
-    "internal-enrichment",
-    "internal-export-file",
-    "internal-import-file",
-    "stream",
-]
+import _matrix_common as common
+
+CONNECTOR_TYPE_DIRS = common.CONNECTOR_TYPE_DIRS
 
 # Paths that, if changed, trigger a full rebuild of all connectors
 SHARED_PATHS = [
@@ -151,15 +147,7 @@ def filter_changed(
     return filtered
 
 
-def write_output(key: str, value: str) -> None:
-    """Write a key=value pair to $GITHUB_OUTPUT (or stdout if not set)."""
-    output_file = os.environ.get("GITHUB_OUTPUT")
-    line = f"{key}={value}\n"
-    if output_file:
-        with Path(output_file).open("a") as f:
-            f.write(line)
-    else:
-        print(line, end="")
+write_output = common.write_output
 
 
 def type_to_output_key(type_dir: str) -> str:

--- a/.github/scripts/build_linter_matrix.py
+++ b/.github/scripts/build_linter_matrix.py
@@ -8,81 +8,26 @@ either **verified** (verified=true AND last_verified_date is set) or
 
 On non-master branches the list is further narrowed to connectors whose
 files actually changed, using the same git-diff logic as build_test_matrix.py.
+
+Shared git/manifest/output/batching helpers live in _matrix_common.py.
 """
 
 import json
-import math
-import os
-import subprocess
-from pathlib import Path
 
-GITHUB_ACTIONS_JOB_LIMIT = 256
-
-CONNECTOR_DIRS = [
-    "external-import",
-    "internal-enrichment",
-    "internal-export-file",
-    "internal-import-file",
-    "stream",
-]
-
-
-# ---------------------------------------------------------------------------
-# Git helpers (same as build_test_matrix.py)
-# ---------------------------------------------------------------------------
-
-
-def git(*args: str) -> str:
-    return subprocess.run(
-        ["git"] + list(args), capture_output=True, text=True
-    ).stdout.strip()
-
-
-def get_base_commit() -> str | None:
-    release_ref = os.environ.get("RELEASE_REF", "master")
-    commit = git("merge-base", f"origin/{release_ref}", "HEAD")
-    return commit or None
-
-
-def has_changes(base_commit: str, *pathspecs: str) -> bool:
-    result = subprocess.run(
-        ["git", "diff", "--name-only", base_commit, "HEAD", "--"] + list(pathspecs),
-        capture_output=True,
-        text=True,
-    )
-    return bool(result.stdout.strip())
-
+import _matrix_common as common
 
 # ---------------------------------------------------------------------------
 # Manifest scanning
 # ---------------------------------------------------------------------------
 
 
-def is_eligible(manifest: dict) -> bool:
-    """Return True if connector is verified-with-date or manager-supported."""
-    verified = manifest.get("verified", False) is True
-    has_date = manifest.get("last_verified_date") not in (None, "", False)
-    manager = manifest.get("manager_supported", False) is True
-    return (verified and has_date) or manager
-
-
-def discover_eligible_connectors() -> list[Path]:
+def discover_eligible_connectors() -> list:
     """Return connector root dirs whose manifest passes eligibility."""
-    eligible: list[Path] = []
-    for ctype in CONNECTOR_DIRS:
-        ctype_dir = Path(ctype)
-        if not ctype_dir.is_dir():
-            continue
-        for manifest_path in sorted(
-            ctype_dir.rglob("__metadata__/connector_manifest.json")
-        ):
-            try:
-                manifest = json.loads(manifest_path.read_text())
-            except (json.JSONDecodeError, OSError):
-                continue
-            if is_eligible(manifest):
-                # connector root is two levels up from __metadata__/connector_manifest.json
-                eligible.append(manifest_path.parent.parent)
+    eligible = []
+    for connector_root in common.discover_connector_roots():
+        manifest = common.load_manifest(connector_root)
+        if common.is_eligible(manifest):
+            eligible.append(connector_root)
     return eligible
 
 
@@ -91,16 +36,10 @@ def discover_eligible_connectors() -> list[Path]:
 # ---------------------------------------------------------------------------
 
 
-def should_run(
-    connector_root: Path,
-    base_commit: str | None,
-) -> bool:
+def should_run(connector_root, base_commit: str | None) -> bool:
     if base_commit is None:
         return True
-
-    if has_changes(base_commit, str(connector_root)):
-        return True
-    return False
+    return common.has_changes(base_commit, str(connector_root))
 
 
 # ---------------------------------------------------------------------------
@@ -108,12 +47,18 @@ def should_run(
 # ---------------------------------------------------------------------------
 
 
-def make_entry(connector_roots: list[Path]) -> dict:
+def make_entry(connector_roots: list) -> dict:
     names = [
         f"{p.parent.name}/{p.name}" if len(p.parts) >= 2 else str(p)
         for p in connector_roots
     ]
     paths = [str(p) for p in connector_roots]
+    # If any connector in the batch is verified-with-date, treat the whole
+    # batch as verified: its linter errors must block the PR. Batches only
+    # ever contain more than one connector when the eligible count exceeds
+    # GITHUB_ACTIONS_JOB_LIMIT, which in practice does not mix verified and
+    # manager-supported-only connectors together.
+    verified = any(common.is_verified(common.load_manifest(r)) for r in connector_roots)
     return {
         "name": (
             ", ".join(names)
@@ -121,44 +66,12 @@ def make_entry(connector_roots: list[Path]) -> dict:
             else f"{names[0]} (+{len(names) - 1} more)"
         ),
         "connector_paths": "\n".join(paths),
+        "verified": verified,
     }
 
 
-def build_matrix(roots: list[Path]) -> list[dict]:
-    if len(roots) <= GITHUB_ACTIONS_JOB_LIMIT:
-        return [make_entry([r]) for r in roots]
-
-    # Batch by connector type to stay under the limit
-    groups: dict[str, list[Path]] = {}
-    for r in roots:
-        ctype = r.parts[0] if r.parts else "unknown"
-        groups.setdefault(ctype, []).append(r)
-
-    batch_size = math.ceil(len(roots) / GITHUB_ACTIONS_JOB_LIMIT)
-    entries = []
-    for _, cpaths in sorted(groups.items()):
-        for i in range(0, len(cpaths), batch_size):
-            entries.append(make_entry(cpaths[i : i + batch_size]))
-    return entries
-
-
-# ---------------------------------------------------------------------------
-# Output
-# ---------------------------------------------------------------------------
-
-
-def write_output(key: str, value: str) -> None:
-    output_file = os.environ.get("GITHUB_OUTPUT")
-    line = f"{key}={value}\n"
-    if output_file:
-        with Path(output_file).open("a") as f:
-            f.write(line)
-    else:
-        print(line, end="")
-
-
 def main() -> None:
-    base_commit = get_base_commit()
+    base_commit = common.get_base_commit()
 
     eligible = discover_eligible_connectors()
     print(f"Total eligible connectors (verified/manager-supported): {len(eligible)}")
@@ -168,14 +81,20 @@ def main() -> None:
 
     if not filtered:
         print("No connectors to lint, skipping.")
-        write_output("has_connectors", "false")
-        write_output("matrix", json.dumps({"include": []}, separators=(",", ":")))
+        common.write_output("has_connectors", "false")
+        common.write_output(
+            "matrix", json.dumps({"include": []}, separators=(",", ":"))
+        )
         return
 
-    entries = build_matrix(filtered)
+    entries = common.build_batched_matrix(
+        filtered, make_entry, type_of=lambda p: p.parts[0] if p.parts else "unknown"
+    )
     print(f"Matrix jobs: {len(entries)}")
-    write_output("has_connectors", "true")
-    write_output("matrix", json.dumps({"include": entries}, separators=(",", ":")))
+    common.write_output("has_connectors", "true")
+    common.write_output(
+        "matrix", json.dumps({"include": entries}, separators=(",", ":"))
+    )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/build_linter_matrix.py
+++ b/.github/scripts/build_linter_matrix.py
@@ -88,7 +88,12 @@ def main() -> None:
         return
 
     entries = common.build_batched_matrix(
-        filtered, make_entry, type_of=lambda p: p.parts[0] if p.parts else "unknown"
+        filtered,
+        make_entry,
+        type_of=lambda p: (
+            f"{p.parts[0] if p.parts else 'unknown'}:"
+            f"{'verified' if common.is_verified(common.load_manifest(p)) else 'manager'}"
+        ),
     )
     print(f"Matrix jobs: {len(entries)}")
     common.write_output("has_connectors", "true")

--- a/.github/scripts/build_new_connector_matrix.py
+++ b/.github/scripts/build_new_connector_matrix.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Generate the GitHub Actions matrix for the "new connector settings" check.
+
+Detects connector directories that are newly added on this branch relative to
+the PR base branch (RELEASE_REF) — i.e., directories that do not exist at all
+at the merge-base commit. These are connectors introduced for the first time
+in this PR, as opposed to existing connectors receiving further changes.
+
+Newly-added connectors must implement configuration via connectors-sdk's
+BaseConnectorSettings (or, at minimum, pydantic_settings.BaseSettings) instead
+of the legacy get_config_variable() pattern. This is enforced by running
+`connector-linter check --select VC305` against them as a blocking check,
+independent of build_linter_matrix.py's eligibility rules (which only cover
+already verified/manager-supported connectors and never block a PR).
+
+Shared git/output/batching helpers live in _matrix_common.py.
+"""
+
+import json
+
+import _matrix_common as common
+
+# ---------------------------------------------------------------------------
+# Connector discovery
+# ---------------------------------------------------------------------------
+
+
+def discover_new_connectors(base_commit: str | None) -> list:
+    """Return connector roots that did not exist at *base_commit* at all.
+
+    If the base commit can't be resolved, we conservatively report no new
+    connectors rather than flagging every pre-existing connector as "new".
+    """
+    if base_commit is None:
+        return []
+    return [
+        root
+        for root in common.discover_connector_roots()
+        if not common.existed_at_commit(base_commit, root)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Matrix building
+# ---------------------------------------------------------------------------
+
+
+def make_entry(connector_roots: list) -> dict:
+    names = [f"{p.parent.name}/{p.name}" for p in connector_roots]
+    paths = [str(p) for p in connector_roots]
+    return {
+        "name": (
+            ", ".join(names)
+            if len(names) <= 3
+            else f"{names[0]} (+{len(names) - 1} more)"
+        ),
+        "connector_paths": "\n".join(paths),
+    }
+
+
+def main() -> None:
+    base_commit = common.get_base_commit()
+    new_connectors = discover_new_connectors(base_commit)
+
+    print(f"Base commit: {base_commit or 'unknown'}")
+    print(f"Newly added connector directories: {len(new_connectors)}")
+    for root in new_connectors:
+        print(f"  - {root}")
+
+    if not new_connectors:
+        print("No newly added connectors, skipping.")
+        common.write_output("has_connectors", "false")
+        common.write_output(
+            "matrix", json.dumps({"include": []}, separators=(",", ":"))
+        )
+        return
+
+    entries = common.build_batched_matrix(
+        new_connectors, make_entry, type_of=lambda p: p.parts[0]
+    )
+    print(f"Matrix jobs: {len(entries)}")
+    common.write_output("has_connectors", "true")
+    common.write_output(
+        "matrix", json.dumps({"include": entries}, separators=(",", ":"))
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/build_test_matrix.py
+++ b/.github/scripts/build_test_matrix.py
@@ -15,51 +15,23 @@ Filtering rules (mirrors run_test.sh):
 Batching rules:
   - Below 256 jobs → one job per connector (maximum granularity)
   - At or above 256 jobs → batch by connector type to stay under the limit
+
+Shared git/output/batching helpers live in _matrix_common.py.
 """
 
 import json
-import math
 import os
 import subprocess
 from pathlib import Path
-from typing import Any
 
-GITHUB_ACTIONS_JOB_LIMIT = 256
+import _matrix_common as common
 
-CONNECTOR_DIRS = [
-    "connectors-sdk",
-    "external-import",
-    "internal-enrichment",
-    "internal-export-file",
-    "internal-import-file",
-    "stream",
-]
+CONNECTOR_DIRS = ["connectors-sdk"] + common.CONNECTOR_TYPE_DIRS
 
 
 # ---------------------------------------------------------------------------
 # Git helpers
 # ---------------------------------------------------------------------------
-
-
-def git(*args: str) -> str:
-    return subprocess.run(
-        ["git"] + list(args), capture_output=True, text=True
-    ).stdout.strip()
-
-
-def get_base_commit() -> str | None:
-    release_ref = os.environ.get("RELEASE_REF", "master")
-    commit = git("merge-base", f"origin/{release_ref}", "HEAD")
-    return commit or None
-
-
-def has_changes(base_commit: str, *pathspecs: str) -> bool:
-    result = subprocess.run(
-        ["git", "diff", "--name-only", base_commit, "HEAD", "--"] + list(pathspecs),
-        capture_output=True,
-        text=True,
-    )
-    return bool(result.stdout.strip())
 
 
 def has_sdk_dependency(connector_dir: Path) -> bool:
@@ -118,7 +90,7 @@ def should_run(
         return True  # no git history, run everything
 
     cdir = connector_dir(req_path)
-    if has_changes(base_commit, str(cdir)):
+    if common.has_changes(base_commit, str(cdir)):
         return True
     if sdk_changed and has_sdk_dependency(cdir):
         return True
@@ -134,18 +106,15 @@ def is_verified(req_path: str) -> bool:
     """Check if the connector has "verified": true in its manifest.
 
     connectors-sdk is always considered verified (it has no manifest).
+
+    Note: unlike _matrix_common.is_verified(), this intentionally does not
+    require last_verified_date — kept as-is to preserve this script's
+    original (currently unused downstream) "verified" output semantics.
     """
     if connector_type(req_path) == "connectors-sdk":
         return True
-    cdir = connector_dir(req_path)
-    manifest_path = cdir / "__metadata__" / "connector_manifest.json"
-    if not manifest_path.exists():
-        return False
-    try:
-        data: dict[str, Any] = json.loads(manifest_path.read_text())
-        return data.get("verified", False) is True
-    except (json.JSONDecodeError, OSError):
-        return False
+    manifest = common.load_manifest(connector_dir(req_path))
+    return manifest.get("verified", False) is True
 
 
 # ---------------------------------------------------------------------------
@@ -167,52 +136,24 @@ def make_entry(req_paths: list[str]) -> dict:
     }
 
 
-def build_matrix(paths: list[str]) -> list[dict]:
-    if len(paths) <= GITHUB_ACTIONS_JOB_LIMIT:
-        return [make_entry([p]) for p in paths]
-
-    # Batch by connector type to stay under the job limit
-    groups: dict[str, list[str]] = {}
-    for p in paths:
-        groups.setdefault(connector_type(p), []).append(p)
-
-    batch_size = math.ceil(len(paths) / GITHUB_ACTIONS_JOB_LIMIT)
-    entries = []
-    for _, cpaths in sorted(groups.items()):
-        for i in range(0, len(cpaths), batch_size):
-            entries.append(make_entry(cpaths[i : i + batch_size]))
-    return entries
-
-
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
 
-def write_output(key: str, value: str) -> None:
-    """Write a key=value pair to $GITHUB_OUTPUT (or stdout if not set)."""
-    output_file = os.environ.get("GITHUB_OUTPUT")
-    line = f"{key}={value}\n"
-    if output_file:
-        with Path(output_file).open("a") as f:
-            f.write(line)
-    else:
-        print(line, end="")
-
-
 def main() -> None:
     release_ref = os.environ.get("RELEASE_REF", "master")
     is_master = os.environ.get("GITHUB_REF_NAME") == release_ref
-    base_commit = get_base_commit()
+    base_commit = common.get_base_commit()
 
     changes_outside_scope = False
     sdk_changed = False
     if base_commit and not is_master:
-        changes_outside_scope = has_changes(
+        changes_outside_scope = common.has_changes(
             base_commit,
             *[f":!{d}/**" for d in CONNECTOR_DIRS],
         )
-        sdk_changed = has_changes(base_commit, "connectors-sdk")
+        sdk_changed = common.has_changes(base_commit, "connectors-sdk")
 
     all_paths = [
         str(Path(p))
@@ -236,14 +177,18 @@ def main() -> None:
 
     if not filtered:
         print("No connectors to test, skipping.")
-        write_output("has_tests", "false")
-        write_output("matrix", json.dumps({"include": []}, separators=(",", ":")))
+        common.write_output("has_tests", "false")
+        common.write_output(
+            "matrix", json.dumps({"include": []}, separators=(",", ":"))
+        )
         return
 
-    entries = build_matrix(filtered)
+    entries = common.build_batched_matrix(filtered, make_entry, type_of=connector_type)
     print(f"Matrix jobs: {len(entries)}")
-    write_output("has_tests", "true")
-    write_output("matrix", json.dumps({"include": entries}, separators=(",", ":")))
+    common.write_output("has_tests", "true")
+    common.write_output(
+        "matrix", json.dumps({"include": entries}, separators=(",", ":"))
+    )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/check_connector_identity_uniqueness.py
+++ b/.github/scripts/check_connector_identity_uniqueness.py
@@ -10,13 +10,9 @@ import json
 from pathlib import Path
 from typing import Any
 
-CONNECTOR_TYPE_DIRS = [
-    "external-import",
-    "internal-enrichment",
-    "internal-export-file",
-    "internal-import-file",
-    "stream",
-]
+import _matrix_common as common
+
+CONNECTOR_TYPE_DIRS = common.CONNECTOR_TYPE_DIRS
 
 FIELDS_TO_CHECK = ["slug", "container_image"]
 

--- a/.github/workflows/ci-connector-verified-linter.yml
+++ b/.github/workflows/ci-connector-verified-linter.yml
@@ -124,6 +124,7 @@ jobs:
       # always exits 0 for them.
       - name: Run connector-linter
         run: |
+          set -o pipefail
           exit_code=0
           : > annotations.txt
           while IFS= read -r connector_path; do
@@ -176,7 +177,6 @@ jobs:
         with:
           pattern: vclint-annotations-*
           path: annotations
-          merge-multiple: true
 
       - name: Build error list
         id: build-errors
@@ -197,7 +197,7 @@ jobs:
               url="https://github.com/${repo}/blob/${sha}/${file}#L${lineno}"
               errors="${errors}- **${code}**: ${msg} ([${file}:${lineno}](${url}))\n"
               count=$((count + 1))
-            done < <(grep -h '^::error ' annotations/*.txt 2>/dev/null || true)
+            done < <(grep -h '^::error ' annotations/*/annotations.txt 2>/dev/null || true)
           fi
 
           echo "count=$count" >> "$GITHUB_OUTPUT"
@@ -263,11 +263,12 @@ jobs:
             }
 
   # Newly-added connectors are not yet "verified" or "manager_supported", so
-  # they are skipped by the `vclint` job above (which is also
-  # continue-on-error and therefore non-blocking). This job enforces VC305
-  # (connectors-sdk BaseConnectorSettings) as a hard, blocking requirement for
-  # any connector introduced for the first time in this PR, so new code never
-  # lands using the legacy get_config_variable() pattern.
+  # they are skipped by the `vclint` job above (which only targets eligible
+  # connectors and is blocking only for the "verified-with-date" subset). This
+  # job enforces VC305 (connectors-sdk BaseConnectorSettings) as a hard,
+  # blocking requirement for any connector introduced for the first time in
+  # this PR, so new code never lands using the legacy get_config_variable()
+  # pattern.
   vclint-new-connector-settings:
     name: VC305 (new connector) ${{ matrix.name }}
     needs:

--- a/.github/workflows/ci-connector-verified-linter.yml
+++ b/.github/workflows/ci-connector-verified-linter.yml
@@ -56,13 +56,48 @@ jobs:
         name: Build linter matrix from connector manifests
         run: python .github/scripts/build_linter_matrix.py
 
+  detect-new-connectors:
+    name: Detect newly added connectors
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has_connectors: ${{ steps.set-matrix.outputs.has_connectors }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Resolve RELEASE_REF
+        run: |
+          PR_BASE_REF="${{ github.base_ref }}"
+
+          if [ -n "${PR_BASE_REF:-}" ]; then
+            case "${PR_BASE_REF}" in
+              master|release/6.9.x|lts/*)
+                RESOLVED_RELEASE_REF="${PR_BASE_REF}"
+                echo "Using PR base branch for RELEASE_REF: ${RESOLVED_RELEASE_REF}"
+                ;;
+              *)
+                RESOLVED_RELEASE_REF="$(bash ./shared/tools/ci/detect-base-branch.sh origin)"
+                echo "PR base '${PR_BASE_REF}' is outside allowed refs, using fallback RELEASE_REF: ${RESOLVED_RELEASE_REF}"
+                ;;
+            esac
+          else
+            RESOLVED_RELEASE_REF="$(bash ./shared/tools/ci/detect-base-branch.sh origin)"
+            echo "Using detected fallback RELEASE_REF: ${RESOLVED_RELEASE_REF}"
+          fi
+          echo "RELEASE_REF=${RESOLVED_RELEASE_REF}" >> "$GITHUB_ENV"
+
+      - id: set-matrix
+        name: Build new-connector matrix
+        run: python .github/scripts/build_new_connector_matrix.py
+
   vclint:
     name: Lint ${{ matrix.name }}
     needs:
       - detect-connectors
     if: needs.detect-connectors.outputs.has_connectors == 'true'
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.detect-connectors.outputs.matrix) }}
@@ -82,15 +117,189 @@ jobs:
       - name: Install connector-linter
         run: uv pip install ./shared/tools/connector_linter
 
+      # Verified connectors must stay error-free (blocking): the step fails
+      # and the PR check goes red. Manager-supported-only connectors are
+      # allowed to have errors (non-blocking): findings are still surfaced as
+      # annotations and in the PR comment (see vclint-comment), but the step
+      # always exits 0 for them.
       - name: Run connector-linter
+        run: |
+          exit_code=0
+          : > annotations.txt
+          while IFS= read -r connector_path; do
+            [ -z "$connector_path" ] && continue
+            echo "::group::Linting ${connector_path}"
+            uv run connector-linter check "$connector_path" --format github | tee -a annotations.txt || exit_code=$?
+            uv run connector-linter check "$connector_path" --format markdown --verbose >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "::endgroup::"
+          done <<< "${{ matrix.connector_paths }}"
+
+          if [ "${{ matrix.verified }}" != "true" ]; then
+            echo "Connector(s) not fully verified (manager-supported only): errors are non-blocking."
+            exit 0
+          fi
+          exit "$exit_code"
+
+      - name: Upload linter annotations
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: vclint-annotations-${{ strategy.job-index }}
+          path: annotations.txt
+          if-no-files-found: ignore
+          retention-days: 1
+
+  # Aggregates ::error annotations from every vclint matrix job (verified and
+  # manager-supported alike) and posts/updates a single PR comment listing
+  # each error's code, message, and a permalink to the offending line. Kept
+  # separate from the blocking pass/fail logic above so manager-supported
+  # connectors' errors stay visible even though they don't fail the check.
+  vclint-comment:
+    name: Comment connector-linter errors on PR
+    needs:
+      - detect-connectors
+      - vclint
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      needs.detect-connectors.outputs.has_connectors == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download linter annotations
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        continue-on-error: true
+        with:
+          pattern: vclint-annotations-*
+          path: annotations
+          merge-multiple: true
+
+      - name: Build error list
+        id: build-errors
+        run: |
+          errors=""
+          count=0
+          repo="${{ github.repository }}"
+          sha="${{ github.event.pull_request.head.sha }}"
+
+          if [ -d annotations ]; then
+            while IFS= read -r line; do
+              [ -z "$line" ] && continue
+              file=$(echo "$line" | sed -E 's/^::error file=([^,]+),line=([0-9]+)::.*/\1/')
+              lineno=$(echo "$line" | sed -E 's/^::error file=([^,]+),line=([0-9]+)::.*/\2/')
+              rest=$(echo "$line" | sed -E 's/^::error file=[^,]+,line=[0-9]+:://')
+              code=$(echo "$rest" | cut -d: -f1)
+              msg=$(echo "$rest" | cut -d: -f2- | sed -E 's/^ //')
+              url="https://github.com/${repo}/blob/${sha}/${file}#L${lineno}"
+              errors="${errors}- **${code}**: ${msg} ([${file}:${lineno}](${url}))\n"
+              count=$((count + 1))
+            done < <(grep -h '^::error ' annotations/*.txt 2>/dev/null || true)
+          fi
+
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          {
+            echo "errors<<EOF"
+            echo -e "$errors"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        if: steps.build-errors.outputs.count != '0'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const marker = '<!-- connector-linter-bot -->';
+            const body = `${marker}\n🔴 **Connector Linter errors detected**\n\n${process.env.ERRORS}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+        env:
+          ERRORS: ${{ steps.build-errors.outputs.errors }}
+
+      - name: Remove comment if no errors
+        if: steps.build-errors.outputs.count == '0'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const marker = '<!-- connector-linter-bot -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+              });
+            }
+
+  # Newly-added connectors are not yet "verified" or "manager_supported", so
+  # they are skipped by the `vclint` job above (which is also
+  # continue-on-error and therefore non-blocking). This job enforces VC305
+  # (connectors-sdk BaseConnectorSettings) as a hard, blocking requirement for
+  # any connector introduced for the first time in this PR, so new code never
+  # lands using the legacy get_config_variable() pattern.
+  vclint-new-connector-settings:
+    name: VC305 (new connector) ${{ matrix.name }}
+    needs:
+      - detect-new-connectors
+    if: needs.detect-new-connectors.outputs.has_connectors == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.detect-new-connectors.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: false
+          python-version: "3.12"
+
+      - name: Create virtual environment
+        run: uv venv
+
+      - name: Install connector-linter
+        run: uv pip install ./shared/tools/connector_linter
+
+      - name: Run VC305 (connectors-sdk settings) on new connectors
         run: |
           exit_code=0
           while IFS= read -r connector_path; do
             [ -z "$connector_path" ] && continue
-            echo "::group::Linting ${connector_path}"
-            uv run connector-linter check "$connector_path" --format github || exit_code=$?
-            uv run connector-linter check "$connector_path" --format markdown --verbose >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
-            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "::group::Checking VC305 for ${connector_path}"
+            uv run connector-linter check "$connector_path" --select VC305 --format github || exit_code=$?
             echo "::endgroup::"
           done <<< "${{ matrix.connector_paths }}"
           exit "$exit_code"


### PR DESCRIPTION
### Proposed changes

* Add a `detect-new-connectors` job and `.github/scripts/build_new_connector_matrix.py` that identify connector directories not present at the merge-base with the PR's base branch, and run a new `vclint-new-connector-settings` job that enforces `connector-linter check --select VC305` (connectors-sdk `BaseConnectorSettings` usage) as a hard **blocking** check on them — so brand-new connectors can never be merged using the legacy `get_config_variable()` pattern, independent of whether they're marked `verified`/`manager_supported` yet.
* Change `vclint` pass/fail semantics: linter errors are now **blocking** for `verified` connectors (the job fails, `continue-on-error` removed), but remain **non-blocking/informational** for connectors that are only `manager_supported`, since those are still mid-migration and shouldn't be required to already be lint-clean.
* Add a `vclint-comment` job that aggregates the `::error` annotations produced by every `vclint` matrix job (uploaded/downloaded as artifacts) and posts/updates/deletes a single PR comment listing each error's code, message, and a GitHub permalink to the offending line — giving authors one consolidated view instead of digging through per-job logs, for both verified and manager-supported connectors.
* Extract the git/manifest/output/batching helper logic that was copy-pasted across `build_linter_matrix.py`, `build_test_matrix.py`, `build_alpine_matrix.py`, and `check_connector_identity_uniqueness.py` (`git()`, `get_base_commit()`, `has_changes()`, `load_manifest()`, `is_verified`/`is_manager_supported`/`is_eligible`, `write_output()`, matrix batching) into a new shared `.github/scripts/_matrix_common.py` module, kept as its own commit since it's a pure, behavior-preserving refactor.

### Related issues

* Closes #6882

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

* **Why verified vs. manager-supported get different blocking behavior**: `verified` connectors have already cleared the full compliance bar and are meant to stay green, so a linter regression should fail the PR immediately. `manager_supported`-only connectors, by contrast, are typically mid-migration and may not yet satisfy every VC rule — making their errors blocking would immediately turn CI red on many existing PRs for debt that predates this change. Keeping them non-blocking still surfaces the findings (via annotations and the new PR comment) without penalizing unrelated work.
* **Why new connectors need their own dedicated check**: a connector introduced for the first time in a PR isn't yet `verified` or `manager_supported` (those flags are only set in later steps), so it would otherwise be completely skipped by `vclint`. Running VC305 as a standalone blocking job on newly-added directories catches the legacy `get_config_variable()` pattern at the cheapest possible point — before merge — instead of requiring a follow-up migration later.
* **Why the PR comment uses artifact upload/download instead of direct job outputs**: the `vclint` matrix can batch/parallelize across many connectors (up to the 256-job GitHub Actions limit), so there's no single job to read structured output from; artifacts are the simplest way to aggregate annotations across an arbitrary, dynamic number of matrix jobs in the same run.
* **Why the refactor is a separate commit**: `_matrix_common.py` only moves existing logic (verified byte-identical script output before/after) with zero behavior change, so isolating it lets reviewers verify it independently from the actual new CI semantics introduced in the second commit.