### PR TITLE
fix(manifests): restore verified and related manifest fields (#6928)

### DIFF
--- a/external-import/hunt-io/__metadata__/connector_manifest.json
+++ b/external-import/hunt-io/__metadata__/connector_manifest.json
@@ -11,6 +11,8 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Commercial",
+  "verified": true,
+  "last_verified_date": "2025-11-12",
   "playbook_supported": false,
   "max_confidence_level": 60,
   "support_version": ">= 6.5.1",

--- a/external-import/ibm-xti/__metadata__/connector_manifest.json
+++ b/external-import/ibm-xti/__metadata__/connector_manifest.json
@@ -11,6 +11,12 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Commercial",
+  "verified": true,
+  "last_verified_date": null,
+  "playbook_supported": false,
+  "max_confidence_level": 50,
+  "support_version": ">= 6.5.1",
+  "subscription_link": "https://www.ibm.com/services/threat-intelligence",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/ibm-xti",
   "manager_supported": true,
   "container_version": "rolling",

--- a/external-import/infoblox/__metadata__/connector_manifest.json
+++ b/external-import/infoblox/__metadata__/connector_manifest.json
@@ -11,6 +11,10 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Commercial",
+  "verified": true,
+  "last_verified_date": null,
+  "playbook_supported": false,
+  "max_confidence_level": 70,
   "support_version": ">= 6.5.1",
   "subscription_link": "https://www.infoblox.com/threat-intel/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/infoblox",

--- a/external-import/intel471-darknet/__metadata__/connector_manifest.json
+++ b/external-import/intel471-darknet/__metadata__/connector_manifest.json
@@ -11,6 +11,7 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Commercial",
+  "verified": false,
   "last_verified_date": null,
   "playbook_supported": false,
   "max_confidence_level": 100,

--- a/external-import/matrix/__metadata__/connector_manifest.json
+++ b/external-import/matrix/__metadata__/connector_manifest.json
@@ -11,6 +11,11 @@
     "Other"
   ],
   "license_type": "Free",
+  "verified": false,
+  "last_verified_date": null,
+  "playbook_supported": false,
+  "max_confidence_level": 100,
+  "support_version": ">=6.7.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/matrix",
   "manager_supported": false,

--- a/external-import/misp-feed/__metadata__/connector_manifest.json
+++ b/external-import/misp-feed/__metadata__/connector_manifest.json
@@ -11,6 +11,11 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Free",
+  "verified": true,
+  "last_verified_date": null,
+  "playbook_supported": false,
+  "max_confidence_level": 50,
+  "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/misp-feed",
   "manager_supported": true,

--- a/external-import/misp/__metadata__/connector_manifest.json
+++ b/external-import/misp/__metadata__/connector_manifest.json
@@ -12,6 +12,8 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Free",
+  "verified": true,
+  "last_verified_date": "2025-01-01",
   "playbook_supported": false,
   "max_confidence_level": 50,
   "support_version": ">= 6.5.1",

--- a/external-import/ransomwarelive/__metadata__/connector_manifest.json
+++ b/external-import/ransomwarelive/__metadata__/connector_manifest.json
@@ -11,6 +11,8 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Free",
+  "verified": true,
+  "last_verified_date": "2025-07-25",
   "playbook_supported": false,
   "max_confidence_level": 50,
   "support_version": ">= 6.7.5",

--- a/external-import/recorded-future/__metadata__/connector_manifest.json
+++ b/external-import/recorded-future/__metadata__/connector_manifest.json
@@ -12,6 +12,10 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Commercial",
+  "verified": true,
+  "last_verified_date": null,
+  "playbook_supported": false,
+  "max_confidence_level": 55,
   "support_version": ">= 6.5.1",
   "subscription_link": "https://www.recordedfuture.com/get-started",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/recorded-future",

--- a/external-import/red-flag-domains/__metadata__/connector_manifest.json
+++ b/external-import/red-flag-domains/__metadata__/connector_manifest.json
@@ -11,6 +11,10 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Free",
+  "verified": true,
+  "last_verified_date": null,
+  "playbook_supported": false,
+  "max_confidence_level": 70,
   "support_version": ">= 6.5.1",
   "subscription_link": "https://red.flag.domains",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/red-flag-domains",

