### PR TITLE
feat(doppel-alert-takedown): add Doppel Alert and Takedown internal enrichment connector (#7033)

### DIFF
--- a/internal-enrichment/doppel-alert-takedown/.dockerignore
+++ b/internal-enrichment/doppel-alert-takedown/.dockerignore
@@ -1,0 +1,9 @@
+__metadata__
+**/__pycache__
+**/__docs__
+**/.venv
+**/venv
+**/logs
+**/config.yml
+**/*.egg-info
+**/*.gql

--- a/internal-enrichment/doppel-alert-takedown/Dockerfile
+++ b/internal-enrichment/doppel-alert-takedown/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-alpine
+ENV CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+
+# Copy the connector
+COPY src /opt/opencti-connector-doppel-alert-takedown
+
+# Install Python modules
+# hadolint ignore=DL3003
+RUN apk update && apk upgrade && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN cd /opt/opencti-connector-doppel-alert-takedown && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+# Expose and entrypoint
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/internal-enrichment/doppel-alert-takedown/Dockerfile
+++ b/internal-enrichment/doppel-alert-takedown/Dockerfile
@@ -13,7 +13,5 @@ RUN cd /opt/opencti-connector-doppel-alert-takedown && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+WORKDIR /opt/opencti-connector-doppel-alert-takedown
+ENTRYPOINT ["python3", "main.py"]

--- a/internal-enrichment/doppel-alert-takedown/README.md
+++ b/internal-enrichment/doppel-alert-takedown/README.md
@@ -1,0 +1,143 @@
+# OpenCTI Doppel Alert and Takedown Connector
+
+The **Doppel Alert and Takedown** connector is an OpenCTI internal enrichment connector
+that integrates with [Doppel](https://www.doppel.com). From a suspicious observable
+(a **URL** or a **Domain-Name**), triggered manually by an analyst, automatically
+(auto-enrichment) or from a playbook, the connector:
+
+1. Creates an alert in Doppel (`POST /v1/alert`).
+2. Automatically requests a takedown for that alert (`PUT /v1/alert?entity=...` with
+   `queue_state: "actioned"`).
+3. Enriches the observable in OpenCTI with an **external reference** to the Doppel
+   alert and a **Note** summarizing the created alert and the takedown request.
+
+Table of Contents
+
+- [Introduction](#introduction)
+- [Installation](#installation)
+  - [Requirements](#requirements)
+- [Configuration variables](#configuration-variables)
+  - [OpenCTI environment variables](#opencti-environment-variables)
+  - [Base connector environment variables](#base-connector-environment-variables)
+  - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
+- [Deployment](#deployment)
+  - [Docker Deployment](#docker-deployment)
+  - [Manual Deployment](#manual-deployment)
+- [Usage](#usage)
+- [Behavior](#behavior)
+- [Debugging](#debugging)
+
+## Introduction
+
+Doppel is a brand protection and digital risk protection platform used to detect and
+take down phishing sites, fraudulent domains and other online threats. This connector
+lets OpenCTI users escalate a suspicious URL or domain to Doppel directly from the
+platform: it opens a Doppel alert and requests a takedown in a single enrichment.
+
+## Installation
+
+### Requirements
+
+- Python >= 3.11
+- OpenCTI Platform >= 6.8.12
+- [`pycti`](https://pypi.org/project/pycti/) library matching your OpenCTI version
+- [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk) library matching your OpenCTI version
+- A Doppel account with an API key and a user API key
+
+## Configuration variables
+
+Configuration options are set either in `docker-compose.yml` (for Docker) or in
+`config.yml` (for manual deployment).
+
+### OpenCTI environment variables
+
+| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
+| ------------- | ---------- | --------------------------- | --------- | ---------------------------------------------------- |
+| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
+| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+
+### Base connector environment variables
+
+| Parameter       | config.yml | Docker environment variable | Default                     | Mandatory | Description                                                             |
+| --------------- | ---------- | --------------------------- |-----------------------------| --------- | ---------------------------------------------------------------------- |
+| Connector ID    | id         | `CONNECTOR_ID`              | /                           | Yes       | A unique `UUIDv4` identifier for this connector instance.              |
+| Connector Type  | type       | `CONNECTOR_TYPE`            | INTERNAL_ENRICHMENT         | Yes       | Should always be set to `INTERNAL_ENRICHMENT` for this connector.     |
+| Connector Name  | name       | `CONNECTOR_NAME`            | Doppel Alert and Takedown   | No        | Name of the connector.                                                 |
+| Connector Scope | scope      | `CONNECTOR_SCOPE`           | Url,Domain-Name             | No        | The types of observables the connector enriches.                       |
+| Log Level       | log_level  | `CONNECTOR_LOG_LEVEL`       | error                       | No        | Log verbosity: `debug`, `info`, `warn`, or `error`.                    |
+| Connector Auto  | auto       | `CONNECTOR_AUTO`            | false                       | No        | `true` or `false` to enable or disable auto-enrichment of observables. |
+
+### Connector extra parameters environment variables
+
+| Parameter        | config.yml         | Docker environment variable | Default                                        | Mandatory | Description                                                          |
+| ---------------- | ------------------ | --------------------------- | ---------------------------------------------- | --------- | ------------------------------------------------------------------- |
+| API key          | api_key            | `DOPPEL_API_KEY`            | /                                              | Yes       | Doppel API key, sent as the `x-api-key` header.                     |
+| User API key     | user_api_key       | `DOPPEL_USER_API_KEY`       | /                                              | Yes       | Doppel user API key, sent as the `x-user-api-key` header.           |
+| API base URL     | api_base_url       | `DOPPEL_API_BASE_URL`       | `https://api.doppel.com`                       | No        | Doppel API base URL.                                                |
+| Tags             | tags               | `DOPPEL_TAGS`               | empty                                          | No        | Comma-separated list of tags added to every alert created.          |
+| Takedown comment | takedown_comment   | `DOPPEL_TAKEDOWN_COMMENT`   | `Confirmed by OpenCTI — requesting takedown.`  | No        | Comment sent to Doppel with the takedown request.                   |
+| Max TLP level    | max_tlp            | `DOPPEL_MAX_TLP`            | empty (no limit)                               | No        | Max TLP of the observables the connector is allowed to enrich. Values: `TLP:CLEAR`, `TLP:WHITE`, `TLP:GREEN`, `TLP:AMBER`, `TLP:AMBER+STRICT`, `TLP:RED`. Empty means no limit. |
+
+## Deployment
+
+### Docker Deployment
+
+Before building the Docker container, set the version of pycti in `requirements.txt`
+equal to whatever version of OpenCTI you're running.
+
+Build a Docker image using the provided `Dockerfile`:
+
+```shell
+docker build . -t opencti/connector-doppel-alert-takedown:latest
+```
+
+Make sure to replace the environment variables in `docker-compose.yml` with the
+appropriate configuration for your environment, then start the container:
+
+```shell
+docker compose up -d
+```
+
+### Manual Deployment
+
+Create a file `config.yml` based on the provided `config.yml.sample`. Replace the
+`ChangeMe` values with your configuration.
+
+Install the required python dependencies (preferably in a virtual environment):
+
+```shell
+pip3 install -r src/requirements.txt
+```
+
+Then start the connector from the `src` directory:
+
+```shell
+python3 main.py
+```
+
+## Usage
+
+To trigger enrichment manually, open a URL or Domain-Name observable in OpenCTI and run
+the **Doppel Alert and Takedown** enrichment from the observable's enrichment menu. To run
+it automatically on every new/updated in-scope observable, set `CONNECTOR_AUTO=true`.
+The connector is also playbook compatible and can be added as a step in a playbook.
+
+## Behavior
+
+For each in-scope observable (URL or Domain-Name), the connector:
+
+- maps the OpenCTI observable type to the Doppel `entity_type`
+  (`url` → `url`, `domain-name` → `domain`);
+- creates a Doppel alert with the configured tags;
+- requests a takedown for the alert using the configured comment;
+- returns a STIX bundle containing the observable enriched with an external reference to
+  the Doppel alert (`doppel_link`) and a Note summarizing the alert and takedown request.
+
+If the takedown request fails, the alert creation is still recorded and the Note reflects
+the failure; the observable is always returned so playbooks are not interrupted.
+
+## Debugging
+
+The connector can be debugged by setting the appropriate log level. Logging messages can
+be added using `self.helper.connector_logger.{LOG_LEVEL}("Sample message")`, e.g.
+`self.helper.connector_logger.error("An error message")`.

--- a/internal-enrichment/doppel-alert-takedown/README.md
+++ b/internal-enrichment/doppel-alert-takedown/README.md
@@ -17,9 +17,6 @@ Table of Contents
 - [Installation](#installation)
   - [Requirements](#requirements)
 - [Configuration variables](#configuration-variables)
-  - [OpenCTI environment variables](#opencti-environment-variables)
-  - [Base connector environment variables](#base-connector-environment-variables)
-  - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
 - [Deployment](#deployment)
   - [Docker Deployment](#docker-deployment)
   - [Manual Deployment](#manual-deployment)
@@ -46,37 +43,10 @@ platform: it opens a Doppel alert and requests a takedown in a single enrichment
 
 ## Configuration variables
 
-Configuration options are set either in `docker-compose.yml` (for Docker) or in
-`config.yml` (for manual deployment).
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-### OpenCTI environment variables
-
-| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
-| ------------- | ---------- | --------------------------- | --------- | ---------------------------------------------------- |
-| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
-| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
-
-### Base connector environment variables
-
-| Parameter       | config.yml | Docker environment variable | Default                     | Mandatory | Description                                                             |
-| --------------- | ---------- | --------------------------- |-----------------------------| --------- | ---------------------------------------------------------------------- |
-| Connector ID    | id         | `CONNECTOR_ID`              | /                           | Yes       | A unique `UUIDv4` identifier for this connector instance.              |
-| Connector Type  | type       | `CONNECTOR_TYPE`            | INTERNAL_ENRICHMENT         | Yes       | Should always be set to `INTERNAL_ENRICHMENT` for this connector.     |
-| Connector Name  | name       | `CONNECTOR_NAME`            | Doppel Alert and Takedown   | No        | Name of the connector.                                                 |
-| Connector Scope | scope      | `CONNECTOR_SCOPE`           | Url,Domain-Name             | No        | The types of observables the connector enriches.                       |
-| Log Level       | log_level  | `CONNECTOR_LOG_LEVEL`       | error                       | No        | Log verbosity: `debug`, `info`, `warn`, or `error`.                    |
-| Connector Auto  | auto       | `CONNECTOR_AUTO`            | false                       | No        | `true` or `false` to enable or disable auto-enrichment of observables. |
-
-### Connector extra parameters environment variables
-
-| Parameter        | config.yml         | Docker environment variable | Default                                        | Mandatory | Description                                                          |
-| ---------------- | ------------------ | --------------------------- | ---------------------------------------------- | --------- | ------------------------------------------------------------------- |
-| API key          | api_key            | `DOPPEL_API_KEY`            | /                                              | Yes       | Doppel API key, sent as the `x-api-key` header.                     |
-| User API key     | user_api_key       | `DOPPEL_USER_API_KEY`       | /                                              | Yes       | Doppel user API key, sent as the `x-user-api-key` header.           |
-| API base URL     | api_base_url       | `DOPPEL_API_BASE_URL`       | `https://api.doppel.com`                       | No        | Doppel API base URL.                                                |
-| Tags             | tags               | `DOPPEL_TAGS`               | empty                                          | No        | Comma-separated list of tags added to every alert created.          |
-| Takedown comment | takedown_comment   | `DOPPEL_TAKEDOWN_COMMENT`   | `Confirmed by OpenCTI — requesting takedown.`  | No        | Comment sent to Doppel with the takedown request.                   |
-| Max TLP level    | max_tlp            | `DOPPEL_MAX_TLP`            | empty (no limit)                               | No        | Max TLP of the observables the connector is allowed to enrich. Values: `TLP:CLEAR`, `TLP:WHITE`, `TLP:GREEN`, `TLP:AMBER`, `TLP:AMBER+STRICT`, `TLP:RED`. Empty means no limit. |
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
 ## Deployment
 

--- a/internal-enrichment/doppel-alert-takedown/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/doppel-alert-takedown/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -4,18 +4,18 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 
 ### Type: `object`
 
-| Property | Type | Required | Possible values | Default                                              | Description |
-| -------- | ---- | -------- | --------------- |------------------------------------------------------| ----------- |
-| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |                                                      | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |                                                      | The API token to connect to OpenCTI. |
-| DOPPEL_API_KEY | `string` | ✅ | string |                                                      | Doppel API key, sent as the `x-api-key` header. |
-| DOPPEL_USER_API_KEY | `string` | ✅ | string |                                                      | Doppel user API key, sent as the `x-user-api-key` header. |
-| CONNECTOR_NAME | `string` |  | string | `"Doppel Alert and Takedown"`                             | The name of the connector. |
-| CONNECTOR_SCOPE | `string` |  | string | `"Url,Domain-Name"`                                  | The scope of the connector (types of observables to enrich). |
-| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"`                                            | The minimum level of logs to display. |
-| CONNECTOR_TYPE | `const` |  | `INTERNAL_ENRICHMENT` | `"INTERNAL_ENRICHMENT"`                              |  |
-| CONNECTOR_AUTO | `boolean` |  | boolean | `false`                                              | Whether the connector should run automatically when an entity is created or updated. |
-| DOPPEL_API_BASE_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"https://api.doppel.com/"`                          | Doppel API base URL. |
-| DOPPEL_TAGS | `array` |  | string |                                                      | List of tags to attach to the alerts created in Doppel. |
-| DOPPEL_TAKEDOWN_COMMENT | `string` |  | string | `"Confirmed by OpenCTI \u2014 requesting takedown."` | Comment sent to Doppel when requesting a takedown. |
-| DOPPEL_MAX_TLP | `string` |  | `TLP:CLEAR` `TLP:WHITE` `TLP:GREEN` `TLP:AMBER` `TLP:AMBER+STRICT` `TLP:RED` `` | `""`                                                 | Max TLP level of entities to enrich (empty = no limit). |
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| DOPPEL_ALERT_TAKEDOWN_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Doppel API key, sent as the `x-api-key` header. |
+| DOPPEL_ALERT_TAKEDOWN_USER_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Doppel user API key, sent as the `x-user-api-key` header. |
+| CONNECTOR_NAME | `string` |  | string | `"Doppel Alert and Takedown"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["Url", "Domain-Name"]` | The scope of the connector (types of observables to enrich). |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `INTERNAL_ENRICHMENT` | `"INTERNAL_ENRICHMENT"` |  |
+| CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |
+| DOPPEL_ALERT_TAKEDOWN_API_BASE_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"https://api.doppel.com/"` | Doppel API base URL. |
+| DOPPEL_ALERT_TAKEDOWN_TAGS | `array` |  | string | `[]` | List of tags to attach to the alerts created in Doppel. |
+| DOPPEL_ALERT_TAKEDOWN_TAKEDOWN_COMMENT | `string` |  | string | `"Confirmed by OpenCTI \u2014 requesting takedown."` | Comment sent to Doppel when requesting a takedown. |
+| DOPPEL_ALERT_TAKEDOWN_MAX_TLP | `string` |  | `TLP:CLEAR` `TLP:WHITE` `TLP:GREEN` `TLP:AMBER` `TLP:AMBER+STRICT` `TLP:RED` | `"TLP:RED"` | Max TLP level of entities to enrich. |

--- a/internal-enrichment/doppel-alert-takedown/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/doppel-alert-takedown/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,21 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default                                              | Description |
+| -------- | ---- | -------- | --------------- |------------------------------------------------------| ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |                                                      | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |                                                      | The API token to connect to OpenCTI. |
+| DOPPEL_API_KEY | `string` | ✅ | string |                                                      | Doppel API key, sent as the `x-api-key` header. |
+| DOPPEL_USER_API_KEY | `string` | ✅ | string |                                                      | Doppel user API key, sent as the `x-user-api-key` header. |
+| CONNECTOR_NAME | `string` |  | string | `"Doppel Alert and Takedown"`                             | The name of the connector. |
+| CONNECTOR_SCOPE | `string` |  | string | `"Url,Domain-Name"`                                  | The scope of the connector (types of observables to enrich). |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"`                                            | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `INTERNAL_ENRICHMENT` | `"INTERNAL_ENRICHMENT"`                              |  |
+| CONNECTOR_AUTO | `boolean` |  | boolean | `false`                                              | Whether the connector should run automatically when an entity is created or updated. |
+| DOPPEL_API_BASE_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"https://api.doppel.com/"`                          | Doppel API base URL. |
+| DOPPEL_TAGS | `array` |  | string |                                                      | List of tags to attach to the alerts created in Doppel. |
+| DOPPEL_TAKEDOWN_COMMENT | `string` |  | string | `"Confirmed by OpenCTI \u2014 requesting takedown."` | Comment sent to Doppel when requesting a takedown. |
+| DOPPEL_MAX_TLP | `string` |  | `TLP:CLEAR` `TLP:WHITE` `TLP:GREEN` `TLP:AMBER` `TLP:AMBER+STRICT` `TLP:RED` `` | `""`                                                 | Max TLP level of entities to enrich (empty = no limit). |

--- a/internal-enrichment/doppel-alert-takedown/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/doppel-alert-takedown/__metadata__/connector_config_schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/doppel-brand-protection_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Doppel Alert and Takedown",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": "Url,Domain-Name",
+      "description": "The scope of the connector (types of observables to enrich).",
+      "type": "string"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Whether the connector should run automatically when an entity is created or updated.",
+      "type": "boolean"
+    },
+    "DOPPEL_API_BASE_URL": {
+      "default": "https://api.doppel.com/",
+      "description": "Doppel API base URL.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "DOPPEL_API_KEY": {
+      "description": "Doppel API key, sent as the `x-api-key` header.",
+      "type": "string"
+    },
+    "DOPPEL_USER_API_KEY": {
+      "description": "Doppel user API key, sent as the `x-user-api-key` header.",
+      "type": "string"
+    },
+    "DOPPEL_TAGS": {
+      "description": "List of tags to attach to the alerts created in Doppel.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "DOPPEL_TAKEDOWN_COMMENT": {
+      "default": "Confirmed by OpenCTI \u2014 requesting takedown.",
+      "description": "Comment sent to Doppel when requesting a takedown.",
+      "type": "string"
+    },
+    "DOPPEL_MAX_TLP": {
+      "default": "",
+      "description": "Max TLP level of entities to enrich (empty = no limit).",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED",
+        ""
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "DOPPEL_API_KEY",
+    "DOPPEL_USER_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/doppel-alert-takedown/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/doppel-alert-takedown/__metadata__/connector_config_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://www.filigran.io/connectors/doppel-brand-protection_config.schema.json",
+  "$id": "https://www.filigran.io/connectors/doppel-alert-takedown_config.schema.json",
   "type": "object",
   "properties": {
     "OPENCTI_URL": {

--- a/internal-enrichment/doppel-alert-takedown/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/doppel-alert-takedown/__metadata__/connector_config_schema.json
@@ -20,9 +20,15 @@
       "type": "string"
     },
     "CONNECTOR_SCOPE": {
-      "default": "Url,Domain-Name",
+      "default": [
+        "Url",
+        "Domain-Name"
+      ],
       "description": "The scope of the connector (types of observables to enrich).",
-      "type": "string"
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
     },
     "CONNECTOR_LOG_LEVEL": {
       "default": "error",
@@ -46,7 +52,7 @@
       "description": "Whether the connector should run automatically when an entity is created or updated.",
       "type": "boolean"
     },
-    "DOPPEL_API_BASE_URL": {
+    "DOPPEL_ALERT_TAKEDOWN_API_BASE_URL": {
       "default": "https://api.doppel.com/",
       "description": "Doppel API base URL.",
       "format": "uri",
@@ -54,37 +60,41 @@
       "minLength": 1,
       "type": "string"
     },
-    "DOPPEL_API_KEY": {
+    "DOPPEL_ALERT_TAKEDOWN_API_KEY": {
       "description": "Doppel API key, sent as the `x-api-key` header.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
-    "DOPPEL_USER_API_KEY": {
+    "DOPPEL_ALERT_TAKEDOWN_USER_API_KEY": {
       "description": "Doppel user API key, sent as the `x-user-api-key` header.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
-    "DOPPEL_TAGS": {
+    "DOPPEL_ALERT_TAKEDOWN_TAGS": {
+      "default": [],
       "description": "List of tags to attach to the alerts created in Doppel.",
       "items": {
         "type": "string"
       },
       "type": "array"
     },
-    "DOPPEL_TAKEDOWN_COMMENT": {
+    "DOPPEL_ALERT_TAKEDOWN_TAKEDOWN_COMMENT": {
       "default": "Confirmed by OpenCTI \u2014 requesting takedown.",
       "description": "Comment sent to Doppel when requesting a takedown.",
       "type": "string"
     },
-    "DOPPEL_MAX_TLP": {
-      "default": "",
-      "description": "Max TLP level of entities to enrich (empty = no limit).",
+    "DOPPEL_ALERT_TAKEDOWN_MAX_TLP": {
+      "default": "TLP:RED",
+      "description": "Max TLP level of entities to enrich.",
       "enum": [
         "TLP:CLEAR",
         "TLP:WHITE",
         "TLP:GREEN",
         "TLP:AMBER",
         "TLP:AMBER+STRICT",
-        "TLP:RED",
-        ""
+        "TLP:RED"
       ],
       "type": "string"
     }
@@ -92,8 +102,8 @@
   "required": [
     "OPENCTI_URL",
     "OPENCTI_TOKEN",
-    "DOPPEL_API_KEY",
-    "DOPPEL_USER_API_KEY"
+    "DOPPEL_ALERT_TAKEDOWN_API_KEY",
+    "DOPPEL_ALERT_TAKEDOWN_USER_API_KEY"
   ],
   "additionalProperties": true
 }

--- a/internal-enrichment/doppel-alert-takedown/__metadata__/connector_manifest.json
+++ b/internal-enrichment/doppel-alert-takedown/__metadata__/connector_manifest.json
@@ -1,6 +1,6 @@
 {
   "title": "Doppel Alert and Takedown",
-  "slug": "doppel-alert-and-takedown",
+  "slug": "doppel-alert-takedown",
   "description": "Enrich URL and Domain-Name observables by creating an alert in Doppel and automatically requesting a takedown. The observable is enriched with an external reference to the Doppel alert and a Note summarizing the alert and takedown request.",
   "short_description": "Create Doppel alerts and request takedowns from suspicious observables.",
   "logo": null,

--- a/internal-enrichment/doppel-alert-takedown/__metadata__/connector_manifest.json
+++ b/internal-enrichment/doppel-alert-takedown/__metadata__/connector_manifest.json
@@ -4,9 +4,16 @@
   "description": "Enrich URL and Domain-Name observables by creating an alert in Doppel and automatically requesting a takedown. The observable is enriched with an external reference to the Doppel alert and a Note summarizing the alert and takedown request.",
   "short_description": "Create Doppel alerts and request takedowns from suspicious observables.",
   "logo": null,
-  "use_cases" : ["Enrichment & Analysis"],
+  "use_cases": [
+    "Brand, Digital Risk & Underground Exposure"
+  ],
+  "solution_categories": [
+    "Digital Risk Protection"
+  ],
+  "license_type": "Commercial",
+  "contact": null,
   "verified": true,
-  "last_verified_date": null,
+  "last_verified_date": "2026-07-21",
   "playbook_supported": true,
   "max_confidence_level": 50,
   "support_version": ">=7.260715.0",

--- a/internal-enrichment/doppel-alert-takedown/__metadata__/connector_manifest.json
+++ b/internal-enrichment/doppel-alert-takedown/__metadata__/connector_manifest.json
@@ -1,0 +1,19 @@
+{
+  "title": "Doppel Alert and Takedown",
+  "slug": "doppel-alert-and-takedown",
+  "description": "Enrich URL and Domain-Name observables by creating an alert in Doppel and automatically requesting a takedown. The observable is enriched with an external reference to the Doppel alert and a Note summarizing the alert and takedown request.",
+  "short_description": "Create Doppel alerts and request takedowns from suspicious observables.",
+  "logo": null,
+  "use_cases" : ["Enrichment & Analysis"],
+  "verified": true,
+  "last_verified_date": null,
+  "playbook_supported": true,
+  "max_confidence_level": 50,
+  "support_version": ">=7.260715.0",
+  "subscription_link": null,
+  "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/doppel-alert-takedown",
+  "manager_supported": true,
+  "container_version": "rolling",
+  "container_image": "opencti/connector-doppel-alert-takedown",
+  "container_type": "INTERNAL_ENRICHMENT"
+}

--- a/internal-enrichment/doppel-alert-takedown/config.yml.sample
+++ b/internal-enrichment/doppel-alert-takedown/config.yml.sample
@@ -1,0 +1,19 @@
+opencti:
+  url: 'http://localhost'
+  token: 'ChangeMe'
+
+connector:
+  type: 'INTERNAL_ENRICHMENT'
+  id: 'ChangeMe'
+  name: 'Doppel Alert and Takedown' # optional (default: 'Doppel Alert and Takedown')
+  scope: 'Url,Domain-Name' # optional (default: 'Url,Domain-Name')
+  log_level: 'error' # optional (default: 'error')
+  auto: false # optional, enable/disable auto-enrichment of OpenCTI entities (default: false)
+
+doppel:
+  api_key: 'ChangeMe'
+  user_api_key: 'ChangeMe'
+  api_base_url: 'https://api.doppel.com' # optional (default: 'https://api.doppel.com')
+  tags: [] # optional, list of tags added to created alerts (default: empty)
+  takedown_comment: 'Confirmed by OpenCTI — requesting takedown.' # optional
+  max_tlp: '' # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED', or empty for no limit (default: empty)

--- a/internal-enrichment/doppel-alert-takedown/config.yml.sample
+++ b/internal-enrichment/doppel-alert-takedown/config.yml.sample
@@ -3,17 +3,16 @@ opencti:
   token: 'ChangeMe'
 
 connector:
-  type: 'INTERNAL_ENRICHMENT'
   id: 'ChangeMe'
   name: 'Doppel Alert and Takedown' # optional (default: 'Doppel Alert and Takedown')
   scope: 'Url,Domain-Name' # optional (default: 'Url,Domain-Name')
   log_level: 'error' # optional (default: 'error')
   auto: false # optional, enable/disable auto-enrichment of OpenCTI entities (default: false)
 
-doppel:
+doppel_alert_takedown:
   api_key: 'ChangeMe'
   user_api_key: 'ChangeMe'
   api_base_url: 'https://api.doppel.com' # optional (default: 'https://api.doppel.com')
   tags: [] # optional, list of tags added to created alerts (default: empty)
   takedown_comment: 'Confirmed by OpenCTI — requesting takedown.' # optional
-  max_tlp: '' # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED', or empty for no limit (default: empty)
+  max_tlp: 'TLP:RED' # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:RED')

--- a/internal-enrichment/doppel-alert-takedown/docker-compose.yml
+++ b/internal-enrichment/doppel-alert-takedown/docker-compose.yml
@@ -8,15 +8,15 @@ services:
       - OPENCTI_TOKEN=ChangeMe
       # Common parameters for connectors of type INTERNAL_ENRICHMENT
       - CONNECTOR_ID=ChangeMe
-      - CONNECTOR_NAME=Doppel Alert and Takedown # optional (default: 'Doppel Alert and Takedown')
-      - CONNECTOR_SCOPE=Url,Domain-Name # optional (default: 'Url,Domain-Name')
-      - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
-      - CONNECTOR_AUTO=false # optional (default: false)
+      #- CONNECTOR_NAME=Doppel Alert and Takedown # optional (default: 'Doppel Alert and Takedown')
+      #- CONNECTOR_SCOPE=Url,Domain-Name # optional (default: 'Url,Domain-Name')
+      #- CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
+      #- CONNECTOR_AUTO=false # optional (default: false)
       # Custom parameters for connector-doppel-alert-takedown
-      - DOPPEL_API_KEY=ChangeMe
-      - DOPPEL_USER_API_KEY=ChangeMe
-      - DOPPEL_API_BASE_URL=https://api.doppel.com # optional (default: 'https://api.doppel.com')
-      - DOPPEL_TAGS= # optional, comma-separated list of tags added to created alerts (default: empty)
-      - DOPPEL_TAKEDOWN_COMMENT=Confirmed by OpenCTI — requesting takedown. # optional
-      - DOPPEL_MAX_TLP=TLP:AMBER+STRICT # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED', or empty for no limit (default: empty)
+      - DOPPEL_ALERT_TAKEDOWN_API_KEY=ChangeMe
+      - DOPPEL_ALERT_TAKEDOWN_USER_API_KEY=ChangeMe
+      #- DOPPEL_ALERT_TAKEDOWN_API_BASE_URL=https://api.doppel.com # optional (default: 'https://api.doppel.com')
+      #- DOPPEL_ALERT_TAKEDOWN_TAGS= # optional, comma-separated list of tags added to created alerts (default: empty)
+      #- DOPPEL_ALERT_TAKEDOWN_TAKEDOWN_COMMENT=Confirmed by OpenCTI — requesting takedown. # optional
+      #- DOPPEL_ALERT_TAKEDOWN_MAX_TLP=TLP:AMBER+STRICT # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED' (default: 'TLP:RED')
     restart: always

--- a/internal-enrichment/doppel-alert-takedown/docker-compose.yml
+++ b/internal-enrichment/doppel-alert-takedown/docker-compose.yml
@@ -5,16 +5,16 @@ services:
     environment:
       # Generic parameters (connection with OpenCTI)
       - OPENCTI_URL=http://localhost
-      - OPENCTI_TOKEN=CHANGEME
+      - OPENCTI_TOKEN=ChangeMe
       # Common parameters for connectors of type INTERNAL_ENRICHMENT
-      - CONNECTOR_ID=CHANGEME
+      - CONNECTOR_ID=ChangeMe
       - CONNECTOR_NAME=Doppel Alert and Takedown # optional (default: 'Doppel Alert and Takedown')
       - CONNECTOR_SCOPE=Url,Domain-Name # optional (default: 'Url,Domain-Name')
       - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
       - CONNECTOR_AUTO=false # optional (default: false)
       # Custom parameters for connector-doppel-alert-takedown
-      - DOPPEL_API_KEY=CHANGEME
-      - DOPPEL_USER_API_KEY=CHANGEME
+      - DOPPEL_API_KEY=ChangeMe
+      - DOPPEL_USER_API_KEY=ChangeMe
       - DOPPEL_API_BASE_URL=https://api.doppel.com # optional (default: 'https://api.doppel.com')
       - DOPPEL_TAGS= # optional, comma-separated list of tags added to created alerts (default: empty)
       - DOPPEL_TAKEDOWN_COMMENT=Confirmed by OpenCTI — requesting takedown. # optional

--- a/internal-enrichment/doppel-alert-takedown/docker-compose.yml
+++ b/internal-enrichment/doppel-alert-takedown/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  connector-doppel-alert-takedown:
+    image: opencti/connector-doppel-alert-takedown:latest
+    environment:
+      # Generic parameters (connection with OpenCTI)
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=CHANGEME
+      # Common parameters for connectors of type INTERNAL_ENRICHMENT
+      - CONNECTOR_ID=CHANGEME
+      - CONNECTOR_NAME=Doppel Alert and Takedown # optional (default: 'Doppel Alert and Takedown')
+      - CONNECTOR_SCOPE=Url,Domain-Name # optional (default: 'Url,Domain-Name')
+      - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
+      - CONNECTOR_AUTO=false # optional (default: false)
+      # Custom parameters for connector-doppel-alert-takedown
+      - DOPPEL_API_KEY=CHANGEME
+      - DOPPEL_USER_API_KEY=CHANGEME
+      - DOPPEL_API_BASE_URL=https://api.doppel.com # optional (default: 'https://api.doppel.com')
+      - DOPPEL_TAGS= # optional, comma-separated list of tags added to created alerts (default: empty)
+      - DOPPEL_TAKEDOWN_COMMENT=Confirmed by OpenCTI — requesting takedown. # optional
+      - DOPPEL_MAX_TLP=TLP:AMBER+STRICT # optional, available values: 'TLP:CLEAR', 'TLP:WHITE', 'TLP:GREEN', 'TLP:AMBER', 'TLP:AMBER+STRICT', 'TLP:RED', or empty for no limit (default: empty)
+    restart: always

--- a/internal-enrichment/doppel-alert-takedown/entrypoint.sh
+++ b/internal-enrichment/doppel-alert-takedown/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-doppel-alert-takedown
-
-# Launch the worker
-python3 main.py

--- a/internal-enrichment/doppel-alert-takedown/entrypoint.sh
+++ b/internal-enrichment/doppel-alert-takedown/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Go to the right directory
+cd /opt/opencti-connector-doppel-alert-takedown
+
+# Launch the worker
+python3 main.py

--- a/internal-enrichment/doppel-alert-takedown/src/connector/__init__.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/__init__.py
@@ -1,0 +1,7 @@
+from connector.connector import DoppelConnector
+from connector.settings import ConnectorSettings
+
+__all__ = [
+    "DoppelConnector",
+    "ConnectorSettings",
+]

--- a/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
@@ -45,7 +45,7 @@ class DoppelConnector:
         :param data: Dictionary of data
         :return: boolean
         """
-        scopes = self.helper.connect_scope.lower().replace(" ", "").split(",")
+        scopes = [scope.lower() for scope in self.config.connector.scope]
         entity_split = data["entity_id"].split("--")
         entity_type = entity_split[0].lower()
         return entity_type in scopes
@@ -56,20 +56,17 @@ class DoppelConnector:
         No check is performed when `max_tlp` is empty (no limit).
         :param opencti_entity: Dict of observable from OpenCTI
         """
+        self.tlp = None
         if len(opencti_entity["objectMarking"]) != 0:
             for marking_definition in opencti_entity["objectMarking"]:
                 if marking_definition["definition_type"] == "TLP":
                     self.tlp = marking_definition["definition"]
 
-        max_tlp = self.config.doppel.max_tlp
-        if not max_tlp:
-            return
-
-        valid_max_tlp = self.helper.check_max_tlp(self.tlp, max_tlp)
-        if not valid_max_tlp:
+        valid_entity_tlp = self.helper.check_max_tlp(self.tlp, self.config.doppel_alert_takedown.max_tlp)  # type: ignore[arg-type]
+        if not valid_entity_tlp:
             raise ValueError(
-                "[CONNECTOR] Do not send any data, TLP of the observable is greater than MAX TLP,"
-                "the connector does not has access to this observable, please check the group of the connector user"
+                f"[CONNECTOR] Observable TLP ({self.tlp}) exceeds "
+                f"maximum allowed TLP ({self.config.doppel_alert_takedown.max_tlp})."
             )
 
     def _collect_intelligence(self, obs_type: str, obs_value: str, obs_id: str) -> list:

--- a/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
@@ -30,9 +30,9 @@ class DoppelConnector:
 
         self.client = DoppelClient(
             self.helper,
-            base_url=self.config.doppel.api_base_url,
-            api_key=self.config.doppel.api_key,
-            user_api_key=self.config.doppel.user_api_key,
+            base_url=self.config.doppel_alert_takedown.api_base_url,
+            api_key=self.config.doppel_alert_takedown.api_key.get_secret_value(),
+            user_api_key=self.config.doppel_alert_takedown.user_api_key.get_secret_value(),
         )
         self.converter_to_stix = ConverterToStix(self.helper)
 
@@ -85,7 +85,7 @@ class DoppelConnector:
         alert = self.client.create_alert(
             entity=obs_value,
             entity_type=doppel_entity_type,
-            tags=self.config.doppel.tags,
+            tags=self.config.doppel_alert_takedown.tags,
         )
         self.helper.connector_logger.info(
             "[CONNECTOR] Doppel alert created",
@@ -96,7 +96,7 @@ class DoppelConnector:
         try:
             self.client.request_takedown(
                 entity=obs_value,
-                comment=self.config.doppel.takedown_comment,
+                comment=self.config.doppel_alert_takedown.takedown_comment,
             )
             takedown_requested = True
             self.helper.connector_logger.info(
@@ -121,7 +121,7 @@ class DoppelConnector:
             observable_ref=obs_id,
             alert=alert,
             takedown_requested=takedown_requested,
-            takedown_comment=self.config.doppel.takedown_comment,
+            takedown_comment=self.config.doppel_alert_takedown.takedown_comment,
             marking=marking,
         )
 

--- a/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
@@ -171,9 +171,10 @@ class DoppelConnector:
                 f"Failed to process observable, {opencti_entity['entity_type']} is not a supported entity type."
             )
         except Exception as err:
-            return self.helper.connector_logger.error(
+            self.helper.connector_logger.error(
                 "[CONNECTOR] Unexpected Error occurred", {"error_message": str(err)}
             )
+            raise err
 
     def _send_bundle(self, stix_objects: list) -> str:
         stix_objects_bundle = self.helper.stix2_create_bundle(stix_objects)

--- a/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
@@ -1,5 +1,6 @@
 from connector.converter_to_stix import ConverterToStix
 from connector.settings import ConnectorSettings
+from connectors_sdk.models import BaseIdentifiedObject
 from doppel_client import DoppelClient, DoppelClientError
 from pycti import OpenCTIConnectorHelper
 
@@ -122,12 +123,13 @@ class DoppelConnector:
             marking=marking,
         )
 
-        stix_objects = [self.converter_to_stix.author.to_stix2_object()]
+        stix_objects: list[BaseIdentifiedObject] = [self.converter_to_stix.author]
         if marking is not None:
-            stix_objects.append(marking.to_stix2_object())
-        stix_objects.append(observable.to_stix2_object())
-        stix_objects.append(note.to_stix2_object())
-        return stix_objects
+            stix_objects.append(marking)
+        stix_objects.append(observable)
+        stix_objects.append(note)
+
+        return [obj.to_stix2_object() for obj in stix_objects]
 
     def process_message(self, data: dict) -> str:
         """

--- a/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
@@ -1,0 +1,185 @@
+from connector.converter_to_stix import ConverterToStix
+from connector.settings import ConnectorSettings
+from doppel_client import DoppelClient, DoppelClientError
+from pycti import OpenCTIConnectorHelper
+
+# Mapping from OpenCTI observable type to Doppel entity_type
+DOPPEL_ENTITY_TYPE_MAPPING = {
+    "url": "url",
+    "domain-name": "domain",
+}
+
+
+class DoppelConnector:
+    """
+    Doppel Alert and Takedown internal enrichment connector.
+
+    On enrichment of a suspicious observable (URL or Domain-Name), this connector:
+      1. Creates an alert in Doppel (POST /v1/alert).
+      2. Requests a takedown for that alert (PUT /v1/alert?entity=...).
+      3. Enriches the observable in OpenCTI with an external reference to the Doppel
+         alert and a Note summarizing the alert and takedown request.
+
+    To be compatible with the "playbook automation" feature, this connector always
+    sends back a STIX bundle containing the entity to enrich.
+    """
+
+    def __init__(self, config: ConnectorSettings, helper: OpenCTIConnectorHelper):
+        self.config = config
+        self.helper = helper
+
+        self.client = DoppelClient(
+            self.helper,
+            base_url=self.config.doppel.api_base_url,
+            api_key=self.config.doppel.api_key,
+            user_api_key=self.config.doppel.user_api_key,
+        )
+        self.converter_to_stix = ConverterToStix(self.helper)
+
+        self.tlp = None
+        self.stix_objects_list = []
+
+    def entity_in_scope(self, data) -> bool:
+        """
+        Security to limit playbook triggers to something other than the initial scope
+        :param data: Dictionary of data
+        :return: boolean
+        """
+        scopes = self.helper.connect_scope.lower().replace(" ", "").split(",")
+        entity_split = data["entity_id"].split("--")
+        entity_type = entity_split[0].lower()
+        return entity_type in scopes
+
+    def extract_and_check_markings(self, opencti_entity: dict) -> None:
+        """
+        Extract TLP and check that the observable's marking is not above `max_tlp`.
+        No check is performed when `max_tlp` is empty (no limit).
+        :param opencti_entity: Dict of observable from OpenCTI
+        """
+        if len(opencti_entity["objectMarking"]) != 0:
+            for marking_definition in opencti_entity["objectMarking"]:
+                if marking_definition["definition_type"] == "TLP":
+                    self.tlp = marking_definition["definition"]
+
+        max_tlp = self.config.doppel.max_tlp
+        if not max_tlp:
+            return
+
+        valid_max_tlp = self.helper.check_max_tlp(self.tlp, max_tlp)
+        if not valid_max_tlp:
+            raise ValueError(
+                "[CONNECTOR] Do not send any data, TLP of the observable is greater than MAX TLP,"
+                "the connector does not has access to this observable, please check the group of the connector user"
+            )
+
+    def _collect_intelligence(self, obs_type: str, obs_value: str, obs_id: str) -> list:
+        """
+        Create the Doppel alert, request a takedown and convert the result into STIX objects.
+        :param obs_type: OpenCTI observable type (lowercased).
+        :param obs_value: Observable value.
+        :param obs_id: Observable STIX id.
+        :return: List of STIX objects to enrich the observable with.
+        """
+        doppel_entity_type = DOPPEL_ENTITY_TYPE_MAPPING[obs_type]
+
+        alert = self.client.create_alert(
+            entity=obs_value,
+            entity_type=doppel_entity_type,
+            tags=self.config.doppel.tags,
+        )
+        self.helper.connector_logger.info(
+            "[CONNECTOR] Doppel alert created",
+            {"alert_id": alert.get("id"), "entity": obs_value},
+        )
+
+        takedown_requested = False
+        try:
+            self.client.request_takedown(
+                entity=obs_value,
+                comment=self.config.doppel.takedown_comment,
+            )
+            takedown_requested = True
+            self.helper.connector_logger.info(
+                "[CONNECTOR] Doppel takedown requested",
+                {"alert_id": alert.get("id"), "entity": obs_value},
+            )
+        except DoppelClientError as err:
+            self.helper.connector_logger.error(
+                "[CONNECTOR] Doppel takedown request failed",
+                {"entity": obs_value, "error": str(err)},
+            )
+
+        external_reference = self.converter_to_stix.build_external_reference(alert)
+        marking = self.converter_to_stix.marking_from_tlp(self.tlp)
+        observable = self.converter_to_stix.build_observable(
+            observable_type=obs_type,
+            value=obs_value,
+            external_reference=external_reference,
+            marking=marking,
+        )
+        note = self.converter_to_stix.build_note(
+            observable_ref=obs_id,
+            alert=alert,
+            takedown_requested=takedown_requested,
+            takedown_comment=self.config.doppel.takedown_comment,
+            marking=marking,
+        )
+
+        stix_objects = [self.converter_to_stix.author.to_stix2_object()]
+        if marking is not None:
+            stix_objects.append(marking.to_stix2_object())
+        stix_objects.append(observable.to_stix2_object())
+        stix_objects.append(note.to_stix2_object())
+        return stix_objects
+
+    def process_message(self, data: dict) -> str:
+        """
+        Get the observable created/modified in OpenCTI and enrich it through Doppel.
+        :param data: dict of data to process
+        :return: string
+        """
+        try:
+            opencti_entity = data["enrichment_entity"]
+            self.extract_and_check_markings(opencti_entity)
+
+            self.stix_objects_list = data["stix_objects"]
+            observable = data["stix_entity"]
+
+            obs_standard_id = observable["id"]
+            obs_value = observable["value"]
+            obs_type = observable["type"].lower()
+
+            self.helper.connector_logger.info(
+                "[CONNECTOR] Processing observable for the following entity type: ",
+                {"type": obs_type},
+            )
+
+            if self.entity_in_scope(data):
+                stix_objects = self._collect_intelligence(
+                    obs_type, obs_value, obs_standard_id
+                )
+                if stix_objects:
+                    self.stix_objects_list.extend(stix_objects)
+                    return self._send_bundle(self.stix_objects_list)
+                return "[CONNECTOR] No information found"
+
+            if not data.get("event_type"):
+                # Not in scope but passed through a playbook: return the bundle unchanged
+                return self._send_bundle(self.stix_objects_list)
+
+            raise ValueError(
+                f"Failed to process observable, {opencti_entity['entity_type']} is not a supported entity type."
+            )
+        except Exception as err:
+            return self.helper.connector_logger.error(
+                "[CONNECTOR] Unexpected Error occurred", {"error_message": str(err)}
+            )
+
+    def _send_bundle(self, stix_objects: list) -> str:
+        stix_objects_bundle = self.helper.stix2_create_bundle(stix_objects)
+        bundles_sent = self.helper.send_stix2_bundle(stix_objects_bundle)
+        return f"Sending {len(bundles_sent)} stix bundle(s) for worker import"
+
+    def run(self) -> None:
+        """Run the main process using the helper's listen method."""
+        self.helper.listen(message_callback=self.process_message)

--- a/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
@@ -44,31 +44,25 @@ class DoppelConnector:
         """
         Security to limit playbook triggers to something other than the initial scope
         :param data: Dictionary of data
-        :return: boolean
+        :return: True if the entity type is in the connector's scope, False otherwise.
         """
         scopes = [scope.lower() for scope in self.config.connector.scope]
-        entity_split = data["entity_id"].split("--")
-        entity_type = entity_split[0].lower()
+        entity_type = data["enrichment_entity"]["entity_type"].lower()
+
         return entity_type in scopes
 
-    def extract_and_check_markings(self, opencti_entity: dict) -> None:
+    def extract_and_check_markings(self, opencti_entity: dict) -> bool:
         """
         Extract TLP and check that the observable's marking is not above `max_tlp`.
-        No check is performed when `max_tlp` is empty (no limit).
         :param opencti_entity: Dict of observable from OpenCTI
+        :return: True if the observable's marking is within the limit, False otherwise.
         """
         self.tlp = None
-        if len(opencti_entity["objectMarking"]) != 0:
-            for marking_definition in opencti_entity["objectMarking"]:
-                if marking_definition["definition_type"] == "TLP":
-                    self.tlp = marking_definition["definition"]
+        for marking_definition in opencti_entity["objectMarking"]:
+            if marking_definition["definition_type"] == "TLP":
+                self.tlp = marking_definition["definition"]
 
-        valid_entity_tlp = self.helper.check_max_tlp(self.tlp, self.config.doppel_alert_takedown.max_tlp)  # type: ignore[arg-type]
-        if not valid_entity_tlp:
-            raise ValueError(
-                f"[CONNECTOR] Observable TLP ({self.tlp}) exceeds "
-                f"maximum allowed TLP ({self.config.doppel_alert_takedown.max_tlp})."
-            )
+        return self.helper.check_max_tlp(self.tlp, self.config.doppel_alert_takedown.max_tlp)  # type: ignore[arg-type]
 
     def _collect_intelligence(self, obs_type: str, obs_value: str, obs_id: str) -> list:
         """
@@ -90,7 +84,6 @@ class DoppelConnector:
             {"alert_id": alert.get("id"), "entity": obs_value},
         )
 
-        takedown_requested = False
         try:
             self.client.request_takedown(
                 entity=obs_value,
@@ -102,8 +95,10 @@ class DoppelConnector:
                 {"alert_id": alert.get("id"), "entity": obs_value},
             )
         except DoppelClientError as err:
+            takedown_requested = False
             self.helper.connector_logger.error(
-                "[CONNECTOR] Doppel takedown request failed",
+                "[CONNECTOR] Doppel takedown request failed, "
+                "enrichment continues with takedown marked as not requested",
                 {"entity": obs_value, "error": str(err)},
             )
 
@@ -135,13 +130,22 @@ class DoppelConnector:
         """
         Get the observable created/modified in OpenCTI and enrich it through Doppel.
         :param data: dict of data to process
-        :return: string
+        :return: Message to attach to enrichment work.
         """
         try:
-            opencti_entity = data["enrichment_entity"]
-            self.extract_and_check_markings(opencti_entity)
-
             self.stix_objects_list = data["stix_objects"]
+            opencti_entity = data["enrichment_entity"]
+
+            if not self.entity_in_scope(data):
+                raise ValueError(
+                    f"Failed to process observable, {opencti_entity['entity_type']} is not a supported entity type."
+                )
+            if not self.extract_and_check_markings(opencti_entity):
+                raise ValueError(
+                    f"Observable TLP ({self.tlp}) exceeds "
+                    f"maximum allowed TLP ({self.config.doppel_alert_takedown.max_tlp})."
+                )
+
             observable = data["stix_entity"]
 
             obs_standard_id = observable["id"]
@@ -153,31 +157,42 @@ class DoppelConnector:
                 {"type": obs_type},
             )
 
-            if self.entity_in_scope(data):
-                stix_objects = self._collect_intelligence(
-                    obs_type, obs_value, obs_standard_id
-                )
-                if stix_objects:
-                    self.stix_objects_list.extend(stix_objects)
-                    return self._send_bundle(self.stix_objects_list)
-                return "[CONNECTOR] No information found"
-
-            if not data.get("event_type"):
-                # Not in scope but passed through a playbook: return the bundle unchanged
-                return self._send_bundle(self.stix_objects_list)
-
-            raise ValueError(
-                f"Failed to process observable, {opencti_entity['entity_type']} is not a supported entity type."
+            stix_objects = self._collect_intelligence(
+                obs_type, obs_value, obs_standard_id
             )
+            if stix_objects:
+                self.helper.connector_logger.info(
+                    "[CONNECTOR] Enrichment completed", {"entity": obs_value}
+                )
+                return self._send_bundle(self.stix_objects_list + stix_objects)
+
+            # Safeguard - not reachable in theory
+            message = "[CONNECTOR] No information found"
+            self.helper.connector_logger.info(message, {"entity": obs_value})
+            if self.helper.playbook:
+                # If inside a playbook, return the bundle unchanged to continue playbook flow
+                return self._send_bundle(self.stix_objects_list)
+            else:
+                return message
+
         except Exception as err:
             self.helper.connector_logger.error(
-                "[CONNECTOR] Unexpected Error occurred", {"error_message": str(err)}
+                "[CONNECTOR] An error occurred while processing the observable",
+                {"error": str(err)},
             )
-            raise err
+
+            if self.helper.playbook:
+                # If inside a playbook, return the bundle unchanged to continue playbook flow
+                return self._send_bundle(self.stix_objects_list)
+            else:
+                raise
 
     def _send_bundle(self, stix_objects: list) -> str:
         stix_objects_bundle = self.helper.stix2_create_bundle(stix_objects)
-        bundles_sent = self.helper.send_stix2_bundle(stix_objects_bundle, cleanup_inconsistent_bundle=True)  # type: ignore[arg-type]
+        bundles_sent = self.helper.send_stix2_bundle(
+            stix_objects_bundle,  # type: ignore[arg-type]
+            cleanup_inconsistent_bundle=True,
+        )
         return f"Sending {len(bundles_sent)} stix bundle(s) for worker import"
 
     def run(self) -> None:

--- a/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/connector.py
@@ -175,7 +175,7 @@ class DoppelConnector:
 
     def _send_bundle(self, stix_objects: list) -> str:
         stix_objects_bundle = self.helper.stix2_create_bundle(stix_objects)
-        bundles_sent = self.helper.send_stix2_bundle(stix_objects_bundle)
+        bundles_sent = self.helper.send_stix2_bundle(stix_objects_bundle, cleanup_inconsistent_bundle=True)  # type: ignore[arg-type]
         return f"Sending {len(bundles_sent)} stix bundle(s) for worker import"
 
     def run(self) -> None:

--- a/internal-enrichment/doppel-alert-takedown/src/connector/converter_to_stix.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/converter_to_stix.py
@@ -1,0 +1,160 @@
+from typing import Literal
+
+from connectors_sdk.models import (
+    URL,
+    DomainName,
+    ExternalReference,
+    Note,
+    OrganizationAuthor,
+    TLPMarking,
+)
+from connectors_sdk.models.reference import Reference
+from pycti import OpenCTIConnectorHelper
+
+AUTHOR_NAME = "Doppel"
+AUTHOR_DESCRIPTION = (
+    "Doppel is a brand protection and digital risk protection platform used to "
+    "detect and take down phishing sites, fraudulent domains and other online threats."
+)
+AUTHOR_URL = "https://www.doppel.com"
+
+TLPLevel = Literal["clear", "white", "green", "amber", "amber+strict", "red"]
+
+# Mapping from OpenCTI TLP marking definition to connectors_sdk TLPMarking level
+TLP_DEFINITION_TO_LEVEL: dict[str, TLPLevel] = {
+    "TLP:CLEAR": "clear",
+    "TLP:WHITE": "white",
+    "TLP:GREEN": "green",
+    "TLP:AMBER": "amber",
+    "TLP:AMBER+STRICT": "amber+strict",
+    "TLP:RED": "red",
+}
+
+
+class ConverterToStix:
+    """
+    Provides methods for converting Doppel data into STIX 2.1 objects.
+
+    Deterministic IDs are handled by the `connectors_sdk` models (author, note, ...)
+    so stix2 never auto-generates non-deterministic IDs for SDOs.
+    """
+
+    def __init__(
+        self,
+        helper: OpenCTIConnectorHelper,
+    ):
+        """
+        Initialize the converter.
+
+        Args:
+            helper (OpenCTIConnectorHelper): The helper of the connector. Used for logs.
+        """
+        self.helper = helper
+        self.author = OrganizationAuthor(
+            name=AUTHOR_NAME,
+            description=AUTHOR_DESCRIPTION,
+            external_references=[
+                ExternalReference(source_name=AUTHOR_NAME, url=AUTHOR_URL)
+            ],
+        )
+
+    @staticmethod
+    def marking_from_tlp(tlp_definition: str | None) -> TLPMarking | None:
+        """
+        Build a TLP marking from an OpenCTI TLP definition (e.g. "TLP:AMBER").
+
+        :param tlp_definition: The TLP definition of the source observable, if any.
+        :return: A `TLPMarking` SDK model, or None if no/unknown TLP.
+        """
+        if not tlp_definition:
+            return None
+        level = TLP_DEFINITION_TO_LEVEL.get(tlp_definition.upper())
+        if level is None:
+            return None
+        return TLPMarking(level=level)
+
+    @staticmethod
+    def build_external_reference(alert: dict) -> ExternalReference:
+        """
+        Build an external reference pointing to the created Doppel alert.
+
+        :param alert: The alert payload returned by the Doppel API.
+        :return: An `ExternalReference` SDK model.
+        """
+        return ExternalReference(
+            source_name="Doppel Alert",
+            url=alert.get("doppel_link"),
+            external_id=alert.get("id"),
+            description="Doppel alert created from the enriched observable.",
+        )
+
+    def build_observable(
+        self,
+        observable_type: str,
+        value: str,
+        external_reference: ExternalReference,
+        marking: TLPMarking | None = None,
+    ) -> URL | DomainName:
+        """
+        Rebuild the enriched observable with the Doppel external reference attached.
+
+        The SDK generates a deterministic STIX id from the observable value, so the
+        returned object merges with the original observable in OpenCTI.
+
+        :param observable_type: The OpenCTI observable type ("url" or "domain-name").
+        :param value: The observable value.
+        :param external_reference: The Doppel alert external reference to attach.
+        :param marking: The TLP marking of the source observable, if any.
+        :return: A URL or DomainName SDK model.
+        """
+        common = {
+            "value": value,
+            "author": self.author,
+            "markings": [marking] if marking is not None else None,
+            "external_references": [external_reference],
+        }
+        if observable_type == "url":
+            return URL(**common)
+        return DomainName(**common)
+
+    def build_note(
+        self,
+        observable_ref: str,
+        alert: dict,
+        takedown_requested: bool,
+        takedown_comment: str,
+        marking: TLPMarking | None = None,
+    ) -> Note:
+        """
+        Build a Note summarizing the Doppel alert and the takedown request.
+
+        :param observable_ref: The STIX id of the enriched observable.
+        :param alert: The alert payload returned by the Doppel API.
+        :param takedown_requested: Whether the takedown request succeeded.
+        :param takedown_comment: The comment used for the takedown request.
+        :param marking: The TLP marking of the source observable, if any.
+        :return: A `Note` SDK model.
+        """
+        takedown_line = (
+            f"- Takedown requested: {takedown_comment}"
+            if takedown_requested
+            else "- Takedown request failed (see connector logs)."
+        )
+        content = "\n".join(
+            [
+                "## Doppel Alert",
+                "",
+                f"- Alert ID: `{alert.get('id')}`",
+                f"- Entity: {alert.get('entity')}",
+                f"- Archetype: {alert.get('archetype')}",
+                f"- Doppel link: {alert.get('doppel_link')}",
+                takedown_line,
+            ]
+        )
+        return Note(
+            content=content,
+            abstract=f"Doppel alert {alert.get('id')}",
+            author=self.author,
+            markings=[marking] if marking is not None else None,
+            objects=[Reference(id=observable_ref)],
+        )

--- a/internal-enrichment/doppel-alert-takedown/src/connector/converter_to_stix.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/converter_to_stix.py
@@ -1,27 +1,16 @@
-from typing import Literal
-
 from connectors_sdk.models import (
     URL,
     DomainName,
     ExternalReference,
     Note,
     OrganizationAuthor,
+    Reference,
     TLPMarking,
 )
-from connectors_sdk.models.reference import Reference
 from pycti import OpenCTIConnectorHelper
 
-AUTHOR_NAME = "Doppel"
-AUTHOR_DESCRIPTION = (
-    "Doppel is a brand protection and digital risk protection platform used to "
-    "detect and take down phishing sites, fraudulent domains and other online threats."
-)
-AUTHOR_URL = "https://www.doppel.com"
-
-TLPLevel = Literal["clear", "white", "green", "amber", "amber+strict", "red"]
-
 # Mapping from OpenCTI TLP marking definition to connectors_sdk TLPMarking level
-TLP_DEFINITION_TO_LEVEL: dict[str, TLPLevel] = {
+TLP_DEFINITION_TO_LEVEL = {
     "TLP:CLEAR": "clear",
     "TLP:WHITE": "white",
     "TLP:GREEN": "green",
@@ -51,10 +40,13 @@ class ConverterToStix:
         """
         self.helper = helper
         self.author = OrganizationAuthor(
-            name=AUTHOR_NAME,
-            description=AUTHOR_DESCRIPTION,
+            name="Doppel",
+            description=(
+                "Doppel is a brand protection and digital risk protection platform used to "
+                "detect and take down phishing sites, fraudulent domains and other online threats."
+            ),
             external_references=[
-                ExternalReference(source_name=AUTHOR_NAME, url=AUTHOR_URL)
+                ExternalReference(source_name="Doppel", url="https://www.doppel.com")
             ],
         )
 
@@ -71,7 +63,7 @@ class ConverterToStix:
         level = TLP_DEFINITION_TO_LEVEL.get(tlp_definition.upper())
         if level is None:
             return None
-        return TLPMarking(level=level)
+        return TLPMarking(level=level)  # type: ignore[arg-type]
 
     @staticmethod
     def build_external_reference(alert: dict) -> ExternalReference:

--- a/internal-enrichment/doppel-alert-takedown/src/connector/settings.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/settings.py
@@ -4,8 +4,9 @@ from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
     BaseInternalEnrichmentConnectorConfig,
+    ListFromString,
 )
-from pydantic import Field, HttpUrl, field_validator
+from pydantic import Field, HttpUrl, SecretStr
 
 
 class InternalEnrichmentConnectorConfig(BaseInternalEnrichmentConnectorConfig):
@@ -14,17 +15,21 @@ class InternalEnrichmentConnectorConfig(BaseInternalEnrichmentConnectorConfig):
     to the configuration for the `Doppel Alert And Takedown` connector.
     """
 
+    id: str = Field(
+        description="The unique identifier of the connector.",
+        default="b8821b12-470d-4037-a8c2-4bcf5432a000",
+    )
     name: str = Field(
         description="The name of the connector.",
         default="Doppel Alert and Takedown",
     )
-    scope: str = Field(
+    scope: ListFromString = Field(
         description="The scope of the connector (types of observables to enrich).",
-        default="Url,Domain-Name",
+        default=["Url", "Domain-Name"],
     )
 
 
-class DoppelConfig(BaseConfigModel):
+class DoppelAlertTakedownConfig(BaseConfigModel):
     """
     Define parameters and/or defaults for the configuration specific to the `Doppel Alert And Takedown` connector.
     """
@@ -33,15 +38,15 @@ class DoppelConfig(BaseConfigModel):
         description="Doppel API base URL.",
         default=HttpUrl("https://api.doppel.com"),
     )
-    api_key: str = Field(
+    api_key: SecretStr = Field(
         description="Doppel API key, sent as the `x-api-key` header.",
     )
-    user_api_key: str = Field(
+    user_api_key: SecretStr = Field(
         description="Doppel user API key, sent as the `x-user-api-key` header.",
     )
-    tags: list[str] = Field(
+    tags: ListFromString = Field(
         description="List of tags to attach to the alerts created in Doppel.",
-        default_factory=list,
+        default=[],
     )
     takedown_comment: str = Field(
         description="Comment sent to Doppel when requesting a takedown.",
@@ -54,19 +59,10 @@ class DoppelConfig(BaseConfigModel):
         "TLP:AMBER",
         "TLP:AMBER+STRICT",
         "TLP:RED",
-        "",
     ] = Field(
-        default="",
-        description="Max TLP level of entities to enrich (empty = no limit).",
+        default="TLP:RED",
+        description="Max TLP level of entities to enrich.",
     )
-
-    @field_validator("tags", mode="before")
-    @classmethod
-    def _split_tags(cls, value: object) -> object:
-        """Allow tags to be provided as a comma-separated string (env var friendly)."""
-        if isinstance(value, str):
-            return [tag.strip() for tag in value.split(",") if tag.strip()]
-        return value
 
 
 class ConnectorSettings(BaseConnectorSettings):
@@ -77,4 +73,6 @@ class ConnectorSettings(BaseConnectorSettings):
     connector: InternalEnrichmentConnectorConfig = Field(
         default_factory=InternalEnrichmentConnectorConfig
     )
-    doppel: DoppelConfig = Field(default_factory=DoppelConfig)
+    doppel_alert_takedown: DoppelAlertTakedownConfig = Field(
+        default_factory=DoppelAlertTakedownConfig
+    )

--- a/internal-enrichment/doppel-alert-takedown/src/connector/settings.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/settings.py
@@ -1,0 +1,80 @@
+from typing import Literal
+
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseInternalEnrichmentConnectorConfig,
+)
+from pydantic import Field, HttpUrl, field_validator
+
+
+class InternalEnrichmentConnectorConfig(BaseInternalEnrichmentConnectorConfig):
+    """
+    Override the `BaseInternalEnrichmentConnectorConfig` to add parameters and/or defaults
+    to the configuration for the `Doppel Alert And Takedown` connector.
+    """
+
+    name: str = Field(
+        description="The name of the connector.",
+        default="Doppel Alert And Takedown",
+    )
+    scope: str = Field(
+        description="The scope of the connector (types of observables to enrich).",
+        default="Url,Domain-Name",
+    )
+
+
+class DoppelConfig(BaseConfigModel):
+    """
+    Define parameters and/or defaults for the configuration specific to the `Doppel Alert And Takedown` connector.
+    """
+
+    api_base_url: HttpUrl = Field(
+        description="Doppel API base URL.",
+        default=HttpUrl("https://api.doppel.com"),
+    )
+    api_key: str = Field(
+        description="Doppel API key, sent as the `x-api-key` header.",
+    )
+    user_api_key: str = Field(
+        description="Doppel user API key, sent as the `x-user-api-key` header.",
+    )
+    tags: list[str] = Field(
+        description="List of tags to attach to the alerts created in Doppel.",
+        default_factory=list,
+    )
+    takedown_comment: str = Field(
+        description="Comment sent to Doppel when requesting a takedown.",
+        default="Confirmed by OpenCTI — requesting takedown.",
+    )
+    max_tlp: Literal[
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED",
+        "",
+    ] = Field(
+        default="",
+        description="Max TLP level of entities to enrich (empty = no limit).",
+    )
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def _split_tags(cls, value: object) -> object:
+        """Allow tags to be provided as a comma-separated string (env var friendly)."""
+        if isinstance(value, str):
+            return [tag.strip() for tag in value.split(",") if tag.strip()]
+        return value
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """
+    Override `BaseConnectorSettings` to include `InternalEnrichmentConnectorConfig` and `DoppelConfig`.
+    """
+
+    connector: InternalEnrichmentConnectorConfig = Field(
+        default_factory=InternalEnrichmentConnectorConfig
+    )
+    doppel: DoppelConfig = Field(default_factory=DoppelConfig)

--- a/internal-enrichment/doppel-alert-takedown/src/connector/settings.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/settings.py
@@ -16,7 +16,7 @@ class InternalEnrichmentConnectorConfig(BaseInternalEnrichmentConnectorConfig):
 
     name: str = Field(
         description="The name of the connector.",
-        default="Doppel Alert And Takedown",
+        default="Doppel Alert and Takedown",
     )
     scope: str = Field(
         description="The scope of the connector (types of observables to enrich).",

--- a/internal-enrichment/doppel-alert-takedown/src/connector/utils.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/utils.py
@@ -1,0 +1,1 @@
+#  Utilities: helper functions, classes, or modules that provide common, reusable functionality across a codebase

--- a/internal-enrichment/doppel-alert-takedown/src/connector/utils.py
+++ b/internal-enrichment/doppel-alert-takedown/src/connector/utils.py
@@ -1,1 +1,0 @@
-#  Utilities: helper functions, classes, or modules that provide common, reusable functionality across a codebase

--- a/internal-enrichment/doppel-alert-takedown/src/doppel_client/__init__.py
+++ b/internal-enrichment/doppel-alert-takedown/src/doppel_client/__init__.py
@@ -1,0 +1,6 @@
+from doppel_client.api_client import DoppelClient, DoppelClientError
+
+__all__ = [
+    "DoppelClient",
+    "DoppelClientError",
+]

--- a/internal-enrichment/doppel-alert-takedown/src/doppel_client/api_client.py
+++ b/internal-enrichment/doppel-alert-takedown/src/doppel_client/api_client.py
@@ -60,7 +60,7 @@ class DoppelClient:
             {"url_path": url, "entity": entity, "entity_type": entity_type},
         )
         try:
-            response = self.session.post(url, json=payload)
+            response = self.session.post(url, json=payload, timeout=30)
             response.raise_for_status()
             return response.json()
         except requests.RequestException as err:
@@ -86,7 +86,9 @@ class DoppelClient:
             {"url_path": url, "entity": entity},
         )
         try:
-            response = self.session.put(url, params={"entity": entity}, json=payload)
+            response = self.session.put(
+                url, params={"entity": entity}, json=payload, timeout=30
+            )
             response.raise_for_status()
             return response.json() if response.content else {}
         except requests.RequestException as err:

--- a/internal-enrichment/doppel-alert-takedown/src/doppel_client/api_client.py
+++ b/internal-enrichment/doppel-alert-takedown/src/doppel_client/api_client.py
@@ -63,7 +63,7 @@ class DoppelClient:
             response = self.session.post(url, json=payload, timeout=30)
             response.raise_for_status()
             return response.json()
-        except requests.RequestException as err:
+        except (requests.RequestException, requests.HTTPError) as err:
             raise DoppelClientError(
                 f"Failed to create Doppel alert for '{entity}': {err}"
             ) from err
@@ -91,7 +91,7 @@ class DoppelClient:
             )
             response.raise_for_status()
             return response.json() if response.content else {}
-        except requests.RequestException as err:
+        except (requests.RequestException, requests.HTTPError) as err:
             raise DoppelClientError(
                 f"Failed to request Doppel takedown for '{entity}': {err}"
             ) from err

--- a/internal-enrichment/doppel-alert-takedown/src/doppel_client/api_client.py
+++ b/internal-enrichment/doppel-alert-takedown/src/doppel_client/api_client.py
@@ -88,7 +88,6 @@ class DoppelClient:
         try:
             response = self.session.put(url, params={"entity": entity}, json=payload)
             response.raise_for_status()
-            print(response.json())
             return response.json() if response.content else {}
         except requests.RequestException as err:
             raise DoppelClientError(

--- a/internal-enrichment/doppel-alert-takedown/src/doppel_client/api_client.py
+++ b/internal-enrichment/doppel-alert-takedown/src/doppel_client/api_client.py
@@ -1,0 +1,96 @@
+import requests
+from pycti import OpenCTIConnectorHelper
+from pydantic import HttpUrl
+
+
+class DoppelClientError(Exception):
+    """Raised when a request to the Doppel API fails."""
+
+
+class DoppelClient:
+    """Thin client for the Doppel Brand Protection API."""
+
+    def __init__(
+        self,
+        helper: OpenCTIConnectorHelper,
+        base_url: HttpUrl,
+        api_key: str,
+        user_api_key: str,
+    ):
+        """
+        Initialize the client with necessary configuration.
+
+        Args:
+            helper (OpenCTIConnectorHelper): The helper of the connector. Used for logs.
+            base_url (HttpUrl): The Doppel API base URL.
+            api_key (str): The Doppel API key (`x-api-key` header).
+            user_api_key (str): The Doppel user API key (`x-user-api-key` header).
+        """
+        self.helper = helper
+        self.base_url = str(base_url).rstrip("/")
+
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Content-Type": "application/json",
+                "x-api-key": api_key,
+                "x-user-api-key": user_api_key,
+            }
+        )
+
+    def create_alert(
+        self, entity: str, entity_type: str, tags: list[str] | None = None
+    ) -> dict:
+        """
+        Create an alert in Doppel for the given entity.
+
+        :param entity: The observable value (URL or domain).
+        :param entity_type: The Doppel entity type (e.g. "url" or "domain").
+        :param tags: Optional list of tags to attach to the alert.
+        :return: The created alert as a dict.
+        """
+        url = f"{self.base_url}/v1/alert"
+        payload = {
+            "entity": entity,
+            "entity_type": entity_type,
+            "tags": tags or [],
+        }
+        self.helper.connector_logger.info(
+            "[API] Creating Doppel alert",
+            {"url_path": url, "entity": entity, "entity_type": entity_type},
+        )
+        try:
+            response = self.session.post(url, json=payload)
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as err:
+            raise DoppelClientError(
+                f"Failed to create Doppel alert for '{entity}': {err}"
+            ) from err
+
+    def request_takedown(self, entity: str, comment: str) -> dict:
+        """
+        Request a takedown for an existing alert by setting its queue state to "actioned".
+
+        :param entity: The observable value used to identify the alert.
+        :param comment: Comment attached to the takedown request.
+        :return: The updated alert as a dict.
+        """
+        url = f"{self.base_url}/v1/alert"
+        payload = {
+            "queue_state": "actioned",
+            "comment": comment,
+        }
+        self.helper.connector_logger.info(
+            "[API] Requesting Doppel takedown",
+            {"url_path": url, "entity": entity},
+        )
+        try:
+            response = self.session.put(url, params={"entity": entity}, json=payload)
+            response.raise_for_status()
+            print(response.json())
+            return response.json() if response.content else {}
+        except requests.RequestException as err:
+            raise DoppelClientError(
+                f"Failed to request Doppel takedown for '{entity}': {err}"
+            ) from err

--- a/internal-enrichment/doppel-alert-takedown/src/main.py
+++ b/internal-enrichment/doppel-alert-takedown/src/main.py
@@ -1,0 +1,19 @@
+import traceback
+
+from connector import ConnectorSettings, DoppelConnector
+from pycti import OpenCTIConnectorHelper
+
+if __name__ == "__main__":
+    try:
+        settings = ConnectorSettings()
+
+        helper = OpenCTIConnectorHelper(
+            config=settings.to_helper_config(),
+            playbook_compatible=True,  # ! `playbook_compatible=True` only if a bundle is sent
+        )
+
+        connector = DoppelConnector(config=settings, helper=helper)
+        connector.run()
+    except Exception:
+        traceback.print_exc()
+        exit(1)

--- a/internal-enrichment/doppel-alert-takedown/src/requirements.txt
+++ b/internal-enrichment/doppel-alert-takedown/src/requirements.txt
@@ -1,0 +1,4 @@
+pycti==7.260715.0
+pydantic~= 2.11.3
+requests~=2.33.0
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/doppel-alert-takedown/tests/conftest.py
+++ b/internal-enrichment/doppel-alert-takedown/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/internal-enrichment/doppel-alert-takedown/tests/test-requirements.txt
+++ b/internal-enrichment/doppel-alert-takedown/tests/test-requirements.txt
@@ -1,0 +1,3 @@
+# Main dependencies needs to be installed
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/internal-enrichment/doppel-alert-takedown/tests/test_main.py
+++ b/internal-enrichment/doppel-alert-takedown/tests/test_main.py
@@ -1,0 +1,78 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from connector import ConnectorSettings, DoppelConnector
+from pycti import OpenCTIConnectorHelper
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """Subclass of `ConnectorSettings` returning a fake but valid config dict."""
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Doppel Alert and Takedown",
+                    "scope": "Url,Domain-Name",
+                    "log_level": "error",
+                    "auto": True,
+                },
+                "doppel": {
+                    "api_base_url": "https://api.doppel.com",
+                    "api_key": "test-api-key",
+                    "user_api_key": "test-user-api-key",
+                    "max_tlp": "TLP:CLEAR",
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "Doppel Brand Protection"
+    assert helper.connect_scope == "Url,Domain-Name"
+    assert helper.log_level == "ERROR"
+    assert helper.connect_auto is True
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper):
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    connector = DoppelConnector(config=settings, helper=helper)
+
+    assert connector.config == settings
+    assert connector.helper == helper

--- a/internal-enrichment/doppel-alert-takedown/tests/test_main.py
+++ b/internal-enrichment/doppel-alert-takedown/tests/test_main.py
@@ -62,7 +62,7 @@ def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper)
     assert helper.opencti_url == "http://localhost:8080/"
     assert helper.opencti_token == "test-token"
     assert helper.connect_id == "connector-id"
-    assert helper.connect_name == "Doppel Brand Protection"
+    assert helper.connect_name == "Doppel Alert and Takedown"
     assert helper.connect_scope == "Url,Domain-Name"
     assert helper.log_level == "ERROR"
     assert helper.connect_auto is True

--- a/internal-enrichment/doppel-alert-takedown/tests/test_main.py
+++ b/internal-enrichment/doppel-alert-takedown/tests/test_main.py
@@ -38,7 +38,7 @@ class StubConnectorSettings(ConnectorSettings):
                     "log_level": "error",
                     "auto": True,
                 },
-                "doppel": {
+                "doppel_alert_takedown": {
                     "api_base_url": "https://api.doppel.com",
                     "api_key": "test-api-key",
                     "user_api_key": "test-user-api-key",

--- a/internal-enrichment/doppel-alert-takedown/tests/tests_connector/test_converter.py
+++ b/internal-enrichment/doppel-alert-takedown/tests/tests_connector/test_converter.py
@@ -1,0 +1,88 @@
+from connector.connector import DOPPEL_ENTITY_TYPE_MAPPING
+from connector.converter_to_stix import ConverterToStix
+
+
+def _make_converter():
+    return ConverterToStix(helper=None)
+
+
+def test_marking_from_tlp():
+    converter = _make_converter()
+    assert converter.marking_from_tlp("TLP:AMBER+STRICT").level == "amber+strict"
+    assert converter.marking_from_tlp("TLP:CLEAR").level == "clear"
+    assert converter.marking_from_tlp(None) is None
+    assert converter.marking_from_tlp("") is None
+    assert converter.marking_from_tlp("UNKNOWN") is None
+
+
+def test_entity_type_mapping():
+    assert DOPPEL_ENTITY_TYPE_MAPPING["url"] == "url"
+    assert DOPPEL_ENTITY_TYPE_MAPPING["domain-name"] == "domain"
+
+
+def test_build_external_reference():
+    converter = _make_converter()
+    alert = {
+        "id": "FLG-38",
+        "doppel_link": "https://app.doppel.com/alerts/FLG-38",
+        "entity": "http://filigran-test-phishing.com",
+    }
+
+    external_reference = converter.build_external_reference(alert)
+
+    assert external_reference.source_name == "Doppel Alert"
+    assert external_reference.url == "https://app.doppel.com/alerts/FLG-38"
+    assert external_reference.external_id == "FLG-38"
+
+
+def test_build_url_observable_carries_external_reference():
+    converter = _make_converter()
+    alert = {"id": "FLG-38", "doppel_link": "https://app.doppel.com/alerts/FLG-38"}
+    external_reference = converter.build_external_reference(alert)
+
+    observable = converter.build_observable(
+        observable_type="url",
+        value="http://filigran-test-phishing.com",
+        external_reference=external_reference,
+    )
+    stix_object = observable.to_stix2_object()
+
+    assert stix_object.type == "url"
+    assert stix_object.value == "http://filigran-test-phishing.com"
+    assert stix_object.x_opencti_external_references[0].url == alert["doppel_link"]
+
+
+def test_build_domain_observable():
+    converter = _make_converter()
+    external_reference = converter.build_external_reference({"id": "FLG-1"})
+
+    observable = converter.build_observable(
+        observable_type="domain-name",
+        value="filigran-test-phishing.com",
+        external_reference=external_reference,
+    )
+    stix_object = observable.to_stix2_object()
+
+    assert stix_object.type == "domain-name"
+    assert stix_object.value == "filigran-test-phishing.com"
+
+
+def test_build_note_mentions_alert_and_takedown():
+    converter = _make_converter()
+    alert = {
+        "id": "FLG-38",
+        "entity": "http://filigran-test-phishing.com",
+        "archetype": "domains",
+        "doppel_link": "https://app.doppel.com/alerts/FLG-38",
+    }
+
+    note = converter.build_note(
+        observable_ref="url--4bf6eebd-e328-5b29-bd66-795f6f823f68",
+        alert=alert,
+        takedown_requested=True,
+        takedown_comment="Confirmed phishing.",
+    )
+
+    assert "FLG-38" in note.content
+    assert "Confirmed phishing." in note.content
+    assert note.objects[0].id == "url--4bf6eebd-e328-5b29-bd66-795f6f823f68"

--- a/internal-enrichment/doppel-alert-takedown/tests/tests_connector/test_settings.py
+++ b/internal-enrichment/doppel-alert-takedown/tests/tests_connector/test_settings.py
@@ -21,7 +21,7 @@ from connectors_sdk import BaseConfigModel, ConfigValidationError
                     "log_level": "error",
                     "auto": True,
                 },
-                "doppel": {
+                "doppel_alert_takedown": {
                     "api_base_url": "https://api.doppel.com",
                     "api_key": "test-api-key",
                     "user_api_key": "test-user-api-key",
@@ -42,7 +42,7 @@ from connectors_sdk import BaseConfigModel, ConfigValidationError
                     "id": "connector-id",
                     "scope": "Url,Domain-Name",
                 },
-                "doppel": {
+                "doppel_alert_takedown": {
                     "api_key": "test-api-key",
                     "user_api_key": "test-user-api-key",
                 },
@@ -65,7 +65,7 @@ def test_settings_should_accept_valid_input(settings_dict):
 
     assert isinstance(settings.opencti, BaseConfigModel) is True
     assert isinstance(settings.connector, BaseConfigModel) is True
-    assert isinstance(settings.doppel, BaseConfigModel) is True
+    assert isinstance(settings.doppel_alert_takedown, BaseConfigModel) is True
 
 
 def test_settings_should_split_comma_separated_tags():
@@ -84,7 +84,7 @@ def test_settings_should_split_comma_separated_tags():
                         "id": "connector-id",
                         "scope": "Url,Domain-Name",
                     },
-                    "doppel": {
+                    "doppel_alert_takedown": {
                         "api_key": "test-api-key",
                         "user_api_key": "test-user-api-key",
                         "tags": "test, filigran-poc ,phishing",
@@ -93,7 +93,7 @@ def test_settings_should_split_comma_separated_tags():
             )
 
     settings = FakeConnectorSettings()
-    assert settings.doppel.tags == ["test", "filigran-poc", "phishing"]
+    assert settings.doppel_alert_takedown.tags == ["test", "filigran-poc", "phishing"]
 
 
 @pytest.mark.parametrize(
@@ -114,29 +114,12 @@ def test_settings_should_split_comma_separated_tags():
                     "id": "connector-id",
                     "scope": "Url,Domain-Name",
                 },
-                "doppel": {
+                "doppel_alert_takedown": {
                     "api_key": "test-api-key",
                 },
             },
-            "doppel.user_api_key",
+            "doppel_alert_takedown.user_api_key",
             id="missing_user_api_key",
-        ),
-        pytest.param(
-            {
-                "opencti": {
-                    "url": "http://localhost:8080",
-                    "token": "test-token",
-                },
-                "connector": {
-                    "scope": "Url,Domain-Name",
-                },
-                "doppel": {
-                    "api_key": "test-api-key",
-                    "user_api_key": "test-user-api-key",
-                },
-            },
-            "connector.id",
-            id="missing_connector_id",
         ),
     ],
 )

--- a/internal-enrichment/doppel-alert-takedown/tests/tests_connector/test_settings.py
+++ b/internal-enrichment/doppel-alert-takedown/tests/tests_connector/test_settings.py
@@ -1,0 +1,155 @@
+from typing import Any
+
+import pytest
+from connector import ConnectorSettings
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Doppel Alert and Takedown",
+                    "scope": "Url,Domain-Name",
+                    "log_level": "error",
+                    "auto": True,
+                },
+                "doppel": {
+                    "api_base_url": "https://api.doppel.com",
+                    "api_key": "test-api-key",
+                    "user_api_key": "test-user-api-key",
+                    "tags": ["test", "poc"],
+                    "takedown_comment": "Confirmed phishing.",
+                    "max_tlp": "TLP:CLEAR",
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "Url,Domain-Name",
+                },
+                "doppel": {
+                    "api_key": "test-api-key",
+                    "user_api_key": "test-user-api-key",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) accepts valid input.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.doppel, BaseConfigModel) is True
+
+
+def test_settings_should_split_comma_separated_tags():
+    """Tags provided as a comma-separated string should be parsed into a list."""
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(
+                {
+                    "opencti": {
+                        "url": "http://localhost:8080",
+                        "token": "test-token",
+                    },
+                    "connector": {
+                        "id": "connector-id",
+                        "scope": "Url,Domain-Name",
+                    },
+                    "doppel": {
+                        "api_key": "test-api-key",
+                        "user_api_key": "test-user-api-key",
+                        "tags": "test, filigran-poc ,phishing",
+                    },
+                }
+            )
+
+    settings = FakeConnectorSettings()
+    assert settings.doppel.tags == ["test", "filigran-poc", "phishing"]
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param(
+            {},
+            "settings",
+            id="empty_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "Url,Domain-Name",
+                },
+                "doppel": {
+                    "api_key": "test-api-key",
+                },
+            },
+            "doppel.user_api_key",
+            id="missing_user_api_key",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "scope": "Url,Domain-Name",
+                },
+                "doppel": {
+                    "api_key": "test-api-key",
+                    "user_api_key": "test-user-api-key",
+                },
+            },
+            "connector.id",
+            id="missing_connector_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) raises on invalid input.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert str("Error validating configuration") in str(err)


### PR DESCRIPTION
### Proposed changes

* New enrichment connector for Doppel that create alert and request a takedown on suspicious domain and URL observables

### Related issues

* closes #7033

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
