### PR TITLE
feat(splunk): migrate connector to manager-supported mode (#6857)

### DIFF
--- a/stream/splunk/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/splunk/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,29 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the live stream to connect to. |
+| SPLUNK_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the Splunk instance (e.g. https://splunk:8089). |
+| SPLUNK_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Token used to authenticate against the Splunk API. |
+| SPLUNK_OWNER | `string` | ✅ | string |  | Splunk owner namespace used to access the KV Store collection. |
+| SPLUNK_APP | `string` | ✅ | string |  | Splunk app namespace hosting the KV Store collection. |
+| SPLUNK_KV_STORE_NAME | `string` | ✅ | string |  | Name of the Splunk KV Store collection to feed. |
+| CONNECTOR_NAME | `string` |  | string | `"Splunk"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `[]` | The scope of the connector |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `STREAM` | `"STREAM"` |  |
+| CONNECTOR_LIVE_STREAM_LISTEN_DELETE | `boolean` |  | boolean | `true` | Whether to listen for delete events on the live stream. |
+| CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES | `boolean` |  | boolean | `true` | Whether to ignore dependencies when processing events from the live stream. |
+| CONNECTOR_CONSUMER_COUNT | `integer` |  | integer | `10` | Number of consumer/worker threads used to push data to Splunk. |
+| SPLUNK_AUTH_TYPE | `string` |  | string | `"Bearer"` | Authorization scheme used with the Splunk token. |
+| SPLUNK_SSL_VERIFY | `boolean` |  | boolean | `true` | Whether to verify the SSL certificate of the Splunk instance. |
+| SPLUNK_IGNORE_TYPES | `array` |  | string | `[]` | Comma-separated list of entity types to ignore. |
+| METRICS_ENABLE | `boolean` |  | boolean | `false` | Whether to expose Prometheus metrics. |
+| METRICS_PORT | `integer` |  | integer | `9113` | Port on which metrics should be exposed. |
+| METRICS_ADDR | `string` |  | string | `"0.0.0.0"` | IP address on which metrics should be exposed. |

--- a/stream/splunk/__metadata__/connector_config_schema.json
+++ b/stream/splunk/__metadata__/connector_config_schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/splunk_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Splunk",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [],
+      "description": "The scope of the connector",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "STREAM",
+      "default": "STREAM",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_ID": {
+      "description": "The ID of the live stream to connect to.",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_LISTEN_DELETE": {
+      "default": true,
+      "description": "Whether to listen for delete events on the live stream.",
+      "type": "boolean"
+    },
+    "CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES": {
+      "default": true,
+      "description": "Whether to ignore dependencies when processing events from the live stream.",
+      "type": "boolean"
+    },
+    "CONNECTOR_CONSUMER_COUNT": {
+      "default": 10,
+      "description": "Number of consumer/worker threads used to push data to Splunk.",
+      "type": "integer"
+    },
+    "SPLUNK_URL": {
+      "description": "Base URL of the Splunk instance (e.g. https://splunk:8089).",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "SPLUNK_TOKEN": {
+      "description": "Token used to authenticate against the Splunk API.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "SPLUNK_AUTH_TYPE": {
+      "default": "Bearer",
+      "description": "Authorization scheme used with the Splunk token.",
+      "type": "string"
+    },
+    "SPLUNK_OWNER": {
+      "description": "Splunk owner namespace used to access the KV Store collection.",
+      "type": "string"
+    },
+    "SPLUNK_SSL_VERIFY": {
+      "default": true,
+      "description": "Whether to verify the SSL certificate of the Splunk instance.",
+      "type": "boolean"
+    },
+    "SPLUNK_APP": {
+      "description": "Splunk app namespace hosting the KV Store collection.",
+      "type": "string"
+    },
+    "SPLUNK_KV_STORE_NAME": {
+      "description": "Name of the Splunk KV Store collection to feed.",
+      "type": "string"
+    },
+    "SPLUNK_IGNORE_TYPES": {
+      "default": [],
+      "description": "Comma-separated list of entity types to ignore.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "METRICS_ENABLE": {
+      "default": false,
+      "description": "Whether to expose Prometheus metrics.",
+      "type": "boolean"
+    },
+    "METRICS_PORT": {
+      "default": 9113,
+      "description": "Port on which metrics should be exposed.",
+      "type": "integer"
+    },
+    "METRICS_ADDR": {
+      "default": "0.0.0.0",
+      "description": "IP address on which metrics should be exposed.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_LIVE_STREAM_ID",
+    "SPLUNK_URL",
+    "SPLUNK_TOKEN",
+    "SPLUNK_OWNER",
+    "SPLUNK_APP",
+    "SPLUNK_KV_STORE_NAME"
+  ],
+  "additionalProperties": true
+}

--- a/stream/splunk/__metadata__/connector_manifest.json
+++ b/stream/splunk/__metadata__/connector_manifest.json
@@ -15,7 +15,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/stream/splunk",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-splunk",
   "container_type": "STREAM"

--- a/stream/splunk/docker-compose.yml
+++ b/stream/splunk/docker-compose.yml
@@ -3,22 +3,30 @@ services:
   connector-splunk:
     image: opencti/connector-splunk:latest
     environment:
+      # Generic parameters (connection with OpenCTI)
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe
+      # Common parameters for connectors of type STREAM
       - CONNECTOR_ID=ChangeMe
-      - CONNECTOR_LIVE_STREAM_ID=ChangeMe # ID of the live stream created in the OpenCTI UI
-      - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=true
-      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true
       - "CONNECTOR_NAME=OpenCTI Splunk Connector"
       - CONNECTOR_SCOPE=splunk
       - CONNECTOR_CONFIDENCE_LEVEL=80 # From 0 (Unknown) to 100 (Fully trusted)
-      - CONNECTOR_LOG_LEVEL=error
-      - SPLUNK_URL=https://splunk1.changeme.com:8089
-      - SPLUNK_TOKEN=Token1
-      - SPLUNK_AUTH_TYPE=Bearer
+      # - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
+      - CONNECTOR_LIVE_STREAM_ID=ChangeMe # ID of the live stream created in the OpenCTI UI
+      # - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=true # optional (default: true)
+      # - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true # optional (default: true)
+      # - CONNECTOR_CONSUMER_COUNT=10 # optional (default: 10)
+      # Splunk parameters
+      - SPLUNK_URL=ChangeMe # e.g. https://splunk1.changeme.com:8089
+      - SPLUNK_TOKEN=ChangeMe
+      # - SPLUNK_AUTH_TYPE=Bearer # optional (default: 'Bearer')
       - SPLUNK_OWNER=nobody
-      - SPLUNK_SSL_VERIFY=true
+      # - SPLUNK_SSL_VERIFY=true # optional (default: true)
       - SPLUNK_APP=search
       - SPLUNK_KV_STORE_NAME=opencti
       - SPLUNK_IGNORE_TYPES="attack-pattern,campaign,course-of-action,data-component,data-source,external-reference,identity,intrusion-set,kill-chain-phase,label,location,malware,marking-definition,relationship,threat-actor,tool,vocabulary,vulnerability"
+      # Prometheus metrics parameters
+      # - METRICS_ENABLE=false # optional (default: false)
+      # - METRICS_PORT=9113 # optional (default: 9113)
+      # - METRICS_ADDR=0.0.0.0 # optional (default: '0.0.0.0')
     restart: always

--- a/stream/splunk/src/__init__.py
+++ b/stream/splunk/src/__init__.py
@@ -1,0 +1,3 @@
+from settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings"]

--- a/stream/splunk/src/config.yml.sample
+++ b/stream/splunk/src/config.yml.sample
@@ -3,27 +3,28 @@ opencti:
   token: 'ChangeMe'
 
 connector:
-  type: 'STREAM'
   id: 'ChangeMe'
+  type: 'STREAM'
+  name: 'OpenCTI Splunk Connector'
+  scope: 'splunk'
+  confidence_level: 80 # From 0 (Unknown) to 100 (Fully trusted)
+  log_level: 'error' # optional (default: 'error')
   live_stream_id: 'ChangeMe' # ID of the live stream created in the OpenCTI UI
-  live_stream_listen_delete: true
-  live_stream_no_dependencies: true
-  name: 'Splunk'
-  scope: 'splunk' # Reserved
-  log_level: 'info'
-  consumer_count: 5 # number of consumer/worker used to push data to splunk
+  live_stream_listen_delete: true # optional (default: true)
+  live_stream_no_dependencies: true # optional (default: true)
+  consumer_count: 10 # optional (default: 10) - number of consumer/worker used to push data to splunk
 
 splunk:
-  url: 'https://splunk1.changeme.com:8089'
+  url: 'ChangeMe' # e.g. https://splunk1.changeme.com:8089
   token: 'ChangeMe'
-  auth_type: 'Bearer'
+  auth_type: 'Bearer' # optional (default: 'Bearer')
   owner: 'nobody'
-  ssl_verify: true
+  ssl_verify: true # optional (default: true)
   app: 'search'
   kv_store_name: 'opencti'
   ignore_types: 'attack-pattern,campaign,course-of-action,data-component,data-source,external-reference,identity,intrusion-set,kill-chain-phase,label,location,malware,marking-definition,relationship,threat-actor,tool,vocabulary,vulnerability'
 
 metrics:
-  enable: true # set to true to expose prometheus metrics
-  port: 9113 # port on which metrics should be exposed
-  addr: 0.0.0.0 # ip on which metrics should be exposed
+  enable: false # optional (default: false) - set to true to expose prometheus metrics
+  port: 9113 # optional (default: 9113) - port on which metrics should be exposed
+  addr: 0.0.0.0 # optional (default: '0.0.0.0') - ip on which metrics should be exposed

--- a/stream/splunk/src/requirements.txt
+++ b/stream/splunk/src/requirements.txt
@@ -2,3 +2,5 @@ pycti==7.260715.0
 stix-shifter==8.0.2
 stix-shifter-utils==8.0.2
 stix-shifter-modules-splunk==8.0.2
+pydantic >=2.8.2, <3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/stream/splunk/src/settings.py
+++ b/stream/splunk/src/settings.py
@@ -1,0 +1,89 @@
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseStreamConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field, HttpUrl, SecretStr
+
+
+class StreamConnectorConfig(BaseStreamConnectorConfig):
+    """
+    Override the `BaseStreamConnectorConfig` to add the connector-specific
+    `consumer_count` parameter used by the Splunk connector.
+    """
+
+    name: str = Field(default="Splunk", description="The name of the connector.")
+
+    consumer_count: int = Field(
+        description="Number of consumer/worker threads used to push data to Splunk.",
+        default=10,
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector",
+        default=[],
+    )
+
+
+class SplunkConfig(BaseConfigModel):
+    """
+    Configuration specific to the Splunk connector (mirror of the existing variables).
+    """
+
+    url: HttpUrl = Field(
+        description="Base URL of the Splunk instance (e.g. https://splunk:8089).",
+    )
+    token: SecretStr = Field(
+        description="Token used to authenticate against the Splunk API.",
+    )
+    auth_type: str = Field(
+        description="Authorization scheme used with the Splunk token.",
+        default="Bearer",
+    )
+    owner: str = Field(
+        description="Splunk owner namespace used to access the KV Store collection.",
+    )
+    ssl_verify: bool = Field(
+        description="Whether to verify the SSL certificate of the Splunk instance.",
+        default=True,
+    )
+    app: str = Field(
+        description="Splunk app namespace hosting the KV Store collection.",
+    )
+    kv_store_name: str = Field(
+        description="Name of the Splunk KV Store collection to feed.",
+    )
+    ignore_types: ListFromString = Field(
+        description="Comma-separated list of entity types to ignore.",
+        default=[],
+    )
+
+
+class MetricsConfig(BaseConfigModel):
+    """
+    Configuration for the optional Prometheus metrics server.
+    """
+
+    enable: bool = Field(
+        description="Whether to expose Prometheus metrics.",
+        default=False,
+    )
+    port: int = Field(
+        description="Port on which metrics should be exposed.",
+        default=9113,
+    )
+    addr: str = Field(
+        description="IP address on which metrics should be exposed.",
+        default="0.0.0.0",
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """
+    Override `BaseConnectorSettings` to include `StreamConnectorConfig`,
+    `SplunkConfig` and `MetricsConfig`.
+    """
+
+    connector: StreamConnectorConfig = Field(default_factory=StreamConnectorConfig)
+    splunk: SplunkConfig = Field(default_factory=SplunkConfig)
+    metrics: MetricsConfig = Field(default_factory=MetricsConfig)

--- a/stream/splunk/src/splunk.py
+++ b/stream/splunk/src/splunk.py
@@ -7,13 +7,12 @@ import logging
 import os
 import traceback
 from concurrent.futures import ThreadPoolExecutor
-from pathlib import Path
 from queue import Queue
 
 import requests
-import yaml
 from prometheus_client import Counter, Gauge, start_http_server
-from pycti import OpenCTIConnectorHelper, get_config_variable
+from pycti import OpenCTIConnectorHelper
+from settings import ConnectorSettings
 from stix_shifter.stix_translation import stix_translation
 
 
@@ -324,17 +323,6 @@ def fix_loggers() -> None:
     ).setLevel(logging.CRITICAL)
 
 
-def load_config_file() -> dict:
-    config_file = Path(__file__).parent / "config.yml"
-
-    if not config_file.is_file():
-        return {}
-
-    config_content = config_file.read_text()
-    config = yaml.safe_load(config_content)
-    return config
-
-
 def check_helper(helper: OpenCTIConnectorHelper) -> None:
     if (
         helper.connect_live_stream_id is None
@@ -350,49 +338,29 @@ if __name__ == "__main__":
         fix_loggers()
 
         # load and check config
-        config = load_config_file()
+        config = ConnectorSettings()
         # create opencti helper
-        helper = OpenCTIConnectorHelper(config)
+        helper = OpenCTIConnectorHelper(config=config.to_helper_config())
         helper.log_info("connector helper initialized")
         check_helper(helper)
 
         # read config
-        ignore_types = get_config_variable(
-            "SPLUNK_IGNORE_TYPES", ["splunk", "ignore_types"], config
-        ).split(",")
-        splunk_url = get_config_variable("SPLUNK_URL", ["splunk", "url"], config)
-        splunk_token = get_config_variable("SPLUNK_TOKEN", ["splunk", "token"], config)
-        splunk_auth_type: str = get_config_variable(
-            "SPLUNK_AUTH_TYPE", ["splunk", "auth_type"], config, default="Bearer"
-        )
-        splunk_owner = get_config_variable("SPLUNK_OWNER", ["splunk", "owner"], config)
-        splunk_ssl_verify = get_config_variable(
-            "SPLUNK_SSL_VERIFY", ["splunk", "ssl_verify"], config, False, True
-        )
-        splunk_app = get_config_variable("SPLUNK_APP", ["splunk", "app"], config)
-        splunk_kv_store_name = get_config_variable(
-            "SPLUNK_KV_STORE_NAME", ["splunk", "kv_store_name"], config
-        )
+        ignore_types = config.splunk.ignore_types
+        splunk_url = config.splunk.url
+        splunk_token = config.splunk.token.get_secret_value()
+        splunk_auth_type: str = config.splunk.auth_type
+        splunk_owner = config.splunk.owner
+        splunk_ssl_verify = config.splunk.ssl_verify
+        splunk_app = config.splunk.app
+        splunk_kv_store_name = config.splunk.kv_store_name
 
         # additional connector conf
-        consumer_count: int = get_config_variable(
-            "CONNECTOR_CONSUMER_COUNT",
-            ["connector", "consumer_count"],
-            config,
-            isNumber=True,
-            default=10,
-        )
+        consumer_count: int = config.connector.consumer_count
 
         # metrics conf
-        enable_prom_metrics: bool = get_config_variable(
-            "METRICS_ENABLE", ["metrics", "enable"], config, default=False
-        )
-        metrics_port: int = get_config_variable(
-            "METRICS_PORT", ["metrics", "port"], config, isNumber=True, default=9113
-        )
-        metrics_addr: str = get_config_variable(
-            "METRICS_ADDR", ["metrics", "addr"], config, default="0.0.0.0"
-        )
+        enable_prom_metrics: bool = config.metrics.enable
+        metrics_port: int = config.metrics.port
+        metrics_addr: str = config.metrics.addr
 
         # create kvstore instance
         kvstore = KVStore(


### PR DESCRIPTION
### Proposed changes

* Normalize the connector configuration files (`docker-compose.yml`, `config.yml.sample`) for the manager-supported migration.
* Add Pydantic settings (`src/settings.py` + `src/__init__.py`) defining `ConnectorSettings` with `StreamConnectorConfig`, `SplunkConfig` and `MetricsConfig`, and add the `connectors-sdk` dependency to `requirements.txt`.
* Wire the new settings into the existing connector code (`src/splunk.py`): replace `get_config_variable`/`load_config_file` and manual YAML loading with `ConnectorSettings()` and `config.to_helper_config()`.
* Set `manager_supported` to `true` in the connector manifest.
* Generate the connector config schema and documentation (`__metadata__/connector_config_schema.json`, `__metadata__/CONNECTOR_CONFIG_DOC.md`).

### Related issues

* Closes #6857

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Config-schema generation for this connector requires Python 3.11 (`UV_PYTHON=3.11`) because stix-shifter pulls an old antlr4 that is incompatible with Python 3.13.
