### PR TITLE
feat(malwarebazaar): add external references and link indicators to malware family (#6940, #2044)

### DIFF
--- a/external-import/malwarebazaar/README.md
+++ b/external-import/malwarebazaar/README.md
@@ -2,7 +2,7 @@
 
 | Status | Date | Comment |
 |--------|------|---------|
-| Community | -    | -       |
+| Verified | - | - |
 
 The MalwareBazaar connector imports malware samples and their hashes from abuse.ch MalwareBazaar into OpenCTI.
 
@@ -29,7 +29,7 @@ The MalwareBazaar connector imports malware samples and their hashes from abuse.
 
 MalwareBazaar is a project from abuse.ch with the goal of sharing malware samples with the infosec community, AV vendors, and threat intelligence providers. The platform collects malware samples submitted by security researchers and organizations.
 
-This connector fetches recent malware sample metadata from MalwareBazaar API and imports them as File observables with associated hashes (MD5, SHA-1, SHA-256) into OpenCTI.
+This connector fetches recent malware sample metadata from MalwareBazaar API and imports them as File observables with associated hashes (MD5, SHA-1, SHA-256), along with a related Indicator and, when available, the detected Malware family, into OpenCTI.
 
 ## Installation
 
@@ -124,11 +124,14 @@ graph LR
     subgraph OpenCTI
         direction LR
         File[File Observable]
+        Indicator[Indicator]
         Malware[Malware]
     end
 
     API --> File
-    File -- related-to --> Malware
+    API --> Indicator
+    Indicator -- based-on --> File
+    Indicator -- indicates --> Malware
 ```
 
 ### Entity Mapping
@@ -141,7 +144,9 @@ graph LR
 | file_name            | File.name               | Original filename                                |
 | file_size            | File.size               | File size in bytes                               |
 | file_type            | File.mime_type          | MIME type                                        |
+| sha256_hash          | Indicator               | STIX indicator based on the SHA-256 hash         |
 | signature            | Malware                 | Detected malware family                          |
+| sha256_hash          | External Reference      | Link to the MalwareBazaar sample page            |
 | tags                 | Labels                  | MalwareBazaar tags                               |
 | reporter             | Description             | Sample submitter                                 |
 
@@ -152,8 +157,14 @@ graph LR
    - `x_opencti_score`: Default 100 (high confidence)
    - Labels from configuration
    - TLP marking
+   - External reference to the MalwareBazaar sample page
 
-2. **Malware Relationship**: If signature is available, creates relationship to malware family
+2. **Indicator**: A STIX indicator is created from the SHA-256 hash, linked to the File
+   observable with a `based-on` relationship, and carries the same TLP marking and an
+   external reference to the MalwareBazaar sample page.
+
+3. **Malware**: If a signature (malware family) is available, a Malware entity is created
+   and linked to the Indicator with an `indicates` relationship.
 
 ### Filtering Options
 

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/connector.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/connector.py
@@ -93,6 +93,11 @@ class ConnectorMalwareBazaar:
                 stix_objects.append(entity_set_to_stix["FILE_OBSERVABLE"])
                 stix_objects.append(entity_set_to_stix["INDICATOR_4_FILE"])
                 stix_objects.append(entity_set_to_stix["FILE_2_INDICATOR_RELATIONSHIP"])
+                if entity_set_to_stix["MALWARE"] is not None:
+                    stix_objects.append(entity_set_to_stix["MALWARE"])
+                    stix_objects.append(
+                        entity_set_to_stix["INDICATOR_2_MALWARE_RELATIONSHIP"]
+                    )
         if len(stix_objects):
             stix_objects.append(self.converter_to_stix.author)
             stix_objects.append(self.converter_to_stix.tlp_marking)

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/converter_to_stix.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/converter_to_stix.py
@@ -1,6 +1,12 @@
 import stix2
 import validators
-from pycti import Identity, Indicator, MarkingDefinition, StixCoreRelationship
+from pycti import (
+    Identity,
+    Indicator,
+    Malware,
+    MarkingDefinition,
+    StixCoreRelationship,
+)
 
 
 class ConverterToStix:
@@ -132,6 +138,21 @@ class ConverterToStix:
 
         return indicator
 
+    def create_malware(self, signature: str) -> dict:
+        """
+        Creates Malware object based on MalwareBazaar signature (malware family)
+        :param signature: Malware family/signature name from MalwareBazaar
+        :return: Malware STIX2 object
+        """
+        malware = stix2.Malware(
+            id=Malware.generate_id(signature),
+            name=signature,
+            is_family=True,
+            created_by_ref=self.author["id"],
+            object_marking_refs=self.tlp_marking,
+        )
+        return malware
+
     def create_relationship(
         self, source_id: str, relationship_type: str, target_id: str, labels: list
     ) -> dict:
@@ -215,6 +236,8 @@ class ConverterToStix:
             "FILE_OBSERVABLE": None,
             "INDICATOR_4_FILE": None,
             "FILE_2_INDICATOR_RELATIONSHIP": None,
+            "MALWARE": None,
+            "INDICATOR_2_MALWARE_RELATIONSHIP": None,
         }
         if (
             self._is_valid_md5(entity["md5_hash"]) is True
@@ -250,8 +273,24 @@ class ConverterToStix:
                 "FILE_OBSERVABLE": file_observable,
                 "INDICATOR_4_FILE": indicator,
                 "FILE_2_INDICATOR_RELATIONSHIP": relationship,
+                "MALWARE": None,
+                "INDICATOR_2_MALWARE_RELATIONSHIP": None,
             }
 
+            # Create Malware from the MalwareBazaar signature (malware family) if present
+            signature = entity.get("signature")
+            if signature and len(signature) >= 1:
+                malware = self.create_malware(signature=signature)
+                indicator_2_malware = self.create_relationship(
+                    source_id=indicator["id"],
+                    relationship_type="indicates",
+                    target_id=malware["id"],
+                    labels=tags_as_labels,
+                )
+                file_observable_set["MALWARE"] = malware
+                file_observable_set["INDICATOR_2_MALWARE_RELATIONSHIP"] = (
+                    indicator_2_malware
+                )
         else:
             self.helper.connector_logger.error(
                 "This observable entity is not a valid for ingest, missing one or more required fields (md5_hash, sha1_hash, sha256_hash, reporter, or filename): ",

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/converter_to_stix.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/converter_to_stix.py
@@ -57,6 +57,19 @@ class ConverterToStix:
         }
         return mapping[level]
 
+    @staticmethod
+    def create_external_reference(sha256_hash: str) -> stix2.ExternalReference:
+        """
+        Create an External Reference pointing to the MalwareBazaar sample page
+        :param sha256_hash: SHA256 hash of the sample
+        :return: External Reference STIX2 object
+        """
+        return stix2.ExternalReference(
+            source_name="MalwareBazaar",
+            url=f"https://bazaar.abuse.ch/sample/{sha256_hash}/",
+            description="MalwareBazaar sample page",
+        )
+
     def create_file_observable(self, entity: dict, labels: list) -> dict:
         """
         Creates File Observable object based on MalwareBazaar Entity Data
@@ -64,6 +77,7 @@ class ConverterToStix:
         :param labels: List of Labels/Tags to apply
         :return: File Observable STIX2 object
         """
+        external_reference = self.create_external_reference(entity["sha256_hash"])
         file_observable = stix2.File(
             name=entity["file_name"],
             size=entity["file_size"],
@@ -77,7 +91,7 @@ class ConverterToStix:
             object_marking_refs=self.tlp_marking,
             custom_properties={
                 "x_opencti_created_by_ref": self.author["id"],
-                # "x_opencti_external_references": self.external_reference,
+                "x_opencti_external_references": [external_reference],
                 "x_opencti_additional_names": [
                     entity["sha256_hash"],
                     # entity["file_name"],
@@ -99,6 +113,7 @@ class ConverterToStix:
         """
         indicator_pattern = f"[file:hashes.'SHA-256' = '{entity['sha256_hash']}']"
         indicator_description = f"Indicator for hash SHA256 {entity['sha256_hash']}"
+        external_reference = self.create_external_reference(entity["sha256_hash"])
         indicator = stix2.Indicator(
             id=Indicator.generate_id(indicator_pattern),
             name=f"{entity['sha256_hash']}",
@@ -108,6 +123,7 @@ class ConverterToStix:
             labels=labels,
             created_by_ref=self.author["id"],
             object_marking_refs=self.tlp_marking,
+            external_references=[external_reference],
             custom_properties={
                 "x_opencti_score": int(self.config.malwarebazaar.x_opencti_score),
                 "x_opencti_main_observable_type": "File",

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/converter_to_stix.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/converter_to_stix.py
@@ -94,7 +94,7 @@ class ConverterToStix:
                 "SHA-256": entity["sha256_hash"],
                 # "SHA-512": entity["sha512_hash"], # API for MalwareBazaar currently does NOT provide a SHA512
             },
-            object_marking_refs=self.tlp_marking,
+            object_marking_refs=[self.tlp_marking],
             custom_properties={
                 "x_opencti_created_by_ref": self.author["id"],
                 "x_opencti_external_references": [external_reference],
@@ -128,7 +128,7 @@ class ConverterToStix:
             description=indicator_description,
             labels=labels,
             created_by_ref=self.author["id"],
-            object_marking_refs=self.tlp_marking,
+            object_marking_refs=[self.tlp_marking],
             external_references=[external_reference],
             custom_properties={
                 "x_opencti_score": int(self.config.malwarebazaar.x_opencti_score),
@@ -149,7 +149,7 @@ class ConverterToStix:
             name=signature,
             is_family=True,
             created_by_ref=self.author["id"],
-            object_marking_refs=self.tlp_marking,
+            object_marking_refs=[self.tlp_marking]
         )
         return malware
 
@@ -173,7 +173,7 @@ class ConverterToStix:
             target_ref=target_id,
             labels=labels,
             created_by_ref=self.author["id"],
-            object_marking_refs=self.tlp_marking,
+            object_marking_refs=[self.tlp_marking]
             # external_references=self.external_reference,
         )
         return relationship

--- a/external-import/malwarebazaar/src/malwarebazaar_connector/converter_to_stix.py
+++ b/external-import/malwarebazaar/src/malwarebazaar_connector/converter_to_stix.py
@@ -149,7 +149,7 @@ class ConverterToStix:
             name=signature,
             is_family=True,
             created_by_ref=self.author["id"],
-            object_marking_refs=[self.tlp_marking]
+            object_marking_refs=[self.tlp_marking],
         )
         return malware
 
@@ -173,7 +173,7 @@ class ConverterToStix:
             target_ref=target_id,
             labels=labels,
             created_by_ref=self.author["id"],
-            object_marking_refs=[self.tlp_marking]
+            object_marking_refs=[self.tlp_marking],
             # external_references=self.external_reference,
         )
         return relationship

--- a/external-import/malwarebazaar/tests/tests_connector/test_converter_to_stix.py
+++ b/external-import/malwarebazaar/tests/tests_connector/test_converter_to_stix.py
@@ -1,0 +1,146 @@
+from unittest.mock import MagicMock
+
+import pytest
+import stix2
+from malwarebazaar_connector.converter_to_stix import ConverterToStix
+
+SHA256 = "a" * 64
+MD5 = "b" * 32
+SHA1 = "c" * 40
+
+
+@pytest.fixture
+def config():
+    """Minimal config exposing the `malwarebazaar` attributes used by the converter."""
+    config = MagicMock()
+    config.malwarebazaar.tlp_level = "clear"
+    config.malwarebazaar.x_opencti_score = 100
+    config.malwarebazaar.labels = ["malware-bazaar"]
+    return config
+
+
+@pytest.fixture
+def helper():
+    helper = MagicMock()
+    helper.connect_name = "Malwarebazaar"
+    return helper
+
+
+@pytest.fixture
+def converter(helper, config):
+    return ConverterToStix(helper=helper, config=config)
+
+
+@pytest.fixture
+def entity():
+    return {
+        "md5_hash": MD5,
+        "sha1_hash": SHA1,
+        "sha256_hash": SHA256,
+        "file_name": "sample.exe",
+        "file_size": 1234,
+        "file_type_mime": "application/x-dosexec",
+        "reporter": "abuse_ch",
+        "tags": ["exe"],
+        "signature": "Emotet",
+    }
+
+
+def test_create_external_reference(converter):
+    """The external reference MUST point to the MalwareBazaar sample page for the given SHA256."""
+    external_reference = converter.create_external_reference(SHA256)
+
+    assert isinstance(external_reference, stix2.ExternalReference)
+    assert external_reference.source_name == "MalwareBazaar"
+    assert external_reference.url == f"https://bazaar.abuse.ch/sample/{SHA256}/"
+    assert external_reference.description == "MalwareBazaar sample page"
+
+
+def test_create_file_observable_has_external_reference(converter, entity):
+    """The File observable MUST embed the MalwareBazaar external reference."""
+    file_observable = converter.create_file_observable(entity, labels=["exe"])
+
+    external_references = file_observable["x_opencti_external_references"]
+    assert len(external_references) == 1
+    assert external_references[0].url == f"https://bazaar.abuse.ch/sample/{SHA256}/"
+
+
+def test_create_file_observable_marking_is_a_list(converter, entity):
+    """`object_marking_refs` MUST be a list to comply with STIX2."""
+    file_observable = converter.create_file_observable(entity, labels=["exe"])
+
+    assert isinstance(file_observable["object_marking_refs"], list)
+
+
+def test_create_indicator_has_external_reference(converter, entity):
+    """The Indicator MUST embed the MalwareBazaar external reference."""
+    indicator = converter.create_indicator(entity, labels=["exe"])
+
+    assert len(indicator["external_references"]) == 1
+    assert (
+        indicator["external_references"][0].url
+        == f"https://bazaar.abuse.ch/sample/{SHA256}/"
+    )
+    assert isinstance(indicator["object_marking_refs"], list)
+
+
+def test_create_malware(converter):
+    """`create_malware` MUST return a Malware family with a deterministic id."""
+    malware = converter.create_malware("Emotet")
+
+    assert isinstance(malware, stix2.Malware)
+    assert malware["name"] == "Emotet"
+    assert malware["is_family"] is True
+    assert isinstance(malware["object_marking_refs"], list)
+
+
+def test_create_obs_with_signature_creates_malware(converter, entity):
+    """When the entity has a signature, the resulting set MUST include the Malware
+    and the Indicator -> Malware `indicates` relationship."""
+    result = converter.create_obs(entity)
+
+    assert result["MALWARE"] is not None
+    assert result["MALWARE"]["name"] == "Emotet"
+
+    relationship = result["INDICATOR_2_MALWARE_RELATIONSHIP"]
+    assert relationship is not None
+    assert relationship["relationship_type"] == "indicates"
+    assert relationship["source_ref"] == result["INDICATOR_4_FILE"]["id"]
+    assert relationship["target_ref"] == result["MALWARE"]["id"]
+
+
+def test_create_obs_without_signature_has_no_malware(converter, entity):
+    """When the entity has no signature, no Malware nor relationship MUST be created."""
+    entity["signature"] = None
+
+    result = converter.create_obs(entity)
+
+    assert result["FILE_OBSERVABLE"] is not None
+    assert result["MALWARE"] is None
+    assert result["INDICATOR_2_MALWARE_RELATIONSHIP"] is None
+
+
+def test_create_obs_with_empty_signature_has_no_malware(converter, entity):
+    """An empty signature string MUST NOT produce a Malware object."""
+    entity["signature"] = ""
+
+    result = converter.create_obs(entity)
+
+    assert result["MALWARE"] is None
+    assert result["INDICATOR_2_MALWARE_RELATIONSHIP"] is None
+
+
+def test_create_obs_invalid_entity_returns_empty_set(converter, entity):
+    """An entity missing required fields MUST return the empty set with no objects."""
+    entity["md5_hash"] = "not-a-valid-hash"
+
+    result = converter.create_obs(entity)
+
+    assert result == {
+        "FILE_OBSERVABLE": None,
+        "INDICATOR_4_FILE": None,
+        "FILE_2_INDICATOR_RELATIONSHIP": None,
+        "MALWARE": None,
+        "INDICATOR_2_MALWARE_RELATIONSHIP": None,
+    }
+    converter.helper.connector_logger.error.assert_called_once()


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.

PR TITLE FORMAT (enforced by CI):
  type(scope?)!?: description (#123)
  - type: feat | fix | chore | docs | style | refactor | perf | test | build | ci | revert
  - scope: optional, e.g. connector name
  - description: must start with a lowercase letter
  - (#123): required linked issue number
  Example: feat(alienvault): add pagination support (#42)
-->

### Proposed changes

This PR improves the `malwarebazaar` (external-import) connector with two related enhancements.

### 1. Add external references to indicators — closes #6940

The connector did not attach any External Reference to the entities it created, so
analysts could not navigate from an OpenCTI entity back to the corresponding
MalwareBazaar sample page.

- Add a `MalwareBazaar` external reference pointing to
  `https://bazaar.abuse.ch/sample/{sha256}/` on each **Indicator** and **File observable**.
- Implemented purely via the STIX bundle (`stix2.ExternalReference`), not through direct
  OpenCTI API calls, unlike the legacy `malwarebazaar-recent-additions` connector.

### 2. Create malware from the signature and link it to the indicator — closes #2044

The MalwareBazaar `signature` column (malware family) was not exploited.

- Create a `Malware` SDO from the `signature` field (deterministic id via
  `Malware.generate_id`, `is_family=True`) when a signature is present.
- Add an `indicates` relationship from the **Indicator** to the **Malware**.
- The `signature == null` case (frequent) is handled and simply skips malware creation.

> Note: the other points originally listed in #2044 (applying a marking on indicators,
> using `based-on` instead of `related-to`) are already satisfied by the current
> connector, so only the signature/malware part is implemented here.

### Related issues

- Closes #6940
- Closes #2044

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
