### PR TITLE
fix(feedly): guard markdown conversion against backtracking (#6611)

### DIFF
--- a/external-import/feedly/src/feedly/opencti_connector/connector.py
+++ b/external-import/feedly/src/feedly/opencti_connector/connector.py
@@ -14,6 +14,32 @@ FEEDLY_AI_UUID = "identity--477866fd-8784-46f9-ab40-5592ed4eddd7"
 # Pattern for IPv4 address followed by colon and port number
 _IPV4_WITH_PORT = re.compile(r"^(?P<addr>\b(?:\d{1,3}\.){3}\d{1,3}\b):(?P<port>\d+)$")
 
+# Guardrail for converting report descriptions to Markdown. Descriptions come from
+# arbitrary external Feedly articles; a long run of the same Markdown-active symbol
+# (e.g. backticks or brackets) triggers catastrophic regex backtracking in the parser,
+# pinning the CPU for minutes with no progress and no logs. We defuse that by shortening
+# only such degenerate symbol runs -- no report text is ever truncated, so nothing is
+# lost. Runs of letters/digits (e.g. base64, hashes) are not Markdown-active and are
+# left untouched.
+_MARKDOWN_MAX_CHAR_RUN = 50
+_MARKDOWN_LONG_RUN = re.compile(r"([^\w\s])\1{%d,}" % _MARKDOWN_MAX_CHAR_RUN)
+
+
+def _sanitize_markdown_input(text: str) -> str:
+    """Make untrusted text safe to feed to python-markdown without losing content.
+
+    Collapses runs of the same Markdown-active symbol longer than
+    ``_MARKDOWN_MAX_CHAR_RUN`` so that pathological article content cannot trigger
+    catastrophic regex backtracking in the Markdown parser (which would otherwise hang
+    the connector at 100% CPU with no logs). Only degenerate symbol runs are shortened;
+    letters, digits and normal text are left untouched and nothing is truncated.
+    """
+    if not isinstance(text, str) or not text:
+        return text
+    return _MARKDOWN_LONG_RUN.sub(
+        lambda match: match.group(1) * _MARKDOWN_MAX_CHAR_RUN, text
+    )
+
 
 class FeedlyConnector:
     def __init__(
@@ -32,6 +58,10 @@ class FeedlyConnector:
         last_article_published_date = None
         total_reports = 0
 
+        self.cti_helper.log_debug(
+            "Initializing Feedly downloader",
+            meta={"stream_id": stream_id, "newer_than": newer_than.isoformat()},
+        )
         downloader = StixIoCDownloader(
             session=self.feedly_session,
             newer_than=newer_than,
@@ -39,12 +69,42 @@ class FeedlyConnector:
             stream_id=stream_id,
         )
 
+        batch_index = 0
         for batch in downloader.stream_bundles():
+            batch_index += 1
+            # Logged only *after* the (blocking) HTTP fetch returns: if Feedly stalls,
+            # the previous log line is the last one seen -> points at the network wait.
+            self.cti_helper.log_debug(
+                "Received Feedly batch",
+                meta={
+                    "stream_id": stream_id,
+                    "batch": batch_index,
+                    "objects": len(batch.get("objects", [])),
+                },
+            )
             bundle = self._process_bundle(batch)
             if not bundle["objects"]:
+                self.cti_helper.log_debug(
+                    "Skipping empty batch after processing",
+                    meta={"stream_id": stream_id, "batch": batch_index},
+                )
                 continue
             total_reports += self._count_reports(bundle)
+            # Logged before the (blocking) send: if serialization/splitting or the
+            # broker stalls, this is the last line seen -> points at the publish step.
+            self.cti_helper.log_debug(
+                "Sending STIX bundle to OpenCTI",
+                meta={
+                    "stream_id": stream_id,
+                    "batch": batch_index,
+                    "objects": len(bundle["objects"]),
+                },
+            )
             self.cti_helper.send_stix2_bundle(json.dumps(bundle))
+            self.cti_helper.log_debug(
+                "STIX bundle accepted by OpenCTI",
+                meta={"stream_id": stream_id, "batch": batch_index},
+            )
             batch_last_date = self._get_last_article_published_date(bundle)
             if batch_last_date:
                 if (
@@ -53,17 +113,35 @@ class FeedlyConnector:
                 ):
                     last_article_published_date = batch_last_date
 
+        self.cti_helper.log_debug(
+            "Feedly stream fully consumed",
+            meta={
+                "stream_id": stream_id,
+                "batches": batch_index,
+                "reports": total_reports,
+            },
+        )
         self.cti_helper.log_info(f"Found {total_reports} new reports")
         return last_article_published_date
 
     def _process_bundle(self, bundle: dict) -> dict:
+        object_count = len(bundle["objects"])
+        self.cti_helper.log_debug(
+            "Converting report descriptions to markdown",
+            meta={"objects": object_count},
+        )
         self._make_reports_content_instead_of_descriptions(bundle)
+        self.cti_helper.log_debug("Adding main observable types to indicators")
         self._add_main_observable_type_to_indicators(bundle)
+        self.cti_helper.log_debug("Transforming threat actors to intrusion sets")
         self._transform_threat_actors_to_intrusion_sets(bundle)
+        self.cti_helper.log_debug("Adding source names as authors")
         self._add_source_name_as_author_to_all_reports(bundle)
+        self.cti_helper.log_debug("Fixing IP addresses with ports")
         self._fix_ip_addresses_with_ports(bundle)
 
         if not self.enable_relationships:
+            self.cti_helper.log_debug("Filtering out relationships")
             self._filter_relationships(bundle)
 
         return bundle
@@ -111,13 +189,35 @@ class FeedlyConnector:
         if new_objects:
             bundle["objects"].extend(new_objects)
 
-    @staticmethod
-    def _make_reports_content_instead_of_descriptions(bundle: dict) -> None:
+    def _make_reports_content_instead_of_descriptions(self, bundle: dict) -> None:
         notes = []
         for o in bundle["objects"]:
             if o["type"] == "report":
+                description = o["description"]
+                sanitized = _sanitize_markdown_input(description)
+                if isinstance(description, str) and sanitized != description:
+                    # The guard only alters pathological content (huge input or long
+                    # runs of Markdown-active characters) that would otherwise hang the
+                    # Markdown parser. Surface it so such reports can be spotted.
+                    self.cti_helper.log_warning(
+                        "Report description sanitized before markdown conversion",
+                        meta={
+                            "report_id": o.get("id"),
+                            "original_length": len(description),
+                            "sanitized_length": len(sanitized),
+                        },
+                    )
+                self.cti_helper.log_debug(
+                    "Converting report description to markdown",
+                    meta={
+                        "report_id": o.get("id"),
+                        "description_length": (
+                            len(description) if isinstance(description, str) else 0
+                        ),
+                    },
+                )
                 o["content"], o["description"] = (
-                    markdown(o["description"]),
+                    markdown(sanitized),
                     o["name"],
                 )
         bundle["objects"].extend([json.loads(note.serialize()) for note in notes])

--- a/external-import/feedly/src/feedly/opencti_connector/runner.py
+++ b/external-import/feedly/src/feedly/opencti_connector/runner.py
@@ -40,23 +40,40 @@ class FeedlyRunner:
         run_name = f"{stream_id} @ {now.strftime('%Y-%m-%d %H:%M:%S')}"
         try:
             self.helper.log_info(f"Fetching stream {stream_id}")
+            self.helper.log_debug(
+                "Reading connector state", meta={"stream_id": stream_id}
+            )
             state = self._get_state()
             stream_state = state["streams"].get(stream_id, {})
 
+            self.helper.log_debug(
+                "Initiating work on OpenCTI", meta={"stream_id": stream_id}
+            )
             self.helper.work_id = self.helper.api.work.initiate_work(
                 self.helper.connect_id, f"Start {run_name}"
             )
 
+            newer_than = self._get_newer_than(stream_id, stream_state)
+            self.helper.log_debug(
+                "Fetching and publishing stream",
+                meta={"stream_id": stream_id, "newer_than": newer_than.isoformat()},
+            )
             last_article_publish_date = self.connector.fetch_and_publish(
                 stream_id,
-                self._get_newer_than(stream_id, stream_state),
+                newer_than,
             )
 
             success_message = f"Finished {run_name}"
             self.helper.log_info(success_message)
+            self.helper.log_debug(
+                "Marking work as processed", meta={"stream_id": stream_id}
+            )
             self.helper.api.work.to_processed(self.helper.work_id, success_message)
 
             self._update_state(state, stream_id, last_article_publish_date, now)
+            self.helper.log_debug(
+                "Connector state updated", meta={"stream_id": stream_id}
+            )
         except Exception as e:
             error_message = f"Failed {run_name} ({e})"
             self.helper.log_error(error_message)

--- a/external-import/feedly/tests/test_markdown_guard.py
+++ b/external-import/feedly/tests/test_markdown_guard.py
@@ -1,0 +1,94 @@
+import time
+from unittest.mock import MagicMock
+
+from feedly.opencti_connector.connector import (
+    _MARKDOWN_MAX_CHAR_RUN,
+    FeedlyConnector,
+    _sanitize_markdown_input,
+)
+from markdown import markdown
+
+
+def test_long_backtick_run_no_longer_hangs():
+    # Without the guard, this pins the CPU for minutes (catastrophic backtracking).
+    text = "`" * 50000 + "x"
+    start = time.perf_counter()
+    markdown(_sanitize_markdown_input(text))
+    assert time.perf_counter() - start < 5.0
+
+
+def test_long_bracket_run_no_longer_hangs():
+    text = "[" * 50000
+    start = time.perf_counter()
+    markdown(_sanitize_markdown_input(text))
+    assert time.perf_counter() - start < 5.0
+
+
+def test_long_symbol_runs_are_collapsed():
+    for char in ("`", "[", "<", "*"):
+        collapsed = _sanitize_markdown_input(char * 500)
+        assert collapsed == char * _MARKDOWN_MAX_CHAR_RUN
+
+
+def test_long_input_is_not_truncated():
+    # No report text may be dropped: a large input without pathological symbol runs
+    # is returned unchanged (only degenerate symbol runs are ever shortened).
+    text = "word " * 100000  # ~500 KB of normal text
+    assert _sanitize_markdown_input(text) == text
+
+
+def test_long_symbol_run_is_shortened_but_surrounding_text_kept():
+    text = "before " + "`" * 500 + " after"
+    sanitized = _sanitize_markdown_input(text)
+    assert sanitized == "before " + "`" * _MARKDOWN_MAX_CHAR_RUN + " after"
+
+
+def test_alphanumeric_runs_are_preserved():
+    # Letters/digits are not Markdown-active; long runs (e.g. base64) must be kept.
+    text = "A" * 500
+    assert _sanitize_markdown_input(text) == text
+
+
+def test_short_symbol_runs_are_preserved():
+    # A horizontal rule and normal formatting must be left intact.
+    for text in ("-" * _MARKDOWN_MAX_CHAR_RUN, "# Title\n\n**bold** `code` [x](y)\n"):
+        assert _sanitize_markdown_input(text) == text
+
+
+def test_non_string_and_empty_passthrough():
+    assert _sanitize_markdown_input(None) is None
+    assert _sanitize_markdown_input("") == ""
+
+
+def test_normal_content_output_is_unchanged():
+    samples = [
+        "# Title\n\nSome **bold**, _italic_, `code`, and a [link](http://x).\n\n- a\n- b\n",
+        "A sentence with C:\\*.exe and a wildcard *.evil.com and a fence ``` here.",
+        "Table:\n\n| a | b |\n|---|---|\n| 1 | 2 |\n",
+    ]
+    for sample in samples:
+        assert markdown(sample) == markdown(_sanitize_markdown_input(sample))
+
+
+def test_process_bundle_sanitizes_report_description_without_hanging():
+    connector = FeedlyConnector.__new__(FeedlyConnector)
+    connector.cti_helper = MagicMock()
+    report = {
+        "type": "report",
+        "id": "report--00000000-0000-4000-8000-000000000000",
+        "name": "My Report",
+        "description": "`" * 50000 + "x",
+        "published": "2024-01-01T00:00:00Z",
+        "external_references": [{"source_name": "feedly"}],
+        "object_refs": [],
+    }
+    bundle = {"type": "bundle", "id": "bundle--x", "objects": [report]}
+
+    start = time.perf_counter()
+    connector._make_reports_content_instead_of_descriptions(bundle)
+
+    assert time.perf_counter() - start < 5.0
+    assert report["content"]  # HTML content was produced
+    assert report["description"] == "My Report"  # description replaced by the name
+    # A warning is emitted when the guard alters pathological content.
+    connector.cti_helper.log_warning.assert_called_once()


### PR DESCRIPTION
### Proposed changes

* Add a `_sanitize_markdown_input()` guard in `connector.py` that collapses runs of the same Markdown-active symbol longer than 50 characters *before* report descriptions are passed to `markdown()`. Long runs of such symbols (e.g. backticks or brackets) in untrusted Feedly article descriptions triggered catastrophic regex backtracking in python-markdown, pinning the CPU at 100% with no progress and no logs — the instability reported as OOM in #6611. Only degenerate symbol runs are shortened; letters/digits (base64, hashes) and normal text are left untouched, so **no report content is truncated or lost**.
* Emit a `log_warning` (with report id and original/sanitized lengths) whenever the guard actually alters a description, so the rare pathological articles that trigger it can be spotted in production.
* Add structured debug logging across the run loop — in `runner.py` (state read, work init, fetch/publish, mark processed, state update) and in `connector.py` (batch fetch, per-transform processing, and STIX bundle send/accept) — to pinpoint where a stalled run is blocked. Lines are deliberately placed *after* each blocking call so that, if the connector hangs, the last emitted log points directly at the blocking step.
* Add comprehensive regression tests in `tests/test_markdown_guard.py`: timing guards proving pathological backtick/bracket inputs no longer hang, non-truncation of large benign text (~500 KB), alphanumeric/base64 preservation, HTML-output equivalence for normal markdown, and an end-to-end `_process_bundle` test asserting content is still produced and the warning is emitted.

### Related issues

* Fixes #6611

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

