### PR TITLE
fix(arcsight-incidents): make connector scope optional with default value (#6959)

### DIFF
--- a/external-import/arcsight-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/arcsight-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -8,11 +8,11 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
 | OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
-| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'flashpoint'. |
 | ARCSIGHT_INCIDENTS_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the ArcSight ESM Manager (e.g. https://arcsight.example.com:8443). |
 | ARCSIGHT_INCIDENTS_USERNAME | `string` | ✅ | string |  | ArcSight ESM user name. |
 | ARCSIGHT_INCIDENTS_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | ArcSight ESM user password. |
 | CONNECTOR_NAME | `string` |  | string | `"ArcSight Incidents"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `[]` | The scope of the connector |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
 | CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"PT15M"` | The period of time to await between two runs of the connector. |

--- a/external-import/arcsight-incidents/__metadata__/connector_config_schema.json
+++ b/external-import/arcsight-incidents/__metadata__/connector_config_schema.json
@@ -20,7 +20,8 @@
       "type": "string"
     },
     "CONNECTOR_SCOPE": {
-      "description": "The scope of the connector, e.g. 'flashpoint'.",
+      "default": [],
+      "description": "The scope of the connector",
       "items": {
         "type": "string"
       },
@@ -94,7 +95,6 @@
   "required": [
     "OPENCTI_URL",
     "OPENCTI_TOKEN",
-    "CONNECTOR_SCOPE",
     "ARCSIGHT_INCIDENTS_API_BASE_URL",
     "ARCSIGHT_INCIDENTS_USERNAME",
     "ARCSIGHT_INCIDENTS_PASSWORD"

--- a/external-import/arcsight-incidents/src/connector/settings.py
+++ b/external-import/arcsight-incidents/src/connector/settings.py
@@ -5,6 +5,7 @@ from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
     BaseExternalImportConnectorConfig,
+    ListFromString,
 )
 from pydantic import AliasChoices, Field, HttpUrl, SecretStr
 
@@ -22,6 +23,10 @@ class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
     duration_period: timedelta = Field(
         description="The period of time to await between two runs of the connector.",
         default=timedelta(minutes=15),
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector",
+        default=[],
     )
 
 


### PR DESCRIPTION
### Proposed changes

* Added a `scope: ListFromString` field with `default=[]` to `ArcSightIncidentsConnectorConfig` in `settings.py`, so the connector no longer requires `CONNECTOR_SCOPE` to be explicitly set — preventing invalid configuration errors when it's omitted.
* Removed `CONNECTOR_SCOPE` from the `required` list in `connector_config_schema.json` and added a `default: []` to match the new optional behavior.
* Regenerated `CONNECTOR_CONFIG_DOC.md` to reflect `CONNECTOR_SCOPE` as optional with a default value of `[]`, keeping documentation in sync with the schema.

### Related issues

* Fixes #6959

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Small, targeted fix aligning the connector's config schema and settings model with the intended optional behavior of `CONNECTOR_SCOPE`. No other logic was touched.