### PR TITLE
fix(tenable-security-center): handle empty string for asset_exposure_score (#6372)

### DIFF
--- a/external-import/tenable-security-center/tenable_security_center/adapters/tsc_api/v5_13_common.py
+++ b/external-import/tenable-security-center/tenable_security_center/adapters/tsc_api/v5_13_common.py
@@ -261,7 +261,7 @@ class FindingPydanticModel(_BaseModelWithoutExtra):
     host_uniqueness: list[str] = Field(...)
     host_uuid: Optional[str] = Field(None)
     acr_score: Optional[float] = Field(None)
-    asset_exposure_score: float = Field(...)
+    asset_exposure_score: Optional[float] = Field(None)
     vuln_uniqueness: list[str] = Field(...)
     vuln_uuid: Optional[str] = Field(None)
     uniqueness: list[str] = Field(...)

--- a/external-import/tenable-security-center/tenable_security_center/adapters/tsc_api/v5_13_from_asset.py
+++ b/external-import/tenable-security-center/tenable_security_center/adapters/tsc_api/v5_13_from_asset.py
@@ -416,7 +416,7 @@ class _FindingAPI(FindingPort):
         return self._pydantic_model.acr_score
 
     @property
-    def asset_exposure_score(self) -> float:
+    def asset_exposure_score(self) -> Optional[float]:
         return self._pydantic_model.asset_exposure_score
 
     @property
@@ -444,7 +444,6 @@ class _FindingAPI(FindingPort):
             "ip",
             "protocol",
             "seol_date",
-            "asset_exposure_score",
             "severity_name",
         ]
         optional_direct_fields = [
@@ -478,6 +477,7 @@ class _FindingAPI(FindingPort):
             "temporal_score",
             "cvss_v3_base_score",
             "cvss_v3_temporal_score",
+            "asset_exposure_score",
         ]
         datetime_fields = ["first_seen", "last_seen"]
         optional_datetime_fields = [

--- a/external-import/tenable-security-center/tenable_security_center/ports/asset.py
+++ b/external-import/tenable-security-center/tenable_security_center/ports/asset.py
@@ -311,8 +311,8 @@ class FindingPort(ABC):
 
     @property
     @abstractmethod
-    def asset_exposure_score(self) -> float:
-        """Score representing the exposure of the asset."""
+    def asset_exposure_score(self) -> Optional[float]:
+        """Score representing the exposure of the asset (optional, may be unavailable)."""
 
     @property
     @abstractmethod

--- a/external-import/tenable-security-center/tests/test_adapters/test_tsc_api/test_v5_13_from_asset.py
+++ b/external-import/tenable-security-center/tests/test_adapters/test_tsc_api/test_v5_13_from_asset.py
@@ -1,6 +1,9 @@
 # isort:skip_file
 # pragma: no cover
-from tenable_security_center.adapters.tsc_api.v5_13_from_asset import _ScanResultsAPI
+from tenable_security_center.adapters.tsc_api.v5_13_from_asset import (
+    _FindingAPI,
+    _ScanResultsAPI,
+)
 
 from unittest.mock import Mock
 
@@ -34,3 +37,65 @@ def test_scan_results_api_get_scanned_assets_info_should_return_tuple_of_string(
     # The method should return a tuple of strings
     assert result[0] == "0.0.0.0"  # noqa: S101 # we use assert in unit test context
     assert result[1] == "1"  # noqa: S101
+
+
+def _make_raw_finding_response(asset_exposure_score="750"):
+    """Build a minimal raw API response for a finding."""
+    return {
+        "pluginName": "Test Plugin",
+        "pluginID": "12345",
+        "ip": "192.168.1.1",
+        "protocol": "TCP",
+        "port": "443",
+        "severity": {"name": "high"},
+        "hasBeenMitigated": "0",
+        "acceptRisk": "0",
+        "recastRisk": "0",
+        "firstSeen": "1700000000",
+        "lastSeen": "1700000000",
+        "exploitAvailable": "No",
+        "hostUniqueness": "ip",
+        "vulnUniqueness": "pluginID",
+        "uniqueness": "ip,pluginID",
+        "assetExposureScore": asset_exposure_score,
+        "seolDate": "1700000000",
+    }
+
+
+def test_parse_response_with_empty_asset_exposure_score():
+    """Regression test for #6372: empty string asset_exposure_score should not crash."""
+
+    # Given a raw response with an empty string for assetExposureScore
+    raw_response = _make_raw_finding_response(asset_exposure_score="")
+
+    # When we parse it
+    result = _FindingAPI.parse_response(raw_response)
+
+    # Then asset_exposure_score should be None (not raise)
+    assert result["asset_exposure_score"] is None  # noqa: S101
+
+
+def test_parse_response_with_valid_asset_exposure_score():
+    """asset_exposure_score should be correctly parsed as a float when present."""
+
+    # Given a raw response with a valid numeric string
+    raw_response = _make_raw_finding_response(asset_exposure_score="750")
+
+    # When we parse it
+    result = _FindingAPI.parse_response(raw_response)
+
+    # Then asset_exposure_score should be the float value
+    assert result["asset_exposure_score"] == 750.0  # noqa: S101
+
+
+def test_parse_response_with_zero_asset_exposure_score():
+    """asset_exposure_score of '0' should be parsed as 0.0, not None."""
+
+    # Given a raw response with "0" as score
+    raw_response = _make_raw_finding_response(asset_exposure_score="0")
+
+    # When we parse it
+    result = _FindingAPI.parse_response(raw_response)
+
+    # Then asset_exposure_score should be 0.0
+    assert result["asset_exposure_score"] == 0.0  # noqa: S101


### PR DESCRIPTION
## Summary

Fixes #6372

The Tenable Security Center connector crashes with a Pydantic validation error when the API returns an empty string (`''`) for `asset_exposure_score`.

## Changes

Makes `asset_exposure_score` optional (mirroring the existing `acr_score` pattern):

- **`v5_13_common.py`** — `FindingPydanticModel.asset_exposure_score`: `float = Field(...)` → `Optional[float] = Field(None)`
- **`v5_13_from_asset.py`** — Moved field from `direct_fields` to `optional_float_fields`; updated property return type to `Optional[float]`
- **`ports/asset.py`** — `FindingPort.asset_exposure_score` interface: `float` → `Optional[float]`

The `float_field(..., optional=True)` helper already handles empty/falsy strings by returning `None`, so no new parsing logic was needed.

## Validation

- All 50 existing tests pass
- Verified manually that `None` is accepted for the field
- Pre-commit hooks (black, flake8, isort) pass