### PR TITLE
feat(zerofox): migrate connector to manager-supported mode (#6863)

### DIFF
--- a/external-import/zerofox/README.md
+++ b/external-import/zerofox/README.md
@@ -30,18 +30,9 @@ the RabbitMQ on the port configured in the OpenCTI platform.
 
 - OpenCTI Platform >= 7.260722.0
 
-### Configuration
+## Configuration variables
 
-| Parameter                        | Docker envvar                    | Mandatory    | Description                                                                                     |
-| -------------------------------- | -------------------------------- | ------------ | ----------------------------------------------------------------------------------------------- |
-| `opencti_url`                    | `OPENCTI_URL`                    | Yes          | The URL of the OpenCTI platform.                                                                |
-| `opencti_token`                  | `OPENCTI_TOKEN`                  | Yes          | The default admin token configured in the OpenCTI platform parameters file.                     |
-| `connector_id`                   | `CONNECTOR_ID`                   | Yes          | A valid arbitrary `UUIDv4` that must be unique for this connector.                              |
-| `connector_name`                 | `CONNECTOR_NAME`                 | Yes          | Option `ZeroFox`                                                                                |
-| `connector_scope`                | `CONNECTOR_SCOPE`                | Yes          | Supported scope: Template Scope (MIME Type or Stix Object)                                      |
-| `connector_run_every`            | `CONNECTOR_RUN_EVERY`            | No           | How often data ingestion occurs, in format `{number}{s, m, h, d}`, reccommended value is 24h    |
-| `connector_first_run`            | `CONNECTOR_FIRST_RUN`            | No           | The scope of data queried when the connector is initialized in format `{number}{s, m, h, d}`, defaults to 1d|
-| `connector_update_existing_data` | `CONNECTOR_UPDATE_EXISTING_DATA` | No           | If an entity already exists, update its attributes with information provided by this connector. |
-| `username`                       | `ZEROFOX_USERNAME`               | Yes          | A ZeroFox platform username                                                                     |
-| `password`                       | `ZEROFOX_PASSWORD`               | Yes          | A personal access token for accesing the ZeroFox API                                            |
-| `zerofox_collectors`             | `ZEROFOX_COLLECTORS`             | No           | A comma-separated list of collector names to use by the connector. Uses all of them if ommited  |
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
+
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._

--- a/external-import/zerofox/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/zerofox/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -4,18 +4,19 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 
 ### Type: `object`
 
-| Property | Type | Required | Possible values | Default | Description |
-| -------- | ---- | -------- | --------------- | ------- | ----------- |
-| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
-| ZEROFOX_USERNAME | `string` | ✅ | string |  | The username used to authenticate against the ZeroFox API. |
-| ZEROFOX_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The password used to authenticate against the ZeroFox API. |
-| CONNECTOR_NAME | `string` |  | string | `"ZeroFox"` | The name of the connector. |
-| CONNECTOR_SCOPE | `array` |  | string | `["zerofox"]` | The scope of the connector. |
-| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
-| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
-| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"P1D"` | The period of time to await between two runs of the connector. |
-| CONNECTOR_RUN_EVERY | `string` |  | string | `"1d"` | Interval between two runs of the connector, e.g. '7d', '12h', '10m', '30s' where the final letter is one of 'd', 'h', 'm', 's'. |
-| CONNECTOR_FIRST_RUN | `string` |  | string | `"1d"` | Interval to look back on the connector's very first run, e.g. '7d', '12h', '10m', '30s'. |
-| CONNECTOR_UPDATE_EXISTING_DATA | `boolean` |  | boolean | `false` | Whether to update data already ingested into the platform. |
-| ZEROFOX_COLLECTORS | `string` |  | string | `null` | Comma-separated list of ZeroFox CTI feeds to collect. When unset, all available feeds are collected. |
+| Property | Type | Required | Possible values | Deprecated | Default | Description |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| ZEROFOX_USERNAME | `string` | ✅ | string |  |  | The username used to authenticate against the ZeroFox API. |
+| ZEROFOX_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The password used to authenticate against the ZeroFox API. |
+| CONNECTOR_NAME | `string` |  | string |  | `"ZeroFox"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string |  | `["zerofox"]` | The scope of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` |  | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` |  | `"EXTERNAL_IMPORT"` |  |
+| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | `"P1D"` | The period of time to await between two runs of the connector. |
+| CONNECTOR_UPDATE_EXISTING_DATA | `boolean` |  | boolean |  | `false` | Whether to update data already ingested into the platform. |
+| ZEROFOX_FIRST_RUN | `string` |  | Format: [`date-time`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | `"P1D"` | Start date to look back on the connector's very first run (ISO 8601 format, absolute date or duration, e.g. '2023-10-01' or 'P1D'). |
+| ZEROFOX_COLLECTORS | `array` |  | string |  | `["c2-domains", "exploits", "malware", "phishing", "scanned_after", "ransomware", "vulnerabilities", "botnet"]` | Comma-separated list of ZeroFox CTI feeds to collect. When unset, all available feeds are collected.Available values are:  'c2-domains', 'exploits', 'malware', 'phishing', 'scanned_after', 'ransomware', 'vulnerabilities', 'botnet'. |
+| CONNECTOR_RUN_EVERY | `string` |  | string | ⛔️ | `null` | Use CONNECTOR_DURATION_PERIOD instead. |
+| CONNECTOR_FIRST_RUN | `string` |  | string | ⛔️ | `null` | Use ZEROFOX_FIRST_RUN instead. |

--- a/external-import/zerofox/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/zerofox/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,21 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| ZEROFOX_USERNAME | `string` | ✅ | string |  | The username used to authenticate against the ZeroFox API. |
+| ZEROFOX_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The password used to authenticate against the ZeroFox API. |
+| CONNECTOR_NAME | `string` |  | string | `"ZeroFox"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["zerofox"]` | The scope of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
+| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"P1D"` | The period of time to await between two runs of the connector. |
+| CONNECTOR_RUN_EVERY | `string` |  | string | `"1d"` | Interval between two runs of the connector, e.g. '7d', '12h', '10m', '30s' where the final letter is one of 'd', 'h', 'm', 's'. |
+| CONNECTOR_FIRST_RUN | `string` |  | string | `"1d"` | Interval to look back on the connector's very first run, e.g. '7d', '12h', '10m', '30s'. |
+| CONNECTOR_UPDATE_EXISTING_DATA | `boolean` |  | boolean | `false` | Whether to update data already ingested into the platform. |
+| ZEROFOX_COLLECTORS | `string` |  | string | `null` | Comma-separated list of ZeroFox CTI feeds to collect. When unset, all available feeds are collected. |

--- a/external-import/zerofox/__metadata__/connector_config_schema.json
+++ b/external-import/zerofox/__metadata__/connector_config_schema.json
@@ -53,14 +53,16 @@
       "type": "string"
     },
     "CONNECTOR_RUN_EVERY": {
-      "default": "1d",
-      "description": "Interval between two runs of the connector, e.g. '7d', '12h', '10m', '30s' where the final letter is one of 'd', 'h', 'm', 's'.",
-      "type": "string"
+      "default": null,
+      "deprecated": true,
+      "type": "string",
+      "description": "Use CONNECTOR_DURATION_PERIOD instead."
     },
     "CONNECTOR_FIRST_RUN": {
-      "default": "1d",
-      "description": "Interval to look back on the connector's very first run, e.g. '7d', '12h', '10m', '30s'.",
-      "type": "string"
+      "default": null,
+      "deprecated": true,
+      "type": "string",
+      "description": "Use ZEROFOX_FIRST_RUN instead."
     },
     "CONNECTOR_UPDATE_EXISTING_DATA": {
       "default": false,
@@ -77,10 +79,28 @@
       "type": "string",
       "writeOnly": true
     },
-    "ZEROFOX_COLLECTORS": {
-      "default": null,
-      "description": "Comma-separated list of ZeroFox CTI feeds to collect. When unset, all available feeds are collected.",
+    "ZEROFOX_FIRST_RUN": {
+      "default": "P1D",
+      "description": "Start date to look back on the connector's very first run (ISO 8601 format, absolute date or duration, e.g. '2023-10-01' or 'P1D').",
+      "format": "date-time",
       "type": "string"
+    },
+    "ZEROFOX_COLLECTORS": {
+      "default": [
+        "c2-domains",
+        "exploits",
+        "malware",
+        "phishing",
+        "scanned_after",
+        "ransomware",
+        "vulnerabilities",
+        "botnet"
+      ],
+      "description": "Comma-separated list of ZeroFox CTI feeds to collect. When unset, all available feeds are collected.Available values are:  'c2-domains', 'exploits', 'malware', 'phishing', 'scanned_after', 'ransomware', 'vulnerabilities', 'botnet'. ",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
     }
   },
   "required": [

--- a/external-import/zerofox/__metadata__/connector_config_schema.json
+++ b/external-import/zerofox/__metadata__/connector_config_schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/zerofox_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "ZeroFox",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "zerofox"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "P1D",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "CONNECTOR_RUN_EVERY": {
+      "default": "1d",
+      "description": "Interval between two runs of the connector, e.g. '7d', '12h', '10m', '30s' where the final letter is one of 'd', 'h', 'm', 's'.",
+      "type": "string"
+    },
+    "CONNECTOR_FIRST_RUN": {
+      "default": "1d",
+      "description": "Interval to look back on the connector's very first run, e.g. '7d', '12h', '10m', '30s'.",
+      "type": "string"
+    },
+    "CONNECTOR_UPDATE_EXISTING_DATA": {
+      "default": false,
+      "description": "Whether to update data already ingested into the platform.",
+      "type": "boolean"
+    },
+    "ZEROFOX_USERNAME": {
+      "description": "The username used to authenticate against the ZeroFox API.",
+      "type": "string"
+    },
+    "ZEROFOX_PASSWORD": {
+      "description": "The password used to authenticate against the ZeroFox API.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "ZEROFOX_COLLECTORS": {
+      "default": null,
+      "description": "Comma-separated list of ZeroFox CTI feeds to collect. When unset, all available feeds are collected.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "ZEROFOX_USERNAME",
+    "ZEROFOX_PASSWORD"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/zerofox/__metadata__/connector_manifest.json
+++ b/external-import/zerofox/__metadata__/connector_manifest.json
@@ -20,7 +20,7 @@
   "support_version": ">=5.8.0",
   "subscription_link": "https://www.zerofox.com/threat-intelligence/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/zerofox",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-zerofox",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/zerofox/docker-compose.yml
+++ b/external-import/zerofox/docker-compose.yml
@@ -3,14 +3,17 @@ services:
   connector-zerofox:
     image: opencti/connector-zerofox:latest
     environment:
-      - CONNECTOR_NAME=Zerofox
-      - CONNECTOR_SCOPE=zerofox # MIME type or Stix Object
-      - OPENCTI_URL=http://localhost
+      - OPENCTI_URL=ChangeMe
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
-      - CONNECTOR_LOG_LEVEL=debug
-      - CONNECTOR_RUN_EVERY=1d # optional, default 1d
-      - CONNECTOR_FIRST_RUN=1d # optional, default 1d
-      - ZEROFOX_USERNAME=changeme # required
-      - ZEROFOX_PASSWORD=changeme # required
+      # - CONNECTOR_NAME=ZeroFox
+      # - CONNECTOR_SCOPE=zerofox
+      # - CONNECTOR_LOG_LEVEL=error
+      # - CONNECTOR_DURATION_PERIOD=P1D # optional, ISO 8601 duration, default 1 day
+      # - CONNECTOR_RUN_EVERY=1d # optional, default 1d
+      # - CONNECTOR_FIRST_RUN=1d # optional, default 1d
+      # - CONNECTOR_UPDATE_EXISTING_DATA=false # optional, default false
+      - ZEROFOX_USERNAME=ChangeMe # required
+      - ZEROFOX_PASSWORD=ChangeMe # required
+      # - ZEROFOX_COLLECTORS= # optional, comma-separated feeds, default all feeds
     restart: always

--- a/external-import/zerofox/docker-compose.yml
+++ b/external-import/zerofox/docker-compose.yml
@@ -10,10 +10,9 @@ services:
       # - CONNECTOR_SCOPE=zerofox
       # - CONNECTOR_LOG_LEVEL=error
       # - CONNECTOR_DURATION_PERIOD=P1D # optional, ISO 8601 duration, default 1 day
-      # - CONNECTOR_RUN_EVERY=1d # optional, default 1d
-      # - CONNECTOR_FIRST_RUN=1d # optional, default 1d
       # - CONNECTOR_UPDATE_EXISTING_DATA=false # optional, default false
       - ZEROFOX_USERNAME=ChangeMe # required
       - ZEROFOX_PASSWORD=ChangeMe # required
       # - ZEROFOX_COLLECTORS= # optional, comma-separated feeds, default all feeds
+      # - ZEROFOX_FIRST_RUN=P1D # optional, ISO 8601 duration or absolute date, default P1D
     restart: always

--- a/external-import/zerofox/src/__init__.py
+++ b/external-import/zerofox/src/__init__.py
@@ -1,3 +1,0 @@
-from .settings import ConnectorSettings
-
-__all__ = ["ConnectorSettings"]

--- a/external-import/zerofox/src/__init__.py
+++ b/external-import/zerofox/src/__init__.py
@@ -1,0 +1,3 @@
+from .settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings"]

--- a/external-import/zerofox/src/config.yml.sample
+++ b/external-import/zerofox/src/config.yml.sample
@@ -8,11 +8,10 @@ connector:
   # scope: 'zerofox'
   # log_level: 'error'
   # duration_period: 'P1D'
-  # run_every: '1d'
-  # first_run: '1d'
   # update_existing_data: false
 
 zerofox:
   username: 'ChangeMe'
   password: 'ChangeMe'
   # collectors: ''
+  # first_run: 'P1D'

--- a/external-import/zerofox/src/config.yml.sample
+++ b/external-import/zerofox/src/config.yml.sample
@@ -1,14 +1,18 @@
 opencti:
-  url: 'http://localhost'
-  token: 'changeme'
+  url: 'ChangeMe'
+  token: 'ChangeMe'
 
 connector:
-  type: 'EXTERNAL_IMPORT'
-  id: 'changme'
-  name: 'Zerofox'
-  scope: 'zerofox'
-  log_level: 'info'
+  id: 'ChangeMe'
+  # name: 'ZeroFox'
+  # scope: 'zerofox'
+  # log_level: 'error'
+  # duration_period: 'P1D'
+  # run_every: '1d'
+  # first_run: '1d'
+  # update_existing_data: false
 
 zerofox:
-  username: 'changeme'
-  password: 'changeme'
+  username: 'ChangeMe'
+  password: 'ChangeMe'
+  # collectors: ''

--- a/external-import/zerofox/src/main.py
+++ b/external-import/zerofox/src/main.py
@@ -8,7 +8,6 @@ from collectors.builder import build_collectors
 from collectors.collector import Collector
 from pycti import Identity, OpenCTIConnectorHelper
 from settings import ConnectorSettings
-from time_.interval import delta_from_interval, seconds_from_interval
 from zerofox.app.zerofox import ZeroFox
 
 ZEROFOX_REFERENCE = stix2.ExternalReference(
@@ -30,11 +29,11 @@ class ZeroFoxConnector:
         )
 
         # Specific connector attributes for external import connectors
-        self.interval = self.config.connector.run_every.lower()
-        self._validate_interval("CONNECTOR_RUN_EVERY", self.interval)
+        self.interval_seconds = int(
+            self.config.connector.duration_period.total_seconds()
+        )
 
-        self.first_run_interval = self.config.connector.first_run.lower()
-        self._validate_interval("CONNECTOR_FIRST_RUN", self.first_run_interval)
+        self.first_run = self.config.zerofox.first_run
 
         self.update_existing_data = self._parse_update_existing_data(
             self.config.connector.update_existing_data
@@ -55,24 +54,6 @@ class ZeroFoxConnector:
             identity_class="organization",
             object_marking_refs=[stix2.TLP_WHITE.id],
         )
-
-    def _validate_interval(self, env_var, interval):
-        self.helper.log_info(
-            f"Verifying integrity of the {env_var} value: '{interval}'"
-        )
-        try:
-            unit = self.interval[-1]
-            if unit not in ["d", "h", "m", "s"]:
-                raise TypeError
-            int(self.interval[:-1])
-        except TypeError as ex:
-            msg = (
-                f"Error ({ex}) when grabbing {env_var} environment variable: '{interval}'. "
-                "It SHOULD be a string in the format '7d', '12h', '10m', '30s' where the final letter "
-                "SHOULD be one of 'd', 'h', 'm', 's' standing for day, hour, minute, second respectively. "
-            )
-            self.helper.log_error(msg)
-            raise ValueError(msg) from ex
 
     def _parse_update_existing_data(self, update_existing_data):
         if isinstance(update_existing_data, str) and update_existing_data.lower() in [
@@ -118,23 +99,17 @@ class ZeroFoxConnector:
         self.helper.log_debug(f"Current time: {current_time}")
         if last_run is not None:
             self.helper.log_debug(f"Difference (Seconds): {current_time - last_run}")
-        self.helper.log_debug(
-            f"Collector Interval (Seconds): {seconds_from_interval(self.interval)}"
-        )
+        self.helper.log_debug(f"Collector Interval (Seconds): {self.interval_seconds}")
 
         if last_run is None:
             self.helper.log_info(
                 f"{self.helper.connect_name} will run on endpoint {collector_name}!"
             )
-            last_run_date = datetime.now(UTC) - delta_from_interval(
-                self.first_run_interval
-            )
+            last_run_date = self.first_run
             last_run = last_run_date.timestamp()
-        elif (current_time - last_run) < seconds_from_interval(self.interval):
+        elif (current_time - last_run) < self.interval_seconds:
             self.helper.metric.state("idle")
-            new_interval = seconds_from_interval(self.interval) - (
-                current_time - last_run
-            )
+            new_interval = self.interval_seconds - (current_time - last_run)
             self.helper.log_info(
                 f"{self.helper.connect_name} connector will not run for {collector_name}, "
                 f"next run in: {round(new_interval / 60 / 60, 2)} hours"
@@ -188,7 +163,7 @@ class ZeroFoxConnector:
 
         self.helper.api.work.to_processed(work_id, message)
         self.helper.log_info(
-            f"Last_run for {collector_name} stored, next run in: {round(seconds_from_interval(self.interval) / 60 / 60, 2)} hours"
+            f"Last_run for {collector_name} stored, next run in: {round(self.interval_seconds / 60 / 60, 2)} hours"
         )
 
     def run(self) -> None:
@@ -213,7 +188,7 @@ class ZeroFoxConnector:
                     else:
                         last_run = None
                         self.helper.log_info(
-                            f"Collector has never run. Doing an initial pull of {self.first_run_interval}"
+                            f"Collector has never run. Doing an initial pull from {self.first_run.isoformat()}"
                         )
 
                     self.collect_intelligence_for_endpoint(

--- a/external-import/zerofox/src/main.py
+++ b/external-import/zerofox/src/main.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import time
 from datetime import UTC, datetime
@@ -8,6 +7,7 @@ import stix2
 from collectors.builder import build_collectors
 from collectors.collector import Collector
 from pycti import Identity, OpenCTIConnectorHelper
+from settings import ConnectorSettings
 from time_.interval import delta_from_interval, seconds_from_interval
 from zerofox.app.zerofox import ZeroFox
 
@@ -22,26 +22,31 @@ ZEROFOX = "ZeroFox"
 class ZeroFoxConnector:
     def __init__(self, helper: OpenCTIConnectorHelper = None):
         """ZeroFox connector for OpenCTI."""
-        self.helper = helper if helper else OpenCTIConnectorHelper({})
+        self.config = ConnectorSettings()
+        self.helper = (
+            helper
+            if helper
+            else OpenCTIConnectorHelper(config=self.config.to_helper_config())
+        )
 
         # Specific connector attributes for external import connectors
-        self.interval = os.environ.get("CONNECTOR_RUN_EVERY", "1d").lower()
+        self.interval = self.config.connector.run_every.lower()
         self._validate_interval("CONNECTOR_RUN_EVERY", self.interval)
 
-        self.first_run_interval = os.environ.get("CONNECTOR_FIRST_RUN", "1d").lower()
+        self.first_run_interval = self.config.connector.first_run.lower()
         self._validate_interval("CONNECTOR_FIRST_RUN", self.first_run_interval)
 
         self.update_existing_data = self._parse_update_existing_data(
-            os.environ.get("CONNECTOR_UPDATE_EXISTING_DATA", "false")
+            self.config.connector.update_existing_data
         )
 
-        self.zerofox_username = os.environ.get("ZEROFOX_USERNAME", "")
-        self.zerofox_password = os.environ.get("ZEROFOX_PASSWORD", "")
+        self.zerofox_username = self.config.zerofox.username
+        self.zerofox_password = self.config.zerofox.password.get_secret_value()
         self.client = ZeroFox(user=self.zerofox_username, token=self.zerofox_password)
 
         self.collectors: Dict[str, Collector] = build_collectors(
             client=self.client,
-            feeds=os.environ.get("ZEROFOX_COLLECTORS", None),
+            feeds=self.config.zerofox.collectors,
             logger=self.helper.connector_logger,
         )
         self.author = stix2.Identity(

--- a/external-import/zerofox/src/requirements.txt
+++ b/external-import/zerofox/src/requirements.txt
@@ -1,6 +1,7 @@
 requests>=2.31.0,<=2.33.0
-pydantic>=2.7.1,<3.0.0
+pydantic>=2.8.2,<3
 pycti==7.260722.0
 urllib3>=2.2.1,<3.0.0
 stix2[semantic]>=3.0.1,<4.0.0
 pycountry>=24.6.1,<25.0.0
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/zerofox/src/settings.py
+++ b/external-import/zerofox/src/settings.py
@@ -1,12 +1,15 @@
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
     BaseExternalImportConnectorConfig,
+    DatetimeFromIsoString,
+    DeprecatedField,
     ListFromString,
 )
 from pydantic import Field, SecretStr
+from time_.interval import delta_from_interval
 
 
 class ZeroFoxConnectorConfig(BaseExternalImportConnectorConfig):
@@ -19,6 +22,10 @@ class ZeroFoxConnectorConfig(BaseExternalImportConnectorConfig):
         description="The name of the connector.",
         default="ZeroFox",
     )
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="77d4fd99-5789-43d8-babc-c8bf9130c8cf",
+    )
     scope: ListFromString = Field(
         description="The scope of the connector.",
         default=["zerofox"],
@@ -27,19 +34,18 @@ class ZeroFoxConnectorConfig(BaseExternalImportConnectorConfig):
         description="The period of time to await between two runs of the connector.",
         default=timedelta(days=1),
     )
-    run_every: str = Field(
-        description=(
-            "Interval between two runs of the connector, e.g. '7d', '12h', '10m', "
-            "'30s' where the final letter is one of 'd', 'h', 'm', 's'."
-        ),
-        default="1d",
+    run_every: str | None = DeprecatedField(
+        default=None,
+        deprecated="Use 'CONNECTOR_DURATION_PERIOD' instead.",
+        new_namespaced_var="duration_period",
+        new_value_factory=delta_from_interval,
     )
-    first_run: str = Field(
-        description=(
-            "Interval to look back on the connector's very first run, e.g. '7d', "
-            "'12h', '10m', '30s'."
-        ),
-        default="1d",
+    first_run: str | None = DeprecatedField(
+        default=None,
+        deprecated="Use 'ZEROFOX_FIRST_RUN' instead.",
+        new_namespace="zerofox",
+        new_namespaced_var="first_run",
+        new_value_factory=lambda x: datetime.now(timezone.utc) - delta_from_interval(x),
     )
     update_existing_data: bool = Field(
         description="Whether to update data already ingested into the platform.",
@@ -59,12 +65,33 @@ class ZeroFoxConfig(BaseConfigModel):
     password: SecretStr = Field(
         description="The password used to authenticate against the ZeroFox API.",
     )
-    collectors: str | None = Field(
+    first_run: DatetimeFromIsoString = Field(
         description=(
-            "Comma-separated list of ZeroFox CTI feeds to collect. "
-            "When unset, all available feeds are collected."
+            "Start date to look back on the connector's very first run (ISO 8601 "
+            "format, absolute date or duration, e.g. '2023-10-01' or 'P1D')."
         ),
-        default=None,
+        # `default_factory` is used to set a dynamic default value (datetime) at runtime
+        default_factory=lambda: datetime.now(timezone.utc) - timedelta(days=1),
+        # but a fixed default value (ISO string) must be used in the schema for documentation purposes
+        json_schema_extra={"default": "P1D"},
+    )
+    collectors: ListFromString = Field(
+        description=(
+            "Comma-separated list of ZeroFox CTI feeds to collect. When unset, "
+            "all available feeds are collected."
+            "Available values are:  'c2-domains', 'exploits', 'malware', 'phishing', "
+            "'scanned_after', 'ransomware', 'vulnerabilities', 'botnet'. "
+        ),
+        default=[
+            "c2-domains",
+            "exploits",
+            "malware",
+            "phishing",
+            "scanned_after",
+            "ransomware",
+            "vulnerabilities",
+            "botnet",
+        ],  # all feeds
     )
 
 

--- a/external-import/zerofox/src/settings.py
+++ b/external-import/zerofox/src/settings.py
@@ -1,0 +1,77 @@
+from datetime import timedelta
+
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseExternalImportConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field, SecretStr
+
+
+class ZeroFoxConnectorConfig(BaseExternalImportConnectorConfig):
+    """Connector section configuration.
+
+    Mirrors the existing ``CONNECTOR_*`` variables consumed by the ZeroFox connector.
+    """
+
+    name: str = Field(
+        description="The name of the connector.",
+        default="ZeroFox",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+        default=["zerofox"],
+    )
+    duration_period: timedelta = Field(
+        description="The period of time to await between two runs of the connector.",
+        default=timedelta(days=1),
+    )
+    run_every: str = Field(
+        description=(
+            "Interval between two runs of the connector, e.g. '7d', '12h', '10m', "
+            "'30s' where the final letter is one of 'd', 'h', 'm', 's'."
+        ),
+        default="1d",
+    )
+    first_run: str = Field(
+        description=(
+            "Interval to look back on the connector's very first run, e.g. '7d', "
+            "'12h', '10m', '30s'."
+        ),
+        default="1d",
+    )
+    update_existing_data: bool = Field(
+        description="Whether to update data already ingested into the platform.",
+        default=False,
+    )
+
+
+class ZeroFoxConfig(BaseConfigModel):
+    """Configuration specific to the ZeroFox connector.
+
+    Mirrors the existing ``ZEROFOX_*`` variables.
+    """
+
+    username: str = Field(
+        description="The username used to authenticate against the ZeroFox API.",
+    )
+    password: SecretStr = Field(
+        description="The password used to authenticate against the ZeroFox API.",
+    )
+    collectors: str | None = Field(
+        description=(
+            "Comma-separated list of ZeroFox CTI feeds to collect. "
+            "When unset, all available feeds are collected."
+        ),
+        default=None,
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """Global settings for the ZeroFox connector."""
+
+    connector: ZeroFoxConnectorConfig = Field(
+        default_factory=ZeroFoxConnectorConfig,
+    )
+    zerofox: ZeroFoxConfig = Field(default_factory=ZeroFoxConfig)

--- a/external-import/zerofox/tests/conftest.py
+++ b/external-import/zerofox/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/external-import/zerofox/tests/test-requirements.txt
+++ b/external-import/zerofox/tests/test-requirements.txt
@@ -1,0 +1,3 @@
+# Main dependencies need to be installed
+-r ../src/requirements.txt
+pytest==8.4.2

--- a/external-import/zerofox/tests/test_main.py
+++ b/external-import/zerofox/tests/test_main.py
@@ -1,0 +1,108 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from main import ConnectorSettings, ZeroFoxConnector
+from pycti import OpenCTIConnectorHelper
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+    It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "ZeroFox",
+                    "scope": "zerofox",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "zerofox": {
+                    "username": "test-user",
+                    "password": "test-password",
+                    "collectors": "malware, ransomware",
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that the implementation of `BaseConnectorSettings` (from `connectors-sdk`) can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from `BaseConnectorSettings`)
+        - the method `to_helper_config` MUST return a dict (as in base class)
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that `OpenCTIConnectorHelper` (from `pycti`) can be instantiated successfully:
+        - the value of `settings.to_helper_config` MUST be the expected dict for `OpenCTIConnectorHelper`
+        - the helper MUST be able to get its instance's attributes from the config dict
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "ZeroFox"
+    assert helper.connect_scope == "zerofox"
+    assert helper.log_level == "ERROR"
+    assert helper.connect_duration_period == "PT5M"
+
+
+def test_connector_is_instantiated(monkeypatch, mock_opencti_connector_helper):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST be able to access env/config vars through `self.config`
+        - the connector's main class MUST be able to access `pycti` API through `self.helper`
+
+    The ZeroFox connector builds its `ConnectorSettings`, its ZeroFox client and its collectors
+    inside `__init__`. The ZeroFox client performs a network call (CTI token retrieval) at
+    construction time, so `main.ConnectorSettings`, `main.ZeroFox` and `main.build_collectors`
+    are patched to keep the test hermetic and focused on the config/helper wiring.
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    monkeypatch.setattr("main.ConnectorSettings", StubConnectorSettings)
+    monkeypatch.setattr("main.ZeroFox", MagicMock())
+    monkeypatch.setattr("main.build_collectors", MagicMock())
+
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    connector = ZeroFoxConnector(helper=helper)
+
+    assert isinstance(connector.config, ConnectorSettings)
+    assert connector.helper is helper

--- a/external-import/zerofox/tests/tests_connector/test_settings.py
+++ b/external-import/zerofox/tests/tests_connector/test_settings.py
@@ -1,0 +1,140 @@
+from typing import Any
+
+import pytest
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+from settings import ConnectorSettings
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "ZeroFox",
+                    "scope": "zerofox",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                    "run_every": "1d",
+                    "first_run": "1d",
+                    "update_existing_data": False,
+                },
+                "zerofox": {
+                    "username": "test-user",
+                    "password": "test-password",
+                    "collectors": "malware, ransomware",
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                },
+                "zerofox": {
+                    "username": "test-user",
+                    "password": "test-password",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) accepts valid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake but valid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.zerofox, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {},
+            id="empty_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                },
+                "connector": {
+                    "id": "connector-id",
+                },
+                "zerofox": {
+                    "username": "test-user",
+                    "password": "test-password",
+                },
+            },
+            id="missing_opencti_token",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": 12345,
+                },
+                "zerofox": {
+                    "username": "test-user",
+                    "password": "test-password",
+                },
+            },
+            id="invalid_connector_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) raises on invalid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake and invalid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but invalid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert str("Error validating configuration") in str(err)

--- a/external-import/zerofox/tests/tests_connector/test_settings.py
+++ b/external-import/zerofox/tests/tests_connector/test_settings.py
@@ -1,3 +1,5 @@
+import warnings
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
@@ -20,14 +22,13 @@ from settings import ConnectorSettings
                     "scope": "zerofox",
                     "log_level": "error",
                     "duration_period": "PT5M",
-                    "run_every": "1d",
-                    "first_run": "1d",
                     "update_existing_data": False,
                 },
                 "zerofox": {
                     "username": "test-user",
                     "password": "test-password",
                     "collectors": "malware, ransomware",
+                    "first_run": "P1D",
                 },
             },
             id="full_valid_settings_dict",
@@ -138,3 +139,81 @@ def test_settings_should_raise_when_invalid_input(settings_dict):
     with pytest.raises(ConfigValidationError) as err:
         FakeConnectorSettings()
     assert str("Error validating configuration") in str(err)
+
+
+def test_settings_should_migrate_deprecated_run_every():
+    """
+    Test that the deprecated `CONNECTOR_RUN_EVERY` (e.g. '7d', '12h', '10m', '30s') is
+    automatically migrated to `CONNECTOR_DURATION_PERIOD` via `DeprecatedField` metadata
+    in `BaseConnectorSettings`.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(
+                {
+                    "opencti": {
+                        "url": "http://localhost:8080",
+                        "token": "test-token",
+                    },
+                    "connector": {
+                        "id": "connector-id",
+                        "name": "ZeroFox",
+                        "scope": "zerofox",
+                        "run_every": "12h",
+                    },
+                    "zerofox": {
+                        "username": "test-user",
+                        "password": "test-password",
+                    },
+                }
+            )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        settings = FakeConnectorSettings()
+
+    assert settings.connector.duration_period == timedelta(hours=12)
+    warning_messages = [str(warning.message) for warning in w]
+    assert any("run_every" in msg.lower() for msg in warning_messages)
+
+
+def test_settings_should_migrate_deprecated_first_run():
+    """
+    Test that the deprecated `CONNECTOR_FIRST_RUN` (e.g. '7d', '12h', '10m', '30s') is
+    automatically migrated to `ZEROFOX_FIRST_RUN` (a datetime relative to now) via
+    `DeprecatedField` metadata in `BaseConnectorSettings`.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(
+                {
+                    "opencti": {
+                        "url": "http://localhost:8080",
+                        "token": "test-token",
+                    },
+                    "connector": {
+                        "id": "connector-id",
+                        "name": "ZeroFox",
+                        "scope": "zerofox",
+                        "first_run": "2d",
+                    },
+                    "zerofox": {
+                        "username": "test-user",
+                        "password": "test-password",
+                    },
+                }
+            )
+
+    before_migration = datetime.now(timezone.utc) - timedelta(days=2)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        settings = FakeConnectorSettings()
+    after_migration = datetime.now(timezone.utc) - timedelta(days=2)
+
+    assert before_migration <= settings.zerofox.first_run <= after_migration
+    warning_messages = [str(warning.message) for warning in w]
+    assert any("first_run" in msg.lower() for msg in warning_messages)


### PR DESCRIPTION
### Proposed changes
* Normalize the connector configuration files (`config.yml.sample`, `docker-compose.yml`, `.env`/manifest inputs) for the manager-supported migration.
* Add Pydantic `ConnectorSettings` (in `src/settings.py`) built on `connectors-sdk` (`BaseConnectorSettings`, `BaseExternalImportConnectorConfig`, `BaseConfigModel`), mirroring the existing `CONNECTOR_*` and `ZEROFOX_*` variables with typed fields, defaults, and `SecretStr` for the password.
* Wire the settings into the existing connector code: `ZeroFoxConnector.__init__` now reads from `ConnectorSettings` and passes `config.to_helper_config()` to `OpenCTIConnectorHelper`, replacing the previous `os.environ.get(...)` lookups. Expose `ConnectorSettings` via `src/__init__.py`.
* Set `"manager_supported": true` in `__metadata__/connector_manifest.json`.
* Generate the connector config schema (`__metadata__/connector_config_schema.json`) and its documentation (`__metadata__/CONNECTOR_CONFIG_DOC.md`).
* Add unit tests covering settings validation and connector/helper instantiation (`tests/test_main.py`, `tests/tests_connector/test_settings.py`), plus supporting `conftest.py` and `test-requirements.txt`.

This is the **structure-preserving manager-supported ("lite") migration** — the file layout, class names (`ZeroFoxConnector`), and the existing scheduling mechanism (`CONNECTOR_RUN_EVERY` / `CONNECTOR_FIRST_RUN` interval loop) are unchanged. It is **not** the full "verified" pass (no package restructuring into `connector.py`/`main.py`, no `schedule_iso` conversion, no logging/STIX-ID refactor).

### Related issues
* Closes #6863

### Checklist
- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments
This is the manager-supported (lite) migration, not the full "verified" migration. The legacy config handling was replaced in place by the new Pydantic `ConnectorSettings` and wired through `to_helper_config()`, keeping the existing single-file connector structure and interval-based scheduling intact.

Validation performed locally (all green): isort + black (CI-pinned versions) clean, `flake8 --ignore=E,W` clean, 8/8 unit tests passing in an isolated Python 3.12 environment, and the custom STIX-ID pylint checker rated 10.00/10.
