### PR TITLE
docs: allow manual do not merge label on pull requests (#7030)

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -77,10 +77,13 @@ type, e.g. a `fix:` that closes a vulnerability), not a title type.
 >   `typescript`, …) and the **`dependencies`** label, both applied automatically
 >   by GitHub/Renovate.
 >
-> Every other label — primary **type** labels, **area/scope** labels and
-> **workflow/triage** labels — is **issue-only** and must **never** be added to a
-> pull request; remove any that appear. The PR's `type:` title prefix and its
-> linked issue already convey the type and the affected area.
+ > Every other label — primary **type** labels, **area/scope** labels,
+ > and **workflow/triage** labels — is **issue-only** and must **never** be
+ > added to a pull request.
+ >
+ > Exception: **`do not merge`** and any uncategorized labels (not listed in
+ > `labels.yml`) may be applied manually to a pull request and must not be
+ > removed once applied.
 
 ## 3. Workflow & ownership labels
 


### PR DESCRIPTION
### Proposed changes

* Update `.github/LABELS.md` to carve out an exception for the `do not merge` label so it can be manually applied to pull requests (previously it was documented as automation-only and excluded from the manual PR label allow-list)
* Clarify that the `do not merge` label must never be removed once applied

### Related issues

* Closes #7030

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This is a documentation/policy change: it amends the label taxonomy so `do not merge` can be intentionally attached to a PR by its author (e.g. to block premature merges), rather than only being bot-applied automation.