### PR TITLE
fix(opencti-stream): add configurable default applicant for stream events without origin user (#7031)

### DIFF
--- a/external-import/opencti-stream/.gitignore
+++ b/external-import/opencti-stream/.gitignore
@@ -1,0 +1,2 @@
+build/
+*.egg-info/

--- a/external-import/opencti-stream/README.md
+++ b/external-import/opencti-stream/README.md
@@ -33,6 +33,7 @@ written into the bundle file and remapped on the target instance via
     - [Base connector environment variables](#base-connector-environment-variables)
     - [Live stream parameters](#live-stream-parameters)
     - [Output mode parameters](#output-mode-parameters)
+    - [OpenCTI Stream parameters](#opencti-stream-parameters)
   - [Deployment](#deployment)
     - [Docker Deployment](#docker-deployment)
     - [Manual Deployment](#manual-deployment)
@@ -120,6 +121,14 @@ toggling the matching flag(s).
 For S3 credentials and endpoint, the connector reuses the OpenCTI platform's S3
 configuration by default. To override, set the standard `S3_ENDPOINT`, `S3_PORT`,
 `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_USE_SSL` and `S3_BUCKET_REGION` variables.
+
+### OpenCTI Stream parameters
+
+These parameters live under the `stream:` section of `config.yml`.
+
+| Parameter            | config.yml           | Docker environment variable          | Default | Mandatory | Description                                                                                                                                                                                                 |
+|----------------------|----------------------|--------------------------------------|---------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Default Applicant ID | default_applicant_id | `STREAM_DEFAULT_APPLICANT_ID`        |         | No        | Fallback `applicant_id` (an OpenCTI user UUID) used when a stream event has no `origin.user_id`. Defaults to empty, which leaves `applicant_id` null. Set it to avoid emitting bundles with a null applicant, which the `diode-import` connector rejects. |
 
 ## Deployment
 
@@ -288,8 +297,12 @@ payload:
   target instance, [`diode-import`](../diode-import/) maps it through
   `DIODE_IMPORT_APPLICANT_MAPPINGS` to the matching local user.
 
-If `origin.user_id` is missing (e.g. system-generated events), the connector's
-registration user is used.
+If `origin.user_id` is missing (e.g. system-generated events such as bulk label
+updates), `applicant_id` is left empty by default, so the bundle is emitted with a null
+applicant. Set `STREAM_DEFAULT_APPLICANT_ID` (`stream.default_applicant_id`)
+to a user UUID to use as a fallback applicant in that case — useful because a null
+applicant otherwise causes the target `diode-import` connector to reject the bundle.
+When `origin.user_id` is present, it always takes precedence over the configured default.
 
 ## Debugging
 

--- a/external-import/opencti-stream/docker-compose.yml
+++ b/external-import/opencti-stream/docker-compose.yml
@@ -34,4 +34,8 @@ services:
       # - CONNECTOR_SEND_TO_S3_BUCKET=my-bucket # optional, uses OpenCTI bucket if empty
       # - CONNECTOR_SEND_TO_S3_FOLDER=connectors
       # - CONNECTOR_SEND_TO_S3_RETENTION=7
+      # Fallback applicant used when a stream event has no origin.user_id (e.g. system-generated
+      # events). Leave unset to emit a null applicant; set a user UUID to avoid bundles the
+      # diode-import connector would reject.
+      # - STREAM_DEFAULT_APPLICANT_ID=ChangeMeUserUUID
     restart: always

--- a/external-import/opencti-stream/pyproject.toml
+++ b/external-import/opencti-stream/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "opencti-stream"
+version = "0.1.0"
+description = "Forward events from an OpenCTI live stream to a queue, directory or S3 bucket as STIX 2.1 bundles."
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = []
+
+[tool.connector-linter]
+# Skip these checks (same as --ignore, merged with CLI --ignore)
+ignore = ["VC301", "VC302", "VC317"]

--- a/external-import/opencti-stream/src/config.yml.sample
+++ b/external-import/opencti-stream/src/config.yml.sample
@@ -33,3 +33,6 @@ connector:
   # send_to_s3_bucket: '' # If empty, uses the OpenCTI bucket
   # send_to_s3_folder: 'connectors'
   # send_to_s3_retention: 7 # Days to keep objects before cleanup (0 = disable)
+
+# stream:
+#   default_applicant_id: null # optional (default: null)

--- a/external-import/opencti-stream/src/opencti_stream/connector.py
+++ b/external-import/opencti-stream/src/opencti_stream/connector.py
@@ -81,7 +81,10 @@ class OpenCTIStream:
         # (used by workers for impersonation).
         # Always assign so that an event without `origin.user_id` (e.g. system-generated
         # event) does not inherit the previous event's applicant.
-        origin_user_id = (payload.get("origin") or {}).get("user_id")
+        origin = payload.get("origin") or {}
+        origin_user_id = (
+            origin.get("user_id") or self.config.stream.default_applicant_id
+        )
         self.helper.applicant_id = origin_user_id
 
         bundle = self.helper.stix2_create_bundle([stix_object])

--- a/external-import/opencti-stream/src/opencti_stream/settings.py
+++ b/external-import/opencti-stream/src/opencti_stream/settings.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from connectors_sdk import (
+    BaseConfigModel,
     BaseConnectorSettings,
     BaseExternalImportConnectorConfig,
 )
@@ -75,9 +76,23 @@ class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
     )
 
 
+class OpenCTIStreamSettings(BaseConfigModel):
+    """Settings for the OpenCTI Stream connector."""
+
+    default_applicant_id: str | None = Field(
+        description=(
+            "The default applicant ID to use when a stream event does not have an "
+            "`origin.user_id`. Defaults to `None`, which means the connector will "
+            "not set an applicant ID in that case."
+        ),
+        default=None,
+    )
+
+
 class ConnectorSettings(BaseConnectorSettings):
     """Top-level settings for the OpenCTI Stream connector."""
 
     connector: ExternalImportConnectorConfig = Field(
         default_factory=ExternalImportConnectorConfig
     )
+    stream: OpenCTIStreamSettings = Field(default_factory=OpenCTIStreamSettings)

--- a/external-import/opencti-stream/tests/tests_connector/test_connector.py
+++ b/external-import/opencti-stream/tests/tests_connector/test_connector.py
@@ -23,10 +23,12 @@ def connector():
     instance.config = MagicMock()
     instance.config.connector.live_stream_opencti_url = None
     instance.config.connector.live_stream_opencti_token = None
+    # Mirror the real default: no fallback applicant unless explicitly configured.
+    instance.config.stream.default_applicant_id = None
     instance.helper = MagicMock()
     instance.helper.connector_logger = MagicMock()
-    instance.helper.stix2_create_bundle.side_effect = (
-        lambda objects: f'{{"type":"bundle","objects":[{json.dumps(objects[0]) if objects else ""}]}}'
+    instance.helper.stix2_create_bundle.side_effect = lambda objects: (
+        f'{{"type":"bundle","objects":[{json.dumps(objects[0]) if objects else ""}]}}'
     )
     instance._stream_thread = None
     return instance
@@ -160,9 +162,38 @@ def test_on_event_resets_applicant_when_origin_user_id_missing(connector):
     assert connector.helper.applicant_id is None
 
 
-# ---------------------------------------------------------------------------
-# URL / token resolution: source (live stream) vs target (helper) OpenCTI
-# ---------------------------------------------------------------------------
+def test_on_event_falls_back_to_default_applicant_when_origin_user_id_missing(
+    connector,
+):
+    """When `origin.user_id` is missing but `default_applicant_id` is configured,
+    `applicant_id` MUST fall back to that default instead of being reset to None."""
+    connector.config.stream.default_applicant_id = "default-user-uuid"
+
+    payload = {
+        "data": {
+            "id": "report--00000000-0000-0000-0000-000000000009",
+            "type": "report",
+        },
+        "origin": {"socket": "query", "ip": "::1"},
+    }
+    connector._on_event(_make_msg("create", payload))
+
+    assert connector.helper.applicant_id == "default-user-uuid"
+    connector.helper.send_stix2_bundle.assert_called_once()
+
+
+def test_on_event_prefers_origin_user_id_over_default_applicant(connector):
+    """A present `origin.user_id` MUST take precedence over the configured default."""
+    connector.config.stream.default_applicant_id = "default-user-uuid"
+
+    stix_object = {
+        "id": "report--00000000-0000-0000-0000-000000000010",
+        "type": "report",
+    }
+    payload = {"data": stix_object, "origin": {"user_id": "event-user-uuid"}}
+    connector._on_event(_make_msg("create", payload))
+
+    assert connector.helper.applicant_id == "event-user-uuid"
 
 
 def test_live_stream_url_falls_back_to_helper_when_not_configured(connector):

--- a/external-import/opencti-stream/tests/tests_connector/test_settings.py
+++ b/external-import/opencti-stream/tests/tests_connector/test_settings.py
@@ -165,3 +165,47 @@ def test_settings_should_raise_when_invalid_input(settings_dict, expected_loc):
     assert any(
         loc and loc[-1] == expected_field for loc in error_locs
     ), f"Expected validation error on field {expected_field!r}, got {error_locs}"
+
+
+def _build_settings(settings_dict: dict[str, Any]) -> ConnectorSettings:
+    """Instantiate `ConnectorSettings` from a fake config dict (no env/config.yml)."""
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    return FakeConnectorSettings()
+
+
+_BASE_SETTINGS_DICT = {
+    "opencti": {
+        "url": "http://localhost:8080",
+        "token": "test-token",
+    },
+    "connector": {
+        "id": "connector-id",
+        "scope": "opencti-stream",
+        "live_stream_id": "live",
+    },
+}
+
+
+def test_default_applicant_id_defaults_to_none():
+    """`stream.default_applicant_id` MUST default to `None` when omitted."""
+    settings = _build_settings(_BASE_SETTINGS_DICT)
+
+    assert isinstance(settings.stream, BaseConfigModel) is True
+    assert settings.stream.default_applicant_id is None
+
+
+def test_default_applicant_id_accepts_configured_value():
+    """`stream.default_applicant_id` MUST accept a configured string value."""
+    settings_dict = {
+        **_BASE_SETTINGS_DICT,
+        "stream": {"default_applicant_id": "default-user-uuid"},
+    }
+
+    settings = _build_settings(settings_dict)
+
+    assert settings.stream.default_applicant_id == "default-user-uuid"


### PR DESCRIPTION
### Proposed changes

* Add a new `OpenCTIStreamSettings` Pydantic model exposing an optional `default_applicant_id` field (default `None`), wired into `ConnectorSettings` as `stream`, so a fallback applicant can be configured when a stream event carries no origin user.
* Update `_on_event` in `src/opencti_stream/connector.py` to fall back to `config.stream.default_applicant_id` when an event's `origin.user_id` is absent, preventing STIX bundles from being emitted with `applicant_id: null` (which the diode-import connector ignores/errors on).
* Document the new optional `stream.default_applicant_id` key (`STREAM_DEFAULT_APPLICANT_ID`) in `config.yml.sample`, `README.md` and `docker-compose.yml` so users can discover and opt into the fallback behavior.
* Add tests covering the new behavior: connector tests verify the fallback is used when `origin.user_id` is missing and that `origin.user_id` takes precedence over the default; settings tests verify `default_applicant_id` defaults to `None` and accepts a configured value.

### Related issues

* Fixes #7031

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The change is fully backward compatible: `default_applicant_id` defaults to `None`, which preserves the current behavior (events without an `origin.user_id` still produce a null applicant), so nothing changes unless the fallback is explicitly configured. The feature is opt-in via the new `stream.default_applicant_id` config key. Precedence is preserved so that an event's `origin.user_id` always wins when present, and the configured default is only used as a fallback when it is absent (`origin.user_id` > `default_applicant_id`).
