### PR TITLE
feat(malcore): migrate connector to manager_supported mode (#6851)

### DIFF
--- a/external-import/malcore/Dockerfile
+++ b/external-import/malcore/Dockerfile
@@ -12,6 +12,5 @@ RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-de
     apk del git build-base
 
 # Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["sh","/entrypoint.sh"]
+WORKDIR /opt/opencti-malcore
+CMD ["python3", "main.py"]

--- a/external-import/malcore/README.md
+++ b/external-import/malcore/README.md
@@ -24,16 +24,7 @@ The connector creates the following OpenCTI entity types:
 
 ### Configuration
 
-| Parameter             | Docker envvar         | Mandatory | Description                                                                                                                           |
-|-----------------------|-----------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `opencti_url`         | `OPENCTI_URL`         | Yes       | The URL of the OpenCTI platform.                                                                                                      |
-| `opencti_token`       | `OPENCTI_TOKEN`       | Yes       | The default admin token configured in the OpenCTI platform parameters file.                                                           |
-| `connector_id`        | `CONNECTOR_ID`        | Yes       | A valid arbitrary `UUIDv4` that must be unique for this connector.                                                                    |
-| `connector_name`      | `CONNECTOR_NAME`      | Yes       | Option `Malcore`                                                                                                                      |
-| `connector_scope`     | `CONNECTOR_SCOPE`     | Yes       | Supported scope: Template Scope (MIME Type or Stix Object)                                                                            |
-| `connector_log_level` | `CONNECTOR_LOG_LEVEL` | Yes       | Log output for the connector. Defaults to `INFO`                                                                                      |
-| `malcore_api_url`     | `MALCORE_API_URL`     | Yes       | Malcore API URL                                                                                                                       |
-| `malcore_api_key`     | `MALCORE_API_KEY`     | Yes       | Malcore API Key                                                                                                                       |
-| `malcore_score`       | `MALCORE_SCORE`       | Yes       | Parameter not used at this moment, but could be used as a default indicator/observable score at a later date                          |
-| `malcore_limit`       | `MALCORE_LIMIT`       | Yes       | Parameter not used at this moment, but could be used as a limit on the number of entities to be retrieved per request at a later date |
-| `malcore_interval`    | `MALCORE_INTERVAL`    | Yes       | Interval between two executions, in hours (must be > 1)                                                                               |
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
+
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._

--- a/external-import/malcore/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/malcore/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -13,8 +13,8 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | CONNECTOR_SCOPE | `array` |  | string |  | `[]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` |  | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` |  | `"EXTERNAL_IMPORT"` |  |
-| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | `"PT1H"` | The period of time to await between two runs of the connector. |
+| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | `"PT12H"` | The period of time to await between two runs of the connector. |
 | MALCORE_API_URL | `string` |  | string |  | `"https://api.malcore.io/api/feed"` | Malcore API URL |
-| MALCORE_INTERVAL | `integer` |  | integer |  | `12` | Interval between two executions, in hours (must be > 1) |
 | MALCORE_SCORE | `integer` |  | integer | ⛔️ | `100` | Parameter not used at this moment, but could be used as a default indicator/observable score at a later date |
 | MALCORE_LIMIT | `integer` |  | integer | ⛔️ | `10000` | Parameter not used at this moment, but could be used as a limit on the number of entities to be retrieved per request at a later date |
+| MALCORE_INTERVAL | `integer` |  | integer | ⛔️ | `null` | Use CONNECTOR_DURATION_PERIOD instead. |

--- a/external-import/malcore/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/malcore/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,20 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Deprecated | Default | Description |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| MALCORE_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Malcore API Key |
+| CONNECTOR_NAME | `string` |  | string |  | `"Malcore"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string |  | `[]` | The scope of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` |  | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` |  | `"EXTERNAL_IMPORT"` |  |
+| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | `"PT1H"` | The period of time to await between two runs of the connector. |
+| MALCORE_API_URL | `string` |  | string |  | `"https://api.malcore.io/api/feed"` | Malcore API URL |
+| MALCORE_INTERVAL | `integer` |  | integer |  | `12` | Interval between two executions, in hours (must be > 1) |
+| MALCORE_SCORE | `integer` |  | integer | ⛔️ | `100` | Parameter not used at this moment, but could be used as a default indicator/observable score at a later date |
+| MALCORE_LIMIT | `integer` |  | integer | ⛔️ | `10000` | Parameter not used at this moment, but could be used as a limit on the number of entities to be retrieved per request at a later date |

--- a/external-import/malcore/__metadata__/connector_config_schema.json
+++ b/external-import/malcore/__metadata__/connector_config_schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/malcore_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Malcore",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT1H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "MALCORE_API_URL": {
+      "default": "https://api.malcore.io/api/feed",
+      "description": "Malcore API URL",
+      "type": "string"
+    },
+    "MALCORE_API_KEY": {
+      "description": "Malcore API Key",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "MALCORE_SCORE": {
+      "default": 100,
+      "deprecated": true,
+      "description": "Parameter not used at this moment, but could be used as a default indicator/observable score at a later date",
+      "type": "integer"
+    },
+    "MALCORE_LIMIT": {
+      "default": 10000,
+      "deprecated": true,
+      "description": "Parameter not used at this moment, but could be used as a limit on the number of entities to be retrieved per request at a later date",
+      "type": "integer"
+    },
+    "MALCORE_INTERVAL": {
+      "default": 12,
+      "description": "Interval between two executions, in hours (must be > 1)",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "MALCORE_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/malcore/__metadata__/connector_config_schema.json
+++ b/external-import/malcore/__metadata__/connector_config_schema.json
@@ -45,7 +45,7 @@
       "type": "string"
     },
     "CONNECTOR_DURATION_PERIOD": {
-      "default": "PT1H",
+      "default": "PT12H",
       "description": "The period of time to await between two runs of the connector.",
       "format": "duration",
       "type": "string"
@@ -74,9 +74,10 @@
       "type": "integer"
     },
     "MALCORE_INTERVAL": {
-      "default": 12,
-      "description": "Interval between two executions, in hours (must be > 1)",
-      "type": "integer"
+      "default": null,
+      "deprecated": true,
+      "type": "integer",
+      "description": "Use CONNECTOR_DURATION_PERIOD instead."
     }
   },
   "required": [

--- a/external-import/malcore/__metadata__/connector_manifest.json
+++ b/external-import/malcore/__metadata__/connector_manifest.json
@@ -18,7 +18,7 @@
   "support_version": ">=6.8.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/malcore",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-malcore",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/malcore/docker-compose.yml
+++ b/external-import/malcore/docker-compose.yml
@@ -9,9 +9,9 @@ services:
       - CONNECTOR_NAME=Malcore
       - CONNECTOR_SCOPE=malcore
       - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_DURATION_PERIOD=PT12H # ISO 8601 duration (12 hours)
       - MALCORE_API_URL=https://api.malcore.io
       - MALCORE_API_KEY=ChangeMe
       - MALCORE_SCORE=100
       - MALCORE_LIMIT=10000
-      - MALCORE_INTERVAL=12 #Hours
     restart: always

--- a/external-import/malcore/entrypoint.sh
+++ b/external-import/malcore/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Correct working directory
-cd /opt/opencti-malcore
-
-# Start the connector
-python3 main.py

--- a/external-import/malcore/src/config.yml.sample
+++ b/external-import/malcore/src/config.yml.sample
@@ -8,10 +8,10 @@ connector:
   name: 'Malcore'
   scope: 'malcore' # MIME type or SCO
   log_level: 'info'
+  duration_period: 'PT12H' # ISO 8601 duration (12 hours)
 
 malcore:
   api_url: 'https://api.malcore.io/api/feed'
   api_key: 'ChangeMe'
   score: 100
   limit: 10000
-  interval: 12 # In hours, must be strictly greater than 1

--- a/external-import/malcore/src/main.py
+++ b/external-import/malcore/src/main.py
@@ -1,12 +1,24 @@
-import sys
 import traceback
 
-from malcore import Malcore
+from malcore import ConnectorSettings, Malcore
+from pycti import OpenCTIConnectorHelper
 
 if __name__ == "__main__":
+    """
+    Entry point of the script
+
+    - traceback.print_exc(): This function prints the traceback of the exception to the standard error (stderr).
+    The traceback includes information about the point in the program where the exception occurred,
+    which is very useful for debugging purposes.
+    - exit(1): effective way to terminate a Python program when an error is encountered.
+    It signals to the operating system and any calling processes that the program did not complete successfully.
+    """
     try:
-        connector = Malcore()
+        settings = ConnectorSettings()
+        helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+        connector = Malcore(config=settings, helper=helper)
         connector.run()
     except Exception:
         traceback.print_exc()
-        sys.exit(1)
+        exit(1)

--- a/external-import/malcore/src/malcore/__init__.py
+++ b/external-import/malcore/src/malcore/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
 """OpenCTI Malcore connector module."""
 
-from malcore.core import Malcore
+from malcore.connector import Malcore
+from malcore.settings import ConnectorSettings
 
-__all__ = ["Malcore"]
+__all__ = ["Malcore", "ConnectorSettings"]

--- a/external-import/malcore/src/malcore/connector.py
+++ b/external-import/malcore/src/malcore/connector.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 """OpenCTI Malcore connector core module."""
 
 import json
-import os
 import ssl
 import sys
 import time
@@ -11,55 +9,38 @@ from datetime import datetime, timezone
 from urllib import parse
 
 import stix2
-import yaml
+from malcore.settings import ConnectorSettings
 from pycti import (
     Identity,
     Indicator,
     Malware,
     OpenCTIConnectorHelper,
     StixCoreRelationship,
-    get_config_variable,
 )
 
 
 class Malcore:
-    def __init__(self):
-        # Instantiate the connector helper from config
-        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/../config.yml"
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
-        self.helper = OpenCTIConnectorHelper(config)
-        self.api_url = get_config_variable(
-            "MALCORE_URL", ["malcore", "api_url"], config
-        )
-        self.api_key = get_config_variable(
-            "MALCORE_API_KEY", ["malcore", "api_key"], config
-        )
-        self.score = get_config_variable(
-            "MALCORE_SCORE", ["malcore", "score"], config, True
-        )
-        self.limit = get_config_variable(
-            "MALCORE_LIMIT", ["malcore", "limit"], config, True
-        )
-        self.interval = get_config_variable(
-            "MALCORE_INTERVAL",
-            ["malcore", "interval"],
-            config,
-            True,
-        )
-        self.update_existing_data = get_config_variable(
-            "CONNECTOR_UPDATE_EXISTING_DATA",
-            ["connector", "update_existing_data"],
-            config,
-        )
+
+    def __init__(self, config: ConnectorSettings, helper: OpenCTIConnectorHelper):
+        # Connector SDK settings + helper (injected from main.py.tmp / tests)
+        self.config = config
+        self.helper = helper
+
+        # Malcore-specific configuration
+        self.api_url = self.config.malcore.api_url
+        self.api_key = self.config.malcore.api_key.get_secret_value()
+        self.score = self.config.malcore.score
+        self.limit = self.config.malcore.limit
+        self.interval = self.config.malcore.interval
+
+        # In previous implementation it was pulled from CONNECTOR_UPDATE_EXISTING_DATA; per instructions keep it fixed.
+        self.update_existing_data = False
+
+        # Create identity in OpenCTI (executed at runtime; tests mock helper internals)
         self.identity = self.helper.api.identity.create(
             type="Organization",
             name="Malcore",
-            description="Malcore is a tool designed to simplify reverse engineering and malware analysis through "
-            "simple file analysis.",
+            description="Malcore is a tool designed to simplify reverse engineering and malware analysis through simple file analysis.",
         )
 
     def get_interval(self):
@@ -74,43 +55,27 @@ class Malcore:
             work_id = self.helper.api.work.initiate_work(
                 self.helper.connect_id, friendly_name
             )
-
             feed_type = "ioc"
             req = urllib.request.Request(self.api_url)
             req.add_header("apikey", self.api_key)
             req.add_header("Accept", "application/json")
             req.add_header("User-Agent", "Malcore/OpenCTI")
             req.method = "POST"
-            body = parse.urlencode(
-                {
-                    "feed_type": feed_type,
-                }
-            ).encode()
-
+            body = parse.urlencode({"feed_type": feed_type}).encode()
             response = urllib.request.urlopen(
-                req,
-                context=ssl.create_default_context(),
-                data=body,
+                req, context=ssl.create_default_context(), data=body
             )
             feed = response.read()
             data_json = json.loads(feed)
-
             malcore_org_id = Identity.generate_id("Malcore", "organization")
             identity = stix2.Identity(
-                id=malcore_org_id,
-                name="Malcore",
-                identity_class="organization",
+                id=malcore_org_id, name="Malcore", identity_class="organization"
             )
-
-            # preparing the bundle to be sent to OpenCTI worker
             bundle_objects = []
             file_objects = []
-
-            # Filling the bundle
             for item in data_json["data"]["data"]:
                 key = next(iter(item))
                 item_data = item[key]
-
                 if "file_exif_data" in item_data:
                     hashes = item_data["hashes"]
                     upload_time = item_data["upload_time"]
@@ -121,10 +86,7 @@ class Malcore:
                     mime_type = file_exif_data["mime_type"]
                     file_size = item_data["file_sizes"]["raw_byte_size"]
                     hashmd5 = hashes["md5"]
-
-                    custom_properties = {
-                        "created_by_ref": malcore_org_id,
-                    }
+                    custom_properties = {"created_by_ref": malcore_org_id}
                     stix_file = stix2.File(
                         name=upload_time + file_extension,
                         hashes={
@@ -137,25 +99,17 @@ class Malcore:
                         custom_properties=custom_properties,
                     )
                     file_objects.append(stix_file)
-
             bundle_objects.append(identity)
             bundle_objects.extend(file_objects)
-            # Creating the bundle from the list
             bundle = stix2.Bundle(objects=bundle_objects, allow_custom=True)
             bundle_json = bundle.serialize()
-
-            # Sending the bundle
             self.helper.send_stix2_bundle(
-                bundle_json,
-                update=self.update_existing_data,
-                work_id=work_id,
+                bundle_json, update=self.update_existing_data, work_id=work_id
             )
-
             message = "IOC successfully run, storing last_run as " + str(timestamp)
             self.helper.log_info(message)
             self.helper.set_state({"last_run": timestamp})
             self.helper.api.work.to_processed(work_id, message)
-
         except Exception as e:
             self.helper.log_error("IOC::" + str(e))
 
@@ -168,37 +122,23 @@ class Malcore:
             work_id = self.helper.api.work.initiate_work(
                 self.helper.connect_id, friendly_name
             )
-
             feed_type = "threat"
             req = urllib.request.Request(self.api_url)
             req.add_header("apikey", self.api_key)
             req.add_header("Accept", "application/json")
             req.add_header("User-Agent", "Malcore/OpenCTI")
             req.method = "POST"
-            body = parse.urlencode(
-                {
-                    "feed_type": feed_type,
-                }
-            ).encode()
-
+            body = parse.urlencode({"feed_type": feed_type}).encode()
             response = urllib.request.urlopen(
-                req,
-                context=ssl.create_default_context(),
-                data=body,
+                req, context=ssl.create_default_context(), data=body
             )
             feed = response.read()
             data_json = json.loads(feed)
-
             malcore_org_id = Identity.generate_id("Malcore", "organization")
             identity = stix2.Identity(
-                id=malcore_org_id,
-                name="Malcore",
-                identity_class="organization",
+                id=malcore_org_id, name="Malcore", identity_class="organization"
             )
-
-            # preparing the bundle to be sent to OpenCTI worker
             bundle_objects = []
-
             external_reference = stix2.ExternalReference(
                 source_name="Malcore database",
                 url="https://app.malcore.io/",
@@ -208,13 +148,10 @@ class Malcore:
             malware_objects = []
             relationships = []
             labels = ["threat"]
-
-            # Filling the bundle
             for item in data_json["data"]["data"]:
                 hash_value = item["hash"]
                 score = item["score"]
                 pattern = "[file:hashes.'SHA-256' = '" + hash_value + "']"
-
                 stix_indicator = stix2.Indicator(
                     id=Indicator.generate_id(pattern),
                     name="Indicator: {}".format(hash_value),
@@ -225,12 +162,9 @@ class Malcore:
                     created_by_ref=malcore_org_id,
                     external_references=[external_reference],
                     object_marking_refs=[stix2.TLP_WHITE],
-                    custom_properties={
-                        "x_opencti_main_observable_type": "StixFile",
-                    },
+                    custom_properties={"x_opencti_main_observable_type": "StixFile"},
                 )
                 indicators.append(stix_indicator)
-
                 stix_malware = stix2.Malware(
                     id=Malware.generate_id(hash_value),
                     name="Malware: {}".format(hash_value),
@@ -241,7 +175,6 @@ class Malcore:
                     object_marking_refs=[stix2.TLP_WHITE],
                 )
                 malware_objects.append(stix_malware)
-
                 relationship = stix2.Relationship(
                     id=StixCoreRelationship.generate_id(
                         "indicates", stix_indicator.id, stix_malware.id
@@ -253,28 +186,19 @@ class Malcore:
                     created_by_ref=malcore_org_id,
                 )
                 relationships.append(relationship)
-
             bundle_objects.append(identity)
             bundle_objects.extend(indicators)
             bundle_objects.extend(malware_objects)
             bundle_objects.extend(relationships)
-
-            # Creating the bundle from the list
             bundle = stix2.Bundle(objects=bundle_objects, allow_custom=True)
             bundle_json = bundle.serialize()
-
-            # Sending the bundle
             self.helper.send_stix2_bundle(
-                bundle_json,
-                update=self.update_existing_data,
-                work_id=work_id,
+                bundle_json, update=self.update_existing_data, work_id=work_id
             )
-
             message = "Threat successfully run, storing last_run as " + str(timestamp)
             self.helper.log_info(message)
             self.helper.set_state({"last_run": timestamp})
             self.helper.api.work.to_processed(work_id, message)
-
         except Exception as e:
             self.helper.log_error("THREAT::" + str(e))
 
@@ -287,49 +211,32 @@ class Malcore:
             work_id = self.helper.api.work.initiate_work(
                 self.helper.connect_id, friendly_name
             )
-
             feed_type = "hash"
             req = urllib.request.Request(self.api_url)
             req.add_header("apikey", self.api_key)
             req.add_header("Accept", "application/json")
             req.add_header("User-Agent", "Malcore/OpenCTI")
             req.method = "POST"
-            body = parse.urlencode(
-                {
-                    "feed_type": feed_type,
-                }
-            ).encode()
-
+            body = parse.urlencode({"feed_type": feed_type}).encode()
             response = urllib.request.urlopen(
-                req,
-                context=ssl.create_default_context(),
-                data=body,
+                req, context=ssl.create_default_context(), data=body
             )
             feed = response.read()
             data_json = json.loads(feed)
-
-            # Preparing the bundle to be sent to OpenCTI worker
             bundle_objects = []
-
             malcore_org_id = Identity.generate_id("Malcore", "organization")
             identity = stix2.Identity(
-                id=malcore_org_id,
-                name="Malcore",
-                identity_class="organization",
+                id=malcore_org_id, name="Malcore", identity_class="organization"
             )
-
             external_reference = stix2.ExternalReference(
                 source_name="Malcore database",
                 url="https://app.malcore.io/",
                 description="Malcore app URL",
             )
             indicators = []
-
-            # Filling the bundle
             for item in data_json["data"]["data"]:
                 hash_value = item["hash"]
                 pattern = "[file:hashes.'SHA-256' = '" + hash_value + "']"
-
                 stix_indicator = stix2.Indicator(
                     id=Indicator.generate_id(hash_value),
                     pattern_type="stix",
@@ -337,37 +244,26 @@ class Malcore:
                     created_by_ref=malcore_org_id,
                     external_references=[external_reference],
                     object_marking_refs=[stix2.TLP_WHITE],
-                    custom_properties={
-                        "x_opencti_main_observable_type": "StixFile",
-                    },
+                    custom_properties={"x_opencti_main_observable_type": "StixFile"},
                 )
                 indicators.append(stix_indicator)
-
             bundle_objects.append(identity)
             bundle_objects.extend(indicators)
-            # Creating the bundle from the list
             bundle = stix2.Bundle(objects=bundle_objects, allow_custom=True)
             bundle_json = bundle.serialize()
-
-            # Sending the bundle
             self.helper.send_stix2_bundle(
-                bundle_json,
-                update=self.update_existing_data,
-                work_id=work_id,
+                bundle_json, update=self.update_existing_data, work_id=work_id
             )
-
             message = "Hash successfully run, storing last_run as " + str(timestamp)
             self.helper.log_info(message)
             self.helper.set_state({"last_run": timestamp})
             self.helper.api.work.to_processed(work_id, message)
-
         except Exception as e:
             self.helper.log_error("HASH::" + str(e))
 
     def run(self):
         while True:
             try:
-                # Get the current timestamp and check
                 timestamp = int(time.time())
                 current_state = self.helper.get_state()
                 if current_state is not None and "last_run" in current_state:
@@ -381,24 +277,14 @@ class Malcore:
                 else:
                     last_run = None
                     self.helper.log_info("Connector has never run")
-
-                # If the last_run is more than interval hour
-                if last_run is None or (
-                    (timestamp - last_run) > (int(self.interval) * 60 * 60)
+                if (
+                    last_run is None
+                    or timestamp - last_run > int(self.interval) * 60 * 60
                 ):
-                    # Initiate the run
                     self.helper.log_info("Connector will run!")
-
-                    # Run for feed type ioc
                     self.run_feed_ioc(timestamp)
-
-                    # Run for feed type threat
                     self.run_feed_threat(timestamp)
-
-                    # Run for feed type hash
                     self.run_feed_hash(timestamp)
-
-                    # Store the current timestamp as a last run
                     self.helper.log_info(
                         "Last_run stored, next run in: "
                         + str(round(self.get_interval() / 60 / 60, 2))
@@ -406,7 +292,6 @@ class Malcore:
                     )
                     time.sleep(self.get_interval())
                 else:
-                    # wait for next run
                     new_interval = self.get_interval() - (timestamp - last_run)
                     self.helper.log_info(
                         "Connector will not run, next run in: "

--- a/external-import/malcore/src/malcore/connector.py
+++ b/external-import/malcore/src/malcore/connector.py
@@ -31,7 +31,6 @@ class Malcore:
         self.api_key = self.config.malcore.api_key.get_secret_value()
         self.score = self.config.malcore.score
         self.limit = self.config.malcore.limit
-        self.interval = self.config.malcore.interval
 
         # In previous implementation it was pulled from CONNECTOR_UPDATE_EXISTING_DATA; per instructions keep it fixed.
         self.update_existing_data = False
@@ -44,7 +43,7 @@ class Malcore:
         )
 
     def get_interval(self):
-        return int(self.interval) * 60 * 60
+        return int(self.config.connector.duration_period.total_seconds())
 
     def run_feed_ioc(self, timestamp):
         try:
@@ -277,10 +276,7 @@ class Malcore:
                 else:
                     last_run = None
                     self.helper.log_info("Connector has never run")
-                if (
-                    last_run is None
-                    or timestamp - last_run > int(self.interval) * 60 * 60
-                ):
+                if last_run is None or timestamp - last_run > self.get_interval():
                     self.helper.log_info("Connector will run!")
                     self.run_feed_ioc(timestamp)
                     self.run_feed_threat(timestamp)

--- a/external-import/malcore/src/malcore/settings.py
+++ b/external-import/malcore/src/malcore/settings.py
@@ -1,0 +1,72 @@
+from datetime import timedelta
+
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseExternalImportConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field, SecretStr
+
+
+class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
+    """
+    Override the `BaseExternalImportConnectorConfig` to add parameters and/or defaults
+    to the configuration for connectors of type `EXTERNAL_IMPORT`.
+    """
+
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="158ee4df-f9b5-47ea-955f-d2b83e8e5659",
+    )
+    name: str = Field(
+        description="The name of the connector.",
+        default="Malcore",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+        default=[],
+    )
+    duration_period: timedelta = Field(
+        description="The period of time to await between two runs of the connector.",
+        default=timedelta(hours=1),
+    )
+
+
+class MalcoreConfig(BaseConfigModel):
+    """
+    Define parameters and/or defaults for the configuration specific to the `MalcoreConnector`.
+    """
+
+    api_url: str = Field(
+        description="Malcore API URL",
+        default="https://api.malcore.io/api/feed",
+    )
+    api_key: SecretStr = Field(
+        description="Malcore API Key",
+    )
+    score: int = Field(
+        description="Parameter not used at this moment, but could be used as a default indicator/observable score at a later date",
+        default=100,
+        deprecated=True,
+    )
+    limit: int = Field(
+        description="Parameter not used at this moment, but could be used as a limit on the number of entities to be retrieved per request at a later date",
+        default=10000,
+        deprecated=True,
+    )
+    interval: int = Field(
+        description="Interval between two executions, in hours (must be > 1)",
+        default=12,
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """
+    Override `BaseConnectorSettings` to include `ExternalImportConnectorConfig` and `MalcoreConfig`.
+    """
+
+    connector: ExternalImportConnectorConfig = Field(
+        default_factory=ExternalImportConnectorConfig
+    )
+    malcore: MalcoreConfig = Field(default_factory=MalcoreConfig)

--- a/external-import/malcore/src/malcore/settings.py
+++ b/external-import/malcore/src/malcore/settings.py
@@ -4,6 +4,7 @@ from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
     BaseExternalImportConnectorConfig,
+    DeprecatedField,
     ListFromString,
 )
 from pydantic import Field, SecretStr
@@ -29,7 +30,7 @@ class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
     )
     duration_period: timedelta = Field(
         description="The period of time to await between two runs of the connector.",
-        default=timedelta(hours=1),
+        default=timedelta(hours=12),
     )
 
 
@@ -55,9 +56,12 @@ class MalcoreConfig(BaseConfigModel):
         default=10000,
         deprecated=True,
     )
-    interval: int = Field(
-        description="Interval between two executions, in hours (must be > 1)",
-        default=12,
+    interval: int | None = DeprecatedField(
+        default=None,
+        deprecated="Use 'CONNECTOR_DURATION_PERIOD' in the 'connector' section instead.",
+        new_namespace="connector",
+        new_namespaced_var="duration_period",
+        new_value_factory=lambda x: timedelta(hours=int(x)),
     )
 
 

--- a/external-import/malcore/src/requirements.txt
+++ b/external-import/malcore/src/requirements.txt
@@ -1,2 +1,4 @@
 pycti==7.260715.0
 urllib3==2.7.0
+pydantic >=2.8.2, <3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/malcore/src/requirements.txt
+++ b/external-import/malcore/src/requirements.txt
@@ -1,4 +1,3 @@
 pycti==7.260715.0
-urllib3==2.7.0
 pydantic >=2.8.2, <3
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/malcore/tests/conftest.py
+++ b/external-import/malcore/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/external-import/malcore/tests/test-requirements.txt
+++ b/external-import/malcore/tests/test-requirements.txt
@@ -1,0 +1,2 @@
+-r ../src/requirements.txt
+pytest==8.4.2

--- a/external-import/malcore/tests/test_main.py
+++ b/external-import/malcore/tests/test_main.py
@@ -1,0 +1,97 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from malcore import ConnectorSettings, Malcore
+from pycti import OpenCTIConnectorHelper
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+    It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "malcore": {
+                    "api_key": "ChangeMe",
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that the implementation of `BaseConnectorSettings` (from `connectors-sdk`) can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from `BaseConnectorSettings`)
+        - the method `to_helper_config` MUST return a dict (as in base class)
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that `OpenCTIConnectorHelper` (from `pycti`) can be instantiated successfully:
+        - the value of `settings.to_helper_config` MUST be the expected dict for `OpenCTIConnectorHelper`
+        - the helper MUST be able to get its instance's attributes from the config dict
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "Test Connector"
+    assert helper.connect_scope == "test,connector"
+    assert helper.log_level == "ERROR"
+    assert helper.connect_duration_period == "PT5M"
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST be able to access env/config vars through `self.config`
+        - the connector's main class MUST be able to access `pycti` API through `self.helper`
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    connector = Malcore(config=settings, helper=helper)
+
+    assert connector.config == settings
+    assert connector.helper == helper

--- a/external-import/malcore/tests/tests_connector/test_settings.py
+++ b/external-import/malcore/tests/tests_connector/test_settings.py
@@ -1,0 +1,137 @@
+from typing import Any
+
+import pytest
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+from malcore import ConnectorSettings
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "malcore": {
+                    "api_url": "https://api.malcore.io/api/feed",
+                    "api_key": "ChangeMe",
+                    "score": 100,
+                    "limit": 10000,
+                    "interval": 12,
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {},
+                "malcore": {
+                    "api_key": "ChangeMe",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) accepts valid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake but valid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.malcore, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param({}, "settings", id="empty_settings_dict"),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080"},
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "malcore": {
+                    "api_url": "https://api.malcore.io/api/feed",
+                    "api_key": "ChangeMe",
+                    "score": 100,
+                    "limit": 10000,
+                    "interval": 12,
+                },
+            },
+            "opencti.token",
+            id="missing_opencti_token",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": 123456,
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "malcore": {
+                    "api_url": "https://api.malcore.io/api/feed",
+                    "api_key": "ChangeMe",
+                    "score": 100,
+                    "limit": 10000,
+                    "interval": 12,
+                },
+            },
+            "connector.id",
+            id="invalid_connector_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) raises on invalid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake and invalid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert str("Error validating configuration") in str(err)


### PR DESCRIPTION
### Proposed changes

* Migrate the Malcore connector to `manager_supported` mode using the official migration scripts, generating Pydantic-based `settings.py` and updated `connector.py`.
* Remove `entrypoint.sh` and use `CMD ["python3", "main.py"]` directly in the Dockerfile.
* Drop the unused `urllib3` dependency and regenerate `__metadata__/connector_config_schema.json` and `CONNECTOR_CONFIG_DOC.md`.

### Related issues

* Closes #6851

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Migration verified: full test suite passes (8/8), connector startup verified both locally and in Docker (podman), and deployment through XTM Composer has been tested and confirmed working.