--- a/external-import/servicenow/__metadata__/connector_manifest.json
+++ b/external-import/servicenow/__metadata__/connector_manifest.json
@@ -11,6 +11,8 @@
     "Incident Response & Case Management"
   ],
   "license_type": "Commercial",
+  "verified": true,
+  "last_verified_date": "2025-06-15",
   "playbook_supported": false,
   "max_confidence_level": 50,
   "support_version": ">= 6.5.1",

--- a/external-import/silobreaker/__metadata__/connector_manifest.json
+++ b/external-import/silobreaker/__metadata__/connector_manifest.json
@@ -11,6 +11,8 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Commercial",
+  "verified": false,
+  "last_verified_date": "2025-03-06",
   "playbook_supported": false,
   "max_confidence_level": 55,
   "support_version": ">= 6.5.1",

--- a/external-import/socradar/__metadata__/connector_manifest.json
+++ b/external-import/socradar/__metadata__/connector_manifest.json
@@ -11,6 +11,8 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Commercial",
+  "verified": true,
+  "last_verified_date": "2025-09-23",
   "playbook_supported": false,
   "max_confidence_level": 50,
   "support_version": ">=6.5.0",

--- a/external-import/urlhaus/__metadata__/connector_manifest.json
+++ b/external-import/urlhaus/__metadata__/connector_manifest.json
@@ -11,6 +11,12 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Free",
+  "verified": true,
+  "last_verified_date": null,
+  "playbook_supported": false,
+  "max_confidence_level": 50,
+  "support_version": ">= 6.5.1",
+  "subscription_link": "",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/urlhaus",
   "manager_supported": true,
   "container_version": "rolling",

--- a/external-import/vxvault/__metadata__/connector_manifest.json
+++ b/external-import/vxvault/__metadata__/connector_manifest.json
@@ -11,6 +11,8 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Free",
+  "verified": true,
+  "last_verified_date": "2026-04-09",
   "playbook_supported": false,
   "max_confidence_level": 50,
   "support_version": ">=5.5.0",

--- a/external-import/zvelo/__metadata__/connector_manifest.json
+++ b/external-import/zvelo/__metadata__/connector_manifest.json
@@ -11,6 +11,10 @@
     "Threat Intelligence Feed"
   ],
   "license_type": "Commercial",
+  "verified": true,
+  "last_verified_date": "2025-06-12",
+  "playbook_supported": false,
+  "max_confidence_level": 60,
   "support_version": ">= 6.4.0",
   "subscription_link": "https://zvelo.com/zvelocti-cyber-threat-intelligence/malicious-detailed-detection-feed/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/zvelo",


### PR DESCRIPTION
### Proposed changes

* Restore the `verified`, `last_verified_date`, `playbook_supported`, and `max_confidence_level` fields (plus `support_version`/`subscription_link` on a few connectors) that were accidentally dropped from 16 connector manifests by #6928.
* Fix the failing `tests/tests_metadata/test_connector_manifest.py` suite, which was erroring with `KeyError: 'verified'` because those required keys were missing.
* Re-insert the removed keys in canonical order using their exact historical values, recovered from the commit prior to #6928 (e.g. infoblox `verified: true, max_confidence_level: 70`; misp `verified: true, last_verified_date: "2025-01-01"`).
* Purely additive change (53 insertions, 0 deletions) — no other manifest fields were modified.
* Affected connectors (all under `external-import/<name>/__metadata__/connector_manifest.json`): hunt-io, ibm-xti, infoblox, intel471-darknet, matrix, misp, misp-feed, ransomwarelive, recorded-future, red-flag-domains, servicenow, silobreaker, socradar, urlhaus, vxvault, zvelo.

### Related issues

* Relates to #6928 — follow-up regression fix for the manifest change introduced there (which added `solution_categories`/`license_type` but inadvertently removed these fields).

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The dropped values were recovered from the commit immediately preceding #6928, so each field is restored to its exact original value rather than a new default. The change only re-inserts previously present keys (53 insertions, 0 deletions) and touches nothing else, which restores the metadata tests to passing. No documentation update is needed, and no refactoring was involved.
