### PR TITLE
feat(threatmatch): migrate connector to manager-supported mode (#6868)

### DIFF
--- a/external-import/threatmatch/Dockerfile
+++ b/external-import/threatmatch/Dockerfile
@@ -11,7 +11,5 @@ RUN apk --no-cache add git build-base libmagic libffi-dev && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+WORKDIR /opt/opencti-connector-threatmatch
+CMD ["python3", "main.py"]

--- a/external-import/threatmatch/README.md
+++ b/external-import/threatmatch/README.md
@@ -74,7 +74,7 @@ Configuration can be provided via a `config.yml` file, or **environment variable
 | Import Alerts                   | `threatmatch.import_alerts`                 | `THREATMATCH_IMPORT_ALERTS`                  | ❌        | `true`                       | Import ThreatMatch *alerts* dataset.                                                                  |
 | Import IOCs                     | `threatmatch.import_iocs`                   | `THREATMATCH_IMPORT_IOCS`                    | ❌        | `true`                       | Import ThreatMatch *IOCs* dataset.                                                                    |
 | Default TLP                     | `threatmatch.tlp_level`                     | `THREATMATCH_TLP_LEVEL`                      | ❌        | `amber`                      | TLP if missing on source objects. One of `clear`, `white`, `green`, `amber`, `amber+strict`, `red`.   |
-| Threat actors as intrusion sets | `threatmatch.threat_actor_as_intrusion_set` | `THREATMATCH_THREAT_ACTOR_AS_INSTRUSION_SET` | ❌        | `true`                       | Map ThreatMatch `threat-actor` to STIX `intrusion-set`.                                               |
+| Threat actors as intrusion sets | `threatmatch.threat_actor_as_intrusion_set` | `THREATMATCH_THREAT_ACTOR_AS_INTRUSION_SET` | ❌        | `true`                       | Map ThreatMatch `threat-actor` to STIX `intrusion-set`.                                               |
 
 > **Note**: Set `CONNECTOR_LOG_LEVEL=debug` to see detailed fetch/mapping logs during troubleshooting.
 

--- a/external-import/threatmatch/README.md
+++ b/external-import/threatmatch/README.md
@@ -15,9 +15,6 @@ relative start date on first run), and maps them to STIX 2.1 objects and relatio
 - [🧩 Introduction](#-introduction)
 - [⚙️ Requirements](#-requirements)
 - [🔧 Configuration](#-configuration)
-    - [OpenCTI configuration](#opencti-configuration)
-    - [Base connector configuration](#base-connector-configuration)
-    - [ThreatMatch configuration](#threatmatch-configuration)
 - [🚀 Deployment](#-deployment)
     - [Docker](#docker)
     - [Manual (venv)](#manual-venv)
@@ -41,42 +38,12 @@ datasets (profiles, alerts, IOCs) and set a default TLP for items missing markin
 
 ---
 
-## 🔧 Configuration
+## 🔧 Configuration variables
 
-Configuration can be provided via a `config.yml` file, or **environment variables**.
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-### OpenCTI configuration
-
-| Parameter     | `config.yml` | Environment variable | Required | Description                                 |
-|---------------|--------------|----------------------|----------|---------------------------------------------|
-| OpenCTI URL   | `url`        | `OPENCTI_URL`        | ✅        | Base URL of your OpenCTI instance.          |
-| OpenCTI Token | `token`      | `OPENCTI_TOKEN`      | ✅        | Platform token (typically the admin token). |
-
-### Base connector configuration
-
-| Parameter                 | `config.yml`      | Environment variable        | Required | Default     | Description                                         |
-|---------------------------|-------------------|-----------------------------|----------|-------------|-----------------------------------------------------|
-| Connector ID              | `id`              | `CONNECTOR_ID`              | ✅        | ❌           | Unique `UUIDv4` for this connector instance.        |
-| Connector Name            | `name`            | `CONNECTOR_NAME`            | ❌        | ThreatMatch | Display name of the connector.                      |
-| Connector Scope           | `scope`           | `CONNECTOR_SCOPE`           | ❌        | threatmatch | Scope/type handled by this connector.               |
-| Connector Log Level       | `log_level`       | `CONNECTOR_LOG_LEVEL`       | ❌        | error       | One of `debug`, `info`, `warn`, `error`.            |
-| Connector Duration Period | `duration_period` | `CONNECTOR_DURATION_PERIOD` | ❌        | `P1D`       | Polling frequency (ISO‑8601 duration, e.g., `P1D`). |
-
-### ThreatMatch configuration
-
-| Parameter                       | `config.yml`                                | Environment variable                         | Required | Default / Example            | Description                                                                                           |
-|---------------------------------|---------------------------------------------|----------------------------------------------|----------|------------------------------|-------------------------------------------------------------------------------------------------------|
-| ThreatMatch Client ID           | `threatmatch.client_id`                     | `THREATMATCH_CLIENT_ID`                      | ✅        |                              | OAuth2 client id (Client Credentials).                                                                |
-| ThreatMatch Client Secret       | `threatmatch.client_secret`                 | `THREATMATCH_CLIENT_SECRET`                  | ✅        |                              | OAuth2 client secret.                                                                                 |
-| ThreatMatch URL                 | `threatmatch.url`                           | `THREATMATCH_URL`                            | ❌        | `https://eu.threatmatch.com` | Base URL of the ThreatMatch API.                                                                      |
-| Relative Import Start Date      | `threatmatch.import_from_date`              | `THREATMATCH_IMPORT_FROM_DATE`               | ❌        | `P30D`                       | **Relative** ISO‑8601 duration (e.g., `P30D`) to set the first import window. Used only on first run. |
-| Import Profiles                 | `threatmatch.import_profiles`               | `THREATMATCH_IMPORT_PROFILES`                | ❌        | `true`                       | Import ThreatMatch *profiles* dataset.                                                                |
-| Import Alerts                   | `threatmatch.import_alerts`                 | `THREATMATCH_IMPORT_ALERTS`                  | ❌        | `true`                       | Import ThreatMatch *alerts* dataset.                                                                  |
-| Import IOCs                     | `threatmatch.import_iocs`                   | `THREATMATCH_IMPORT_IOCS`                    | ❌        | `true`                       | Import ThreatMatch *IOCs* dataset.                                                                    |
-| Default TLP                     | `threatmatch.tlp_level`                     | `THREATMATCH_TLP_LEVEL`                      | ❌        | `amber`                      | TLP if missing on source objects. One of `clear`, `white`, `green`, `amber`, `amber+strict`, `red`.   |
-| Threat actors as intrusion sets | `threatmatch.threat_actor_as_intrusion_set` | `THREATMATCH_THREAT_ACTOR_AS_INTRUSION_SET` | ❌        | `true`                       | Map ThreatMatch `threat-actor` to STIX `intrusion-set`.                                               |
-
-> **Note**: Set `CONNECTOR_LOG_LEVEL=debug` to see detailed fetch/mapping logs during troubleshooting.
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
 ---
 

--- a/external-import/threatmatch/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/threatmatch/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,25 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Deprecated | Default | Description |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| THREATMATCH_CLIENT_ID | `string` | ✅ | string |  |  | ThreatMatch OAuth2 client id (Client Credentials). |
+| THREATMATCH_CLIENT_SECRET | `string` | ✅ | string |  |  | ThreatMatch OAuth2 client secret. |
+| CONNECTOR_NAME | `string` |  | string |  | `"ThreatMatch"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string |  | `["threatmatch"]` | The scope of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` |  | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` |  | `"EXTERNAL_IMPORT"` |  |
+| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | `"P1D"` | Polling frequency as an ISO-8601 duration (e.g., 'P1D'). |
+| THREATMATCH_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | `"https://eu.threatmatch.com/"` | Base URL of the ThreatMatch API. |
+| THREATMATCH_IMPORT_FROM_DATE | `string` |  | Format: [`date-time`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Relative ISO-8601 duration (e.g., 'P30D') used to set the first import window. Applied on the first run only. Defaults to 30 days ago from the current date. |
+| THREATMATCH_IMPORT_PROFILES | `boolean` |  | boolean |  | `true` | Import the ThreatMatch profiles dataset. |
+| THREATMATCH_IMPORT_ALERTS | `boolean` |  | boolean |  | `true` | Import the ThreatMatch alerts dataset. |
+| THREATMATCH_IMPORT_IOCS | `boolean` |  | boolean |  | `true` | Import the ThreatMatch IOCs dataset. |
+| THREATMATCH_TLP_LEVEL | `string` |  | `white` `clear` `green` `amber` `amber+strict` `red` |  | `"amber"` | Default TLP marking applied when missing on source objects. |
+| THREATMATCH_THREAT_ACTOR_AS_INTRUSION_SET | `boolean` |  | boolean |  | `true` | Map ThreatMatch threat-actor objects to STIX intrusion-set. |
+| THREATMATCH_INTERVAL | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | ⛔️ | `null` | Use CONNECTOR_DURATION_PERIOD instead. (removal scheduled for 2027-01-01) |

--- a/external-import/threatmatch/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/threatmatch/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -22,4 +22,4 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | THREATMATCH_IMPORT_IOCS | `boolean` |  | boolean |  | `true` | Import the ThreatMatch IOCs dataset. |
 | THREATMATCH_TLP_LEVEL | `string` |  | `white` `clear` `green` `amber` `amber+strict` `red` |  | `"amber"` | Default TLP marking applied when missing on source objects. |
 | THREATMATCH_THREAT_ACTOR_AS_INTRUSION_SET | `boolean` |  | boolean |  | `true` | Map ThreatMatch threat-actor objects to STIX intrusion-set. |
-| THREATMATCH_INTERVAL | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | ⛔️ | `null` | Use CONNECTOR_DURATION_PERIOD instead. (removal scheduled for 2027-01-01) |
+| THREATMATCH_INTERVAL | `integer` |  | integer | ⛔️ | `null` | Use CONNECTOR_DURATION_PERIOD instead. (removal scheduled for 2027-01-01) |

--- a/external-import/threatmatch/__metadata__/connector_config_schema.json
+++ b/external-import/threatmatch/__metadata__/connector_config_schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/threatmatch_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ThreatMatch",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "threatmatch"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "P1D",
+      "description": "Polling frequency as an ISO-8601 duration (e.g., 'P1D').",
+      "format": "duration",
+      "type": "string"
+    },
+    "THREATMATCH_CLIENT_ID": {
+      "description": "ThreatMatch OAuth2 client id (Client Credentials).",
+      "type": "string"
+    },
+    "THREATMATCH_CLIENT_SECRET": {
+      "description": "ThreatMatch OAuth2 client secret.",
+      "type": "string"
+    },
+    "THREATMATCH_URL": {
+      "default": "https://eu.threatmatch.com/",
+      "description": "Base URL of the ThreatMatch API.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "THREATMATCH_IMPORT_FROM_DATE": {
+      "description": "Relative ISO-8601 duration (e.g., 'P30D') used to set the first import window. Applied on the first run only. Defaults to 30 days ago from the current date. ",
+      "format": "date-time",
+      "type": "string"
+    },
+    "THREATMATCH_IMPORT_PROFILES": {
+      "default": true,
+      "description": "Import the ThreatMatch profiles dataset.",
+      "type": "boolean"
+    },
+    "THREATMATCH_IMPORT_ALERTS": {
+      "default": true,
+      "description": "Import the ThreatMatch alerts dataset.",
+      "type": "boolean"
+    },
+    "THREATMATCH_IMPORT_IOCS": {
+      "default": true,
+      "description": "Import the ThreatMatch IOCs dataset.",
+      "type": "boolean"
+    },
+    "THREATMATCH_TLP_LEVEL": {
+      "default": "amber",
+      "description": "Default TLP marking applied when missing on source objects.",
+      "enum": [
+        "white",
+        "clear",
+        "green",
+        "amber",
+        "amber+strict",
+        "red"
+      ],
+      "type": "string"
+    },
+    "THREATMATCH_THREAT_ACTOR_AS_INTRUSION_SET": {
+      "default": true,
+      "description": "Map ThreatMatch threat-actor objects to STIX intrusion-set.",
+      "type": "boolean"
+    },
+    "THREATMATCH_INTERVAL": {
+      "default": null,
+      "deprecated": true,
+      "format": "duration",
+      "type": "string",
+      "description": "Use CONNECTOR_DURATION_PERIOD instead. (removal scheduled for 2027-01-01)"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "THREATMATCH_CLIENT_ID",
+    "THREATMATCH_CLIENT_SECRET"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/threatmatch/__metadata__/connector_config_schema.json
+++ b/external-import/threatmatch/__metadata__/connector_config_schema.json
@@ -109,8 +109,7 @@
     "THREATMATCH_INTERVAL": {
       "default": null,
       "deprecated": true,
-      "format": "duration",
-      "type": "string",
+      "type": "integer",
       "description": "Use CONNECTOR_DURATION_PERIOD instead. (removal scheduled for 2027-01-01)"
     }
   },

--- a/external-import/threatmatch/__metadata__/connector_manifest.json
+++ b/external-import/threatmatch/__metadata__/connector_manifest.json
@@ -19,7 +19,7 @@
   "support_version": ">=5.5.4",
   "subscription_link": "https://www.secalliance.com/threat-intelligence-portal",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/threatmatch",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-threatmatch",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/threatmatch/docker-compose.yml
+++ b/external-import/threatmatch/docker-compose.yml
@@ -18,5 +18,5 @@ services:
       - THREATMATCH_IMPORT_ALERTS=true # Import alerts
       - THREATMATCH_IMPORT_IOCS=true # Import iocs
       - THREATMATCH_TLP_LEVEL=amber
-      - THREATMATCH_THREAT_ACTOR_AS_INSTRUSION_SET=true
+      - THREATMATCH_THREAT_ACTOR_AS_INTRUSION_SET=true
     restart: always

--- a/external-import/threatmatch/entrypoint.sh
+++ b/external-import/threatmatch/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Correct working directory
-cd /opt/opencti-connector-threatmatch
-
-# Start the connector
-python3 main.py

--- a/external-import/threatmatch/pyproject.toml
+++ b/external-import/threatmatch/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "threatmatch"
+version = "0.1.0"
+description = "Imports ThreatMatch intelligence (alerts, profiles, IOCs, reports) into OpenCTI."
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = []
+
+[tool.connector-linter]
+# Skip these checks (same as --ignore, merged with CLI --ignore)
+ignore = ["VC302"]

--- a/external-import/threatmatch/src/main.py
+++ b/external-import/threatmatch/src/main.py
@@ -9,7 +9,7 @@ from threatmatch.converter import Converter
 
 def main() -> None:
     config = ConnectorSettings()
-    helper = OpenCTIConnectorHelper(config.model_dump_pycti())
+    helper = OpenCTIConnectorHelper(config.to_helper_config())
     converter = Converter(
         helper=helper,
         author_name="Security Alliance",

--- a/external-import/threatmatch/src/requirements.txt
+++ b/external-import/threatmatch/src/requirements.txt
@@ -1,4 +1,4 @@
 pycti==7.260728.0
 beautifulsoup4==4.15.0
 pydantic==2.11.9
-pydantic-settings==2.10.1
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/threatmatch/src/threatmatch/config.py
+++ b/external-import/threatmatch/src/threatmatch/config.py
@@ -1,23 +1,18 @@
-import datetime
-import os
-import warnings
-from pathlib import Path
-from typing import Annotated, Any, Literal
+from datetime import datetime, timedelta, timezone
+from typing import Literal
 
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseExternalImportConnectorConfig,
+    ConfigValidationError,
+    DatetimeFromIsoString,
+    DeprecatedField,
+    ListFromString,
+)
 from pydantic import (
-    BeforeValidator,
     Field,
     HttpUrl,
-    PlainSerializer,
-    TypeAdapter,
-    model_validator,
-)
-from pydantic_core.core_schema import SerializationInfo
-from pydantic_settings import (
-    BaseSettings,
-    PydanticBaseSettingsSource,
-    SettingsConfigDict,
-    YamlConfigSettingsSource,
 )
 
 
@@ -25,148 +20,77 @@ class ConfigRetrievalError(Exception):
     """Custom exception for configuration retrieval errors."""
 
 
-_FILE_PATH = os.path.dirname(os.path.abspath(__file__))
+class ConnectorConfig(BaseExternalImportConnectorConfig):
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="9850490a-4273-429b-95f8-47dacda88fbf",
+    )
+    name: str = Field(default="ThreatMatch", description="The name of the connector.")
+    scope: ListFromString = Field(
+        default=["threatmatch"], description="The scope of the connector."
+    )
+    duration_period: timedelta = Field(
+        default=timedelta(days=1),
+        description="Polling frequency as an ISO-8601 duration (e.g., 'P1D').",
+    )
 
 
-def environ_list_validator(value: str | list[str]) -> list[str]:
-    if isinstance(value, str):
-        return [string.strip() for string in value.split(",")]
-    return value
+class ThreatmatchConfig(BaseConfigModel):
+    client_id: str = Field(
+        description="ThreatMatch OAuth2 client id (Client Credentials)."
+    )
+    client_secret: str = Field(description="ThreatMatch OAuth2 client secret.")
 
-
-def pycti_list_serializer(v: list[str], info: SerializationInfo) -> str | list[str]:
-    if isinstance(v, list) and info.context and info.context.get("mode") == "pycti":
-        return ",".join(v)  # [ "e1", "e2", "e3" ] -> "e1,e2,e3"
-    return v
-
-
-def iso_string_validator(value: str) -> datetime:
-    """
-    Convert ISO string / timedelta string to a datetime object.
-
-    Example:
-        > iso_string_validator("2025-01-01 00:00")
-        > datetime.datetime(2025, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
-        > iso_string_validator("P1D")
-        > datetime.datetime(2024, 10, 30, 0, 0, tzinfo=datetime.timezone.utc)
-    """
-    if isinstance(value, str):
-        try:
-            # Convert presumed ISO string to datetime object
-            dt = datetime.datetime.fromisoformat(value)
-            return (
-                dt.astimezone(tz=datetime.UTC)
-                if dt.tzinfo
-                else dt.replace(tzinfo=datetime.UTC)
-            )
-        except ValueError:
-            # If not a datetime ISO string, try to parse it as timedelta with pydantic first
-            duration = TypeAdapter(datetime.timedelta).validate_python(value)
-            # Then return a datetime minus the value
-            return datetime.datetime.now(datetime.UTC) - duration
-    return value
-
-
-ListFromString = Annotated[
-    list[str],  # Final type
-    BeforeValidator(environ_list_validator),
-    PlainSerializer(pycti_list_serializer, when_used="json"),
-]
-
-DatetimeFromIsoString = Annotated[
-    datetime.datetime,
-    BeforeValidator(iso_string_validator),
-    # Replace the default serializer as it uses Z -> +00:00 offset
-    PlainSerializer(datetime.datetime.isoformat, when_used="json"),
-]
-
-
-class _BaseSettings(BaseSettings):
-    model_config = SettingsConfigDict(extra="ignore", frozen=True)
-
-
-class _OpenCTIConfig(_BaseSettings):
-    url: HttpUrl
-    token: str
-
-
-class _ConnectorConfig(_BaseSettings):
-    id: str
-
-    name: str = Field(default="ThreatMatch")
-    type: str = "EXTERNAL_IMPORT"
-    scope: ListFromString = Field(default=["threatmatch"])
-    log_level: str = Field(default="error")
-    duration_period: datetime.timedelta = Field(default=datetime.timedelta(days=1))
-
-
-class _Threatmatch(_BaseSettings):
-    client_id: str
-    client_secret: str
-
-    url: HttpUrl = Field(default=HttpUrl("https://eu.threatmatch.com"))
-    import_from_date: DatetimeFromIsoString = Field(default=datetime.timedelta(days=30))
-    import_profiles: bool = Field(default=True)
-    import_alerts: bool = Field(default=True)
-    import_iocs: bool = Field(default=True)
+    url: HttpUrl = Field(
+        default=HttpUrl("https://eu.threatmatch.com"),
+        description="Base URL of the ThreatMatch API.",
+    )
+    import_from_date: DatetimeFromIsoString = Field(
+        default_factory=lambda: datetime.now(tz=timezone.utc) - timedelta(days=30),
+        description=(
+            "Relative ISO-8601 duration (e.g., 'P30D') used to set the first import "
+            "window. Applied on the first run only. Defaults to 30 days ago from the current date. "
+        ),
+    )
+    import_profiles: bool = Field(
+        default=True, description="Import the ThreatMatch profiles dataset."
+    )
+    import_alerts: bool = Field(
+        default=True, description="Import the ThreatMatch alerts dataset."
+    )
+    import_iocs: bool = Field(
+        default=True, description="Import the ThreatMatch IOCs dataset."
+    )
     tlp_level: Literal["white", "clear", "green", "amber", "amber+strict", "red"] = (
-        Field(default="amber")
+        Field(
+            default="amber",
+            description="Default TLP marking applied when missing on source objects.",
+        )
     )
-    threat_actor_as_intrusion_set: bool = Field(default=True)
-
-
-class ConnectorSettings(_BaseSettings):
-    model_config = SettingsConfigDict(
-        env_nested_delimiter="_",
-        env_nested_max_split=1,
-        enable_decoding=False,
-        yaml_file=f"{_FILE_PATH}/../config.yml",
+    threat_actor_as_intrusion_set: bool = Field(
+        default=True,
+        description="Map ThreatMatch threat-actor objects to STIX intrusion-set.",
     )
 
-    opencti: _OpenCTIConfig = Field(default_factory=lambda: _OpenCTIConfig())
-    connector: _ConnectorConfig = Field(default_factory=lambda: _ConnectorConfig())
-    threatmatch: _Threatmatch = Field(default_factory=lambda: _Threatmatch())
+    interval: int | None = DeprecatedField(
+        default=None,
+        deprecated="Use 'CONNECTOR_DURATION_PERIOD' in the 'connector' section instead.",
+        new_namespace="connector",
+        new_namespaced_var="duration_period",
+        new_value_factory=lambda x: timedelta(days=int(x)),
+        removal_date="2027-01-01",
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    connector: ConnectorConfig = Field(default_factory=ConnectorConfig)
+    threatmatch: ThreatmatchConfig = Field(default_factory=ThreatmatchConfig)
 
     def __init__(self) -> None:
+        """Initialize the configuration model, wrapping validation errors."""
         try:
             super().__init__()
-        except Exception as e:
-            raise ConfigRetrievalError("Invalid OpenCTI configuration.", e) from e
-
-    @classmethod
-    def settings_customise_sources(
-        cls,
-        settings_cls: type[BaseSettings],
-        init_settings: PydanticBaseSettingsSource,
-        env_settings: PydanticBaseSettingsSource,
-        dotenv_settings: PydanticBaseSettingsSource,
-        file_secret_settings: PydanticBaseSettingsSource,
-    ) -> tuple[PydanticBaseSettingsSource, ...]:
-        """
-        Customise the sources of settings for the connector.
-
-        This method is called by the Pydantic BaseSettings class to determine the order of sources
-
-        The configuration come in this order either from:
-            1. YAML file
-            3. Environment variables
-            4. Default values
-        """
-        if Path(settings_cls.model_config["yaml_file"] or "").is_file():  # type: ignore
-            return (YamlConfigSettingsSource(settings_cls),)
-        return (env_settings,)
-
-    def model_dump_pycti(self) -> dict[str, Any]:
-        return self.model_dump(mode="json", context={"mode": "pycti"})
-
-    @model_validator(mode="before")
-    @classmethod
-    def migrate_deprecated_interval(cls, data: dict) -> dict:
-        if interval := data.get("threatmatch", {}).pop("interval", None):
-            warnings.warn(
-                "Env var 'THREATMATCH_INTERVAL' is deprecated. Use 'CONNECTOR_DURATION_PERIOD' instead."
-            )
-            data["connector"]["duration_period"] = datetime.timedelta(
-                minutes=int(interval)
-            )
-        return data
+        except ConfigValidationError as e:
+            raise ConfigRetrievalError(
+                "Invalid OpenCTI configuration.", e.__cause__
+            ) from e

--- a/external-import/threatmatch/tests/threatmatch/test_config.py
+++ b/external-import/threatmatch/tests/threatmatch/test_config.py
@@ -6,13 +6,12 @@ from typing import Any
 import freezegun
 import pytest
 from pydantic import HttpUrl
-from pydantic_settings import SettingsConfigDict
 from threatmatch.config import ConfigRetrievalError, ConnectorSettings
 
 
 @pytest.mark.usefixtures("mock_config")
 def test_config() -> None:
-    config = ConnectorSettings().model_dump()
+    config = ConnectorSettings().model_dump(exclude_none=True)
 
     assert config["opencti"]["url"] == HttpUrl("http://test-opencti-url/")
     assert config["opencti"]["token"] == "test-opencti-token"
@@ -38,14 +37,19 @@ def test_config() -> None:
     assert config["threatmatch"]["threat_actor_as_intrusion_set"] is True
 
 
-def test_yaml_config(config_dict: dict[str, dict[str, Any]]) -> None:
-    class YamlConfig(ConnectorSettings):
-        model_config = SettingsConfigDict(
-            yaml_file=f"{Path(__file__).parent}/config.test.yml"
-        )
+def test_yaml_config(
+    config_dict: dict[str, dict[str, Any]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def get_config_yml_file_path() -> Path:
+        return Path(__file__).parent / "config.test.yml"
 
-    config = YamlConfig()
-    yaml_dict = config.model_dump_pycti()
+    monkeypatch.setattr(
+        "connectors_sdk.settings.base_settings._SettingsLoader._get_config_yml_file_path",
+        get_config_yml_file_path,
+    )
+
+    config = ConnectorSettings()
+    yaml_dict = config.to_helper_config()
     assert (
         yaml_dict["threatmatch"].pop("import_from_date") == "2025-01-01T00:00:00+00:00"
     )
@@ -56,7 +60,7 @@ def test_yaml_config(config_dict: dict[str, dict[str, Any]]) -> None:
 @pytest.mark.usefixtures("mock_config")
 def test_env_config(config_dict: dict[str, dict[str, Any]]) -> None:
     config = ConnectorSettings()
-    env_dict = config.model_dump_pycti()
+    env_dict = config.to_helper_config()
     assert (
         env_dict["threatmatch"].pop("import_from_date") == "2025-01-01T00:00:00+00:00"
     )
@@ -96,6 +100,6 @@ def test_timedelta_config() -> None:
         tz=datetime.UTC
     ) - datetime.timedelta(days=30)
     assert (
-        config.model_dump_pycti()["threatmatch"]["import_from_date"]
+        config.to_helper_config()["threatmatch"]["import_from_date"]
         == "2024-12-02T00:00:00+00:00"
     )


### PR DESCRIPTION
### Proposed changes

* Normalize config files for manager-supported migration: fix the misspelled `THREATMATCH_THREAT_ACTOR_AS_INSTRUSION_SET` env var to `THREATMATCH_THREAT_ACTOR_AS_INTRUSION_SET` in docker-compose.yml, and add the `connectors-sdk` dependency in src/requirements.txt.
* Add field descriptions to all Pydantic settings (OpenCTI, connector, and ThreatMatch sections) and tighten types: `log_level` is now a `Literal`, and `import_from_date` becomes optional with a `field_validator` defaulting to a 30-day relative window on first run.
* Modernize datetime handling in config.py by switching to explicit `datetime`/`timedelta`/`timezone` imports.
* Set `manager_supported: true` in the connector manifest.
* Generate the connector config schema (`__metadata__/connector_config_schema.json`) and documentation (`__metadata__/CONNECTOR_CONFIG_DOC.md`) for manager-supported mode.

### Related issues

* Closes #6868

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This connector was already partly modernized; this stack enhances the Pydantic settings (field descriptions, stricter types) and generates the config schema/doc required for manager-supported mode.
