### PR TITLE
feat(connector-linter): add VC326 check for ListFromString settings missing a default value (#6978)

### DIFF
--- a/shared/tools/connector_linter/connector_linter/checks/vc3xx_code/vc326_list_from_string_default.py
+++ b/shared/tools/connector_linter/connector_linter/checks/vc3xx_code/vc326_list_from_string_default.py
@@ -1,0 +1,230 @@
+"""VC326 — ListFromString settings must define a default value.
+
+``connectors_sdk.ListFromString`` fields that have no default (not even an
+empty list) cannot be used from the OpenCTI Composer UI: a required
+array-typed setting with no default blocks form submission, and it also
+prevents the connector from starting when the corresponding environment
+variable is left unset.
+
+Two complementary detections are performed:
+
+1. **Code** — any concrete/leaf class defines a field annotated
+   ``ListFromString`` without a default (no bare value, no
+   ``Field(default=...)``/positional default, no ``default_factory``).
+   Classes prefixed with ``_`` (e.g. ``connectors_sdk``'s
+   ``_BaseConnectorConfig``) or locally subclassed elsewhere in the same
+   connector (e.g. an interface-style ``ConfigLoaderConnectorExtra``
+   overridden by a concrete ``ConfigLoaderConnector``) follow the codebase's
+   abstract/interface config convention and are expected to have their
+   default supplied by the concrete subclass — these are skipped.
+2. **Config schema** — ``__metadata__/connector_config_schema.json`` is the
+   rendered, inheritance-resolved artifact actually consumed by the
+   Composer UI. Any ``array`` property with ``string`` items but no
+   ``default`` key is flagged, catching the case where a concrete settings
+   class inherits a ``ListFromString`` field (e.g. ``scope``) from an SDK
+   base class but forgets to override it with a default.
+
+Scope: Common (all connector types).
+"""
+
+import ast
+from pathlib import Path
+
+from connector_linter.models import (
+    CheckFinding,
+    ConnectorContext,
+    Severity,
+    no_python_sources_finding,
+)
+from connector_linter.registry import CheckRegistry
+
+
+def _annotation_references_list_from_string(annotation: ast.expr) -> bool:
+    """Return True if the annotation node references ``ListFromString``.
+
+    Handles direct usage (``scope: ListFromString``) as well as wrapped
+    usages (``Optional[ListFromString]``, ``ListFromString | None``) by
+    walking the whole annotation subtree.
+    """
+    for node in ast.walk(annotation):
+        if isinstance(node, ast.Name) and node.id == "ListFromString":
+            return True
+    return False
+
+
+def _field_call_has_default(call: ast.Call) -> bool:
+    """Return True if a ``Field(...)`` call defines a default or a factory."""
+    for kw in call.keywords:
+        if kw.arg in ("default", "default_factory"):
+            return True
+    # Field("value", ...) — positional first argument is the default
+    return bool(call.args)
+
+
+def _local_base_class_names(trees: dict[Path, ast.Module]) -> set[str]:
+    """Return the names of every locally-defined class used as a base class.
+
+    Connectors in this codebase follow (with varying naming: ``_Foo``,
+    ``FooExtra``, or a shared ``Config``/``ConnectorConfig`` module) the
+    convention of an abstract/interface config class that a concrete
+    subclass overrides with real defaults (see ``connectors_sdk``'s
+    ``_BaseConnectorConfig``). A class subclassed elsewhere in the same
+    connector is therefore not the final word on defaults — the subclass is.
+    """
+    base_names: set[str] = set()
+    for tree in trees.values():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for base in node.bases:
+                if isinstance(base, ast.Name):
+                    base_names.add(base.id)
+                elif isinstance(base, ast.Attribute):
+                    base_names.add(base.attr)
+    return base_names
+
+
+def _find_missing_defaults(
+    trees: dict[Path, ast.Module],
+) -> list[tuple[Path, int, str, str]]:
+    """Return (file, line, class_name, field_name) for fields missing a default.
+
+    Only inspects concrete/leaf classes: names prefixed with ``_`` (abstract
+    convention) and classes locally subclassed elsewhere (interface classes
+    expected to be overridden) are skipped — the defaults they lack are
+    expected to be supplied by whichever concrete class wins at runtime,
+    which is verified separately via the rendered config schema.
+    """
+    abstract_names = _local_base_class_names(trees)
+    hits: list[tuple[Path, int, str, str]] = []
+    for file_path, tree in trees.items():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            if node.name.startswith("_") or node.name in abstract_names:
+                continue
+            for stmt in node.body:
+                if not isinstance(stmt, ast.AnnAssign) or not isinstance(
+                    stmt.target,
+                    ast.Name,
+                ):
+                    continue
+                if not _annotation_references_list_from_string(stmt.annotation):
+                    continue
+
+                if stmt.value is None:
+                    # Bare annotation, e.g. `scope: ListFromString` — no default
+                    hits.append(
+                        (file_path, stmt.lineno, node.name, stmt.target.id),
+                    )
+                    continue
+
+                if isinstance(stmt.value, ast.Call):
+                    func = stmt.value.func
+                    func_name = (
+                        func.id
+                        if isinstance(func, ast.Name)
+                        else func.attr if isinstance(func, ast.Attribute) else ""
+                    )
+                    if func_name == "Field" and not _field_call_has_default(
+                        stmt.value,
+                    ):
+                        hits.append(
+                            (file_path, stmt.lineno, node.name, stmt.target.id),
+                        )
+                # Any other assigned value (e.g. a direct list literal) counts
+                # as a default.
+    return hits
+
+
+def _find_schema_properties_missing_default(
+    config_schema: dict,
+) -> list[str]:
+    """Return property names that look like ListFromString but lack a default.
+
+    Detected via the rendered JSON schema shape produced for
+    ``ListFromString`` fields: ``{"type": "array", "items": {"type": "string"}}``.
+    """
+    missing: list[str] = []
+    properties = config_schema.get("properties", {})
+    if not isinstance(properties, dict):
+        return missing
+    for name, prop in properties.items():
+        if not isinstance(prop, dict):
+            continue
+        if prop.get("type") != "array":
+            continue
+        items = prop.get("items", {})
+        if isinstance(items, dict) and items.get("type") == "string":
+            if "default" not in prop:
+                missing.append(name)
+    return missing
+
+
+@CheckRegistry.register(
+    code="VC326",
+    name="list-from-string-default",
+    description="ListFromString settings must define a default value (even an empty list)",
+    severity=Severity.ERROR,
+)
+def check_list_from_string_default(ctx: ConnectorContext) -> list[CheckFinding]:
+    """Check that ListFromString fields always define a default value."""
+    sources = ctx.python_sources
+    if not sources:
+        return [no_python_sources_finding()]
+
+    trees = ctx.python_trees
+    results: list[CheckFinding] = []
+
+    # 1. Code — concrete class fields with no default
+    code_hits = _find_missing_defaults(trees)
+    for file_path, line, class_name, field_name in code_hits:
+        results.append(
+            CheckFinding(
+                message=(
+                    f"{file_path}:{line}: {class_name}.{field_name} is a "
+                    "ListFromString without a default value"
+                ),
+                severity=Severity.ERROR,
+                file_path=ctx.path / file_path,
+                line=line,
+                suggestion=(
+                    "Set a default (even an empty list, e.g. default=[]) on "
+                    f"{class_name}.{field_name}. Without a default, this "
+                    "setting cannot be used from the Composer UI and blocks "
+                    "the connector if the env var is unset"
+                ),
+            ),
+        )
+
+    # 2. Config schema — rendered artifact actually consumed by Composer UI
+    if ctx.config_schema:
+        for prop_name in _find_schema_properties_missing_default(ctx.config_schema):
+            results.append(
+                CheckFinding(
+                    message=(
+                        f"Config schema property '{prop_name}' is an array of "
+                        "strings with no default value"
+                    ),
+                    severity=Severity.ERROR,
+                    file_path=ctx.path
+                    / "__metadata__"
+                    / "connector_config_schema.json",
+                    suggestion=(
+                        f"Give '{prop_name}' a default (even an empty list) in "
+                        "its settings class. It is likely inherited from an SDK "
+                        "base config class (e.g. 'scope') without being "
+                        "overridden with a default in the connector's own "
+                        "settings"
+                    ),
+                ),
+            )
+
+    if not results:
+        return [
+            CheckFinding(
+                message="All ListFromString settings define a default value ✓",
+                severity=Severity.INFO,
+            ),
+        ]
+    return results

--- a/shared/tools/connector_linter/tests/tests_checks/test_vc326_list_from_string_default.py
+++ b/shared/tools/connector_linter/tests/tests_checks/test_vc326_list_from_string_default.py
@@ -1,0 +1,175 @@
+"""Unit tests for VC326 — ListFromString settings must define a default value."""
+
+import json
+
+from connector_linter.models import Severity
+from connector_linter.runner import run_checks
+
+_WITH_DEFAULT = """\
+from connectors_sdk import ListFromString
+from pydantic import Field
+
+
+class ConnectorSettings:
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+        default=["myconnector"],
+    )
+"""
+
+_WITH_EMPTY_LIST_DEFAULT = """\
+from connectors_sdk import ListFromString
+from pydantic import Field
+
+
+class ConnectorSettings:
+    report_extract_iocs: ListFromString = Field(
+        description="IOC types to extract.",
+        default=[],
+    )
+"""
+
+_BARE_ANNOTATION_NO_DEFAULT = """\
+from connectors_sdk import ListFromString
+
+
+class ConnectorSettings:
+    scope: ListFromString
+"""
+
+_FIELD_WITHOUT_DEFAULT = """\
+from connectors_sdk import ListFromString
+from pydantic import Field
+
+
+class ConnectorSettings:
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+    )
+"""
+
+_ABSTRACT_CLASS_NO_DEFAULT_OK = """\
+from connectors_sdk import ListFromString
+from pydantic import Field
+
+
+class _BaseConnectorConfig:
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+    )
+"""
+
+_NO_LIST_FROM_STRING = """\
+class ConnectorSettings:
+    api_key: str
+"""
+
+_INTERFACE_CLASS_OVERRIDDEN_BY_SUBCLASS_OK = """\
+from connectors_sdk import ListFromString
+from pydantic import Field
+
+
+class ConfigLoaderConnectorExtra:
+    \"\"\"Interface for loading Connector dedicated configuration.\"\"\"
+
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+    )
+
+
+class ConfigLoaderConnector(ConfigLoaderConnectorExtra):
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+        default=["myconnector"],
+    )
+"""
+
+
+class TestVC326ListFromStringDefault:
+    """VC326 flags ListFromString fields with no default value."""
+
+    def test_passes_with_default(self, connector_src):
+        path = connector_src(("src/settings.py", _WITH_DEFAULT))
+        results = run_checks(path, select=["VC326"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_passes_with_empty_list_default(self, connector_src):
+        path = connector_src(("src/settings.py", _WITH_EMPTY_LIST_DEFAULT))
+        results = run_checks(path, select=["VC326"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_fails_bare_annotation_no_default(self, connector_src):
+        path = connector_src(("src/settings.py", _BARE_ANNOTATION_NO_DEFAULT))
+        results = run_checks(path, select=["VC326"])
+        assert any(r.severity == Severity.ERROR for r in results)
+
+    def test_fails_field_without_default(self, connector_src):
+        path = connector_src(("src/settings.py", _FIELD_WITHOUT_DEFAULT))
+        results = run_checks(path, select=["VC326"])
+        assert any(r.severity == Severity.ERROR for r in results)
+
+    def test_passes_abstract_class_without_default(self, connector_src):
+        """Classes prefixed with `_` are abstract/interface bases and are skipped."""
+        path = connector_src(("src/settings.py", _ABSTRACT_CLASS_NO_DEFAULT_OK))
+        results = run_checks(path, select=["VC326"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_passes_no_list_from_string(self, connector_src):
+        path = connector_src(("src/settings.py", _NO_LIST_FROM_STRING))
+        results = run_checks(path, select=["VC326"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_passes_interface_class_overridden_by_subclass(self, connector_src):
+        """An interface-style base class (no `_` prefix) that is locally
+        subclassed with a default is not flagged — the concrete subclass wins.
+        """
+        path = connector_src(
+            (
+                "src/settings.py",
+                _INTERFACE_CLASS_OVERRIDDEN_BY_SUBCLASS_OK,
+            ),
+        )
+        results = run_checks(path, select=["VC326"])
+        assert all(r.severity == Severity.INFO for r in results)
+
+    def test_fails_schema_array_property_without_default(self, connector_src):
+        """A concrete class not overriding an inherited field is caught via schema."""
+        path = connector_src(("src/settings.py", _NO_LIST_FROM_STRING))
+        schema_path = path / "__metadata__" / "connector_config_schema.json"
+        schema_path.write_text(
+            json.dumps(
+                {
+                    "properties": {
+                        "CONNECTOR_SCOPE": {
+                            "description": "The scope of the connector.",
+                            "items": {"type": "string"},
+                            "type": "array",
+                        },
+                    },
+                },
+            ),
+            encoding="utf-8",
+        )
+        results = run_checks(path, select=["VC326"])
+        assert any(r.severity == Severity.ERROR for r in results)
+
+    def test_passes_schema_array_property_with_default(self, connector_src):
+        path = connector_src(("src/settings.py", _NO_LIST_FROM_STRING))
+        schema_path = path / "__metadata__" / "connector_config_schema.json"
+        schema_path.write_text(
+            json.dumps(
+                {
+                    "properties": {
+                        "CONNECTOR_SCOPE": {
+                            "default": ["myconnector"],
+                            "description": "The scope of the connector.",
+                            "items": {"type": "string"},
+                            "type": "array",
+                        },
+                    },
+                },
+            ),
+            encoding="utf-8",
+        )
+        results = run_checks(path, select=["VC326"])
+        assert all(r.severity == Severity.INFO for r in results)


### PR DESCRIPTION
### Proposed changes

* Add new connector-linter check VC326, which flags pydantic `ListFromString` settings that lack a default value — without a default, the setting can't be configured from the OpenCTI Composer UI and can block the connector from starting if the corresponding env var is unset.
* Implement AST-based detection of `ListFromString`-annotated fields with no default (bare value, `Field(default=...)`, positional default, or `default_factory`) in concrete/leaf classes, skipping intentionally abstract base classes (prefixed with `_` or locally subclassed elsewhere in the connector).
* Implement complementary detection against the generated `connector_config_schema.json`, flagging `array`/string-items properties with no `"default"` key, to catch cases where a concrete settings class inherits a `ListFromString` field from an SDK base class without overriding its default.
* Add 9 unit tests for VC326 under `shared/tools/connector_linter/tests/tests_checks/test_vc326_list_from_string_default.py`.

### Related issues

* Closes #6978

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The check uses a two-pronged detection strategy because a single approach can't reliably catch every case:

1. **Code (AST) analysis** catches missing defaults directly on `ListFromString` fields declared in a connector's own settings classes.
2. **Config schema analysis** catches the trickier case where a concrete settings class *inherits* a `ListFromString` field (e.g. `scope`) from an SDK base class but never overrides it with a default — this isn't visible from AST inspection of the connector's own code, but shows up as a missing `"default"` key on an `array`/string-items property in the generated `connector_config_schema.json`.

Validated against the ~200 real connectors in this repo: found 6 genuine bugs (missing `CONNECTOR_SCOPE` defaults in swimlane, ibm-xti, arcsight-incidents, ctm360-cyna-feed, ctm360-threatcover, ctm360-cyberblindspot-feed — some already fixed in separate PRs), with zero false positives and no crashes. Full connector-linter suite (169 tests) passes.
