### PR TITLE
fix(ibm-xti): make connector scope optional with default value (#6977)

### DIFF
--- a/external-import/ibm-xti/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/ibm-xti/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -8,11 +8,11 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
 | OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
-| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'flashpoint'. |
 | IBM_XTI_TAXII_SERVER_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the IBM X-Force PTI TAXII Server. |
 | IBM_XTI_TAXII_USER | `string` | ✅ | string |  | Your TAXII Server username. |
 | IBM_XTI_TAXII_PASS | `string` | ✅ | string |  | Your TAXII Server password. |
 | CONNECTOR_NAME | `string` |  | string | `"IBMXTIConnector"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `[]` | The scope of the connector |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
 | CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"PT5M"` | The period of time to await between two runs of the connector. |

--- a/external-import/ibm-xti/__metadata__/connector_config_schema.json
+++ b/external-import/ibm-xti/__metadata__/connector_config_schema.json
@@ -20,7 +20,8 @@
       "type": "string"
     },
     "CONNECTOR_SCOPE": {
-      "description": "The scope of the connector, e.g. 'flashpoint'.",
+      "default": [],
+      "description": "The scope of the connector",
       "items": {
         "type": "string"
       },
@@ -83,7 +84,6 @@
   "required": [
     "OPENCTI_URL",
     "OPENCTI_TOKEN",
-    "CONNECTOR_SCOPE",
     "IBM_XTI_TAXII_SERVER_URL",
     "IBM_XTI_TAXII_USER",
     "IBM_XTI_TAXII_PASS"

--- a/external-import/ibm-xti/src/external_import_connector/settings.py
+++ b/external-import/ibm-xti/src/external_import_connector/settings.py
@@ -4,6 +4,7 @@ from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
     BaseExternalImportConnectorConfig,
+    ListFromString,
 )
 from pydantic import Field, HttpUrl
 
@@ -21,6 +22,10 @@ class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
     duration_period: timedelta = Field(
         description="The period of time to await between two runs of the connector.",
         default=timedelta(minutes=5),
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector",
+        default=[],
     )
 
 


### PR DESCRIPTION
### Proposed changes

* Add `scope: ListFromString` field with `default=[]` to `IBMXTIConfig` settings so the connector no longer requires `CONNECTOR_SCOPE` to be explicitly set
* Remove `CONNECTOR_SCOPE` from the `required` list in `connector_config_schema.json` and add a `default: []`, matching the new optional behavior in code
* Regenerate `CONNECTOR_CONFIG_DOC.md` to reflect `CONNECTOR_SCOPE` as optional with default `[]`, moved alongside other optional connector settings

### Related issues

* Fixes #6977

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Small, targeted fix: `CONNECTOR_SCOPE` was marked required in the schema but had no default or optional handling in code, causing invalid configuration errors. This aligns the settings model, schema, and docs.