### PR TITLE
feat(ibm-xti): migrate connector to manager-supported mode (#6842)

### DIFF
--- a/external-import/ibm-xti/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/ibm-xti/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,21 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'flashpoint'. |
+| IBM_XTI_TAXII_SERVER_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the IBM X-Force PTI TAXII Server. |
+| IBM_XTI_TAXII_USER | `string` | ✅ | string |  | Your TAXII Server username. |
+| IBM_XTI_TAXII_PASS | `string` | ✅ | string |  | Your TAXII Server password. |
+| CONNECTOR_NAME | `string` |  | string | `"IBMXTIConnector"` | The name of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
+| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"PT5M"` | The period of time to await between two runs of the connector. |
+| IBM_XTI_TAXII_COLLECTIONS | `string` |  | string | `""` | Comma-separated list of collection IDs to ingest. |
+| IBM_XTI_CREATE_OBSERVABLES | `boolean` |  | boolean | `false` | Create observables from indicators. |
+| IBM_XTI_DEBUG | `boolean` |  | boolean | `false` | Enable debug mode (developers only) |

--- a/external-import/ibm-xti/__metadata__/connector_config_schema.json
+++ b/external-import/ibm-xti/__metadata__/connector_config_schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/ibm-xti_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "IBMXTIConnector",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "description": "The scope of the connector, e.g. 'flashpoint'.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT5M",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "IBM_XTI_TAXII_SERVER_URL": {
+      "description": "The base URL of the IBM X-Force PTI TAXII Server.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "IBM_XTI_TAXII_USER": {
+      "description": "Your TAXII Server username.",
+      "type": "string"
+    },
+    "IBM_XTI_TAXII_PASS": {
+      "description": "Your TAXII Server password.",
+      "type": "string"
+    },
+    "IBM_XTI_TAXII_COLLECTIONS": {
+      "default": "",
+      "description": "Comma-separated list of collection IDs to ingest.",
+      "type": "string"
+    },
+    "IBM_XTI_CREATE_OBSERVABLES": {
+      "default": false,
+      "description": "Create observables from indicators.",
+      "type": "boolean"
+    },
+    "IBM_XTI_DEBUG": {
+      "default": false,
+      "description": "Enable debug mode (developers only)",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_SCOPE",
+    "IBM_XTI_TAXII_SERVER_URL",
+    "IBM_XTI_TAXII_USER",
+    "IBM_XTI_TAXII_PASS"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/ibm-xti/__metadata__/connector_manifest.json
+++ b/external-import/ibm-xti/__metadata__/connector_manifest.json
@@ -15,7 +15,7 @@
   "support_version": ">= 6.5.1",
   "subscription_link": "https://www.ibm.com/services/threat-intelligence",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/ibm-xti",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-ibm-xti",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/ibm-xti/docker-compose.yml
+++ b/external-import/ibm-xti/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - CONNECTOR_NAME=ChangeMe
       - CONNECTOR_SCOPE=ChangeMe
       - CONNECTOR_LOG_LEVEL=info
-      - CONNECTOR_DURATION_PERIOD=ChangeMe # ISO8601 format in String, start with 'P...' for Period
+      - CONNECTOR_DURATION_PERIOD=PT5M # ISO8601 format in String, start with 'P...' for Period
 
       # Connector's definition parameters OPTIONAL
       # - CONNECTOR_QUEUE_THRESHOLD=500 # Default 500Mo, Float accepted
@@ -22,9 +22,10 @@ services:
       # - CONNECTOR_SEND_TO_DIRECTORY_RETENTION=7 # Default 7, in days
 
       # Connector's custom execution parameters
-      - CONNECTOR_IBM_XTI_TAXII_SERVER_URL=ChangeMe
-      - CONNECTOR_IBM_XTI_TAXII_USER=ChangeMe
-      - CONNECTOR_IBM_XTI_TAXII_PASS=ChangeMe
-      # - CONNECTOR_IBM_XTI_TAXII_COLLECTIONS="ChangeMe, ChangeMe"
-      # - CONNECTOR_IBM_XTI_CREATE_OBSERVABLES=True
+      - IBM_XTI_TAXII_SERVER_URL=ChangeMe
+      - IBM_XTI_TAXII_USER=ChangeMe
+      - IBM_XTI_TAXII_PASS=ChangeMe
+      # - IBM_XTI_TAXII_COLLECTIONS=ChangeMe, ChangeMe # Optional: comma-separated collection IDs to ingest
+      # - IBM_XTI_CREATE_OBSERVABLES=false # Optional: defaults to false
+      # - IBM_XTI_DEBUG=false # Optional: developers only, defaults to false
     restart: always

--- a/external-import/ibm-xti/src/config.yml.sample
+++ b/external-import/ibm-xti/src/config.yml.sample
@@ -24,4 +24,5 @@ ibm_xti:
   taxii_user: 'ChangeMe'
   taxii_pass: 'ChangeMe'
   #taxii_collections: 'ChangeMe, ChangeMe'
-  #create_observables: 'True'
+  #create_observables: 'false'
+  #debug: 'false'

--- a/external-import/ibm-xti/src/external_import_connector/__init__.py
+++ b/external-import/ibm-xti/src/external_import_connector/__init__.py
@@ -1,3 +1,4 @@
-from .connector import IBMXTIConnector
+from external_import_connector.connector import IBMXTIConnector
+from external_import_connector.settings import ConnectorSettings
 
-__all__ = ["IBMXTIConnector"]
+__all__ = ["IBMXTIConnector", "ConnectorSettings"]

--- a/external-import/ibm-xti/src/external_import_connector/connector.py
+++ b/external-import/ibm-xti/src/external_import_connector/connector.py
@@ -271,7 +271,7 @@ class IBMXTIConnector:
         Example:
             - If `CONNECTOR_DURATION_PERIOD=PT5M`, then the connector is running every 5 minutes.
         """
-        self.__helper.schedule_process(
+        self.__helper.schedule_iso(
             message_callback=self.process_message,
-            duration_period=self.__config.connector.duration_period.total_seconds(),
+            duration_period=self.__config.connector.duration_period,
         )

--- a/external-import/ibm-xti/src/main.py
+++ b/external-import/ibm-xti/src/main.py
@@ -1,8 +1,6 @@
-import sys
 import traceback
 
-from external_import_connector import IBMXTIConnector
-from external_import_connector.settings import ConnectorSettings
+from external_import_connector import ConnectorSettings, IBMXTIConnector
 from pycti import OpenCTIConnectorHelper
 
 if __name__ == "__main__":
@@ -23,4 +21,4 @@ if __name__ == "__main__":
         connector.run()
     except Exception:
         traceback.print_exc()
-        sys.exit(1)
+        exit(1)

--- a/external-import/ibm-xti/tests/conftest.py
+++ b/external-import/ibm-xti/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/external-import/ibm-xti/tests/test-requirements.txt
+++ b/external-import/ibm-xti/tests/test-requirements.txt
@@ -1,7 +1,3 @@
 # Main dependencies needs to be installed
 -r ../src/requirements.txt
-pytest
-pytest-mock
-pylint
-black
-flake8
+pytest==9.0.3

--- a/external-import/ibm-xti/tests/test_main.py
+++ b/external-import/ibm-xti/tests/test_main.py
@@ -1,0 +1,102 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from external_import_connector import ConnectorSettings, IBMXTIConnector
+from pycti import OpenCTIConnectorHelper
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+    It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "ibm-xti",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "ibm_xti": {
+                    "taxii_server_url": "https://example.taxii.ibm.com",
+                    "taxii_user": "test-user",
+                    "taxii_pass": "test-pass",
+                    "taxii_collections": "",
+                    "create_observables": False,
+                    "debug": False,
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that the implementation of `BaseConnectorSettings` (from `connectors-sdk`) can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from `BaseConnectorSettings`)
+        - the method `to_helper_config` MUST return a dict (as in base class)
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that `OpenCTIConnectorHelper` (from `pycti`) can be instantiated successfully:
+        - the value of `settings.to_helper_config` MUST be the expected dict for `OpenCTIConnectorHelper`
+        - the helper MUST be able to get its instance's attributes from the config dict
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "Test Connector"
+    assert helper.connect_scope == "ibm-xti"
+    assert helper.log_level == "ERROR"
+    assert helper.connect_duration_period == "PT5M"
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST be able to access env/config vars through `self.config`
+        - the connector's main class MUST be able to access `pycti` API through `self.helper`
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    connector = IBMXTIConnector(config=settings, helper=helper)
+
+    assert connector._IBMXTIConnector__config is settings
+    assert connector._IBMXTIConnector__helper is helper

--- a/external-import/ibm-xti/tests/tests_connector/test_settings.py
+++ b/external-import/ibm-xti/tests/tests_connector/test_settings.py
@@ -1,0 +1,132 @@
+from typing import Any
+
+import pytest
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+from external_import_connector import ConnectorSettings
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "ibm-xti",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "ibm_xti": {
+                    "taxii_server_url": "https://example.taxii.ibm.com",
+                    "taxii_user": "test-user",
+                    "taxii_pass": "test-pass",
+                    "taxii_collections": "collection-1, collection-2",
+                    "create_observables": True,
+                    "debug": False,
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {"id": "connector-id", "scope": "ibm-xti"},
+                "ibm_xti": {
+                    "taxii_server_url": "https://example.taxii.ibm.com",
+                    "taxii_user": "test-user",
+                    "taxii_pass": "test-pass",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) accepts valid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake but valid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.ibm_xti, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param({}, "settings", id="empty_settings_dict"),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080"},
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "ibm-xti",
+                    "duration_period": "PT5M",
+                },
+                "ibm_xti": {
+                    "taxii_server_url": "https://example.taxii.ibm.com",
+                    "taxii_user": "test-user",
+                    "taxii_pass": "test-pass",
+                },
+            },
+            "opencti.token",
+            id="missing_opencti_token",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": 123456,
+                    "scope": "ibm-xti",
+                    "duration_period": "PT5M",
+                },
+                "ibm_xti": {
+                    "taxii_server_url": "https://example.taxii.ibm.com",
+                    "taxii_user": "test-user",
+                    "taxii_pass": "test-pass",
+                },
+            },
+            "connector.id",
+            id="invalid_connector_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) raises on invalid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake and invalid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert str("Error validating configuration") in str(err)


### PR DESCRIPTION
### Proposed changes

* Migrate the **IBM X-Force** connector to **manager-supported** mode using the `connectors-sdk` Pydantic settings (`ConnectorSettings`).
* Fix the custom environment-variable prefix from `CONNECTOR_IBM_XTI_*` to `IBM_XTI_*` so pydantic-settings maps them to the `ibm_xti` section instead of the reserved `connector` section.
* Standardize the connector run loop on `helper.schedule_iso(duration_period=...)` (replacing the previous `schedule_process` with a raw seconds value).
* Export `ConnectorSettings` from the package `__init__` and update `src/main.py` to the SDK entry point.
* Update config files (`docker-compose.yml`, `config.yml.sample`) to the manager-supported convention.
* Add unit tests (`tests/test_main.py`, `tests/tests_connector/test_settings.py`) covering settings validation and connector instantiation.
* Set `manager_supported: true` and add generated `__metadata__/connector_config_schema.json` + `CONNECTOR_CONFIG_DOC.md`.

### Related issues

* Closes #6842

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Validated with `flake8`, `pytest` (9 passing), `isort`/`black`, and the repository's custom STIX-ID pylint checker (10/10). The branch is rebased on the latest `master`, preserving the connector-manifest taxonomy introduced in #6905.
