### PR TITLE
ci: add bulk connector release orchestration (#6936)

### DIFF
--- a/.github/scripts/bulk_release.py
+++ b/.github/scripts/bulk_release.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""
+Bulk connector release resolver.
+
+Resolves a set of connectors (a named list or *all*) and a single shared CalVer
+version into the list of per-connector releases to dispatch. It performs **no git
+mutations** — it only reads the working tree (and, for idempotency, the remote
+tag list) and emits the resolved connector list. The actual release of each
+connector (build image, push, create the GitHub Release, which creates the tag)
+is performed by the per-connector `release-connector.yml` workflow, which
+`release-bulk-connectors.yml` dispatches once per connector.
+
+This read-only design deliberately avoids the fragility of pushing many tags at
+once (GitHub drops push events beyond three tags per push, and tags pushed with
+GITHUB_TOKEN do not trigger downstream workflows). Each connector is released by
+an independent `release-connector.yml` run dispatched via `workflow_dispatch`,
+which — unlike tag pushes — always creates a run even when triggered with
+GITHUB_TOKEN, and is not subject to the 256-job matrix limit.
+
+Typical use cases:
+  - Security fix in a shared dependency → rebuild all affected connectors
+  - pycti version bump after a platform release
+  - connectors-sdk breaking change
+  - LTS alignment (release everything in sync)
+
+Release tag/version format (produced later by release-connector.yml):
+    {connector-name}/{MAJOR.YYMMDD.PATCH}     e.g.  mitre/7.260706.0
+
+Examples:
+    # Preview the connectors to release for two names
+    python bulk_release.py --connectors mitre,crowdstrike
+
+    # Resolve every connector with today's auto-computed CalVer
+    python bulk_release.py --all
+
+    # Resolve all connectors for an explicit version, ignoring idempotency
+    python bulk_release.py --all --version 7.260706.1 --include-released
+
+Outputs (written to $GITHUB_OUTPUT when set, and always printed as a summary):
+    version         the shared CalVer applied to every connector
+    connectors      JSON array of connector names to release
+    count           number of connectors to release
+    skipped         JSON array of connector names skipped (already released)
+    skipped_count   number of skipped connectors
+    has_connectors  "true" if at least one connector will be released
+"""
+
+import argparse
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+
+import _matrix_common  as common
+
+
+# Default CalVer major, matching release-connector.yml (MAJOR=7).
+DEFAULT_MAJOR = 7
+
+# CalVer format MAJOR.YYMMDD.PATCH — identical to release-connector.yml.
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]{6}\.[0-9]+$")
+
+
+class BulkReleaseError(Exception):
+    """Raised for user-facing errors (bad input, resolution, matrix overflow)."""
+
+
+@dataclass(frozen=True)
+class Connector:
+    """A resolved connector: its short name and repo-relative directory."""
+
+    name: str
+    path: str  # e.g. "external-import/mitre"
+
+
+# ──────────────────────────────────────────────────────────────
+# Version helpers
+# ──────────────────────────────────────────────────────────────
+def compute_calver(
+    major: int = DEFAULT_MAJOR, today: datetime.date | None = None
+) -> str:
+    """Compute today's CalVer as ``MAJOR.YYMMDD.0`` (UTC), matching the workflow."""
+    if today is None:
+        today = datetime.datetime.now(datetime.timezone.utc).date()
+    return f"{major}.{today:%y%m%d}.0"
+
+
+def validate_version(version: str) -> str:
+    """Validate a CalVer string against the release-connector.yml format."""
+    if not VERSION_RE.match(version):
+        raise BulkReleaseError(
+            f"Invalid CalVer version '{version}'. "
+            "Expected format: MAJOR.YYMMDD.PATCH (e.g. 7.260706.0)."
+        )
+    return version
+
+
+def build_tag(connector_name: str, version: str) -> str:
+    """Build the release tag for a connector: ``{name}/{version}``."""
+    return f"{connector_name}/{version}"
+
+
+# ──────────────────────────────────────────────────────────────
+# Connector discovery / resolution
+# ──────────────────────────────────────────────────────────────
+def discover_all_connectors(repo_root: Path) -> list[Connector]:
+    """Discover every buildable connector across all type directories.
+
+    A directory is a connector when it lives directly under a type directory,
+    does not start with '.' or '_', and contains a ``Dockerfile``. This mirrors
+    the CI build matrix (.github/scripts/build_alpine_matrix.py) so that every
+    connector the pipeline can build is releasable in bulk.
+    """
+    connectors: list[Connector] = []
+    for type_dir in common.CONNECTOR_TYPE_DIRS:
+        type_path = repo_root / type_dir
+        if not type_path.is_dir():
+            continue
+        for connector_path in sorted(type_path.iterdir()):
+            if not connector_path.is_dir():
+                continue
+            if connector_path.name.startswith((".", "_")):
+                continue
+            if not (connector_path / "Dockerfile").exists():
+                continue
+            connectors.append(
+                Connector(
+                    name=connector_path.name,
+                    path=f"{type_dir}/{connector_path.name}",
+                )
+            )
+    return sorted(connectors, key=lambda c: c.name)
+
+
+def find_connector(repo_root: Path, name: str) -> Connector:
+    """Resolve a single connector by name, scanning all type directories.
+
+    Raises BulkReleaseError if the name is not found or is ambiguous (present in
+    more than one type directory), mirroring release-connector.yml resolution.
+    """
+    matches = [
+        f"{type_dir}/{name}"
+        for type_dir in common.CONNECTOR_TYPE_DIRS
+        if (repo_root / type_dir / name).is_dir()
+    ]
+    if not matches:
+        raise BulkReleaseError(
+            f"Connector '{name}' not found in any type directory "
+            f"({', '.join(common.CONNECTOR_TYPE_DIRS)})."
+        )
+    if len(matches) > 1:
+        joined = ", ".join(matches)
+        raise BulkReleaseError(
+            f"Ambiguous connector name '{name}' — found in multiple "
+            f"directories: {joined}."
+        )
+    return Connector(name=name, path=matches[0])
+
+
+def resolve_named_connectors(repo_root: Path, names: list[str]) -> list[Connector]:
+    """Resolve a list of connector names, aggregating all resolution errors."""
+    connectors: list[Connector] = []
+    errors: list[str] = []
+    for name in names:
+        try:
+            connectors.append(find_connector(repo_root, name))
+        except BulkReleaseError as exc:
+            errors.append(str(exc))
+    if errors:
+        raise BulkReleaseError("\n".join(errors))
+    return connectors
+
+
+def parse_connector_names(raw: str) -> list[str]:
+    """Parse a comma-separated connector list into a de-duplicated ordered list."""
+    seen: set[str] = set()
+    names: list[str] = []
+    for chunk in raw.split(","):
+        name = chunk.strip()
+        if name and name not in seen:
+            seen.add(name)
+            names.append(name)
+    if not names:
+        raise BulkReleaseError("No connector names provided in --connectors.")
+    return names
+
+
+# ──────────────────────────────────────────────────────────────
+# Git helpers (read-only)
+# ──────────────────────────────────────────────────────────────
+def resolve_repo_root(explicit: str | None) -> Path:
+    """Resolve the repository root from an explicit path or the current git repo."""
+    if explicit:
+        root = Path(explicit).resolve()
+        if not root.is_dir():
+            raise BulkReleaseError(f"--repo-root '{explicit}' is not a directory.")
+        return root
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        raise BulkReleaseError(
+            "Not inside a git repository. Run from the connectors repo or pass "
+            "--repo-root."
+        ) from exc
+    return Path(result.stdout.strip())
+
+
+def parse_remote_tags(ls_remote_output: str) -> set[str]:
+    """Parse ``git ls-remote --tags`` output into a set of tag names."""
+    tags: set[str] = set()
+    for line in ls_remote_output.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 2:
+            continue
+        ref = parts[1]
+        prefix = "refs/tags/"
+        if not ref.startswith(prefix):
+            continue
+        tag = ref[len(prefix) :]
+        if tag.endswith("^{}"):  # dereferenced annotated tag entry
+            tag = tag[: -len("^{}")]
+        tags.add(tag)
+    return tags
+
+
+def get_remote_tags(repo_root: Path, remote: str) -> set[str]:
+    """Return the set of tags currently present on the remote (single fetch).
+
+    Read-only. On failure (no network, unknown remote), a warning is printed and
+    an empty set is returned so idempotency degrades gracefully rather than
+    blocking the resolution.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-remote", "--tags", remote],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        stderr = getattr(exc, "stderr", "") or ""
+        print(
+            f"⚠️  Could not list tags on remote '{remote}' "
+            f"({stderr.strip() or exc}); not skipping any connector.",
+            file=sys.stderr,
+        )
+        return set()
+    return parse_remote_tags(result.stdout)
+
+
+# ──────────────────────────────────────────────────────────────
+# Planning / output
+# ──────────────────────────────────────────────────────────────
+@dataclass
+class ReleasePlan:
+    """The computed plan: which connectors to release vs. skip."""
+
+    version: str
+    pending: list[Connector]  # to release (the matrix)
+    skipped: list[Connector]  # already released at this version
+
+
+def build_plan(
+    connectors: list[Connector], version: str, released_tags: set[str]
+) -> ReleasePlan:
+    """Partition connectors into pending vs. already-released (idempotency)."""
+    pending: list[Connector] = []
+    skipped: list[Connector] = []
+    for connector in connectors:
+        if build_tag(connector.name, version) in released_tags:
+            skipped.append(connector)
+        else:
+            pending.append(connector)
+    return ReleasePlan(version=version, pending=pending, skipped=skipped)
+
+
+def print_plan(plan: ReleasePlan) -> None:
+    """Print a human-readable summary of the release plan (to stderr)."""
+    total = len(plan.pending) + len(plan.skipped)
+    print(f"🔖 Bulk release plan (version {plan.version})", file=sys.stderr)
+    print(f"  Targets: {total} connector(s)", file=sys.stderr)
+
+    print(f"  To release ({len(plan.pending)}):", file=sys.stderr)
+    for connector in plan.pending:
+        print(f"    + {build_tag(connector.name, plan.version)}", file=sys.stderr)
+    if not plan.pending:
+        print("    (none)", file=sys.stderr)
+
+    if plan.skipped:
+        print(f"  Already released — skipping ({len(plan.skipped)}):", file=sys.stderr)
+        for connector in plan.skipped:
+            print(f"    = {build_tag(connector.name, plan.version)}", file=sys.stderr)
+
+
+def emit_outputs(plan: ReleasePlan, github_output: str | None) -> None:
+    """Write GitHub Actions job outputs (and echo them for local runs)."""
+    connectors = json.dumps([c.name for c in plan.pending], separators=(",", ":"))
+    skipped = json.dumps([c.name for c in plan.skipped], separators=(",", ":"))
+    outputs = {
+        "version": plan.version,
+        "connectors": connectors,
+        "count": str(len(plan.pending)),
+        "skipped": skipped,
+        "skipped_count": str(len(plan.skipped)),
+        "has_connectors": "true" if plan.pending else "false",
+    }
+
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as handle:
+            for key, value in outputs.items():
+                handle.write(f"{key}={value}\n")
+
+    print("📤 Outputs:", file=sys.stderr)
+    for key, value in outputs.items():
+        print(f"  {key}={value}", file=sys.stderr)
+
+
+# ──────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="bulk_release.py",
+        description="Resolve connectors into a bulk-release build matrix.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument(
+        "--connectors",
+        metavar="NAME1,NAME2",
+        help="Comma-separated connector names to release (e.g. 'mitre,crowdstrike').",
+    )
+    target.add_argument(
+        "--all",
+        action="store_true",
+        help="Release every connector (all type directories, regardless of changes).",
+    )
+    parser.add_argument(
+        "--version",
+        default="",
+        help="CalVer version to tag, same for all connectors (e.g. 7.260706.0). "
+        "Defaults to today's auto-computed 7.YYMMDD.0.",
+    )
+    parser.add_argument(
+        "--major",
+        type=int,
+        default=DEFAULT_MAJOR,
+        help=f"CalVer major used when auto-computing the version (default: {DEFAULT_MAJOR}).",
+    )
+    parser.add_argument(
+        "--remote",
+        default="origin",
+        help="Git remote inspected for already-released tags (default: origin).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Path to the connectors repo root (default: auto-detected via git).",
+    )
+    parser.add_argument(
+        "--include-released",
+        action="store_true",
+        help="Do not skip connectors already released at this version "
+        "(disables idempotency filtering; useful for a full dry-run preview).",
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT"),
+        help="Path to write matrix outputs (defaults to $GITHUB_OUTPUT).",
+    )
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    repo_root = resolve_repo_root(args.repo_root)
+
+    version = (
+        validate_version(args.version) if args.version else compute_calver(args.major)
+    )
+
+    if args.all:
+        connectors = discover_all_connectors(repo_root)
+        if not connectors:
+            raise BulkReleaseError(
+                f"No connectors discovered under {repo_root}. "
+                "Are you pointing at the connectors repo root?"
+            )
+    else:
+        connectors = resolve_named_connectors(
+            repo_root, parse_connector_names(args.connectors)
+        )
+
+    released_tags: set[str] = set()
+    if not args.include_released:
+        released_tags = get_remote_tags(repo_root, args.remote)
+
+    plan = build_plan(connectors, version, released_tags)
+
+    print_plan(plan)
+    emit_outputs(plan, args.github_output)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        return run(args)
+    except BulkReleaseError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)

--- a/.github/workflows/release-bulk-connectors.yml
+++ b/.github/workflows/release-bulk-connectors.yml
@@ -1,0 +1,223 @@
+name: "Release Connectors (bulk)"
+
+# Bulk release orchestrator.
+#
+# Resolves a set of connectors (a named list or "all") and a single shared CalVer
+# version, then dispatches one independent `release-connector.yml` run per
+# connector via workflow_dispatch. Each dispatched run performs the full per-
+# connector pipeline (build → push → create the GitHub Release, which creates the
+# tag). This workflow itself does no building or tagging.
+#
+# Why dispatch instead of pushing tags or a matrix?
+#   - workflow_dispatch events always create a workflow run, even when triggered
+#     with the default GITHUB_TOKEN (unlike tag pushes, which do not) — so no PAT
+#     is required.
+#   - One run per connector is not bound by the 256-job matrix limit, so "all"
+#     (250+ connectors) works in a single orchestration.
+#
+# Use cases: shared-dependency security fix, pycti bump, connectors-sdk breaking
+# change, LTS alignment.
+#
+# Transition trigger — platform CalVer tag push (e.g. `7.260706.0`):
+# automatically runs a manifest-only bulk release for every connector. Each
+# dispatched per-connector run still produces its full tag, GitHub Release,
+# manifest fragment, and container_version commit-back — only the Docker
+# build/push step is skipped, since image builds for the platform release are
+# still handled by CircleCI at this stage. This lets the platform release keep
+# flowing through the current CircleCI pipeline while per-connector tags,
+# releases, and manifest fragments are produced in parallel via GitHub Actions.
+
+on:
+  push:
+    tags:
+      # Platform (OCTI) CalVer release tags, e.g. 7.260706.0. These never
+      # contain '/', unlike per-connector tags `{name}/{version}` matched by
+      # release-connector.yml's own '*/*' filter (glob '*' does not match
+      # '/', so the two patterns can never collide).
+      # NOTE: bulk_release.py currently only validates the plain
+      # MAJOR.YYMMDD.PATCH format; an `-lts.N`-suffixed platform tag would
+      # match this trigger but fail version validation in the resolve step.
+      - '*.*.*'
+  workflow_dispatch:
+    inputs:
+      connectors:
+        description: >
+          Connectors to release: "all" or a comma-separated list
+          (e.g. "mitre,crowdstrike").
+        required: true
+        type: string
+        default: "all"
+      version:
+        description: >
+          Optional CalVer to tag, same for all connectors (e.g. 7.260706.0).
+          Leave empty to auto-compute today's 7.YYMMDD.0.
+        required: false
+        type: string
+        default: ""
+      manifest_only:
+        description: >
+          Manifest-only — skip Docker build/push only for every dispatched
+          connector (still handled by CircleCI during the transition). Tag,
+          GitHub Release, manifest fragment, and container_version
+          commit-back are still fully produced for each connector. Always
+          forced to true when this workflow is triggered by a platform
+          CalVer tag push.
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: "Dry run — resolve and preview connectors without dispatching releases."
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: release-bulk-connectors
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  bulk-release:
+    name: Dispatch connector releases
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required to dispatch release-connector.yml via `gh workflow run`.
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Determine effective inputs
+        id: trigger
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG_NAME: ${{ github.ref_name }}
+          INPUT_CONNECTORS: ${{ inputs.connectors }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          INPUT_MANIFEST_ONLY: ${{ inputs.manifest_only }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "push" ]; then
+            # Platform CalVer tag push: dispatch a full release (tag, GitHub
+            # Release, manifest fragment, commit-back) for every connector at
+            # this exact version, but skip the Docker build — still on CircleCI.
+            echo "connectors=all" >> "$GITHUB_OUTPUT"
+            echo "version=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            echo "manifest_only=true" >> "$GITHUB_OUTPUT"
+            echo "🏷️ Platform release tag: ${TAG_NAME} → bulk manifest-only run for all connectors"
+          else
+            echo "connectors=${INPUT_CONNECTORS}" >> "$GITHUB_OUTPUT"
+            echo "version=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "dry_run=${INPUT_DRY_RUN}" >> "$GITHUB_OUTPUT"
+            echo "manifest_only=${INPUT_MANIFEST_ONLY}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve connectors and version
+        id: resolve
+        env:
+          CONNECTORS: ${{ steps.trigger.outputs.connectors }}
+          VERSION: ${{ steps.trigger.outputs.version }}
+          DRY_RUN: ${{ steps.trigger.outputs.dry_run }}
+          MANIFEST_ONLY: ${{ steps.trigger.outputs.manifest_only }}
+        run: |
+          set -euo pipefail
+
+          ARGS=()
+          if [ "${CONNECTORS,,}" = "all" ]; then
+            ARGS+=("--all")
+          else
+            ARGS+=("--connectors" "${CONNECTORS}")
+          fi
+
+          if [ -n "${VERSION}" ]; then
+            ARGS+=("--version" "${VERSION}")
+          fi
+
+          # A dry run previews the full intended set, including connectors already
+          # released at this version. A real run (manifest-only or not) skips them,
+          # since it creates a real tag/GitHub Release per connector and re-running
+          # for an already-released version would collide with the existing tag.
+          if [ "${DRY_RUN}" = "true" ]; then
+            ARGS+=("--include-released")
+          fi
+
+          python .github/scripts/bulk_release.py "${ARGS[@]}"
+
+      - name: Dispatch per-connector releases
+        if: ${{ steps.trigger.outputs.dry_run != 'true' && steps.resolve.outputs.has_connectors == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONNECTORS_JSON: ${{ steps.resolve.outputs.connectors }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+          MANIFEST_ONLY: ${{ steps.trigger.outputs.manifest_only }}
+          REF: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "## Bulk release — version \`$VERSION\`"
+            echo ""
+            if [ "$MANIFEST_ONLY" = "true" ]; then
+              echo "🧩 **Manifest-only mode** — Docker build/push is skipped for every connector (still handled by CircleCI during the transition). Tag, GitHub Release, manifest fragment, and container_version commit-back are still fully produced for each connector."
+              echo ""
+            fi
+            echo "Dispatching connector release(s) on ref \`$REF\`."
+            echo ""
+            echo "| Connector | Target | Status |"
+            echo "|-----------|--------|--------|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          ok=0
+          failed=0
+          while IFS= read -r name; do
+            [ -z "$name" ] && continue
+            target_label="${name}/${VERSION}"
+            if gh workflow run release-connector.yml \
+                 --ref "$REF" \
+                 -f connector_name="$name" \
+                 -f version="$VERSION" \
+                 -f dry_run=false \
+                 -f manifest_only="$MANIFEST_ONLY"; then
+              echo "| $name | $target_label | ✅ dispatched |" >> "$GITHUB_STEP_SUMMARY"
+              ok=$((ok + 1))
+            else
+              echo "| $name | $target_label | ❌ dispatch failed |" >> "$GITHUB_STEP_SUMMARY"
+              failed=$((failed + 1))
+            fi
+            # Space out mutating API calls to stay clear of secondary rate limits.
+            sleep 1
+          done < <(printf '%s' "$CONNECTORS_JSON" | jq -r '.[]')
+
+          {
+            echo ""
+            echo "**${ok} dispatched, ${failed} failed.**"
+            echo ""
+            echo "🔎 Track the runs: https://github.com/${REPO}/actions/workflows/release-connector.yml"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "✅ ${ok} dispatched, ${failed} failed."
+          if [ "$failed" -gt 0 ]; then
+            exit 1
+          fi
+
+      - name: Dry run notice
+        if: ${{ steps.trigger.outputs.dry_run == 'true' }}
+        run: |
+          echo "🔎 Dry run — connectors resolved and previewed above; no releases dispatched."
+          echo "Re-run with dry_run=false to dispatch the per-connector release workflows."
+

--- a/.github/workflows/release-bulk-connectors.yml
+++ b/.github/workflows/release-bulk-connectors.yml
@@ -1,5 +1,20 @@
 name: "Release Connectors (bulk)"
 
+# Dynamic run name shown in the Actions run list, so it's obvious at a glance
+# which connectors/version a bulk run targets instead of a generic "Release
+# Connectors (bulk) #NNN". Same context limitation as release-connector.yml:
+# only `github`, `inputs`, `vars` are available here.
+run-name: >-
+  ${{
+    github.event_name == 'push'
+      && format('🚀 bulk (platform tag {0})', github.ref_name)
+      || format('🚀 bulk: {0}{1}{2}{3}',
+           inputs.connectors,
+           inputs.version != '' && format('@{0}', inputs.version) || '',
+           inputs.dry_run && ' · dry-run' || '',
+           inputs.manifest_only && ' · manifest-only' || '')
+  }}
+
 # Bulk release orchestrator.
 #
 # Resolves a set of connectors (a named list or "all") and a single shared CalVer

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -1,5 +1,22 @@
 name: "Release Connector"
 
+# Dynamic run name shown in the Actions run list, so it's obvious at a glance
+# which connector/version each run is for instead of a generic "Release
+# Connector #NNN". Context availability for `run-name` is limited to
+# `github`, `inputs`, `vars` (no job outputs), so on tag push we just reuse
+# the tag itself (already "{connector}/{version}"); on workflow_dispatch we
+# build the label from the raw inputs.
+run-name: >-
+  ${{
+    github.event_name == 'push'
+      && format('🚀 {0}', github.ref_name)
+      || format('🚀 {0}{1}{2}{3}',
+           inputs.connector_name,
+           inputs.version != '' && format('@{0}', inputs.version) || '',
+           inputs.dry_run && ' · dry-run' || '',
+           inputs.manifest_only && ' · manifest-only' || '')
+  }}
+
 # Production release pipeline for individual connectors.
 #
 # Triggers:

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -572,9 +572,11 @@ jobs:
             while IFS= read -r file; do
               rel="${file#"$PINNED_DIR"/}"
               asset="${CONNECTOR_NAME}-$(echo "$rel" | tr '/' '-')"
-              cp "$file" "${RUNNER_TEMP}/${asset}"
-              gh release upload "$TAG" "${RUNNER_TEMP}/${asset}" --clobber
-              echo "📎 Attached pinned dependency file: $asset"
+              if [ -f "$file" ]; then
+                cp "$file" "${RUNNER_TEMP}/${asset}"
+                gh release upload "$TAG" "${RUNNER_TEMP}/${asset}" --clobber
+                echo "📎 Attached pinned dependency file: $asset"
+              fi
             done < <(find "$PINNED_DIR" -type f \( -name requirements.txt -o -name pyproject.toml \))
           else
             echo "ℹ️ No pinned dependency files to attach"

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -81,7 +81,7 @@ jobs:
   # 1. Resolve connector directory and build configuration
   # ──────────────────────────────────────────────────────────
   resolve:
-    name: Resolve connector
+    name: Resolve connector ${{ inputs.connector_name}}
     runs-on: ubuntu-latest
     outputs:
       connector_name: ${{ steps.parse.outputs.connector_name }}
@@ -393,15 +393,24 @@ jobs:
   # ──────────────────────────────────────────────────────────
   # 4. Create GitHub Release + update manifest version
   # ──────────────────────────────────────────────────────────
-  # `build` is skipped (not failed) when manifest_only is true. This job's
-  # explicit `if:` (below) replaces the default `success()` gate that GitHub
-  # Actions would otherwise apply to `needs`, so it still runs in that case —
-  # only the `dry_run` (old-style build-without-push) case is excluded here.
+  # `build` is skipped (not failed) when manifest_only is true. Per GitHub's
+  # docs on `jobs.<job_id>.needs`: "If a job fails or is skipped, all jobs
+  # that need it are skipped unless the jobs use a conditional expression
+  # that causes the job to continue" — a plain custom `if:` does NOT bypass
+  # this cascade, only `always()` does. So we must use `always()` here and
+  # explicitly re-check resolve/release-notes succeeded and build didn't
+  # fail/get cancelled (skipped is fine).
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: [resolve, release-notes, build]
-    if: needs.resolve.outputs.dry_run != 'true'
+    if: |
+      always() &&
+      needs.resolve.result == 'success' &&
+      needs.release-notes.result == 'success' &&
+      needs.build.result != 'failure' &&
+      needs.build.result != 'cancelled' &&
+      needs.resolve.outputs.dry_run != 'true'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -14,6 +14,13 @@ name: "Release Connector"
 #   4. Build & push Docker image (DockerHub + GHCR)
 #   5. Create GitHub Release with changelog + manifest/schema/fragment assets
 #   6. Update container_version in manifest and commit back to default branch
+#
+# Transition mode — `manifest_only` (workflow_dispatch only, never on tag push):
+# skips step 4 (Docker build/push) only — everything else (release notes, tag,
+# GitHub Release, manifest fragment, container_version commit-back) still runs
+# normally. Used while image builds are still handled by CircleCI (see
+# release-bulk-connectors.yml, which forces this mode when triggered by a
+# platform CalVer tag push).
 
 on:
   push:
@@ -42,6 +49,15 @@ on:
         required: false
         type: boolean
         default: false
+      manifest_only:
+        description: >
+          Manifest-only — skip Docker build/push only (still handled by
+          CircleCI during the transition). Release notes, tag, GitHub
+          Release, manifest fragment, and container_version commit-back are
+          still fully produced.
+        required: false
+        type: boolean
+        default: false
       sdk_ref:
         description: >
           Optional git ref to pin connectors-sdk to in the built image.
@@ -51,7 +67,10 @@ on:
         default: ""
 
 concurrency:
-  group: release-connector-${{ github.ref_name }}
+  # Per-connector group so bulk releases (which dispatch one run per connector,
+  # all on the same branch ref) run in parallel rather than serialize. On tag
+  # push there are no inputs, so github.ref_name (the tag) is already unique.
+  group: release-connector-${{ inputs.connector_name || github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -75,6 +94,7 @@ jobs:
       image_tag: ${{ steps.meta.outputs.image_tag }}
       is_tag_push: ${{ steps.parse.outputs.is_tag_push }}
       dry_run: ${{ steps.parse.outputs.dry_run }}
+      manifest_only: ${{ steps.parse.outputs.manifest_only }}
       tag: ${{ steps.version.outputs.tag }}
       matrix_json: ${{ steps.matrix.outputs.matrix_json }}
     steps:
@@ -95,12 +115,14 @@ jobs:
             echo "connector_name=$CONNECTOR_NAME" >> "$GITHUB_OUTPUT"
             echo "is_tag_push=true" >> "$GITHUB_OUTPUT"
             echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            echo "manifest_only=false" >> "$GITHUB_OUTPUT"
             echo "🏷️ Tag push: $TAG → connector=$CONNECTOR_NAME version=$VERSION"
           else
             # workflow_dispatch: use inputs directly
             echo "connector_name=${{ inputs.connector_name }}" >> "$GITHUB_OUTPUT"
             echo "is_tag_push=false" >> "$GITHUB_OUTPUT"
             echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+            echo "manifest_only=${{ inputs.manifest_only }}" >> "$GITHUB_OUTPUT"
             echo "📋 Manual dispatch: connector=${{ inputs.connector_name }}"
           fi
 
@@ -351,6 +373,7 @@ jobs:
   # ──────────────────────────────────────────────────────────
   build:
     needs: resolve
+    if: needs.resolve.outputs.manifest_only != 'true'
     uses: ./.github/workflows/build-connector-type.yml
     permissions:
       contents: read
@@ -370,6 +393,10 @@ jobs:
   # ──────────────────────────────────────────────────────────
   # 4. Create GitHub Release + update manifest version
   # ──────────────────────────────────────────────────────────
+  # `build` is skipped (not failed) when manifest_only is true. This job's
+  # explicit `if:` (below) replaces the default `success()` gate that GitHub
+  # Actions would otherwise apply to `needs`, so it still runs in that case —
+  # only the `dry_run` (old-style build-without-push) case is excluded here.
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
@@ -468,6 +495,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHANGELOG: ${{ needs.release-notes.outputs.changelog }}
+          MANIFEST_ONLY: ${{ needs.resolve.outputs.manifest_only }}
         run: |
           CONNECTOR_NAME="${{ needs.resolve.outputs.connector_name }}"
           CONNECTOR_DIR="${{ needs.resolve.outputs.connector_dir }}"
@@ -477,9 +505,15 @@ jobs:
 
           echo "📋 Creating release: $TITLE"
 
+          NOTES="$CHANGELOG"
+          if [ "$MANIFEST_ONLY" = "true" ]; then
+            NOTICE="> 🧩 **Manifest-only release** — Docker build/push is still handled by CircleCI during the CircleCI→GitHub Actions transition; no image was built by this workflow run for this tag."
+            NOTES="${NOTICE}"$'\n\n'"${NOTES}"
+          fi
+
           gh release create "$TAG" \
             --title "$TITLE" \
-            --notes "$CHANGELOG" \
+            --notes "$NOTES" \
             --target "${{ github.sha }}"
 
           # Attach connector manifest, config schema, and manifest fragment as release assets
@@ -599,6 +633,7 @@ jobs:
       - name: Print summary
         run: |
           DRY_RUN="${{ needs.resolve.outputs.dry_run }}"
+          MANIFEST_ONLY="${{ needs.resolve.outputs.manifest_only }}"
           CONNECTOR="${{ needs.resolve.outputs.connector_name }}"
           VERSION="${{ needs.resolve.outputs.version }}"
           DIR="${{ needs.resolve.outputs.connector_dir }}"
@@ -610,7 +645,10 @@ jobs:
           {
             echo "## 🚀 Release Connector — Summary"
             echo ""
-            if [ "$DRY_RUN" = "true" ]; then
+            if [ "$MANIFEST_ONLY" = "true" ]; then
+              echo "> 🧩 **MANIFEST-ONLY** — Docker build/push was skipped (still handled by CircleCI during the transition); tag, GitHub Release, manifest fragment, and container_version commit-back were still produced normally."
+              echo ""
+            elif [ "$DRY_RUN" = "true" ]; then
               echo "> ⚠️ **DRY RUN** — no images were pushed and no release was created."
               echo ""
             fi
@@ -624,6 +662,7 @@ jobs:
             echo "| FIPS | ${FIPS} |"
             echo "| Trigger | $([ \"$IS_TAG_PUSH\" = \"true\" ] && echo \"tag push\" || echo \"manual dispatch\") |"
             echo "| Dry Run | ${DRY_RUN} |"
+            echo "| Manifest Only | ${MANIFEST_ONLY} |"
             echo ""
 
             echo "### Job Results"


### PR DESCRIPTION
## Proposed changes

* Add `.github/scripts/bulk_release.py`, a read-only resolver that computes a shared CalVer version (`MAJOR.YYMMDD.PATCH`, e.g. `7.260706.0`) and resolves which connectors to release — either an explicit `--connectors mitre,crowdstrike` list or `--all` (auto-discovered from every `CONNECTOR_TYPE_DIRS` type directory, mirroring the CI build matrix). It checks existing remote tags via `git ls-remote --tags` for idempotency (skipping already-released connector/version pairs unless `--include-released` is passed) and emits `version`/`connectors`/`count`/`skipped`/`skipped_count`/`has_connectors` outputs for a workflow to consume — no git mutations are performed by the script itself.
* Add `.github/workflows/release-bulk-connectors.yml`, a new orchestrator that calls `bulk_release.py` and then dispatches one independent `release-connector.yml` run per connector via `workflow_dispatch` (`gh workflow run`), rather than pushing multiple tags at once. It supports manual dispatch (`connectors`, `version`, `manifest_only`, `dry_run` inputs) and is also triggered by platform CalVer tag pushes (`*.*.*`), in which case it automatically runs a manifest-only bulk release for every connector in parallel with the existing CircleCI platform pipeline.
* Modify `.github/workflows/release-connector.yml` to add a `manifest_only` input/mode that skips only the Docker build/push job (`build`, gated by `needs.resolve.outputs.manifest_only != 'true'`) while still producing the tag, GitHub Release, manifest fragment, and `container_version` commit-back; also scope the concurrency group per connector (`release-connector-${{ inputs.connector_name || github.ref_name }}`) so dispatched bulk releases run in parallel instead of serializing.

## Related issues

Closes #6936

## Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

## Further comments

The core design decision here is that `bulk_release.py` and `release-bulk-connectors.yml` never push tags or build a job matrix directly — they only *resolve* what needs releasing and then fan out via `workflow_dispatch` calls to the existing per-connector `release-connector.yml`. Two GitHub platform constraints rule out the more "obvious" approaches:

- **Pushing many tags in one `git push`**: GitHub only fires push events for the first 3 tags in a single push, so bulk-tagging 250+ connectors would silently drop most of the downstream `release-connector.yml` runs.
- **Tags pushed with `GITHUB_TOKEN`**: these don't trigger tag-push-triggered workflows at all (to prevent infinite workflow loops), so any orchestrator that mutated tags itself would need a PAT with elevated permissions.

Dispatching one `workflow_dispatch` run per connector avoids both problems (dispatch always creates a run, even with the default `GITHUB_TOKEN`) and isn't subject to the 256-job matrix limit, so `--all` scales to the full connector set. The tradeoff is sequential dispatch calls with a 1s spacing to stay clear of secondary rate limits — acceptable since dispatching is cheap and the actual builds/releases still run independently and in parallel afterward.

The `manifest_only` mode exists specifically for the transition period where Docker image builds are still handled by CircleCI: the platform's CalVer tag push now also triggers a bulk manifest-only run so that per-connector tags, GitHub Releases, and manifest fragments stay in sync with the platform release, without duplicating image builds already happening in CircleCI. This is temporary scaffolding until image builds are fully migrated to GitHub Actions.

Test run on my fork: https://github.com/jabesq/connectors

<img width="1347" height="899" alt="CleanShot 2026-07-08 at 14 59 46" src="https://github.com/user-attachments/assets/81279351-d52e-4713-a947-8c44899e8f69" />

