### PR TITLE
fix(ctm360-threatcover): make connector scope optional with default value (#6960)

### DIFF
--- a/external-import/ctm360-threatcover/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/ctm360-threatcover/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -8,10 +8,10 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
 | OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
-| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'flashpoint'. |
 | CTM360_THREATCOVER_DISCOVERY_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | CTM360 ThreatCover TAXII discovery URL (e.g. https://<tenant>.ctm360.com/taxii2/). |
 | CTM360_THREATCOVER_COLLECTION | `string` | ✅ | string |  | TAXII collection to poll (the ThreatCover 'Observables' collection id or title). |
 | CONNECTOR_NAME | `string` |  | string | `"CTM360 ThreatCover"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `[]` | The scope of the connector |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
 | CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"PT1H"` | The period of time to await between two runs of the connector. |

--- a/external-import/ctm360-threatcover/__metadata__/connector_config_schema.json
+++ b/external-import/ctm360-threatcover/__metadata__/connector_config_schema.json
@@ -20,7 +20,8 @@
       "type": "string"
     },
     "CONNECTOR_SCOPE": {
-      "description": "The scope of the connector, e.g. 'flashpoint'.",
+      "default": [],
+      "description": "The scope of the connector",
       "items": {
         "type": "string"
       },
@@ -133,7 +134,6 @@
   "required": [
     "OPENCTI_URL",
     "OPENCTI_TOKEN",
-    "CONNECTOR_SCOPE",
     "CTM360_THREATCOVER_DISCOVERY_URL",
     "CTM360_THREATCOVER_COLLECTION"
   ],

--- a/external-import/ctm360-threatcover/src/connector/settings.py
+++ b/external-import/ctm360-threatcover/src/connector/settings.py
@@ -5,6 +5,7 @@ from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
     BaseExternalImportConnectorConfig,
+    ListFromString,
 )
 from pydantic import Field, HttpUrl, SecretStr
 
@@ -22,6 +23,10 @@ class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
     duration_period: timedelta = Field(
         description="The period of time to await between two runs of the connector.",
         default=timedelta(hours=1),
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector",
+        default=[],
     )
 
 


### PR DESCRIPTION
### Proposed changes

* Added a `scope: ListFromString` field with `default=[]` to `Ctm360ThreatcoverConfig` in `settings.py`, so the connector no longer requires `CONNECTOR_SCOPE` to be explicitly set
* Regenerated `connector_config_schema.json` to mark `CONNECTOR_SCOPE` as optional (removed from `required`) and added `"default": []`
* Regenerated `CONNECTOR_CONFIG_DOC.md` to reflect `CONNECTOR_SCOPE` as optional with a default of `[]`, moved to the optional parameters section

### Related issues

* Fixes #6960

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

None — small, self-contained fix that makes `CONNECTOR_SCOPE` optional with a sensible default, matching the actual runtime behavior expected by the connector.