### PR TITLE
feat(ioc-extractor): upgrade connector to verified status (#6983)

### DIFF
--- a/internal-enrichment/ioc-extractor/README.md
+++ b/internal-enrichment/ioc-extractor/README.md
@@ -60,14 +60,15 @@ The **IOC Extractor** enrichment connector extracts Observables from unstructure
 
 ### Connector-specific parameters
 
-| Parameter                 | Docker environment variable               | Default | Description                                                   |
-|---------------------------|-------------------------------------------|---------|---------------------------------------------------------------|
-| Extract hashes            | `IOC_EXTRACTOR_EXTRACT_HASHES`            | `true`  | Extract MD5, SHA-1, SHA-256 file hashes                       |
-| Extract IPv4              | `IOC_EXTRACTOR_EXTRACT_IPV4`              | `true`  | Extract IPv4 addresses                                        |
-| Extract IPv6              | `IOC_EXTRACTOR_EXTRACT_IPV6`              | `true`  | Extract IPv6 addresses                                        |
-| Extract domains           | `IOC_EXTRACTOR_EXTRACT_DOMAINS`           | `true`  | Extract domain names                                          |
-| Extract URLs              | `IOC_EXTRACTOR_EXTRACT_URLS`              | `true`  | Extract URLs                                                  |
-| Skip private IPs          | `IOC_EXTRACTOR_SKIP_PRIVATE_IPS`          | `true`  | Skip private/reserved IP addresses (RFC 1918, loopback, etc.) |
+| Parameter                 | Docker environment variable               | Default      | Description                                                   |
+|---------------------------|-------------------------------------------|--------------|---------------------------------------------------------------|
+| Extract hashes            | `IOC_EXTRACTOR_EXTRACT_HASHES`            | `true`       | Extract MD5, SHA-1, SHA-256 file hashes                       |
+| Extract IPv4              | `IOC_EXTRACTOR_EXTRACT_IPV4`              | `true`       | Extract IPv4 addresses                                        |
+| Extract IPv6              | `IOC_EXTRACTOR_EXTRACT_IPV6`              | `true`       | Extract IPv6 addresses                                        |
+| Extract domains           | `IOC_EXTRACTOR_EXTRACT_DOMAINS`           | `true`       | Extract domain names                                          |
+| Extract URLs              | `IOC_EXTRACTOR_EXTRACT_URLS`              | `true`       | Extract URLs                                                  |
+| Skip private IPs          | `IOC_EXTRACTOR_SKIP_PRIVATE_IPS`          | `true`       | Skip private/reserved IP addresses (RFC 1918, loopback, etc.) |
+| Max TLP                   | `IOC_EXTRACTOR_MAX_TLP`                   | `TLP:AMBER`  | The maximal TLP of the observable being enriched              |
 
 ## Deployment
 

--- a/internal-enrichment/ioc-extractor/README.md
+++ b/internal-enrichment/ioc-extractor/README.md
@@ -41,34 +41,14 @@ The **IOC Extractor** enrichment connector extracts Observables from unstructure
 
 ## Configuration
 
+There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or in `config.yml` (for manual deployment).
+
 ### OpenCTI environment variables
 
-| Parameter     | Docker environment variable | Mandatory | Description                                          |
-| ------------- | --------------------------- | --------- | ---------------------------------------------------- |
-| OpenCTI URL   | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
-| OpenCTI Token | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-### Base connector environment variables
-
-| Parameter       | Docker environment variable | Default       | Mandatory | Description                                                   |
-|-----------------|-----------------------------|---------------|-----------|---------------------------------------------------------------|
-| Connector ID    | `CONNECTOR_ID`              | /             | Yes       | A unique `UUIDv4` identifier for this connector instance.     |
-| Connector Name  | `CONNECTOR_NAME`            | IOC Extractor | No        | Name of the connector.                                        |
-| Connector Scope | `CONNECTOR_SCOPE`           | Report,...    | No        | The scope of entities to enrich (comma-separated STIX types). |
-| Log Level       | `CONNECTOR_LOG_LEVEL`       | info          | No        | Log verbosity: `debug`, `info`, `warn`, or `error`.           |
-| Connector Auto  | `CONNECTOR_AUTO`            | false         | No        | Enable auto-enrichment on entity creation.                    |
-
-### Connector-specific parameters
-
-| Parameter                 | Docker environment variable               | Default      | Description                                                   |
-|---------------------------|-------------------------------------------|--------------|---------------------------------------------------------------|
-| Extract hashes            | `IOC_EXTRACTOR_EXTRACT_HASHES`            | `true`       | Extract MD5, SHA-1, SHA-256 file hashes                       |
-| Extract IPv4              | `IOC_EXTRACTOR_EXTRACT_IPV4`              | `true`       | Extract IPv4 addresses                                        |
-| Extract IPv6              | `IOC_EXTRACTOR_EXTRACT_IPV6`              | `true`       | Extract IPv6 addresses                                        |
-| Extract domains           | `IOC_EXTRACTOR_EXTRACT_DOMAINS`           | `true`       | Extract domain names                                          |
-| Extract URLs              | `IOC_EXTRACTOR_EXTRACT_URLS`              | `true`       | Extract URLs                                                  |
-| Skip private IPs          | `IOC_EXTRACTOR_SKIP_PRIVATE_IPS`          | `true`       | Skip private/reserved IP addresses (RFC 1918, loopback, etc.) |
-| Max TLP                   | `IOC_EXTRACTOR_MAX_TLP`                   | `TLP:AMBER`  | The maximal TLP of the observable being enriched              |
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
 ## Deployment
 

--- a/internal-enrichment/ioc-extractor/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/ioc-extractor/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -19,3 +19,4 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | IOC_EXTRACTOR_EXTRACT_DOMAINS | `boolean` |  | boolean | `true` | Extract domain names. |
 | IOC_EXTRACTOR_EXTRACT_URLS | `boolean` |  | boolean | `true` | Extract URLs. |
 | IOC_EXTRACTOR_SKIP_PRIVATE_IPS | `boolean` |  | boolean | `true` | Skip private/reserved IP addresses (RFC 1918, loopback, etc.). |
+| IOC_EXTRACTOR_MAX_TLP | `string` |  | `TLP:CLEAR` `TLP:WHITE` `TLP:GREEN` `TLP:AMBER` `TLP:AMBER+STRICT` `TLP:RED` | `"TLP:AMBER"` | The maximal TLP of the observable being enriched. |

--- a/internal-enrichment/ioc-extractor/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/ioc-extractor/__metadata__/connector_config_schema.json
@@ -80,6 +80,19 @@
       "default": true,
       "description": "Skip private/reserved IP addresses (RFC 1918, loopback, etc.).",
       "type": "boolean"
+    },
+    "IOC_EXTRACTOR_MAX_TLP": {
+      "default": "TLP:AMBER",
+      "description": "The maximal TLP of the observable being enriched.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
     }
   },
   "required": [

--- a/internal-enrichment/ioc-extractor/__metadata__/connector_manifest.json
+++ b/internal-enrichment/ioc-extractor/__metadata__/connector_manifest.json
@@ -11,8 +11,8 @@
     "Enrichment & Reputation"
   ],
   "license_type": "Free",
