### PR TITLE
feat(maltiverse): migrate connector to manager_supported mode (#6852)

### DIFF
--- a/external-import/maltiverse/Dockerfile
+++ b/external-import/maltiverse/Dockerfile
@@ -11,7 +11,6 @@ RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-de
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+WORKDIR /opt/maltiverse
+
+CMD ["python3", "main.py"]

--- a/external-import/maltiverse/README.md
+++ b/external-import/maltiverse/README.md
@@ -14,9 +14,6 @@ The Maltiverse connector imports threat intelligence data from the Maltiverse pl
   - [Installation](#installation)
     - [Requirements](#requirements)
   - [Configuration variables](#configuration-variables)
-    - [OpenCTI environment variables](#opencti-environment-variables)
-    - [Base connector environment variables](#base-connector-environment-variables)
-    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
   - [Deployment](#deployment)
     - [Docker Deployment](#docker-deployment)
     - [Manual Deployment](#manual-deployment)
@@ -41,34 +38,10 @@ This connector fetches STIX bundles from Maltiverse TAXII 2.1 collections and im
 
 ## Configuration variables
 
-There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or in `config.yml` (for manual deployment).
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-### OpenCTI environment variables
-
-| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
-|---------------|------------|-----------------------------|-----------|------------------------------------------------------|
-| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
-| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
-
-### Base connector environment variables
-
-| Parameter        | config.yml | Docker environment variable | Default    | Mandatory | Description                                                              |
-|------------------|------------|-----------------------------|------------|-----------|--------------------------------------------------------------------------|
-| Connector ID     | id         | `CONNECTOR_ID`              |            | Yes       | A unique `UUIDv4` identifier for this connector instance.                |
-| Connector Name   | name       | `CONNECTOR_NAME`            | MALTIVERSE | Yes       | Name of the connector.                                                   |
-| Connector Scope  | scope      | `CONNECTOR_SCOPE`           |            | Yes       | The scope or type of data the connector is importing (see below).        |
-| Log Level        | log_level  | `CONNECTOR_LOG_LEVEL`       | info       | No        | Determines the verbosity of logs: `debug`, `info`, `warn`, or `error`.   |
-
-**Recommended Scope**: `ipv4-addr,ipv6-addr,vulnerability,domain,url,file-sha256,file-md5,file-sha1`
-
-### Connector extra parameters environment variables
-
-| Parameter     | config.yml           | Docker environment variable   | Default | Mandatory | Description                                                    |
-|---------------|----------------------|-------------------------------|---------|-----------|----------------------------------------------------------------|
-| User          | maltiverse.user      | `MALTIVERSE_USER`             |         | Yes       | Maltiverse account username/email.                             |
-| Password      | maltiverse.passwd    | `MALTIVERSE_PASSWD`           |         | Yes       | Maltiverse account password.                                   |
-| Feeds         | maltiverse.feeds     | `MALTIVERSE_FEEDS`            |         | Yes       | Comma-separated list of feed/collection IDs to fetch.          |
-| Poll Interval | maltiverse.poll_interval | `MALTIVERSE_POLL_INTERVAL`|         | Yes       | Polling interval in hours between connector runs.              |
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
 ## Deployment
 
@@ -95,7 +68,7 @@ Configure the connector in `docker-compose.yml`:
       - MALTIVERSE_USER=your@email.com
       - MALTIVERSE_PASSWD=ChangeMe
       - MALTIVERSE_FEEDS=VdhZV34B4jHUXfKt_gDi,another_feed_id
-      - MALTIVERSE_POLL_INTERVAL=4
+      - CONNECTOR_DURATION_PERIOD=PT4H
     restart: always
 ```
 
@@ -123,7 +96,7 @@ python3 main.py
 
 ## Usage
 
-The connector runs automatically at the interval defined by `MALTIVERSE_POLL_INTERVAL`. To force an immediate run:
+The connector runs automatically at the interval defined by `CONNECTOR_DURATION_PERIOD`. To force an immediate run:
 
 **Data Management → Ingestion → Connectors**
 

--- a/external-import/maltiverse/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/maltiverse/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,19 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Deprecated | Default | Description |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| MALTIVERSE_USER | `string` | ✅ | string |  |  | Maltiverse account username/email. |
+| MALTIVERSE_PASSWD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Maltiverse account password. |
+| MALTIVERSE_FEEDS | `string` | ✅ | string |  |  | Comma-separated list of feed/collection IDs to fetch. |
+| CONNECTOR_NAME | `string` |  | string |  | `"Maltiverse"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string |  | `[]` | The scope of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` |  | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` |  | `"EXTERNAL_IMPORT"` |  |
+| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | `"PT1H"` | The period of time to await between two runs of the connector. |
+| MALTIVERSE_POLL_INTERVAL | `integer` |  | integer | ⛔️ | `null` | Use CONNECTOR_DURATION_PERIOD instead. |

--- a/external-import/maltiverse/__metadata__/connector_config_schema.json
+++ b/external-import/maltiverse/__metadata__/connector_config_schema.json
@@ -56,7 +56,9 @@
     },
     "MALTIVERSE_PASSWD": {
       "description": "Maltiverse account password.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "MALTIVERSE_FEEDS": {
       "description": "Comma-separated list of feed/collection IDs to fetch.",

--- a/external-import/maltiverse/__metadata__/connector_config_schema.json
+++ b/external-import/maltiverse/__metadata__/connector_config_schema.json
@@ -65,8 +65,10 @@
       "type": "string"
     },
     "MALTIVERSE_POLL_INTERVAL": {
-      "description": "Polling interval in hours between connector runs.",
-      "type": "integer"
+      "default": null,
+      "deprecated": true,
+      "type": "integer",
+      "description": "Use CONNECTOR_DURATION_PERIOD instead."
     }
   },
   "required": [
@@ -74,8 +76,7 @@
     "OPENCTI_TOKEN",
     "MALTIVERSE_USER",
     "MALTIVERSE_PASSWD",
-    "MALTIVERSE_FEEDS",
-    "MALTIVERSE_POLL_INTERVAL"
+    "MALTIVERSE_FEEDS"
   ],
   "additionalProperties": true
 }

--- a/external-import/maltiverse/__metadata__/connector_config_schema.json
+++ b/external-import/maltiverse/__metadata__/connector_config_schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/maltiverse_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "type": "string"
+    },
+    "CONNECTOR_NAME": {
+      "default": "Maltiverse",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "PT1H",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
+    "MALTIVERSE_USER": {
+      "description": "Maltiverse account username/email.",
+      "type": "string"
+    },
+    "MALTIVERSE_PASSWD": {
+      "description": "Maltiverse account password.",
+      "type": "string"
+    },
+    "MALTIVERSE_FEEDS": {
+      "description": "Comma-separated list of feed/collection IDs to fetch.",
+      "type": "string"
+    },
+    "MALTIVERSE_POLL_INTERVAL": {
+      "description": "Polling interval in hours between connector runs.",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "MALTIVERSE_USER",
+    "MALTIVERSE_PASSWD",
+    "MALTIVERSE_FEEDS",
+    "MALTIVERSE_POLL_INTERVAL"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/maltiverse/__metadata__/connector_manifest.json
+++ b/external-import/maltiverse/__metadata__/connector_manifest.json
@@ -19,7 +19,7 @@
   "support_version": ">=5.5.4",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/maltiverse",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-maltiverse",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/maltiverse/docker-compose.yml
+++ b/external-import/maltiverse/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       - CONNECTOR_NAME=MALTIVERSE
       - CONNECTOR_SCOPE=ipv4-addr,ipv6-addr,vulnerability,domain,url,file-sha256,file-md5,file-sha1 # MIME type or Stix Object
       - CONNECTOR_LOG_LEVEL=error
+      - CONNECTOR_DURATION_PERIOD=PT4H # ISO 8601 duration (4 hours)
       - MALTIVERSE_USER=change@me.com # Username from Maltiverse
       - MALTIVERSE_PASSWD=ChAnGeMe! # PAssword for the user provided
       - MALTIVERSE_FEEDS=VdhZV34B4jHUXfKt_gDi # Your feeds selection between commas
-      - MALTIVERSE_POLL_INTERVAL=4 # in hours!
     restart: always

--- a/external-import/maltiverse/entrypoint.sh
+++ b/external-import/maltiverse/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Correct working directory
-cd /opt/maltiverse
-
-# Start the connector
-python3 main.py

--- a/external-import/maltiverse/src/config.yml.sample
+++ b/external-import/maltiverse/src/config.yml.sample
@@ -9,9 +9,9 @@ connector:
   scope: 'ipv4-addr,ipv6-addr,vulnerability,domain,url,file-sha256,file-md5,file-sha1' # MIME type or SCO
   confidence_level: 80 # From 0 (Unknown) to 100 (Fully trusted)
   log_level: 'info'
+  duration_period: 'PT4H' # ISO 8601 duration (4 hours)
 
 maltiverse:
   user: MAIL
   passwd: ChangeMe
   feeds: "VdhZV34B4jHUXfKt_gDi"
-  poll_interval: 4

--- a/external-import/maltiverse/src/connector/__init__.py
+++ b/external-import/maltiverse/src/connector/__init__.py
@@ -1,0 +1,7 @@
+from connector.connector import MaltiverseConnector
+from connector.settings import ConnectorSettings
+
+__all__ = [
+    "MaltiverseConnector",
+    "ConnectorSettings",
+]

--- a/external-import/maltiverse/src/connector/connector.py
+++ b/external-import/maltiverse/src/connector/connector.py
@@ -13,14 +13,13 @@ class MaltiverseConnector:
         self.helper = helper
 
         # Keep existing runtime attributes for minimal changes in the rest of the class
-        self.interval = self.config.maltiverse.poll_interval
         self.user = self.config.maltiverse.user
         self.passwd = self.config.maltiverse.passwd
         feeds = self.config.maltiverse.feeds or ""
         self.feeds = [f.strip() for f in feeds.split(",") if f.strip()]
 
     def get_interval(self) -> int:
-        return int(self.interval) * 3600
+        return int(self.config.connector.duration_period.total_seconds())
 
     def run(self):
         self.helper.log_info("Fetching knowledge...")

--- a/external-import/maltiverse/src/connector/connector.py
+++ b/external-import/maltiverse/src/connector/connector.py
@@ -53,7 +53,7 @@ class MaltiverseConnector:
                     cli = taxiicli.Server(
                         "https://api.maltiverse.com/taxii2/",
                         user=self.user,
-                        password=self.passwd,
+                        password=self.passwd.get_secret_value(),
                     )
                     collections = [
                         col for col in cli.default.collections if col.id in self.feeds

--- a/external-import/maltiverse/src/connector/connector.py
+++ b/external-import/maltiverse/src/connector/connector.py
@@ -1,0 +1,91 @@
+import json
+import time
+from datetime import datetime, timezone
+
+import taxii2client.v21 as taxiicli
+from connector.settings import ConnectorSettings
+from pycti import OpenCTIConnectorHelper
+
+
+class MaltiverseConnector:
+    def __init__(self, config: ConnectorSettings, helper: OpenCTIConnectorHelper):
+        self.config = config
+        self.helper = helper
+
+        # Keep existing runtime attributes for minimal changes in the rest of the class
+        self.interval = self.config.maltiverse.poll_interval
+        self.user = self.config.maltiverse.user
+        self.passwd = self.config.maltiverse.passwd
+        feeds = self.config.maltiverse.feeds or ""
+        self.feeds = [f.strip() for f in feeds.split(",") if f.strip()]
+
+    def get_interval(self) -> int:
+        return int(self.interval) * 3600
+
+    def run(self):
+        self.helper.log_info("Fetching knowledge...")
+        while True:
+            try:
+                timestamp = int(time.time())
+                current_state = self.helper.get_state()
+                if current_state is not None and "last_run" in current_state:
+                    last_run = current_state["last_run"]
+                    self.helper.log_info(
+                        "Connector last run: "
+                        + datetime.fromtimestamp(last_run, tz=timezone.utc).strftime(
+                            "%Y-%m-%d %H:%M:%S"
+                        )
+                    )
+                else:
+                    last_run = None
+                    self.helper.log_info("Connector has never run")
+
+                if last_run is None or timestamp - last_run > self.get_interval():
+                    timestamp = int(time.time())
+                    now = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+                    friendly_name = "Connector run @ " + now.strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
+                    work_id = self.helper.api.work.initiate_work(
+                        self.helper.connect_id, friendly_name
+                    )
+
+                    cli = taxiicli.Server(
+                        "https://api.maltiverse.com/taxii2/",
+                        user=self.user,
+                        password=self.passwd,
+                    )
+                    collections = [
+                        col for col in cli.default.collections if col.id in self.feeds
+                    ]
+                    for col in collections:
+                        try:
+                            self.helper.send_stix2_bundle(
+                                json.dumps(col.get_objects()), work_id=work_id
+                            )
+                        except Exception as e:
+                            self.helper.log_error("error sending collection: " + str(e))
+
+                    self.helper.log_info(
+                        "Connector successfully run, storing last_run as "
+                        + str(timestamp)
+                    )
+                    self.helper.set_state({"last_run": timestamp})
+                    message = (
+                        "Last_run stored, next run in: "
+                        + str(round(self.get_interval() / 60 / 60 / 24, 2))
+                        + " days"
+                    )
+                    self.helper.api.work.to_processed(work_id, message)
+                    self.helper.log_info(message)
+                    time.sleep(60)
+                else:
+                    new_interval = self.get_interval() - (timestamp - last_run)
+                    self.helper.log_info(
+                        "Connector will not run, next run in: "
+                        + str(round(new_interval / 60 / 60 / 24, 2))
+                        + " days"
+                    )
+                    time.sleep(360)
+            except Exception as e:
+                self.helper.log_error(str(e))

--- a/external-import/maltiverse/src/connector/settings.py
+++ b/external-import/maltiverse/src/connector/settings.py
@@ -4,6 +4,7 @@ from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
     BaseExternalImportConnectorConfig,
+    DeprecatedField,
     ListFromString,
 )
 from pydantic import Field, SecretStr
@@ -43,8 +44,12 @@ class MaltiverseConfig(BaseConfigModel):
     feeds: str = Field(
         description="Comma-separated list of feed/collection IDs to fetch."
     )
-    poll_interval: int = Field(
-        description="Polling interval in hours between connector runs."
+    poll_interval: int | None = DeprecatedField(
+        default=None,
+        deprecated="Use 'CONNECTOR_DURATION_PERIOD' in the 'connector' section instead.",
+        new_namespace="connector",
+        new_namespaced_var="duration_period",
+        new_value_factory=lambda x: timedelta(hours=int(x)),
     )
 
 

--- a/external-import/maltiverse/src/connector/settings.py
+++ b/external-import/maltiverse/src/connector/settings.py
@@ -6,7 +6,7 @@ from connectors_sdk import (
     BaseExternalImportConnectorConfig,
     ListFromString,
 )
-from pydantic import Field
+from pydantic import Field, SecretStr
 
 
 class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
@@ -39,7 +39,7 @@ class MaltiverseConfig(BaseConfigModel):
     """
 
     user: str = Field(description="Maltiverse account username/email.")
-    passwd: str = Field(description="Maltiverse account password.")
+    passwd: SecretStr = Field(description="Maltiverse account password.")
     feeds: str = Field(
         description="Comma-separated list of feed/collection IDs to fetch."
     )

--- a/external-import/maltiverse/src/connector/settings.py
+++ b/external-import/maltiverse/src/connector/settings.py
@@ -1,0 +1,59 @@
+from datetime import timedelta
+
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseExternalImportConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field
+
+
+class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
+    """
+    Override the `BaseExternalImportConnectorConfig` to add parameters and/or defaults
+    to the configuration for connectors of type `EXTERNAL_IMPORT`.
+    """
+
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="6c54218c-0098-4446-86a8-a6da32949c1e",
+    )
+    name: str = Field(
+        description="The name of the connector.",
+        default="Maltiverse",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+        default=[],
+    )
+    duration_period: timedelta = Field(
+        description="The period of time to await between two runs of the connector.",
+        default=timedelta(hours=1),
+    )
+
+
+class MaltiverseConfig(BaseConfigModel):
+    """
+    Define parameters and/or defaults for the configuration specific to the `MaltiverseConnector`.
+    """
+
+    user: str = Field(description="Maltiverse account username/email.")
+    passwd: str = Field(description="Maltiverse account password.")
+    feeds: str = Field(
+        description="Comma-separated list of feed/collection IDs to fetch."
+    )
+    poll_interval: int = Field(
+        description="Polling interval in hours between connector runs."
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """
+    Override `BaseConnectorSettings` to include `ExternalImportConnectorConfig` and `MaltiverseConfig`.
+    """
+
+    connector: ExternalImportConnectorConfig = Field(
+        default_factory=ExternalImportConnectorConfig
+    )
+    maltiverse: MaltiverseConfig = Field(default_factory=MaltiverseConfig)

--- a/external-import/maltiverse/src/main.py
+++ b/external-import/maltiverse/src/main.py
@@ -1,120 +1,24 @@
-import json
-import os
-import sys
-import time
-from datetime import datetime, timezone
+import traceback
 
-import taxii2client.v21 as taxiicli
-import yaml
-from pycti import OpenCTIConnectorHelper, get_config_variable
-
-
-class MaltiverseConnector:
-    def __init__(self):
-        # Instantiate the connector helper from config
-        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
-        self.helper = OpenCTIConnectorHelper(config)
-        self.interval = get_config_variable(
-            "MALTIVERSE_POLL_INTERVAL", ["maltiverse", "poll_interval"], config, True
-        )
-        self.user = get_config_variable(
-            "MALTIVERSE_USER", ["maltiverse", "user"], config, False
-        )
-        self.passwd = get_config_variable(
-            "MALTIVERSE_PASSWD", ["maltiverse", "passwd"], config, False
-        )
-        feeds = get_config_variable(
-            "MALTIVERSE_FEEDS", ["maltiverse", "feeds"], config, False
-        )
-        self.feeds = feeds.split(",")
-
-    def get_interval(self) -> int:
-        return int(self.interval) * 3600
-
-    def run(self):
-        self.helper.log_info("Fetching knowledge...")
-        while True:
-            try:
-                # Get the current timestamp and check
-                timestamp = int(time.time())
-                current_state = self.helper.get_state()
-                if current_state is not None and "last_run" in current_state:
-                    last_run = current_state["last_run"]
-                    self.helper.log_info(
-                        "Connector last run: "
-                        + datetime.fromtimestamp(last_run, tz=timezone.utc).strftime(
-                            "%Y-%m-%d %H:%M:%S"
-                        )
-                    )
-                else:
-                    last_run = None
-                    self.helper.log_info("Connector has never run")
-                # If the last_run is more than interval-1 day
-                if last_run is None or ((timestamp - last_run) > (self.get_interval())):
-                    timestamp = int(time.time())
-                    now = datetime.fromtimestamp(timestamp, tz=timezone.utc)
-                    friendly_name = "Connector run @ " + now.strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    )
-                    work_id = self.helper.api.work.initiate_work(
-                        self.helper.connect_id, friendly_name
-                    )
-
-                    cli = taxiicli.Server(
-                        "https://api.maltiverse.com/taxii2/",
-                        user=self.user,
-                        password=self.passwd,
-                    )
-
-                    collections = [
-                        col for col in cli.default.collections if col.id in self.feeds
-                    ]
-
-                    for col in collections:
-                        try:
-                            self.helper.send_stix2_bundle(
-                                json.dumps(col.get_objects()), work_id=work_id
-                            )
-                        except Exception as e:
-                            self.helper.log_error("error sending collection: " + str(e))
-
-                    # Store the current timestamp as a last run
-                    self.helper.log_info(
-                        "Connector successfully run, storing last_run as "
-                        + str(timestamp)
-                    )
-                    self.helper.set_state({"last_run": timestamp})
-                    message = (
-                        "Last_run stored, next run in: "
-                        + str(round(self.get_interval() / 60 / 60 / 24, 2))
-                        + " days"
-                    )
-                    self.helper.api.work.to_processed(work_id, message)
-                    self.helper.log_info(message)
-                    time.sleep(60)
-                else:
-                    new_interval = self.get_interval() - (timestamp - last_run)
-                    self.helper.log_info(
-                        "Connector will not run, next run in: "
-                        + str(round(new_interval / 60 / 60 / 24, 2))
-                        + " days"
-                    )
-                    time.sleep(360)
-            except Exception as e:
-                self.helper.log_error(str(e))
-
+from connector import ConnectorSettings, MaltiverseConnector
+from pycti import OpenCTIConnectorHelper
 
 if __name__ == "__main__":
+    """
+    Entry point of the script
+
+    - traceback.print_exc(): This function prints the traceback of the exception to the standard error (stderr).
+    The traceback includes information about the point in the program where the exception occurred,
+    which is very useful for debugging purposes.
+    - exit(1): effective way to terminate a Python program when an error is encountered.
+    It signals to the operating system and any calling processes that the program did not complete successfully.
+    """
     try:
-        connector = MaltiverseConnector()
+        settings = ConnectorSettings()
+        helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+        connector = MaltiverseConnector(config=settings, helper=helper)
         connector.run()
     except Exception:
-        import traceback
-
         traceback.print_exc()
-        sys.exit(1)
+        exit(1)

--- a/external-import/maltiverse/src/requirements.txt
+++ b/external-import/maltiverse/src/requirements.txt
@@ -1,2 +1,4 @@
 pycti==7.260715.0
 taxii2-client
+pydantic >=2.8.2, <3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/maltiverse/tests/conftest.py
+++ b/external-import/maltiverse/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/external-import/maltiverse/tests/test-requirements.txt
+++ b/external-import/maltiverse/tests/test-requirements.txt
@@ -1,0 +1,2 @@
+-r ../src/requirements.txt
+pytest==8.4.2

--- a/external-import/maltiverse/tests/test_main.py
+++ b/external-import/maltiverse/tests/test_main.py
@@ -1,0 +1,100 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from connector import ConnectorSettings, MaltiverseConnector
+from pycti import OpenCTIConnectorHelper
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+    It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "maltiverse": {
+                    "user": "change@me.com",
+                    "passwd": "ChAnGeMe!",
+                    "feeds": "VdhZV34B4jHUXfKt_gDi",
+                    "poll_interval": 4,
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that the implementation of `BaseConnectorSettings` (from `connectors-sdk`) can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from `BaseConnectorSettings`)
+        - the method `to_helper_config` MUST return a dict (as in base class)
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that `OpenCTIConnectorHelper` (from `pycti`) can be instantiated successfully:
+        - the value of `settings.to_helper_config` MUST be the expected dict for `OpenCTIConnectorHelper`
+        - the helper MUST be able to get its instance's attributes from the config dict
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "Test Connector"
+    assert helper.connect_scope == "test,connector"
+    assert helper.log_level == "ERROR"
+    assert helper.connect_duration_period == "PT5M"
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST be able to access env/config vars through `self.config`
+        - the connector's main class MUST be able to access `pycti` API through `self.helper`
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    connector = MaltiverseConnector(config=settings, helper=helper)
+
+    assert connector.config == settings
+    assert connector.helper == helper

--- a/external-import/maltiverse/tests/tests_connector/test_settings.py
+++ b/external-import/maltiverse/tests/tests_connector/test_settings.py
@@ -1,0 +1,137 @@
+from typing import Any
+
+import pytest
+from connector import ConnectorSettings
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "maltiverse": {
+                    "user": "change@me.com",
+                    "passwd": "ChAnGeMe!",
+                    "feeds": "VdhZV34B4jHUXfKt_gDi",
+                    "poll_interval": 4,
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {},
+                "maltiverse": {
+                    "user": "change@me.com",
+                    "passwd": "ChAnGeMe!",
+                    "feeds": "VdhZV34B4jHUXfKt_gDi",
+                    "poll_interval": 4,
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) accepts valid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake but valid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.maltiverse, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param({}, "settings", id="empty_settings_dict"),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080"},
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "maltiverse": {
+                    "user": "change@me.com",
+                    "passwd": "ChAnGeMe!",
+                    "feeds": "VdhZV34B4jHUXfKt_gDi",
+                    "poll_interval": 4,
+                },
+            },
+            "opencti.token",
+            id="missing_opencti_token",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": 123456,
+                    "name": "Test Connector",
+                    "scope": "test, connector",
+                    "log_level": "error",
+                    "duration_period": "PT5M",
+                },
+                "maltiverse": {
+                    "user": "change@me.com",
+                    "passwd": "ChAnGeMe!",
+                    "feeds": "VdhZV34B4jHUXfKt_gDi",
+                    "poll_interval": 4,
+                },
+            },
+            "connector.id",
+            id="invalid_connector_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) raises on invalid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake and invalid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert str("Error validating configuration") in str(err)


### PR DESCRIPTION
### Proposed changes

* Migrate the Maltiverse connector to `manager_supported` mode using the official migration scripts, generating Pydantic-based `settings.py` and updated `connector.py`.
* Mark `maltiverse.passwd` as a secret (`SecretStr`) and use `CMD ["python3", "main.py"]` directly in the Dockerfile instead of `entrypoint.sh`.
* Deprecate `maltiverse.poll_interval` in favor of `connector.duration_period` (via `DeprecatedField`), updating the connector's run loop, README, docker-compose.yml, and config.yml.sample accordingly.
* Regenerate `__metadata__/connector_config_schema.json` and `CONNECTOR_CONFIG_DOC.md`, and link them from the README instead of duplicating config tables.

### Related issues

* Closes #6852

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Migration verified: full test suite passes (8/8), connector startup verified both locally and in Docker (podman), and deployment through XTM Composer has been tested and confirmed working.