### PR TITLE
fix(swimlane): make connector scope optional with default value (#6961)

### DIFF
--- a/external-import/swimlane/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/swimlane/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -8,11 +8,11 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
 | OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
-| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'flashpoint'. |
 | SWIMLANE_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the Swimlane instance (e.g. https://swimlane.example.com). |
 | SWIMLANE_API_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Swimlane API token (Personal Access Token) used for authentication. |
 | SWIMLANE_APPLICATION_ID | `string` | ✅ | string |  | ID of the Swimlane application whose records are imported. |
 | CONNECTOR_NAME | `string` |  | string | `"Swimlane"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `[]` | The scope of the connector |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
 | CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"PT15M"` | The period of time to await between two runs of the connector. |

--- a/external-import/swimlane/__metadata__/connector_config_schema.json
+++ b/external-import/swimlane/__metadata__/connector_config_schema.json
@@ -20,7 +20,8 @@
       "type": "string"
     },
     "CONNECTOR_SCOPE": {
-      "description": "The scope of the connector, e.g. 'flashpoint'.",
+      "default": [],
+      "description": "The scope of the connector",
       "items": {
         "type": "string"
       },
@@ -94,7 +95,6 @@
   "required": [
     "OPENCTI_URL",
     "OPENCTI_TOKEN",
-    "CONNECTOR_SCOPE",
     "SWIMLANE_API_BASE_URL",
     "SWIMLANE_API_TOKEN",
     "SWIMLANE_APPLICATION_ID"

--- a/external-import/swimlane/src/connector/settings.py
+++ b/external-import/swimlane/src/connector/settings.py
@@ -5,6 +5,7 @@ from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
     BaseExternalImportConnectorConfig,
+    ListFromString,
 )
 from pydantic import AliasChoices, Field, HttpUrl, SecretStr
 
@@ -22,6 +23,10 @@ class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
     duration_period: timedelta = Field(
         description="The period of time to await between two runs of the connector.",
         default=timedelta(minutes=15),
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector",
+        default=[],
     )
 
 


### PR DESCRIPTION
### Proposed changes

* Added a `scope: ListFromString` field with `default=[]` to the Swimlane connector's Pydantic settings model, so `CONNECTOR_SCOPE` is no longer required to be explicitly set.
* Regenerated `connector_config_schema.json` to remove `CONNECTOR_SCOPE` from the `required` list and add a `default: []`, matching the new optional behavior.
* Regenerated `CONNECTOR_CONFIG_DOC.md` to reflect `CONNECTOR_SCOPE` as optional with a default of `[]`, moved to the optional parameters section.

### Related issues

* Fixes #6961

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Small, targeted fix: no behavior change beyond making `CONNECTOR_SCOPE` optional with an empty-list default. Config schema and docs were regenerated to stay in sync with the settings model.