### PR TITLE
feat(malbeacon): migrate connector to manager-supported mode (#6853)

### DIFF
--- a/internal-enrichment/malbeacon/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/malbeacon/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,19 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| MALBEACON_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API key used to authenticate against the Malbeacon API. |
+| CONNECTOR_NAME | `string` |  | string | `"Malbeacon"` | The name of the internal enrichment connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["IPv4-Addr", "IPv6-Addr", "Domain-Name"]` | The scope of the connector |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `INTERNAL_ENRICHMENT` | `"INTERNAL_ENRICHMENT"` |  |
+| CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |
+| MALBEACON_API_BASE_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"https://api.malbeacon.com/v1/"` | The base URL of the Malbeacon API. |
+| MALBEACON_INDICATOR_SCORE_LEVEL | `integer` |  | integer | `50` | The score assigned to indicators created by the connector. |
+| MALBEACON_MAX_TLP | `string` |  | `TLP:CLEAR` `TLP:WHITE` `TLP:GREEN` `TLP:AMBER` `TLP:AMBER+STRICT` `TLP:RED` | `"TLP:AMBER"` | The maximum TLP marking the connector is allowed to enrich. |

--- a/internal-enrichment/malbeacon/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/malbeacon/__metadata__/connector_config_schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/malbeacon_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Malbeacon",
+      "description": "The name of the internal enrichment connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "IPv4-Addr",
+        "IPv6-Addr",
+        "Domain-Name"
+      ],
+      "description": "The scope of the connector",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_ENRICHMENT",
+      "default": "INTERNAL_ENRICHMENT",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Whether the connector should run automatically when an entity is created or updated.",
+      "type": "boolean"
+    },
+    "MALBEACON_API_KEY": {
+      "description": "The API key used to authenticate against the Malbeacon API.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "MALBEACON_API_BASE_URL": {
+      "default": "https://api.malbeacon.com/v1/",
+      "description": "The base URL of the Malbeacon API.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "MALBEACON_INDICATOR_SCORE_LEVEL": {
+      "default": 50,
+      "description": "The score assigned to indicators created by the connector.",
+      "type": "integer"
+    },
+    "MALBEACON_MAX_TLP": {
+      "default": "TLP:AMBER",
+      "description": "The maximum TLP marking the connector is allowed to enrich.",
+      "enum": [
+        "TLP:CLEAR",
+        "TLP:WHITE",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "MALBEACON_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/internal-enrichment/malbeacon/__metadata__/connector_manifest.json
+++ b/internal-enrichment/malbeacon/__metadata__/connector_manifest.json
@@ -19,7 +19,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": "https://www.malbeacon.com",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/malbeacon",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-malbeacon",
   "container_type": "INTERNAL_ENRICHMENT"

--- a/internal-enrichment/malbeacon/docker-compose.yml
+++ b/internal-enrichment/malbeacon/docker-compose.yml
@@ -7,11 +7,11 @@ services:
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
       - CONNECTOR_NAME=Malbeacon
-      - CONNECTOR_AUTO=false # Enable/disable auto-enrichment of observables
       - CONNECTOR_SCOPE=IPv4-Addr,IPv6-Addr,Domain-Name
-      - CONNECTOR_LOG_LEVEL=error
+#      - CONNECTOR_AUTO=false # Enable/disable auto-enrichment of observables
+#      - CONNECTOR_LOG_LEVEL=error
       - MALBEACON_API_KEY=ChangeMe # Required
-      - MALBEACON_API_BASE_URL=https://api.malbeacon.com/v1/ # Required
-      - MALBEACON_INDICATOR_SCORE_LEVEL=50 # Optional
-      - MALBEACON_MAX_TLP=TLP:AMBER # Required, Available values: TLP:CLEAR, TLP:WHITE, TLP:GREEN, TLP:AMBER, TLP:AMBER+STRICT, TLP:RED
+#      - MALBEACON_API_BASE_URL=https://api.malbeacon.com/v1/
+#      - MALBEACON_INDICATOR_SCORE_LEVEL=50
+#      - MALBEACON_MAX_TLP=TLP:AMBER # Available values: TLP:CLEAR, TLP:WHITE, TLP:GREEN, TLP:AMBER, TLP:AMBER+STRICT, TLP:RED
     restart: always

--- a/internal-enrichment/malbeacon/src/config.yml.sample
+++ b/internal-enrichment/malbeacon/src/config.yml.sample
@@ -7,11 +7,11 @@ connector:
   id: "ChangeMe"
   name: "Malbeacon"
   scope: "IPv4-Addr,IPv6-Addr,Domain-Name"
-  auto: false # Enable/disable auto-enrichment of observables
-  log_level: "info"
+  #auto: false # Enable/disable auto-enrichment of observables
+  #log_level: "error"
 
 malbeacon:
   api_key: "ChangeMe"
-  api_base_url: "https://api.malbeacon.com/v1/" # Required
-  indicator_score_level: 50
-  max_tlp: "TLP:AMBER" # Required, Available values: TLP:CLEAR, TLP:WHITE, TLP:GREEN, TLP:AMBER, TLP:AMBER+STRICT, TLP:RED
+  #api_base_url: "https://api.malbeacon.com/v1/"
+  #indicator_score_level: 50
+  #max_tlp: "TLP:AMBER" # Available values: TLP:CLEAR, TLP:WHITE, TLP:GREEN, TLP:AMBER, TLP:AMBER+STRICT, TLP:RED

--- a/internal-enrichment/malbeacon/src/main.py
+++ b/internal-enrichment/malbeacon/src/main.py
@@ -4,6 +4,7 @@ from malbeacon_converter import MalbeaconConverter
 from malbeacon_endpoints import C2_PATH
 from models.c2_model import C2Beacon
 from pycti import OpenCTIConnectorHelper
+from settings import ConnectorSettings  # noqa
 
 
 class MalBeaconConnector:

--- a/internal-enrichment/malbeacon/src/malbeacon_config_variables.py
+++ b/internal-enrichment/malbeacon/src/malbeacon_config_variables.py
@@ -1,7 +1,4 @@
-import os
-
-import yaml
-from pycti import get_config_variable
+from settings import ConnectorSettings
 
 
 class ConfigMalbeacon:
@@ -10,24 +7,10 @@ class ConfigMalbeacon:
         Initialize the Malbeacon connector with necessary configurations
         """
 
-        # Load configuration file and connection helper
-        self.load = self._load_config()
+        # Load and validate configuration through Pydantic settings
+        self.settings = ConnectorSettings()
+        self.load = self.settings.to_helper_config()
         self._initialize_configurations()
-
-    @staticmethod
-    def _load_config() -> dict:
-        """
-        Load the configuration from the YAML file
-        :return: Configuration dictionary
-        """
-        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
-
-        return config
 
     def _initialize_configurations(self) -> None:
         """
@@ -35,28 +18,12 @@ class ConfigMalbeacon:
         :return: None
         """
 
-        self.connector_scope = get_config_variable(
-            "CONNECTOR_SCOPE",
-            ["connector", "scope"],
-            self.load,
-        )
+        self.connector_scope = ",".join(self.settings.connector.scope)
 
-        self.api_key = get_config_variable(
-            "MALBEACON_API_KEY", ["malbeacon", "api_key"], self.load
-        )
+        self.api_key = self.settings.malbeacon.api_key.get_secret_value()
 
-        self.api_base_url = get_config_variable(
-            "MALBEACON_API_BASE_URL", ["malbeacon", "api_base_url"], self.load
-        )
+        self.api_base_url = str(self.settings.malbeacon.api_base_url)
 
-        self.indicator_score_level = get_config_variable(
-            "MALBEACON_INDICATOR_SCORE_LEVEL",
-            ["malbeacon", "indicator_score_level"],
-            self.load,
-        )
+        self.indicator_score_level = self.settings.malbeacon.indicator_score_level
 
-        self.max_tlp = get_config_variable(
-            "MALBEACON_MAX_TLP",
-            ["malbeacon", "max_tlp"],
-            self.load,
-        )
+        self.max_tlp = self.settings.malbeacon.max_tlp

--- a/internal-enrichment/malbeacon/src/requirements.txt
+++ b/internal-enrichment/malbeacon/src/requirements.txt
@@ -1,4 +1,5 @@
 pycti==7.260722.0
 pydantic>=2.8.2,<3.0.0
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk
 urllib3==2.7.0
 validators==0.35.0

--- a/internal-enrichment/malbeacon/src/settings.py
+++ b/internal-enrichment/malbeacon/src/settings.py
@@ -1,0 +1,59 @@
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseInternalEnrichmentConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field, HttpUrl, SecretStr
+
+
+class InternalEnrichmentConnectorConfig(BaseInternalEnrichmentConnectorConfig):
+    """Configuration specific to the internal enrichment connector."""
+
+    name: str = Field(
+        description="The name of the internal enrichment connector.",
+        default="Malbeacon",
+    )
+    id: str = Field(
+        description="The unique identifier of the internal enrichment connector.",
+        default="e7361ca6-8c71-46fc-9ab6-4837e14af66a",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector",
+        default=["IPv4-Addr", "IPv6-Addr", "Domain-Name"],
+    )
+
+
+class MalbeaconConfig(BaseConfigModel):
+    """Configuration specific to the Malbeacon connector (mirror of the existing variables)."""
+
+    api_key: SecretStr = Field(
+        description="The API key used to authenticate against the Malbeacon API.",
+    )
+    api_base_url: HttpUrl = Field(
+        description="The base URL of the Malbeacon API.",
+        default=HttpUrl("https://api.malbeacon.com/v1/"),
+    )
+    indicator_score_level: int = Field(
+        description="The score assigned to indicators created by the connector.",
+        default=50,
+    )
+    max_tlp: str = Field(
+        description="The maximum TLP marking the connector is allowed to enrich.",
+        default="TLP:AMBER",
+        enum=[
+            "TLP:CLEAR",
+            "TLP:WHITE",
+            "TLP:GREEN",
+            "TLP:AMBER",
+            "TLP:AMBER+STRICT",
+            "TLP:RED",
+        ],
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    connector: InternalEnrichmentConnectorConfig = Field(
+        default_factory=InternalEnrichmentConnectorConfig
+    )
+    malbeacon: MalbeaconConfig = Field(default_factory=MalbeaconConfig)

--- a/internal-enrichment/malbeacon/tests/conftest.py
+++ b/internal-enrichment/malbeacon/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())

--- a/internal-enrichment/malbeacon/tests/test-requirements.txt
+++ b/internal-enrichment/malbeacon/tests/test-requirements.txt
@@ -1,0 +1,2 @@
+-r ../src/requirements.txt
+pytest==8.4.2

--- a/internal-enrichment/malbeacon/tests/test_main.py
+++ b/internal-enrichment/malbeacon/tests/test_main.py
@@ -1,0 +1,93 @@
+from typing import Any
+
+import malbeacon_config_variables
+from main import MalBeaconConnector
+from malbeacon_config_variables import ConfigMalbeacon
+from pycti import OpenCTIConnectorHelper
+from settings import ConnectorSettings
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+    It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Malbeacon",
+                    "scope": "IPv4-Addr,IPv6-Addr,Domain-Name",
+                    "log_level": "error",
+                    "auto": True,
+                },
+                "malbeacon": {
+                    "api_key": "test-api-key",
+                    "api_base_url": "https://api.malbeacon.com/v1/",
+                    "indicator_score_level": 50,
+                    "max_tlp": "TLP:AMBER",
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that the implementation of `BaseConnectorSettings` (from `connectors-sdk`) can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from `BaseConnectorSettings`)
+        - the method `to_helper_config` MUST return a dict (as in base class)
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that `OpenCTIConnectorHelper` (from `pycti`) can be instantiated successfully:
+        - the value of `settings.to_helper_config` MUST be the expected dict for `OpenCTIConnectorHelper`
+        - the helper MUST be able to get its instance's attributes from the config dict
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "Malbeacon"
+    assert helper.connect_scope == "IPv4-Addr,IPv6-Addr,Domain-Name"
+    assert helper.log_level == "ERROR"
+    assert helper.connect_auto is True
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper, monkeypatch):
+    """
+    Test that the connector's main class can be instantiated successfully.
+
+    The `MalBeaconConnector` builds its own configuration and helper internally
+    (via `ConfigMalbeacon` -> `ConnectorSettings`). We patch `ConnectorSettings`
+    where `ConfigMalbeacon` looks it up so the connector uses the stubbed config:
+        - the connector's main class MUST be able to access env/config vars through `self.config`
+        - the connector's main class MUST be able to access `pycti` API through `self.helper`
+    """
+    monkeypatch.setattr(
+        malbeacon_config_variables, "ConnectorSettings", StubConnectorSettings
+    )
+
+    connector = MalBeaconConnector()
+
+    assert isinstance(connector.config, ConfigMalbeacon)
+    assert connector.helper is not None
+    assert connector.config.api_key == "test-api-key"
+    assert connector.config.api_base_url == "https://api.malbeacon.com/v1/"
+    assert connector.config.indicator_score_level == 50
+    assert connector.config.max_tlp == "TLP:AMBER"
+    assert connector.config.connector_scope == "IPv4-Addr,IPv6-Addr,Domain-Name"

--- a/internal-enrichment/malbeacon/tests/tests_connector/test_settings.py
+++ b/internal-enrichment/malbeacon/tests/tests_connector/test_settings.py
@@ -1,0 +1,128 @@
+from typing import Any
+
+import pytest
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+from settings import ConnectorSettings
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Malbeacon",
+                    "scope": "IPv4-Addr,IPv6-Addr,Domain-Name",
+                    "log_level": "error",
+                    "auto": True,
+                },
+                "malbeacon": {
+                    "api_key": "test-api-key",
+                    "api_base_url": "https://api.malbeacon.com/v1/",
+                    "indicator_score_level": 50,
+                    "max_tlp": "TLP:AMBER",
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Malbeacon",
+                    "scope": "IPv4-Addr",
+                },
+                "malbeacon": {
+                    "api_key": "test-api-key",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` accepts valid input.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.malbeacon, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param({}, "url", id="empty_settings_dict"),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080"},
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Malbeacon",
+                    "scope": "IPv4-Addr",
+                    "log_level": "error",
+                },
+                "malbeacon": {
+                    "api_key": "test-api-key",
+                },
+            },
+            "opencti.token",
+            id="missing_opencti_token",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": 123456,
+                    "name": "Malbeacon",
+                    "scope": "IPv4-Addr",
+                    "log_level": "error",
+                },
+                "malbeacon": {
+                    "api_key": "test-api-key",
+                },
+            },
+            "connector.id",
+            id="invalid_connector_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that `ConnectorSettings` raises on invalid input.
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    :param field_name: The field name that is expected to be reported in the
+        validation error. Asserting the error mentions this field prevents
+        regressions where the wrong field becomes the failing one.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert "Error validating configuration" in str(err.value)
+    # Walk the chained pydantic ValidationError to assert that the expected
+    # field path is among the failing ones. Without this assertion the
+    # parametrized field_name would not actually be exercised.
+    cause = err.value.__cause__
+    assert cause is not None, "ConfigValidationError must wrap the pydantic error"
+    expected_field = field_name.split(".")[-1]
+    error_fields = [str(error["loc"][-1]) for error in cause.errors() if error["loc"]]
+    assert expected_field in error_fields, (
+        f"Expected a validation error for field {field_name!r}, "
+        f"got errors for: {error_fields}"
+    )


### PR DESCRIPTION
### Proposed changes

* Normalize config files (`config.yml.sample`, `docker-compose.yml`, `.env.sample`, `requirements.txt`) for the manager-supported migration.
* Add Pydantic `ConnectorSettings` (`src/settings.py`) built on `connectors-sdk` (`BaseConnectorSettings`, `BaseInternalEnrichmentConnectorConfig`), modelling the connector scope and Malbeacon-specific options (`api_key`, `api_base_url`, `indicator_score_level`, `max_tlp`).
* Wire the new settings into the existing connector code via `to_helper_config()`, replacing the legacy `get_config_variable` / YAML loading in `malbeacon_config_variables.py` while keeping the current file structure, class names, and scheduling unchanged.
* Set `manager_supported: true` in `__metadata__/connector_manifest.json`.
* Generate the connector config schema (`__metadata__/connector_config_schema.json`) and configuration documentation (`__metadata__/CONNECTOR_CONFIG_DOC.md`).
* Add unit tests covering settings validation and connector wiring (`tests/test_main.py`, `tests/tests_connector/test_settings.py`).

This is a structure-preserving, manager-supported (lite) migration — it intentionally does NOT include the broader "verified" work (package restructuring, connector.py/main.py split, schedule_iso conversion, logging refactor, STIX-ID changes).

### Related issues

* Closes #6853

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This migration makes the connector **manager-supported**, not **verified**. The scope is deliberately minimal and structure-preserving: existing file names, class names, and the scheduling mechanism are unchanged. Documentation is the generated `__metadata__/CONNECTOR_CONFIG_DOC.md`.

Validation performed locally (all green): isort/black clean, flake8 clean, 8/8 unit tests passing (Python 3.12), STIX-ID pylint 10.00/10.