-  "verified": false,
-  "last_verified_date": null,
+  "verified": true,
+  "last_verified_date": "2026-07-10",
   "playbook_supported": true,
   "max_confidence_level": 50,
   "support_version": ">=7.260701.0",

--- a/internal-enrichment/ioc-extractor/src/connector/connector.py
+++ b/internal-enrichment/ioc-extractor/src/connector/connector.py
@@ -37,11 +37,11 @@ class IOCExtractorConnector:
         for marking_definition in opencti_entity.get("objectMarking", []):
             if marking_definition["definition_type"] == "TLP":
                 tlp = marking_definition["definition"]
-        if not OpenCTIConnectorHelper.check_max_tlp(
-            tlp, self.config.ioc_extractor.max_tlp
-        ):
+        max_tlp = self.config.ioc_extractor.max_tlp
+        if not OpenCTIConnectorHelper.check_max_tlp(tlp, max_tlp):
             raise ValueError(
-                "Do not send any data, TLP of the observable is greater than MAX TLP"
+                f"Do not send any data, TLP of the observable ({tlp}) is greater "
+                f"than MAX TLP ({max_tlp})"
             )
 
     @staticmethod

--- a/internal-enrichment/ioc-extractor/src/connector/connector.py
+++ b/internal-enrichment/ioc-extractor/src/connector/connector.py
@@ -6,6 +6,7 @@ from connectors_sdk.models import (
     File,
     IPV4Address,
     IPV6Address,
+    OrganizationAuthor,
     Relationship,
 )
 from connectors_sdk.models.enums import HashAlgorithm, RelationshipType
@@ -17,6 +18,7 @@ class IOCExtractorConnector:
     def __init__(self, config: ConnectorSettings, helper: OpenCTIConnectorHelper):
         self.config = config
         self.helper = helper
+        self.author = OrganizationAuthor(name="IOC Extractor")
 
     @staticmethod
     def _get_description(stix_entity: dict, opencti_entity: dict) -> str:
@@ -29,24 +31,49 @@ class IOCExtractorConnector:
         marking_refs = stix_entity.get("object_marking_refs", [])
         return [Reference(id=ref) for ref in marking_refs] if marking_refs else None
 
