### PR TITLE
feat(manifest-fragment): enforce enum-based fields and passthrough unmapped keys (#6928)

### DIFF
--- a/shared/tools/composer/generate_manifest_fragment/connector_manifest_schema.json
+++ b/shared/tools/composer/generate_manifest_fragment/connector_manifest_schema.json
@@ -12,6 +12,11 @@
     "short_description",
     "logo",
     "use_cases",
+    "solution_categories",
+    "license_type",
+    "contact",
+    "verified",
+    "last_verified_date",
     "subscription_link",
     "source_code",
     "manager_supported",
@@ -24,7 +29,7 @@
     "additional_properties",
     "config_schema"
   ],
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "id": {
       "type": "string",
@@ -66,15 +71,70 @@
       "description": "List of use case categories this connector supports.",
       "items": {
         "type": "string",
-        "minLength": 1
+        "enum": [
+          "Adversary & Campaign Insights",
+          "Vulnerability & Exploit Awareness",
+          "Infrastructure & Attack Surface Visibility",
+          "Detection & Response Enablement",
+          "Fraud, Financial Crime & Cryptocurrency Monitoring",
+          "Brand, Digital Risk & Underground Exposure",
+          "Third-Party & Supply Chain Oversight",
+          "Cloud, SaaS & Platform Security",
+          "Geopolitical, Physical & Hybrid Risk Analysis",
+          "Market Vertical & Mission-Specific Intelligence",
+          "FIMI & Disinformation",
+          "Other"
+        ]
       },
-      "minItems": 0,
+      "minItems": 1,
+      "maxItems": 3,
       "uniqueItems": true,
       "examples": [
-        ["Open Source Threat Intel"],
-        ["Commercial Threat Intel", "Threat Intelligence Enrichment"],
-        ["SIEM & Analytics", "Incident Response & Ticketing"]
+        ["Adversary & Campaign Insights"],
+        ["Vulnerability & Exploit Awareness", "Detection & Response Enablement"]
       ]
+    },
+    "solution_categories": {
+      "type": "array",
+      "description": "List of solution categories this connector belongs to.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "Threat Intelligence Feed",
+          "Endpoint Detection & Response",
+          "SIEM & Security Analytics",
+          "Malware Analysis & Sandbox",
+          "SOAR & Security Automation",
+          "Vulnerability & Exposure Management",
+          "Attack Surface Management",
+          "Network Security",
+          "Email Security",
+          "AI Security",
+          "Incident Response & Case Management",
+          "Digital Risk Protection",
+          "Governance, Risk & Compliance",
+          "Cloud Security",
+          "Enrichment & Reputation",
+          "Import, Export & Sharing",
+          "Other"
+        ]
+      },
+      "minItems": 1,
+      "maxItems": 3,
+      "uniqueItems": true,
+      "examples": [
+        ["Threat Intelligence Feed"],
+        ["SIEM & Security Analytics", "Vulnerability & Exposure Management"]
+      ]
+    },
+    "license_type": {
+      "type": ["string"],
+      "description": "Licensing model of the connector.",
+      "enum": ["Free", "Commercial", ""]
+    },
+    "contact": {
+      "type": ["string"],
+      "description": "Contact information for support or questions about the connector."
     },
     "verified": {
       "type": ["boolean", "null"],

--- a/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
+++ b/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
@@ -31,6 +31,10 @@ Field mapping (existing manifest -> fragment):
     container_type    -> image_type
     playbook_supported, max_confidence_level -> additional_properties
     connector_config_schema.json -> config_schema (embedded)
+    <any other manifest key> -> copied through as-is (see
+        MANIFEST_KEYS_HANDLED_EXPLICITLY), so new manifest fields (e.g.
+        solution_categories, license_type, contact) automatically appear in
+        the fragment without requiring a code change here.
 Constant fields:
     platform = "OpenCTI", integration_type = "connector"
 """
@@ -52,6 +56,36 @@ CONNECTOR_CONFIG_SCHEMA_FILENAME = "connector_config_schema.json"
 
 PLATFORM = "OpenCTI"
 INTEGRATION_TYPE = "connector"
+
+# Manifest keys that are explicitly transformed (renamed, reshaped, truncated,
+# or moved into a nested object) when building the fragment. Every other
+# manifest key is copied through as-is in `build_fragment`, so new manifest
+# fields automatically flow into the fragment without requiring a code change
+# here — only a schema update if strict validation of the new field is desired.
+MANIFEST_KEYS_HANDLED_EXPLICITLY = frozenset(
+    {
+        "title",
+        "slug",
+        "description",
+        "short_description",
+        "logo",
+        "verified",
+        "use_cases",
+        "solution_categories",
+        "license_type",
+        "contact",
+        "last_verified_date",
+        "subscription_link",
+        "source_code",
+        "manager_supported",
+        "support_version",
+        "container_image",
+        "container_type",
+        "container_version",
+        "playbook_supported",
+        "max_confidence_level",
+    }
+)
 
 # Maximum length allowed by the schema for `short_description`.
 SHORT_DESCRIPTION_MAX_LENGTH = 200
@@ -145,8 +179,11 @@ def build_fragment(connector_dir: Path, version: str) -> dict:
         "short_description": truncate_short_description(manifest["short_description"]),
         "logo": logo,
         "use_cases": manifest["use_cases"],
-        "verified": manifest.get("verified"),
-        "last_verified_date": manifest.get("last_verified_date"),
+        "solution_categories": manifest["solution_categories"],
+        "license_type": manifest.get("license_type") or "",
+        "contact": manifest.get("contact") or "",
+        "verified": manifest.get("verified", False),
+        "last_verified_date": manifest.get("last_verified_date") or "",
         "subscription_link": manifest.get("subscription_link") or "",
         "source_code": manifest["source_code"],
         "manager_supported": manifest["manager_supported"],
@@ -162,6 +199,14 @@ def build_fragment(connector_dir: Path, version: str) -> dict:
         },
         "config_schema": config_schema,
     }
+
+    # Copy through any manifest key not explicitly handled above (e.g. 
+    # any future addition) so the fragment stays in sync with the manifest 
+    # without code changes.
+    for key, value in manifest.items():
+        if key not in MANIFEST_KEYS_HANDLED_EXPLICITLY and key not in fragment:
+            fragment[key] = value
+
     return fragment
 
 
@@ -172,6 +217,26 @@ def validate_fragment(fragment: dict, schema_path: Path) -> None:
         instance=fragment, schema=schema, format_checker=jsonschema.FormatChecker()
     )
     print("✅ Fragment validated against schema.")
+    warn_unchecked_keys(fragment, schema)
+
+
+def warn_unchecked_keys(fragment: dict, schema: dict) -> None:
+    """Warn loudly about fragment keys the schema does not declare.
+
+    Because `additionalProperties` is `true`, these keys are accepted as-is by
+    `jsonschema.validate` above without any type/enum/format check — they are
+    passed through from the manifest (see `MANIFEST_KEYS_HANDLED_EXPLICITLY`)
+    but are otherwise unvalidated.
+    """
+    known_properties = set(schema.get("properties", {}))
+    unchecked_keys = sorted(set(fragment) - known_properties)
+    if unchecked_keys:
+        print(
+            "⚠️⚠️⚠️  WARNING: the following fragment key(s) are NOT declared in "
+            f"the JSON schema and will NOT be validated (type, enum, format, ...): "
+            f"{', '.join(unchecked_keys)}. Add them to connector_manifest_schema.json "
+            "to enforce their format.  ⚠️⚠️⚠️"
+        )
 
 
 def main() -> None:


### PR DESCRIPTION
### Proposed changes

* Enforce enum-based allowed values for `use_cases` and `solution_categories` in `connector_manifest_schema.json`, replacing free-form strings with a fixed, explicit taxonomy (mirroring the `Literal` types already added to `ConnectorManifest` in `generate_connectors_manifests.py`), and add optional `solution_categories`, `license_type` (`Open Source` | `Commercial`), and `contact` properties to the schema, so these new manifest fields are properly validated.
* Set the schema's top-level `additionalProperties` to `true` to allow forward-compatible passthrough of manifest keys not yet formally declared in the schema.
* Add automatic passthrough of any manifest key not explicitly handled by `build_fragment()` (via a new `MANIFEST_KEYS_HANDLED_EXPLICITLY` constant), so new/unknown/future manifest fields (e.g. `solution_categories`, `license_type`, `contact`) flow into the generated fragment without requiring code changes to the generator script.
* Add a `warn_unchecked_keys()` check, run after successful JSON-schema validation, that prints a visible warning listing any fragment keys not covered by the schema's declared `properties` — flagging to maintainers that a new field should be formally added to the schema to get real validation coverage.

### Related issues

* Relates to #6888
* Relates to #6946
* Relates to #6926
* Relates to #6927
* Relates to #6928


### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The schema now sets `additionalProperties: true` and the generator passes through any manifest key it doesn't explicitly handle, rather than requiring every new manifest field to be added to the schema before it can be used. This trades strict validation coverage for forward compatibility: new fields (e.g. future taxonomy additions) won't break the fragment generation pipeline just because the schema hasn't caught up yet. The tradeoff is that such passthrough fields receive no type/enum/format validation until they're formally declared — to mitigate this, `warn_unchecked_keys()` prints a loud warning at generation time listing any keys not covered by the schema, so maintainers get a clear, actionable signal to add proper validation rather than the gap going unnoticed silently.
