### PR TITLE
fix(cve): use proxy from environment (#6915)

### DIFF
--- a/external-import/cve/src/services/client/api.py
+++ b/external-import/cve/src/services/client/api.py
@@ -35,6 +35,7 @@ class CVEClient:
             self._session = aiohttp.ClientSession(
                 headers=self._headers,
                 timeout=timeout,
+                trust_env=True,
             )
         return self._session
 


### PR DESCRIPTION
This configures the CVE client to use HTTP[S]_PROXY if available.

### Proposed changes

* Allow CVE client to access environment variables.

### Related issues

* Closes #6915 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality