### PR TITLE
feat(urlscan): migrate connector to manager-supported mode (#6866)

### DIFF
--- a/external-import/urlscan/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/urlscan/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,24 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| URLSCAN_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The Urlscan API key. |
+| CONNECTOR_NAME | `string` |  | string | `"Urlscan"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["urlscan"]` | The scope of the connector, e.g. 'urlscan'. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
+| CONNECTOR_INTERVAL | `integer` |  | integer | `86400` | Interval between two runs of the connector, in seconds. |
+| CONNECTOR_LOOKBACK | `integer` |  | integer | `3` | How far to look back in days if the connector has never run or its last run is older than this value. |
+| URLSCAN_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"https://urlscan.io/api/v1/pro/phishfeed?format=json"` | The Urlscan feed URL to query. |
+| URLSCAN_CREATE_INDICATORS | `boolean` |  | boolean | `true` | Whether to create indicators for imported observables. |
+| URLSCAN_UPDATE_EXISTING_DATA | `boolean` |  | boolean | `true` | Whether to update data already ingested into the platform. |
+| URLSCAN_DEFAULT_TLP | `string` |  | string | `"white"` | Default TLP marking applied to imported data. |
+| URLSCAN_DEFAULT_X_OPENCTI_SCORE | `integer` |  | integer | `50` | Default x_opencti_score applied to imported data. |
+| URLSCAN_X_OPENCTI_SCORE_DOMAIN | `integer` |  | integer | `null` | Optional x_opencti_score for domain-name observables. |
+| URLSCAN_X_OPENCTI_SCORE_URL | `integer` |  | integer | `null` | Optional x_opencti_score for url observables. |

--- a/external-import/urlscan/__metadata__/connector_config_schema.json
+++ b/external-import/urlscan/__metadata__/connector_config_schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/urlscan_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Urlscan",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "urlscan"
+      ],
+      "description": "The scope of the connector, e.g. 'urlscan'.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_INTERVAL": {
+      "default": 86400,
+      "description": "Interval between two runs of the connector, in seconds.",
+      "type": "integer"
+    },
+    "CONNECTOR_LOOKBACK": {
+      "default": 3,
+      "description": "How far to look back in days if the connector has never run or its last run is older than this value.",
+      "type": "integer"
+    },
+    "URLSCAN_URL": {
+      "default": "https://urlscan.io/api/v1/pro/phishfeed?format=json",
+      "description": "The Urlscan feed URL to query.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "URLSCAN_API_KEY": {
+      "description": "The Urlscan API key.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "URLSCAN_CREATE_INDICATORS": {
+      "default": true,
+      "description": "Whether to create indicators for imported observables.",
+      "type": "boolean"
+    },
+    "URLSCAN_UPDATE_EXISTING_DATA": {
+      "default": true,
+      "description": "Whether to update data already ingested into the platform.",
+      "type": "boolean"
+    },
+    "URLSCAN_DEFAULT_TLP": {
+      "default": "white",
+      "description": "Default TLP marking applied to imported data.",
+      "type": "string"
+    },
+    "URLSCAN_DEFAULT_X_OPENCTI_SCORE": {
+      "default": 50,
+      "description": "Default x_opencti_score applied to imported data.",
+      "type": "integer"
+    },
+    "URLSCAN_X_OPENCTI_SCORE_DOMAIN": {
+      "default": null,
+      "description": "Optional x_opencti_score for domain-name observables.",
+      "type": "integer"
+    },
+    "URLSCAN_X_OPENCTI_SCORE_URL": {
+      "default": null,
+      "description": "Optional x_opencti_score for url observables.",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "URLSCAN_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/urlscan/__metadata__/connector_manifest.json
+++ b/external-import/urlscan/__metadata__/connector_manifest.json
@@ -15,7 +15,7 @@
   "support_version": ">=6.8.0",
   "subscription_link": "https://urlscan.io/pricing/phishingfeed/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/urlscan",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-urlscan",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/urlscan/docker-compose.yml
+++ b/external-import/urlscan/docker-compose.yml
@@ -6,15 +6,17 @@ services:
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
-      - CONNECTOR_NAME=Urlscan
-      - CONNECTOR_SCOPE=urlscan
-      - CONNECTOR_LOG_LEVEL=error
-      - CONNECTOR_CREATE_INDICATORS=true
-      - CONNECTOR_TLP=white
-      - CONNECTOR_LABELS=Phishing,Phishfeed
-      - CONNECTOR_INTERVAL=86400 # seconds, 1d
-      - CONNECTOR_LOOKBACK=3 # days
-      - URLSCAN_URL=https://urlscan.io/api/v1/pro/phishfeed?format=json
-      - URLSCAN_API_KEY=
-      - URLSCAN_DEFAULT_X_OPENCTI_SCORE=50
+      - CONNECTOR_NAME=Urlscan # Optional (default: 'Urlscan')
+      - CONNECTOR_SCOPE=urlscan # Optional (default: 'urlscan')
+      - CONNECTOR_LOG_LEVEL=error # Optional (default: 'error')
+      - CONNECTOR_INTERVAL=86400 # Optional (default: 86400) seconds, 1d
+      - CONNECTOR_LOOKBACK=3 # Optional (default: 3) days
+      - URLSCAN_URL=https://urlscan.io/api/v1/pro/phishfeed?format=json # Optional (default: 'https://urlscan.io/api/v1/pro/phishfeed?format=json')
+      - URLSCAN_API_KEY=ChangeMe
+      - URLSCAN_CREATE_INDICATORS=true # Optional (default: true)
+      - URLSCAN_UPDATE_EXISTING_DATA=true # Optional (default: true)
+      - URLSCAN_DEFAULT_TLP=white # Optional (default: 'white')
+      - URLSCAN_DEFAULT_X_OPENCTI_SCORE=50 # Optional (default: 50)
+      # - URLSCAN_X_OPENCTI_SCORE_DOMAIN=50 # Optional (default: null)
+      # - URLSCAN_X_OPENCTI_SCORE_URL=50 # Optional (default: null)
     restart: always

--- a/external-import/urlscan/src/__init__.py
+++ b/external-import/urlscan/src/__init__.py
@@ -1,0 +1,3 @@
+from urlscan.settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings"]

--- a/external-import/urlscan/src/config.yml.sample
+++ b/external-import/urlscan/src/config.yml.sample
@@ -7,18 +7,18 @@ opencti:
 connector:
   type: 'EXTERNAL_IMPORT'
   id: "ChangeMe"
-  name: "Urlscan"
-  scope: "urlscan"
-  log_level: "info"
-  confidence_level: 50 # From 0 (Unknown) to 100 (Fully trusted)
-  update_existing_data: false
-  create_indicators: true
-  tlp: "white"
-  labels: "Phishing,Phishfeed"
-  interval: 86400 # seconds, 1d
-  lookback: 3 # days
+  name: "Urlscan" # Optional (default: 'Urlscan')
+  scope: "urlscan" # Optional (default: 'urlscan')
+  log_level: "info" # Optional (default: 'error')
+  interval: 86400 # Optional (default: 86400) seconds, 1d
+  lookback: 3 # Optional (default: 3) days
 
 urlscan:
-  url: "https://urlscan.io/api/v1/pro/phishfeed?format=json"
-  api_key: ""
-  default_x_opencti_score: 50
+  url: "https://urlscan.io/api/v1/pro/phishfeed?format=json" # Optional (default: 'https://urlscan.io/api/v1/pro/phishfeed?format=json')
+  api_key: "ChangeMe"
+  create_indicators: true # Optional (default: true)
+  update_existing_data: true # Optional (default: true)
+  default_tlp: "white" # Optional (default: 'white')
+  default_x_opencti_score: 50 # Optional (default: 50)
+  # x_opencti_score_domain: 50 # Optional (default: null)
+  # x_opencti_score_url: 50 # Optional (default: null)

--- a/external-import/urlscan/src/requirements.txt
+++ b/external-import/urlscan/src/requirements.txt
@@ -1,3 +1,4 @@
 pycti==7.260710.0
 pydantic>=2.8.2,<3.0.0
 validators==0.35.0
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/urlscan/src/urlscan/connector.py
+++ b/external-import/urlscan/src/urlscan/connector.py
@@ -4,18 +4,13 @@ from __future__ import annotations
 
 import logging
 from collections import Counter
-from pathlib import Path
 from typing import Iterator, NamedTuple
 from urllib.parse import urlparse
 
 import stix2
 import validators
-import yaml
 from pycti import Indicator, StixCoreRelationship
-from pycti.connector.opencti_connector_helper import (
-    OpenCTIConnectorHelper,
-    get_config_variable,
-)
+from pycti.connector.opencti_connector_helper import OpenCTIConnectorHelper
 from stix2.v21 import _Observable as Observable  # noqa
 
 from .client import UrlscanClient
@@ -25,6 +20,7 @@ from .patterns import (
     create_indicator_pattern_domain_name,
     create_indicator_pattern_url,
 )
+from .settings import ConnectorSettings
 
 __all__ = [
     "UrlscanConnector",
@@ -38,86 +34,30 @@ class UrlscanConnector:
 
     def __init__(self):
         """Initialization."""
-        config_path = Path(__file__).parent.parent.joinpath("config.yml")
-        config = (
-            yaml.load(config_path.open(), Loader=yaml.SafeLoader)
-            if config_path.is_file()
-            else {}
-        )
+        self._config = ConnectorSettings()
 
-        self._helper = OpenCTIConnectorHelper(config)
-        interval = get_config_variable(
-            "CONNECTOR_INTERVAL",
-            ["connector", "interval"],
-            config,
-            default=86400,
-            isNumber=True,
-        )
-        lookback = get_config_variable(
-            "CONNECTOR_LOOKBACK",
-            ["connector", "lookback"],
-            config,
-            default=3,
-            isNumber=True,
-        )
+        self._helper = OpenCTIConnectorHelper(config=self._config.to_helper_config())
+        interval = self._config.connector.interval
+        lookback = self._config.connector.lookback
 
-        urlscan_url = get_config_variable(
-            "URLSCAN_URL",
-            ["urlscan", "url"],
-            config,
-        )
+        urlscan_url = str(self._config.urlscan.url)
 
-        urlscan_api_key = get_config_variable(
-            "URLSCAN_API_KEY",
-            ["urlscan", "api_key"],
-            config,
-        )
+        urlscan_api_key = self._config.urlscan.api_key.get_secret_value()
 
-        self._create_indicators = get_config_variable(
-            "URLSCAN_CREATE_INDICATORS",
-            ["urlscan", "create_indicators"],
-            config,
-            default=True,
+        self._create_indicators = self._config.urlscan.create_indicators  # type: bool
+
+        self._update_existing_data = (
+            self._config.urlscan.update_existing_data
         )  # type: bool
 
-        self._update_existing_data = get_config_variable(
-            "URLSCAN_UPDATE_EXISTING_DATA",
-            ["urlscan", "update_existing_data"],
-            config,
-            default=True,
-        )  # type: bool
-
-        default_tlp = get_config_variable(
-            "URLSCAN_DEFAULT_TLP",
-            ["urlscan", "default_tlp"],
-            config,
-            default="white",
-        )  # type: str
+        default_tlp = self._config.urlscan.default_tlp  # type: str
 
         # Default x_opencti_score
-        self._x_opencti_score = get_config_variable(
-            "URLSCAN_DEFAULT_X_OPENCTI_SCORE",
-            ["urlscan", "default_x_opencti_score"],
-            config,
-            default=50,
-            isNumber=True,
-        )
+        self._x_opencti_score = self._config.urlscan.default_x_opencti_score
         # Optional x_opencti_score for domain-name type
-        self._x_opencti_score_domain = get_config_variable(
-            "URLSCAN_X_OPENCTI_SCORE_DOMAIN",
-            ["urlscan", "x_opencti_score_domain"],
-            config,
-            default=None,
-            isNumber=True,
-        )
+        self._x_opencti_score_domain = self._config.urlscan.x_opencti_score_domain
         # Optional x_opencti_score for url type
-        self._x_opencti_score_url = get_config_variable(
-            "URLSCAN_X_OPENCTI_SCORE_URL",
-            ["urlscan", "x_opencti_score_url"],
-            config,
-            default=None,
-            isNumber=True,
-        )
+        self._x_opencti_score_url = self._config.urlscan.x_opencti_score_url
 
         self._default_tlp = getattr(stix2, f"TLP_{default_tlp}".upper(), None)
         if not isinstance(self._default_tlp, stix2.MarkingDefinition):

--- a/external-import/urlscan/src/urlscan/settings.py
+++ b/external-import/urlscan/src/urlscan/settings.py
@@ -1,0 +1,93 @@
+"""Urlscan connector settings"""
+
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseExternalImportConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field, HttpUrl, SecretStr
+from pydantic.json_schema import SkipJsonSchema
+
+__all__ = [
+    "ConnectorSettings",
+]
+
+
+class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
+    """Extend the base external-import connector config with Urlscan's connector-level fields.
+
+    The connector schedules itself through its own ``ConnectorLoop`` (see ``loop.py``),
+    so the standard ``duration_period`` is disabled and the legacy ``interval`` /
+    ``lookback`` fields are preserved as-is.
+    """
+
+    name: str = Field(
+        description="The name of the connector.",
+        default="Urlscan",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector, e.g. 'urlscan'.",
+        default=["urlscan"],
+    )
+    interval: int = Field(
+        description="Interval between two runs of the connector, in seconds.",
+        default=86400,
+    )
+    lookback: int = Field(
+        description=(
+            "How far to look back in days if the connector has never run "
+            "or its last run is older than this value."
+        ),
+        default=3,
+    )
+    # Override `duration_period` as scheduling is handled by the connector's own loop.
+    duration_period: SkipJsonSchema[None] = Field(
+        description="Do not use. Scheduling is handled by the connector's own loop.",
+        default=None,
+    )
+
+
+class UrlscanConfig(BaseConfigModel):
+    """Config fields specific to the Urlscan connector (mirror of the existing variables)."""
+
+    url: HttpUrl = Field(
+        description="The Urlscan feed URL to query.",
+        default=HttpUrl("https://urlscan.io/api/v1/pro/phishfeed?format=json"),
+    )
+    api_key: SecretStr = Field(
+        description="The Urlscan API key.",
+    )
+    create_indicators: bool = Field(
+        description="Whether to create indicators for imported observables.",
+        default=True,
+    )
+    update_existing_data: bool = Field(
+        description="Whether to update data already ingested into the platform.",
+        default=True,
+    )
+    default_tlp: str = Field(
+        description="Default TLP marking applied to imported data.",
+        default="white",
+    )
+    default_x_opencti_score: int = Field(
+        description="Default x_opencti_score applied to imported data.",
+        default=50,
+    )
+    x_opencti_score_domain: int | None = Field(
+        description="Optional x_opencti_score for domain-name observables.",
+        default=None,
+    )
+    x_opencti_score_url: int | None = Field(
+        description="Optional x_opencti_score for url observables.",
+        default=None,
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """Global settings for the Urlscan connector."""
+
+    connector: ExternalImportConnectorConfig = Field(
+        default_factory=ExternalImportConnectorConfig
+    )
+    urlscan: UrlscanConfig = Field(default_factory=UrlscanConfig)


### PR DESCRIPTION
### Proposed changes

* Normalize config files (`config.yml.sample`, `docker-compose.yml`) with optional/default annotations and consistent key naming for manager-supported migration.
* Add Pydantic settings (`src/urlscan/settings.py`) built on `connectors-sdk` (`BaseConnectorSettings`, `BaseExternalImportConnectorConfig`, `BaseConfigModel`), including a `ConnectorSettings` entrypoint exported from `src/__init__.py`; add `connectors-sdk` to `requirements.txt`.
* Wire the new Pydantic settings into the existing connector code (`src/urlscan/connector.py`), replacing `get_config_variable` / manual YAML loading with typed `ConnectorSettings`.
* Set `manager_supported: true` in `__metadata__/connector_manifest.json`.
* Generate connector config schema and documentation (`__metadata__/connector_config_schema.json`, `__metadata__/CONNECTOR_CONFIG_DOC.md`).

### Related issues

* Closes #6866

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Structure-preserving manager-supported migration: file layout, class names and the connector's own scheduling loop (interval/lookback) are kept unchanged.