+    def _extract_and_check_markings(self, opencti_entity: dict) -> None:
+        """Extract TLP from entity and check against max_tlp config."""
+        tlp = "TLP:CLEAR"
+        for marking_definition in opencti_entity.get("objectMarking", []):
+            if marking_definition["definition_type"] == "TLP":
+                tlp = marking_definition["definition"]
+        if not OpenCTIConnectorHelper.check_max_tlp(
+            tlp, self.config.ioc_extractor.max_tlp
+        ):
+            raise ValueError(
+                "Do not send any data, TLP of the observable is greater than MAX TLP"
+            )
+
     @staticmethod
-    def _ioc_to_stix_object(ioc: ExtractedIOC, markings=None):
+    def _ioc_to_stix_object(ioc: ExtractedIOC, markings=None, author=None):
         """Convert an ExtractedIOC to a connectors-sdk model instance."""
         match ioc.type:
             case "ipv4":
-                return IPV4Address(value=ioc.value, markings=markings)
+                return IPV4Address(value=ioc.value, markings=markings, author=author)
             case "ipv6":
-                return IPV6Address(value=ioc.value, markings=markings)
+                return IPV6Address(value=ioc.value, markings=markings, author=author)
             case "domain":
-                return DomainName(value=ioc.value, markings=markings)
+                return DomainName(value=ioc.value, markings=markings, author=author)
             case "url":
-                return URL(value=ioc.value, markings=markings)
+                return URL(value=ioc.value, markings=markings, author=author)
             case "md5":
-                return File(hashes={HashAlgorithm.MD5: ioc.value}, markings=markings)
+                return File(
+                    hashes={HashAlgorithm.MD5: ioc.value},
+                    markings=markings,
+                    author=author,
+                )
             case "sha1":
-                return File(hashes={HashAlgorithm.SHA1: ioc.value}, markings=markings)
+                return File(
+                    hashes={HashAlgorithm.SHA1: ioc.value},
+                    markings=markings,
+                    author=author,
+                )
             case "sha256":
-                return File(hashes={HashAlgorithm.SHA256: ioc.value}, markings=markings)
+                return File(
+                    hashes={HashAlgorithm.SHA256: ioc.value},
+                    markings=markings,
+                    author=author,
+                )
             case _:
                 return None
 
@@ -58,7 +85,9 @@ class IOCExtractorConnector:
         observable_ids = []
 
         for ioc in iocs:
-            sdk_object = self._ioc_to_stix_object(ioc, markings=markings)
+            sdk_object = self._ioc_to_stix_object(
+                ioc, markings=markings, author=self.author
+            )
             if sdk_object is None:
                 continue
 
@@ -98,6 +127,9 @@ class IOCExtractorConnector:
             opencti_entity = data["enrichment_entity"]
             stix_objects = data["stix_objects"]
             stix_entity = data["stix_entity"]
+
+            # Check TLP marking against max_tlp configuration
+            self._extract_and_check_markings(opencti_entity)
 
             config = self.config.ioc_extractor
             description = self._get_description(stix_entity, opencti_entity)
@@ -142,8 +174,10 @@ class IOCExtractorConnector:
                     )
                     stix_objects.append(relationship.to_stix2_object())
 
-            # Merge enrichment objects with original bundle
-            all_objects = stix_objects + enrichment_objects
+            # Merge enrichment objects with original bundle (include author identity)
+            all_objects = (
+                [self.author.to_stix2_object()] + stix_objects + enrichment_objects
+            )
             bundles_sent = self._send_bundle(all_objects)
 
             self.helper.connector_logger.info(

--- a/internal-enrichment/ioc-extractor/src/connector/settings.py
+++ b/internal-enrichment/ioc-extractor/src/connector/settings.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
@@ -31,6 +33,17 @@ class IOCExtractorConfig(BaseConfigModel):
     skip_private_ips: bool = Field(
         description="Skip private/reserved IP addresses (RFC 1918, loopback, etc.).",
         default=True,
+    )
+    max_tlp: Literal[
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED",
+    ] = Field(
+        description="The maximal TLP of the observable being enriched.",
+        default="TLP:AMBER",
     )
 
 


### PR DESCRIPTION
## Description

Upgrades the IOC Extractor connector to **Verified** status and fixes verification errors.

Closes #6983

## Changes

- **Manifest**: Set `verified: true` and `last_verified_date: 2026-07-10`
- **Author identity** (VC301/VC302): Added `OrganizationAuthor(name="IOC Extractor")` and passed to all SDK model constructors
- **TLP check** (VC304/VC320): Added `max_tlp` config setting (default `TLP:AMBER`) and `_extract_and_check_markings()` reading `opencti_entity["objectMarking"]`
- **Bundle**: Author identity included for `cleanup_inconsistent_bundle` support
- **README**: Documented new `IOC_EXTRACTOR_MAX_TLP` parameter