### PR TITLE
fix(taxii-post): empty token env var prevents basic auth fallback (#7070)

### DIFF
--- a/stream/taxii-post/src/taxii_post_connector/connector.py
+++ b/stream/taxii-post/src/taxii_post_connector/connector.py
@@ -98,7 +98,7 @@ class TaxiiPostConnector:
                 "id": "bundle--" + str(uuid.uuid4()),
                 "objects": [data_object],
             }
-            if self.config.token is not None:
+            if self.config.token is not None and self.config.token.get_secret_value():
                 self.helper.log_info("Posting to TAXII URL (using token): " + url)
                 self.helper.log_info(str(bundle))
                 headers["Authorization"] = (

--- a/stream/taxii-post/tests/test_connector.py
+++ b/stream/taxii-post/tests/test_connector.py
@@ -1,5 +1,11 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 import pytest
+from pydantic import SecretStr
 from taxii_post_connector.connector import (
+    TaxiiPostConnector,
     accept_header_by_taxii_version,
     content_type_by_stix_version,
 )
@@ -39,3 +45,90 @@ def test_content_type_by_stix_version(stix_version, expected_result):
     result = content_type_by_stix_version(stix_version)
     # Then the custom properties are correctly formatted
     assert result == expected_result
+
+
+# -----------------------------------------
+# --- Auth Selection in _process_message ---
+# -----------------------------------------
+
+STIX_OBJECT = {
+    "id": "indicator--fa42a846-8d90-4e51-bc29-71d5b4802168",
+    "type": "indicator",
+    "extensions": {},
+}
+
+
+def _make_stream_msg():
+    return SimpleNamespace(
+        data=json.dumps({"data": STIX_OBJECT.copy()}),
+    )
+
+
+def _make_taxii_config(**overrides):
+    """Build a minimal TaxiiConfig-like namespace for the connector."""
+    defaults = dict(
+        url="https://taxii.example.com",
+        ssl_verify=False,
+        api_root="root",
+        collection_id="col-1",
+        token=None,
+        login=SecretStr("user"),
+        password=SecretStr("pass"),
+        version="2.1",
+        stix_version="2.1",
+        delete_created_by_ref=True,
+        delete_marking_definition=True,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_connector(taxii_config):
+    """Build a TaxiiPostConnector with a mocked helper and the given taxii config."""
+    settings = MagicMock()
+    settings.taxii = taxii_config
+    helper = MagicMock()
+    return TaxiiPostConnector(settings, helper)
+
+
+@patch("taxii_post_connector.connector.requests.post")
+def test_empty_token_falls_back_to_basic_auth(mock_post):
+    """When token is an empty SecretStr, basic auth should be used."""
+    mock_post.return_value = MagicMock(status_code=200, content=b"ok")
+    connector = _make_connector(_make_taxii_config(token=SecretStr("")))
+
+    connector._process_message(_make_stream_msg())
+
+    mock_post.assert_called_once()
+    call_kwargs = mock_post.call_args
+    assert "auth" in call_kwargs.kwargs, "Expected basic auth, got token auth"
+    assert "Authorization" not in call_kwargs.kwargs.get("headers", {})
+
+
+@patch("taxii_post_connector.connector.requests.post")
+def test_none_token_uses_basic_auth(mock_post):
+    """When token is None, basic auth should be used."""
+    mock_post.return_value = MagicMock(status_code=200, content=b"ok")
+    connector = _make_connector(_make_taxii_config(token=None))
+
+    connector._process_message(_make_stream_msg())
+
+    mock_post.assert_called_once()
+    call_kwargs = mock_post.call_args
+    assert "auth" in call_kwargs.kwargs, "Expected basic auth, got token auth"
+    assert "Authorization" not in call_kwargs.kwargs.get("headers", {})
+
+
+@patch("taxii_post_connector.connector.requests.post")
+def test_valid_token_uses_bearer_auth(mock_post):
+    """When token has a real value, Bearer auth should be used."""
+    mock_post.return_value = MagicMock(status_code=200, content=b"ok")
+    connector = _make_connector(_make_taxii_config(token=SecretStr("my-secret-token")))
+
+    connector._process_message(_make_stream_msg())
+
+    mock_post.assert_called_once()
+    call_kwargs = mock_post.call_args
+    headers = call_kwargs.kwargs.get("headers", {})
+    assert headers.get("Authorization") == "Bearer my-secret-token"
+    assert "auth" not in call_kwargs.kwargs


### PR DESCRIPTION
### Proposed changes

* Check that `TAXII_TOKEN` value is non-empty before using Bearer auth, so an empty env var correctly falls back to basic auth (login/password)
* Add tests covering all three auth scenarios: empty token, None token, and valid token

### Related issues

* Fixes #7070

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Pydantic parses an empty `TAXII_TOKEN=""` env var into `SecretStr("")`, which passes `is not None`. The connector then sends an empty `Authorization: Bearer ` header and gets a 401 instead of falling back to basic auth. The fix adds `.get_secret_value()` as a truthiness check.