### PR TITLE
feat(tweetfeed): migrate connector to manager-supported mode (#6867)

### DIFF
--- a/external-import/tweetfeed/.gitignore
+++ b/external-import/tweetfeed/.gitignore
@@ -26,7 +26,6 @@ dist/
 
 # JetBrains IDE
 .idea/
-src/
 # Unit test reports
 TEST*.xml
 

--- a/external-import/tweetfeed/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/tweetfeed/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,23 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| CONNECTOR_NAME | `string` |  | string | `"TweetFeed"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `[]` | The scope of the connector |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
+| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"P1D"` | The period of time to await between two runs of the connector. |
+| TWEETFEED_CONFIDENCE_LEVEL | `integer` |  | integer | `25` | Score applied to imported data, from 0 (Unknown) to 100 (Fully trusted). |
+| TWEETFEED_CREATE_INDICATORS | `boolean` |  | boolean | `true` | Whether to create indicators from the imported IOCs. |
+| TWEETFEED_CREATE_OBSERVABLES | `boolean` |  | boolean | `true` | Whether to create observables from the imported IOCs. |
+| TWEETFEED_INTERVAL | `integer` |  | integer | `1` | Interval, in days, between two runs of the connector. |
+| TWEETFEED_UPDATE_EXISTING_DATA | `boolean` |  | boolean | `true` | Whether to update data already present in OpenCTI. |
+| TWEETFEED_ORG_NAME | `string` |  | string | `null` | Name of the author organization created in OpenCTI. |
+| TWEETFEED_ORG_DESCRIPTION | `string` |  | string | `null` | Description of the author organization created in OpenCTI. |
+| TWEETFEED_DAYS_BACK_IN_TIME | `integer` |  | integer | `30` | Number of days to retrieve data back in time. |

--- a/external-import/tweetfeed/__metadata__/connector_config_schema.json
+++ b/external-import/tweetfeed/__metadata__/connector_config_schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/tweetfeed_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "TweetFeed",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [],
+      "description": "The scope of the connector",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "P1D",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "TWEETFEED_CONFIDENCE_LEVEL": {
+      "default": 25,
+      "description": "Score applied to imported data, from 0 (Unknown) to 100 (Fully trusted).",
+      "type": "integer"
+    },
+    "TWEETFEED_CREATE_INDICATORS": {
+      "default": true,
+      "description": "Whether to create indicators from the imported IOCs.",
+      "type": "boolean"
+    },
+    "TWEETFEED_CREATE_OBSERVABLES": {
+      "default": true,
+      "description": "Whether to create observables from the imported IOCs.",
+      "type": "boolean"
+    },
+    "TWEETFEED_INTERVAL": {
+      "default": 1,
+      "description": "Interval, in days, between two runs of the connector.",
+      "type": "integer"
+    },
+    "TWEETFEED_UPDATE_EXISTING_DATA": {
+      "default": true,
+      "description": "Whether to update data already present in OpenCTI.",
+      "type": "boolean"
+    },
+    "TWEETFEED_ORG_NAME": {
+      "default": null,
+      "description": "Name of the author organization created in OpenCTI.",
+      "type": "string"
+    },
+    "TWEETFEED_ORG_DESCRIPTION": {
+      "default": null,
+      "description": "Description of the author organization created in OpenCTI.",
+      "type": "string"
+    },
+    "TWEETFEED_DAYS_BACK_IN_TIME": {
+      "default": 30,
+      "description": "Number of days to retrieve data back in time.",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/tweetfeed/__metadata__/connector_manifest.json
+++ b/external-import/tweetfeed/__metadata__/connector_manifest.json
@@ -14,7 +14,7 @@
   "support_version": ">=6.8.0",
   "subscription_link": "https://tweetfeed.live",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/tweetfeed",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-tweetfeed",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/tweetfeed/docker-compose.yml
+++ b/external-import/tweetfeed/docker-compose.yml
@@ -3,18 +3,22 @@ services:
   connector-tweetfeed:
     image: opencti/connector-tweetfeed:latest
     environment:
+      # Connector's generic execution parameters
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe
+      # Connector's definition parameters
       - CONNECTOR_ID=ChangeMe
       - CONNECTOR_NAME=Tweetfeed
       - CONNECTOR_SCOPE=tweetfeed
-      - CONNECTOR_LOG_LEVEL=error
-      - TWEETFEED_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
-      - TWEETFEED_CREATE_INDICATORS=true
-      - TWEETFEED_CREATE_OBSERVABLES=true
-      - TWEETFEED_INTERVAL=1
-      - TWEETFEED_UPDATE_EXISTING_DATA=true
-      - "TWEETFEED_ORG_DESCRIPTION=Tweetfeed, a connector to import IOC from Twitter."
-      - TWEETFEED_ORG_NAME=Tweetfeed
-      - TWEETFEED_DAYS_BACK_IN_TIME=30 # Number of days to retrieve data back in time
+      # - CONNECTOR_LOG_LEVEL=error
+      # - CONNECTOR_DURATION_PERIOD=P1D # ISO8601 format in String, start with 'P...' for Period
+      # Connector's custom execution parameters
+      # - TWEETFEED_CONFIDENCE_LEVEL=25 # From 0 (Unknown) to 100 (Fully trusted)
+      # - TWEETFEED_CREATE_INDICATORS=true
+      # - TWEETFEED_CREATE_OBSERVABLES=true
+      # - TWEETFEED_INTERVAL=1 # In days
+      # - TWEETFEED_UPDATE_EXISTING_DATA=true
+      # - TWEETFEED_ORG_NAME=Tweetfeed
+      # - "TWEETFEED_ORG_DESCRIPTION=Tweetfeed, a connector to import IOC from Twitter."
+      # - TWEETFEED_DAYS_BACK_IN_TIME=30 # Number of days to retrieve data back in time
     restart: always

--- a/external-import/tweetfeed/src/__init__.py
+++ b/external-import/tweetfeed/src/__init__.py
@@ -1,0 +1,3 @@
+from settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings"]

--- a/external-import/tweetfeed/src/config.yml.sample
+++ b/external-import/tweetfeed/src/config.yml.sample
@@ -4,16 +4,17 @@ opencti:
 
 connector:
   id: 'ChangeMe'
-  name: 'TWEETFEED'
+  name: 'Tweetfeed'
   scope: 'tweetfeed'
-  log_level: 'info'
+  # log_level: 'error'
+  # duration_period: 'P1D' # ISO 8601 duration (1 day)
 
-tweetfeed:
-  confidence_level: 60 # From 0 (Unknown) to 100 (Fully trusted)
-  create_indicators: true
-  create_observables: true
-  interval: 1 # In days, must be strictly greater than 1
-  update_existing_data: false
-  org_description: 'Tweetfeed, a connector to import IOC from Twitter.'
-  org_name: 'Tweetfeed'
-  days_back_in_time: 30
+# tweetfeed:
+#   confidence_level: 25 # From 0 (Unknown) to 100 (Fully trusted)
+#   create_indicators: true
+#   create_observables: true
+#   interval: 1 # In days
+#   update_existing_data: true
+#   org_name: 'Tweetfeed'
+#   org_description: 'Tweetfeed, a connector to import IOC from Twitter.'
+#   days_back_in_time: 30

--- a/external-import/tweetfeed/src/config.yml.sample
+++ b/external-import/tweetfeed/src/config.yml.sample
@@ -3,7 +3,6 @@ opencti:
   token: 'ChangeMe'
 
 connector:
-  type: 'EXTERNAL_IMPORT'
   id: 'ChangeMe'
   name: 'TWEETFEED'
   scope: 'tweetfeed'
@@ -11,8 +10,8 @@ connector:
 
 tweetfeed:
   confidence_level: 60 # From 0 (Unknown) to 100 (Fully trusted)
-  create_indicators: True
-  create_observables: True
+  create_indicators: true
+  create_observables: true
   interval: 1 # In days, must be strictly greater than 1
   update_existing_data: false
   org_description: 'Tweetfeed, a connector to import IOC from Twitter.'

--- a/external-import/tweetfeed/src/requirements.txt
+++ b/external-import/tweetfeed/src/requirements.txt
@@ -1,1 +1,3 @@
 pycti==7.260715.0
+pydantic >=2.8.2, <3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/tweetfeed/src/settings.py
+++ b/external-import/tweetfeed/src/settings.py
@@ -58,11 +58,11 @@ class TweetFeedConfig(BaseConfigModel):
     )
     org_name: Optional[str] = Field(
         description="Name of the author organization created in OpenCTI.",
-        default=None,
+        default="Tweetfeed",
     )
     org_description: Optional[str] = Field(
         description="Description of the author organization created in OpenCTI.",
-        default=None,
+        default="Tweetfeed, a connector to import IOC from Twitter.",
     )
     days_back_in_time: int = Field(
         description="Number of days to retrieve data back in time.",

--- a/external-import/tweetfeed/src/settings.py
+++ b/external-import/tweetfeed/src/settings.py
@@ -1,0 +1,79 @@
+from datetime import timedelta
+from typing import Optional
+
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseExternalImportConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field
+
+
+class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
+    """Connector-level configuration for the TweetFeed connector.
+
+    Provides a default for the SDK's structural ``duration_period`` field. The
+    connector keeps its own ``tweetfeed.interval`` scheduling loop, so this value
+    is only used to satisfy the manager-supported contract.
+    """
+
+    name: str = Field(default="TweetFeed", description="The name of the connector.")
+
+    duration_period: timedelta = Field(
+        description="The period of time to await between two runs of the connector.",
+        default=timedelta(days=1),
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector",
+        default=[],
+    )
+
+
+class TweetFeedConfig(BaseConfigModel):
+    """Config fields specific to the TweetFeed connector.
+
+    Mirrors the connector's existing configuration variables one-to-one.
+    """
+
+    confidence_level: int = Field(
+        description="Score applied to imported data, from 0 (Unknown) to 100 (Fully trusted).",
+        default=25,
+    )
+    create_indicators: bool = Field(
+        description="Whether to create indicators from the imported IOCs.",
+        default=True,
+    )
+    create_observables: bool = Field(
+        description="Whether to create observables from the imported IOCs.",
+        default=True,
+    )
+    interval: int = Field(
+        description="Interval, in days, between two runs of the connector.",
+        default=1,
+    )
+    update_existing_data: bool = Field(
+        description="Whether to update data already present in OpenCTI.",
+        default=True,
+    )
+    org_name: Optional[str] = Field(
+        description="Name of the author organization created in OpenCTI.",
+        default=None,
+    )
+    org_description: Optional[str] = Field(
+        description="Description of the author organization created in OpenCTI.",
+        default=None,
+    )
+    days_back_in_time: int = Field(
+        description="Number of days to retrieve data back in time.",
+        default=30,
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """Global settings for the TweetFeed connector."""
+
+    connector: ExternalImportConnectorConfig = Field(
+        default_factory=ExternalImportConnectorConfig
+    )
+    tweetfeed: TweetFeedConfig = Field(default_factory=TweetFeedConfig)

--- a/external-import/tweetfeed/src/tweetfeed.py
+++ b/external-import/tweetfeed/src/tweetfeed.py
@@ -1,4 +1,3 @@
-import os
 import random
 import re
 import sys
@@ -8,8 +7,8 @@ from typing import Any, Dict, Mapping, Optional
 
 import requests
 import stix2
-import yaml
-from pycti import OpenCTIConnectorHelper, get_config_variable
+from pycti import OpenCTIConnectorHelper
+from settings import ConnectorSettings
 
 __version__ = "0.0.1"
 BANNER = f"""
@@ -95,50 +94,15 @@ class TweetFeed:
     def __init__(self):
         print(BANNER)
         self.session = requests.session()
-        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
-        self.helper = OpenCTIConnectorHelper(config)
-        self.tweetfeed_days_back_in_time = get_config_variable(
-            "TWEETFEED_DAYS_BACK_IN_TIME",
-            ["tweetfeed", "days_back_in_time"],
-            config,
-            True,
-            30,
-        )
-        self.tweetfeed_interval = get_config_variable(
-            "TWEETFEED_INTERVAL", ["tweetfeed", "interval"], config, True
-        )
-        self.create_indicators = get_config_variable(
-            "TWEETFEED_CREATE_INDICATORS",
-            ["tweetfeed", "create_indicators"],
-            config,
-            False,
-            True,
-        )
-        self.create_observables = get_config_variable(
-            "TWEETFEED_CREATE_OBSERVABLES",
-            ["tweetfeed", "create_observables"],
-            config,
-            False,
-            True,
-        )
-        self.update = get_config_variable(
-            "TWEETFEED_UPDATE",
-            ["tweetfeed", "update_existing_data"],
-            config,
-            False,
-            True,
-        )
-        self.org_name = get_config_variable(
-            "TWEETFEED_ORG_NAME", ["tweetfeed", "org_name"], config, False, False
-        )
-        self.org_desc = get_config_variable(
-            "TWEETFEED_ORG_NAME", ["tweetfeed", "org_description"], config, False, False
-        )
+        self.config = ConnectorSettings()
+        self.helper = OpenCTIConnectorHelper(config=self.config.to_helper_config())
+        self.tweetfeed_days_back_in_time = self.config.tweetfeed.days_back_in_time
+        self.tweetfeed_interval = self.config.tweetfeed.interval
+        self.create_indicators = self.config.tweetfeed.create_indicators
+        self.create_observables = self.config.tweetfeed.create_observables
+        self.update = self.config.tweetfeed.update_existing_data
+        self.org_name = self.config.tweetfeed.org_name
+        self.org_desc = self.config.tweetfeed.org_description
         external_reference_org = self.helper.api.external_reference.create(
             source_name="TWEETFEEED",
             url="https://tweetfeed.live/",
@@ -150,20 +114,8 @@ class TweetFeed:
             externalReferences=[external_reference_org["id"]],
             contact_information="'TWITTER: https://twitter.com/0xDanielLopez'",
         )
-        self.update_existing_data = get_config_variable(
-            "TWEETFEED_UPDATE_EXISTING_DATA",
-            ["tweetfeed", "update_existing_data"],
-            config,
-            False,
-            True,
-        )
-        self.score = get_config_variable(
-            "TWEETFEED_CONFIDENCE_LEVEL",
-            ["tweetfeed", "confidence_level"],
-            config,
-            True,
-            25,
-        )
+        self.update_existing_data = self.config.tweetfeed.update_existing_data
+        self.score = self.config.tweetfeed.confidence_level
         self.data = {}
 
     def create_label(self, label_name):

--- a/external-import/tweetfeed/src/tweetfeed.py
+++ b/external-import/tweetfeed/src/tweetfeed.py
@@ -114,7 +114,6 @@ class TweetFeed:
             externalReferences=[external_reference_org["id"]],
             contact_information="'TWITTER: https://twitter.com/0xDanielLopez'",
         )
-        self.update_existing_data = self.config.tweetfeed.update_existing_data
         self.score = self.config.tweetfeed.confidence_level
         self.data = {}
 

--- a/external-import/tweetfeed/tests/tests_connector/test_configuration.py
+++ b/external-import/tweetfeed/tests/tests_connector/test_configuration.py
@@ -1,0 +1,136 @@
+from unittest.mock import Mock
+
+import pytest
+from pytest_mock.plugin import MockerFixture
+from tweetfeed import TweetFeed
+
+# ---------------------------------------------------------------------------
+# These tests exercise TweetFeed's own configuration wiring: given env vars
+# are set (the connector's real config source), does `TweetFeed.__init__`
+# correctly read `ConnectorSettings` and map values onto the attributes the
+# rest of the connector's code relies on, and do the connector's own methods
+# that derive from those attributes (`get_interval`, `is_scheduled`) behave
+# accordingly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def required_env(monkeypatch):
+    """Minimal env vars required to build a valid `ConnectorSettings`."""
+    monkeypatch.setenv("OPENCTI_URL", "http://opencti:8080")
+    monkeypatch.setenv("OPENCTI_TOKEN", "test-token")
+    monkeypatch.setenv("CONNECTOR_ID", "test-connector-id")
+
+
+@pytest.fixture
+def mocked_helper_class(mocker: MockerFixture):
+    """Patch the `OpenCTIConnectorHelper` used by `tweetfeed.py` so `TweetFeed()`
+    can be instantiated without any real network/API calls."""
+    mocked_class = mocker.patch("tweetfeed.OpenCTIConnectorHelper")
+    instance = mocked_class.return_value
+    instance.api = Mock()
+    instance.api.external_reference.create.return_value = {
+        "id": "external-reference--id"
+    }
+    instance.api.identity.create.return_value = {"id": "identity--id"}
+    return mocked_class
+
+
+class TestTweetFeedInit:
+    def test_maps_env_vars_to_instance_attributes(
+        self, required_env, monkeypatch, mocked_helper_class
+    ):
+        monkeypatch.setenv("TWEETFEED_INTERVAL", "5")
+        monkeypatch.setenv("TWEETFEED_DAYS_BACK_IN_TIME", "10")
+        monkeypatch.setenv("TWEETFEED_CONFIDENCE_LEVEL", "50")
+        monkeypatch.setenv("TWEETFEED_CREATE_INDICATORS", "false")
+        monkeypatch.setenv("TWEETFEED_CREATE_OBSERVABLES", "false")
+        monkeypatch.setenv("TWEETFEED_UPDATE_EXISTING_DATA", "false")
+        monkeypatch.setenv("TWEETFEED_ORG_NAME", "My Custom Org")
+        monkeypatch.setenv("TWEETFEED_ORG_DESCRIPTION", "My Custom Org Description")
+        monkeypatch.setenv("CONNECTOR_LOG_LEVEL", "debug")
+
+        connector = TweetFeed()
+
+        assert connector.tweetfeed_interval == 5
+        assert connector.tweetfeed_days_back_in_time == 10
+        assert connector.score == 50
+        assert connector.create_indicators is False
+        assert connector.create_observables is False
+        assert connector.update is False
+        assert connector.org_name == "My Custom Org"
+        assert connector.org_desc == "My Custom Org Description"
+
+        # TweetFeed.__init__ must build the helper with the mapped config
+        # (including the CONNECTOR_LOG_LEVEL override), since the rest of the
+        # connector relies on `self.helper` being wired from `self.config`.
+        _, kwargs = mocked_helper_class.call_args
+        helper_config = kwargs["config"]
+        assert helper_config["connector"]["log_level"] == "debug"
+        assert helper_config["connector"]["name"] == "TweetFeed"
+
+    def test_default_env_vars_are_mapped(self, required_env, mocked_helper_class):
+        connector = TweetFeed()
+
+        assert connector.tweetfeed_interval == 1
+        assert connector.tweetfeed_days_back_in_time == 30
+        assert connector.score == 25
+        assert connector.create_indicators is True
+        assert connector.create_observables is True
+        assert connector.update is True
+
+    def test_organization_created_from_configured_org_name_and_description(
+        self, required_env, monkeypatch, mocked_helper_class
+    ):
+        monkeypatch.setenv("TWEETFEED_ORG_NAME", "My Custom Org")
+        monkeypatch.setenv("TWEETFEED_ORG_DESCRIPTION", "My Custom Org Description")
+
+        TweetFeed()
+
+        instance = mocked_helper_class.return_value
+        _, kwargs = instance.api.identity.create.call_args
+        assert kwargs["name"] == "My Custom Org"
+        assert kwargs["description"] == "My Custom Org Description"
+
+
+class TestTweetFeedIntervalBehavior:
+    """`get_interval`/`is_scheduled` are TweetFeed's own scheduling logic,
+    built on top of the `TWEETFEED_INTERVAL` config value."""
+
+    def test_get_interval_converts_configured_days_to_seconds(
+        self, required_env, monkeypatch, mocked_helper_class
+    ):
+        monkeypatch.setenv("TWEETFEED_INTERVAL", "2")
+
+        connector = TweetFeed()
+
+        assert connector.get_interval() == 2 * 60 * 60 * 24
+
+    def test_is_scheduled_true_on_first_run(self, required_env, mocked_helper_class):
+        connector = TweetFeed()
+        connector.helper.log_info = Mock()
+
+        assert connector.is_scheduled(last_run=None, current_time=0) is True
+
+    def test_is_scheduled_false_before_interval_elapsed(
+        self, required_env, monkeypatch, mocked_helper_class
+    ):
+        monkeypatch.setenv("TWEETFEED_INTERVAL", "1")
+        connector = TweetFeed()
+
+        one_day_in_seconds = 60 * 60 * 24
+        assert (
+            connector.is_scheduled(last_run=0, current_time=one_day_in_seconds - 1)
+            is False
+        )
+
+    def test_is_scheduled_true_after_interval_elapsed(
+        self, required_env, monkeypatch, mocked_helper_class
+    ):
+        monkeypatch.setenv("TWEETFEED_INTERVAL", "1")
+        connector = TweetFeed()
+
+        one_day_in_seconds = 60 * 60 * 24
+        assert (
+            connector.is_scheduled(last_run=0, current_time=one_day_in_seconds) is True
+        )


### PR DESCRIPTION
### Proposed changes

* Normalize config files (config.yml.sample, docker-compose.yml, .gitignore) for the manager-supported layout, commenting out optional parameters and aligning defaults.
* Add Pydantic settings (src/settings.py) built on connectors-sdk (BaseConnectorSettings, BaseExternalImportConnectorConfig, BaseConfigModel), with a src/__init__.py exporting ConnectorSettings; add pydantic and connectors-sdk to requirements.txt.
* Wire the new settings into the existing connector code, replacing os/yaml/get_config_variable loading with ConnectorSettings() and helper config via to_helper_config().
* Set manager_supported: true in __metadata__/connector_manifest.json.
* Generate the connector config schema and docs (__metadata__/connector_config_schema.json and CONNECTOR_CONFIG_DOC.md).

### Related issues

* Closes #6867

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Structure-preserving manager-supported migration: file names, class names, and the connector's own tweetfeed.interval scheduling loop are unchanged.
