### PR TITLE
feat(whoisfreaks): add WhoisFreaks internal enrichment connector

### DIFF
--- a/internal-enrichment/whoisfreaks/Dockerfile
+++ b/internal-enrichment/whoisfreaks/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+# Set working directory inside container
+WORKDIR /opt/opencti-connector-whoisfreaks
+
+# Install system runtime dependencies needed by pycti and stix2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    libmagic1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python package dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source code and entrypoint
+COPY src ./src
+COPY entrypoint.sh .
+
+# Ensure entrypoint is executable
+RUN chmod +x entrypoint.sh
+
+# Run startup script
+ENTRYPOINT ["/bin/sh", "./entrypoint.sh"]

--- a/internal-enrichment/whoisfreaks/README.md
+++ b/internal-enrichment/whoisfreaks/README.md
@@ -1,0 +1,60 @@
+# OpenCTI WhoisFreaks Enrichment Connector
+
+An official internal enrichment connector for the **OpenCTI** (Open Cyber Threat Intelligence) platform powered by the **WhoisFreaks API**.
+
+This connector enables security analysts to enrich `Domain-Name`, `IPv4-Addr`, and `IPv6-Addr` observables on demand or via automated OpenCTI playbooks.
+
+---
+
+## Features
+
+- **WHOIS Registration Intelligence**: Fetches live WHOIS records and converts Registrars and Registrants into STIX 2.1 `Identity` SDOs linked via `registered-by` and `owned-by` relationships.
+- **DNS Record Mapping**: Parses live DNS responses (A, AAAA, MX, NS, CNAME, TXT) and maps resolutions into the OpenCTI graph using `resolves-to` and `related-to` relationships.
+- **Subdomain Discovery**: Maps parent-child domain hierarchies and populates subdomains as related `Domain-Name` observables.
+- **SSL/TLS Certificate Metadata**: Extracts X.509 certificate metadata and attaches `X509-Certificate` observables to target domains.
+- **IP Geolocation & Reverse DNS**: Translates IPv4/IPv6 observables into STIX `Location` SDOs (`located-at`) and maps reverse DNS domain associations.
+- **IP Reputation Context**: Evaluates threat scores and attaches contextual security notes to IP entities.
+
+---
+
+## Configuration Variables
+
+The connector is configured using environment variables (or `.env` / `config.yml`):
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `OPENCTI_URL` | Yes | - | Base URL of your OpenCTI platform instance (e.g. `http://opencti:4000`). |
+| `OPENCTI_TOKEN` | Yes | - | OpenCTI User / Admin API Token for authentication. |
+| `CONNECTOR_ID` | Yes | - | A unique UUIDv4 string generated specifically for this connector. |
+| `CONNECTOR_NAME` | No | `WhoisFreaks` | Display name of the connector inside the OpenCTI dashboard. |
+| `CONNECTOR_TYPE` | No | `INTERNAL_ENRICHMENT` | Connector operational category in OpenCTI. |
+| `CONNECTOR_SCOPE` | No | `Domain-Name,IPv4-Addr,IPv6-Addr` | Supported STIX 2.1 entity types. |
+| `CONNECTOR_AUTO` | No | `false` | Enable automatic enrichment on observable creation (`true`/`false`). |
+| `CONNECTOR_CONFIDENCE_LEVEL` | No | `100` | Confidence score (0-100) assigned to created STIX objects. |
+| `CONNECTOR_LOG_LEVEL` | No | `INFO` | Log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`). |
+| `WHOISFREAKS_API_KEY` | Yes | - | Your active WhoisFreaks API key. |
+
+---
+
+## Deployment via Docker Compose
+
+Add the service block below to your OpenCTI stack `docker-compose.yml`:
+
+```yaml
+  connector-whoisfreaks:
+    image: opencti-connector-whoisfreaks:latest
+    container_name: opencti-connector-whoisfreaks
+    environment:
+      - OPENCTI_URL=http://opencti:4000
+      - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
+      - CONNECTOR_ID=${CONNECTOR_KEY}
+      - CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+      - CONNECTOR_NAME=WhoisFreaks
+      - CONNECTOR_SCOPE=Domain-Name,IPv4-Addr,IPv6-Addr
+      - CONNECTOR_AUTO=false
+      - CONNECTOR_CONFIDENCE_LEVEL=100
+      - CONNECTOR_LOG_LEVEL=INFO
+      - WHOISFREAKS_API_KEY=${WHOISFREAKS_API_KEY}
+    depends_on:
+      - opencti
+    restart: always

--- a/internal-enrichment/whoisfreaks/docker-compose.yml
+++ b/internal-enrichment/whoisfreaks/docker-compose.yml
@@ -1,0 +1,87 @@
+version: "3"
+
+services:
+  redis:
+    image: redis:7.2-alpine
+    restart: always
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.2
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    restart: always
+
+  minio:
+    image: minio/minio:RELEASE.2024-02-17T01-15-57Z
+    command: server /data
+    environment:
+      - MINIO_ROOT_USER=opencti
+      - MINIO_ROOT_PASSWORD=opencti_minio_password
+    restart: always
+
+  rabbitmq:
+    image: rabbitmq:3.12-management-alpine
+    restart: always
+
+  opencti:
+    image: opencti/platform:6.0.5
+    environment:
+      - NODE_OPTIONS=--max-old-space-size=4096
+      - APP__ADMIN__EMAIL=${OPENCTI_ADMIN_EMAIL}
+      - APP__ADMIN__PASSWORD=${OPENCTI_ADMIN_PASSWORD}
+      - APP__ADMIN__TOKEN=${OPENCTI_ADMIN_TOKEN}
+      - APP__BASE_URL=${OPENCTI_BASE_URL}
+      - REDIS__HOSTNAME=redis
+      - REDIS__PORT=6379
+      - ELASTICSEARCH__URL=http://elasticsearch:9200
+      - MINIO__ENDPOINT=minio
+      - MINIO__PORT=9000
+      - MINIO__USE_SSL=false
+      - MINIO__ACCESS_KEY=opencti
+      - MINIO__SECRET_KEY=opencti_minio_password
+      - RABBITMQ__HOSTNAME=rabbitmq
+      - RABBITMQ__PORT=5672
+      - RABBITMQ__PORT_MANAGEMENT=15672
+      - RABBITMQ__USER=guest
+      - RABBITMQ__PASSWORD=guest
+    ports:
+      - "8080:4000"
+    depends_on:
+      - redis
+      - elasticsearch
+      - minio
+      - rabbitmq
+    restart: always
+  
+  worker:
+    image: opencti/worker:6.0.5
+    environment:
+      - OPENCTI_URL=http://opencti:4000
+      - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
+      - WORKER_LOG_LEVEL=INFO
+    depends_on:
+      - opencti
+    restart: always
+
+  connector-whoisfreaks:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: opencti-connector-whoisfreaks:latest
+    container_name: opencti-connector-whoisfreaks
+    environment:
+      - OPENCTI_URL=http://opencti:4000
+      - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
+      - CONNECTOR_ID=${CONNECTOR_KEY}
+      - CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+      - CONNECTOR_NAME=WhoisFreaks
+      - CONNECTOR_SCOPE=Domain-Name,IPv4-Addr,IPv6-Addr
+      - CONNECTOR_AUTO=false
+      - CONNECTOR_CONFIDENCE_LEVEL=100
+      - CONNECTOR_LOG_LEVEL=INFO
+      - WHOISFREAKS_API_KEY=${WHOISFREAKS_API_KEY}
+    depends_on:
+      - opencti
+    restart: always

--- a/internal-enrichment/whoisfreaks/entrypoint.sh
+++ b/internal-enrichment/whoisfreaks/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Navigate to app directory
+cd /opt/opencti-connector-whoisfreaks
+
+# Start the OpenCTI WhoisFreaks connector main script
+exec python3 src/main.py

--- a/internal-enrichment/whoisfreaks/requirements.txt
+++ b/internal-enrichment/whoisfreaks/requirements.txt
@@ -1,0 +1,5 @@
+pycti==6.0.5
+stix2>=3.0.1
+requests>=2.31.0
+pyyaml>=6.0.1
+python-dotenv>=1.0.0

--- a/internal-enrichment/whoisfreaks/src/builder.py
+++ b/internal-enrichment/whoisfreaks/src/builder.py
@@ -1,0 +1,346 @@
+import logging
+import stix2
+from typing import Any, Dict, Optional, List
+
+logger = logging.getLogger(__name__)
+
+
+class WhoisFreaksStixBuilder:
+    """
+    A builder for creating valid STIX 2.1 bundles from WhoisFreaks API responses.
+    """
+
+    def __init__(self, author_name: str = "WhoisFreaks"):
+        self.author = stix2.Identity(
+            name=author_name,
+            identity_class="organization",
+            description="WhoisFreaks Domain & IP Threat Intelligence Provider.",
+        )
+
+    def build_whois_bundle(
+        self, domain_name: str, whois_data: Dict[str, Any]
+    ) -> Optional[stix2.Bundle]:
+        if not whois_data:
+            return None
+
+        objects: List[Any] = [self.author]
+        clean_domain = domain_name.strip().lower()
+        domain_stix = stix2.DomainName(value=clean_domain)
+        objects.append(domain_stix)
+
+        records = whois_data.get("whois_domains_historical") or [whois_data]
+
+        # Registrar
+        registrar_name = next(
+            (
+                rec.get("domain_registrar", {}).get("registrar_name")
+                for rec in records
+                if isinstance(rec, dict) and rec.get("domain_registrar")
+            ),
+            whois_data.get("registrar_name"),
+        )
+
+        if registrar_name and str(registrar_name).strip():
+            registrar_stix = stix2.Identity(
+                name=str(registrar_name).strip(),
+                identity_class="organization",
+                created_by_ref=self.author.id,
+            )
+            objects.append(registrar_stix)
+            objects.append(
+                stix2.Relationship(
+                    source_ref=domain_stix.id,
+                    target_ref=registrar_stix.id,
+                    relationship_type="registered-by",
+                    created_by_ref=self.author.id,
+                )
+            )
+
+        # Registrant
+        registrant_data = next(
+            (
+                rec.get("registrant_contact", {})
+                for rec in records
+                if isinstance(rec, dict) and rec.get("registrant_contact")
+            ),
+            whois_data.get("registrant", {}),
+        )
+
+        registrant_name = (
+            registrant_data.get("name")
+            if isinstance(registrant_data, dict)
+            else str(registrant_data)
+        )
+        if registrant_name and not self.is_privacy_protected(str(registrant_name)):
+            registrant_stix = stix2.Identity(
+                name=str(registrant_name).strip(),
+                identity_class=(
+                    "organization"
+                    if isinstance(registrant_data, dict)
+                    and registrant_data.get("company")
+                    else "individual"
+                ),
+                created_by_ref=self.author.id,
+            )
+            objects.append(registrant_stix)
+            objects.append(
+                stix2.Relationship(
+                    source_ref=domain_stix.id,
+                    target_ref=registrant_stix.id,
+                    relationship_type="owned-by",
+                    created_by_ref=self.author.id,
+                )
+            )
+
+        # Name Servers (Domain -> Domain uses 'related-to')
+        for ns in whois_data.get("name_servers", []):
+            if ns and str(ns).strip() and str(ns).strip().lower() != clean_domain:
+                ns_stix = stix2.DomainName(value=str(ns).strip().lower())
+                objects.append(ns_stix)
+                objects.append(
+                    stix2.Relationship(
+                        source_ref=domain_stix.id,
+                        target_ref=ns_stix.id,
+                        relationship_type="related-to",
+                        created_by_ref=self.author.id,
+                    )
+                )
+
+        return stix2.Bundle(objects=objects, allow_custom=True)
+
+    def build_dns_bundle(
+        self, domain_or_ip: str, dns_data: Dict[str, Any]
+    ) -> Optional[stix2.Bundle]:
+        if not dns_data:
+            return None
+
+        objects: List[Any] = [self.author]
+        clean_value = domain_or_ip.strip().lower()
+
+        # Unified source observable handler
+        if self.is_ip_address(clean_value):
+            source_stix = (
+                stix2.IPv6Addr(value=clean_value)
+                if ":" in clean_value
+                else stix2.IPv4Address(value=clean_value)
+            )
+        else:
+            source_stix = stix2.DomainName(value=clean_value)
+        objects.append(source_stix)
+
+        dns_records = dns_data.get("dns_records") or dns_data.get("dnsRecords") or []
+        if not dns_records and "historicalDnsRecords" in dns_data:
+            hist = dns_data["historicalDnsRecords"]
+            if hist and isinstance(hist, list):
+                dns_records = hist[0].get("dnsRecords", [])
+
+        for record in dns_records:
+            record_type = (record.get("dnsType") or record.get("type", "")).upper()
+            record_value = record.get("address") or record.get("value")
+            if not record_type or not record_value:
+                continue
+
+            if record_type == "A":
+                target_stix = stix2.IPv4Address(value=record_value.strip())
+                rel_type = "resolves-to"
+            elif record_type == "AAAA":
+                target_stix = stix2.IPv6Addr(value=record_value.strip())
+                rel_type = "resolves-to"
+            elif record_type in ["CNAME", "MX", "NS"]:
+                target_stix = stix2.DomainName(value=record_value.strip().lower())
+                rel_type = "related-to"
+            else:
+                continue
+
+            objects.append(target_stix)
+            objects.append(
+                stix2.Relationship(
+                    source_ref=source_stix.id,
+                    target_ref=target_stix.id,
+                    relationship_type=rel_type,
+                    created_by_ref=self.author.id,
+                )
+            )
+
+        return stix2.Bundle(objects=objects, allow_custom=True)
+
+    def build_ssl_bundle(
+        self, target: str, ssl_data: Dict[str, Any]
+    ) -> Optional[stix2.Bundle]:
+        if not ssl_data:
+            return None
+
+        objects: List[Any] = [self.author]
+        clean_target = target.strip().lower()
+
+        if self.is_ip_address(clean_target):
+            target_stix = stix2.IPv4Address(value=clean_target)
+        else:
+            target_stix = stix2.DomainName(value=clean_target)
+        objects.append(target_stix)
+
+        ssl_certificates = ssl_data.get("sslCertificates") or [ssl_data]
+        for cert in ssl_certificates:
+            cert_info = cert.get("certificate_info") or cert
+            issuer = cert_info.get("issuer_dn") or "Unknown Issuer"
+            subject = cert_info.get("subject_dn") or clean_target
+            serial = str(cert_info.get("serial_number", ""))
+
+            cert_stix = stix2.X509Certificate(
+                issuer=str(issuer),
+                subject=str(subject),
+                serial_number=serial,
+            )
+            objects.append(cert_stix)
+            objects.append(
+                stix2.Relationship(
+                    source_ref=target_stix.id,
+                    target_ref=cert_stix.id,
+                    relationship_type="related-to",
+                    created_by_ref=self.author.id,
+                )
+            )
+
+        return stix2.Bundle(objects=objects, allow_custom=True)
+
+    def build_ip_geolocation_bundle(
+        self, ip_address: str, geolocation_data: Dict[str, Any]
+    ) -> Optional[stix2.Bundle]:
+        if not geolocation_data:
+            return None
+
+        objects: List[Any] = [self.author]
+        clean_ip = ip_address.strip()
+        ip_stix = stix2.IPv4Address(value=clean_ip)
+        objects.append(ip_stix)
+
+        loc_data = geolocation_data.get("location") or geolocation_data
+        country = loc_data.get("country_name") or loc_data.get("country_code")
+        city = loc_data.get("city")
+
+        if country or city:
+            location_stix = stix2.Location(
+                country=country,
+                city=city,
+                latitude=(
+                    float(loc_data["latitude"]) if loc_data.get("latitude") else None
+                ),
+                longitude=(
+                    float(loc_data["longitude"]) if loc_data.get("longitude") else None
+                ),
+                created_by_ref=self.author.id,
+            )
+            objects.append(location_stix)
+            objects.append(
+                stix2.Relationship(
+                    source_ref=ip_stix.id,
+                    target_ref=location_stix.id,
+                    relationship_type="located-at",
+                    created_by_ref=self.author.id,
+                )
+            )
+
+        return stix2.Bundle(objects=objects, allow_custom=True)
+
+    def build_subdomains_bundle(
+        self, domain: str, subdomains_data: Dict[str, Any]
+    ) -> Optional[stix2.Bundle]:
+        if not subdomains_data:
+            return None
+
+        objects: List[Any] = [self.author]
+        clean_domain = domain.strip().lower()
+        domain_stix = stix2.DomainName(value=clean_domain)
+        objects.append(domain_stix)
+
+        subdomains = subdomains_data.get("subdomains", [])
+        for subdomain in subdomains:
+            sub_val = (
+                subdomain.get("subdomain")
+                if isinstance(subdomain, dict)
+                else str(subdomain)
+            )
+            if sub_val and sub_val.strip():
+                sub_stix = stix2.DomainName(value=sub_val.strip().lower())
+                objects.append(sub_stix)
+                objects.append(
+                    stix2.Relationship(
+                        source_ref=sub_stix.id,
+                        target_ref=domain_stix.id,
+                        relationship_type="related-to",
+                        created_by_ref=self.author.id,
+                    )
+                )
+
+        return stix2.Bundle(objects=objects, allow_custom=True)
+
+    def build_ip_reputation_bundle(
+        self, ip_address: str, reputation_data: Dict[str, Any]
+    ) -> Optional[stix2.Bundle]:
+        if not reputation_data:
+            return None
+
+        objects: List[Any] = [self.author]
+        clean_ip = ip_address.strip()
+        ip_stix = stix2.IPv4Address(value=clean_ip)
+        objects.append(ip_stix)
+
+        sec_data = reputation_data.get("security") or reputation_data
+        threat_score = sec_data.get("threat_score") or sec_data.get("score")
+
+        if threat_score is not None:
+            note_stix = stix2.Note(
+                abstract=f"WhoisFreaks Threat Score: {threat_score}",
+                content=f"Reputation Analysis for IP {clean_ip}:\nThreat Score: {threat_score}\nDetails: {sec_data}",
+                object_refs=[ip_stix.id],
+                created_by_ref=self.author.id,
+            )
+            objects.append(note_stix)
+
+        return stix2.Bundle(objects=objects, allow_custom=True)
+
+    def build_domain_reputation_bundle(
+        self, domain: str, reputation_data: Dict[str, Any]
+    ) -> Optional[stix2.Bundle]:
+        if not reputation_data:
+            return None
+
+        objects: List[Any] = [self.author]
+        clean_dom = domain.strip().lower()
+        dom_stix = stix2.DomainName(value=clean_dom)
+        objects.append(dom_stix)
+
+        score = reputation_data.get("reputation_score") or reputation_data.get("score")
+        if score is not None:
+            note_stix = stix2.Note(
+                abstract=f"WhoisFreaks Domain Reputation Score: {score}",
+                content=f"Domain Reputation Analysis for {clean_dom}:\nScore: {score}",
+                object_refs=[dom_stix.id],
+                created_by_ref=self.author.id,
+            )
+            objects.append(note_stix)
+
+        return stix2.Bundle(objects=objects, allow_custom=True)
+
+    @staticmethod
+    def is_privacy_protected(name: str) -> bool:
+        privacy_indicators = [
+            "privacy",
+            "protected",
+            "redacted",
+            "anonymous",
+            "whoisguard",
+            "contact privacy",
+            "data protected",
+        ]
+        return any(indicator in name.lower() for indicator in privacy_indicators)
+
+    @staticmethod
+    def is_ip_address(value: str) -> bool:
+        import ipaddress
+
+        try:
+            ipaddress.ip_address(value.strip())
+            return True
+        except ValueError:
+            return False

--- a/internal-enrichment/whoisfreaks/src/client.py
+++ b/internal-enrichment/whoisfreaks/src/client.py
@@ -1,0 +1,252 @@
+import logging
+import requests
+from typing import Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class WhoisFreaksClient:
+    """
+    Client for interacting with WhoisFreaks REST APIs.
+    Docs: https://whoisfreaks.com/documentation
+    """
+
+    BASE_URL = "https://api.whoisfreaks.com"
+
+    def __init__(self, api_key: str, timeout: Optional[int] = 30):
+        self.api_key = api_key
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "User-Agent": "OpenCTI-WhoisFreaks-Connector/1.0",
+                "Accept": "application/json",
+            }
+        )
+
+    def _post(
+        self,
+        endpoint: str,
+        params: Optional[dict] = None,
+        body: Optional[dict] = None,
+        timeout: int = 30,
+    ) -> Optional[Dict[str, Any]]:
+        url = f"{self.BASE_URL}{endpoint}"
+        if params is None:
+            params = {}
+        params["apiKey"] = self.api_key
+
+        try:
+            response = self.session.post(url, params=params, json=body, timeout=timeout)
+            if response.status_code == 200:
+                return response.json()
+            else:
+                logger.error(
+                    f"[WhoisFreaks API] POST {url} failed HTTP {response.status_code}: {response.text}"
+                )
+                return None
+        except requests.exceptions.Timeout:
+            logger.error(f"[WhoisFreaks API] Timeout reaching {url}.")
+            return None
+        except requests.RequestException as e:
+            logger.error(f"[WhoisFreaks API] Error during POST {url}: {e}")
+            return None
+
+    def _get(
+        self, endpoint: str, params: Optional[dict] = None, timeout: int = 30
+    ) -> Optional[Dict[str, Any]]:
+        url = f"{self.BASE_URL}{endpoint}"
+        if params is None:
+            params = {}
+        params["apiKey"] = self.api_key
+
+        try:
+            response = self.session.get(url, params=params, timeout=timeout)
+
+            if response.status_code == 200:
+                return response.json()
+            elif response.status_code == 404:
+                logger.info(f"[WhoisFreaks API] No record found at {endpoint}")
+                return None
+            elif response.status_code == 401:
+                logger.error(
+                    "[WhoisFreaks API] Unauthorized - Check WHOISFREAKS_API_KEY."
+                )
+                return None
+            elif response.status_code == 429:
+                logger.error(
+                    "[WhoisFreaks API] Rate limit reached or insufficient credits."
+                )
+                return None
+            else:
+                logger.error(
+                    f"[WhoisFreaks API] GET {url} failed HTTP {response.status_code}: {response.text}"
+                )
+                return None
+        except requests.exceptions.Timeout:
+            logger.error(f"[WhoisFreaks API] Timeout reaching {url}.")
+            return None
+        except requests.RequestException as e:
+            logger.error(f"[WhoisFreaks API] Error during GET {url}: {e}")
+            return None
+
+    # --- API ENDPOINT WRAPPERS ---
+    def live_whois_lookup(
+        self, domain: str, format: Optional[str] = "json"
+    ) -> Optional[Dict[str, Any]]:
+        return self._get(
+            "/v2.0/whois/live", params={"format": format, "domainName": domain}
+        )
+
+    def historical_whois_lookup(
+        self, domain: str, format: Optional[str] = "json"
+    ) -> Optional[Dict[str, Any]]:
+        return self._get(
+            "/v2.0/whois",
+            params={"format": format, "domainName": domain, "whois": "historical"},
+        )
+
+    def reverse_whois_lookup(
+        self, keyword: str, format: Optional[str] = "json"
+    ) -> Optional[Dict[str, Any]]:
+        return self._get(
+            "/v1.0/whois",
+            params={"format": format, "keyword": keyword, "whois": "reverse"},
+        )
+
+    def bulk_whois_lookup(
+        self, domains: list[str], format: Optional[str] = "json"
+    ) -> Optional[Dict[str, Any]]:
+        return self._post(
+            "/v2.0/bulkwhois/live",
+            params={"format": format},
+            body={"domainNames": domains},
+        )
+
+    def live_dns_lookup(
+        self, domain: str, format: Optional[str] = "json"
+    ) -> Optional[Dict[str, Any]]:
+        return self._get(
+            "/v2.0/dns/live",
+            params={"format": format, "domainName": domain, "type": "all"},
+        )
+
+    def historical_dns_lookup(
+        self, domain: str, format: Optional[str] = "json", page: Optional[int] = 1
+    ) -> Optional[Dict[str, Any]]:
+        return self._get(
+            "/v2.0/dns/historical",
+            params={
+                "format": format,
+                "domainName": domain,
+                "type": "all",
+                "page": page,
+            },
+        )
+
+    def reverse_dns_lookup(
+        self, ip_address: str, format: Optional[str] = "json", page: Optional[int] = 1
+    ) -> Optional[Dict[str, Any]]:
+        return self._get(
+            "/v2.0/dns/reverse",
+            params={
+                "format": format,
+                "value": ip_address,
+                "page": page,
+                "type": "a",
+                "exact": True,
+            },
+        )
+
+    def bulk_dns_lookup(
+        self, domains: list[str], ipAddresses: list[str], format: Optional[str] = "json"
+    ) -> Optional[Dict[str, Any]]:
+        return self._post(
+            "/v2.0/dns/bulk/live",
+            params={"format": format, "type": "all"},
+            body={"domainNames": domains, "ipAddresses": ipAddresses},
+        )
+
+    def domain_availability_lookup(
+        self, domain: str, format: Optional[str] = "json"
+    ) -> Optional[Dict[str, Any]]:
+        return self._get(
+            "/v1.0/domain/availability",
+            params={"format": format, "domainName": domain, "sug": False},
+        )
+
+    def bulk_domain_availability_lookup(
+        self, domains: list[str], format: Optional[str] = "json"
+    ) -> Optional[Dict[str, Any]]:
+        return self._post(
+            "/v1.0/domain/availability",
+            params={"format": format},
+            body={"domainNames": domains},
+        )
+
+    def typosquatting_lookup(self, keyword: str) -> Optional[Dict[str, Any]]:
+        return self._get("/v3.0/domain/typos", params={"keyword": keyword})
+
+    def ssl_lookup(
+        self, domain: str, format: Optional[str] = "json"
+    ) -> Optional[Dict[str, Any]]:
+        return self._get(
+            "/v1.0/ssl/live",
+            params={
+                "format": format,
+                "domainName": domain,
+                "chain": True,
+                "sslRaw": False,
+            },
+        )
+
+    def ip_geolocation_lookup(
+        self, ip_address: str, format: Optional[str] = "json"
+    ) -> Optional[Dict[str, Any]]:
+        return self._get(
+            "/v1.0/geolocation", params={"format": format, "ip": ip_address}
+        )
+
+    def bulk_ip_geolocation_lookup(
+        self, ip_addresses: list[str]
+    ) -> Optional[Dict[str, Any]]:
+        return self._post("/v1.0/geolocation", body={"ips": ip_addresses})
+
+    def subdomains_lookup(
+        self, domain: str, format: Optional[str] = "json", page: Optional[int] = 1
+    ) -> Optional[Dict[str, Any]]:
+        return self._get(
+            "/v1.0/subdomains",
+            params={"format": format, "domain": domain, "page": page},
+        )
+
+    def ip_reputation_lookup(self, ip_address: str) -> Optional[Dict[str, Any]]:
+        return self._get("/v1.0/security", params={"ip": ip_address})
+
+    def bulk_ip_reputation_lookup(
+        self, ip_addresses: list[str]
+    ) -> Optional[Dict[str, Any]]:
+        return self._post("/v1.0/security", body={"ips": ip_addresses})
+
+    def asn_whois_lookup(
+        self, asn: str, format: Optional[str] = "json"
+    ) -> Optional[Dict[str, Any]]:
+        return self._get("/v2.0/asn-whois", params={"asn": asn, "format": format})
+
+    def ip_whois_lookup(
+        self, ip_address: str, format: Optional[str] = "json"
+    ) -> Optional[Dict[str, Any]]:
+        return self._get("/v1.0/ip-whois", params={"ip": ip_address, "format": format})
+
+    def domain_reputation_lookup(
+        self, domain: str, format: Optional[str] = "json"
+    ) -> Optional[Dict[str, Any]]:
+        return self._get(
+            "/v1.0/domain-reputation", params={"domainName": domain, "format": format}
+        )
+
+    def account_usage(self) -> Optional[Dict[str, Any]]:
+        return self._get("/v1.0/whoisapi/usage")
+
+    def rotate_api_key(self) -> Optional[Dict[str, Any]]:
+        return self._post("/v1.0/api-key/rotate")

--- a/internal-enrichment/whoisfreaks/src/configVariables.py
+++ b/internal-enrichment/whoisfreaks/src/configVariables.py
@@ -1,0 +1,78 @@
+import sys
+from pathlib import Path
+import yaml
+from pycti import get_config_variable
+
+
+class ConfigVariables:
+    """
+    Configuration loader for WhoisFreaks OpenCTI Connector.
+    Reads settings from config.yml or environment variables.
+    """
+
+    def __init__(self):
+
+        config_file_path = Path(__file__).parents[1] / "config.yml"
+        config = {}
+
+        if config_file_path.is_file():
+            with open(config_file_path, "r", encoding="utf-8") as file:
+                config = yaml.safe_load(file) or {}
+
+        self.opencti_url = get_config_variable(
+            "OPENCTI_URL", ["opencti", "url"], config
+        )
+
+        self.opencti_token = get_config_variable(
+            "OPENCTI_TOKEN", ["opencti", "token"], config
+        )
+
+        self.connector_id = get_config_variable(
+            "CONNECTOR_ID", ["connector", "id"], config
+        )
+        self.connector_type = get_config_variable(
+            "CONNECTOR_TYPE", ["connector", "type"], config
+        )
+        self.connector_name = get_config_variable(
+            "CONNECTOR_NAME", ["connector", "name"], config
+        )
+        self.connector_scope = get_config_variable(
+            "CONNECTOR_SCOPE", ["connector", "scope"], config
+        )
+        self.connector_confidence_level = get_config_variable(
+            "CONNECTOR_CONFIDENCE", ["connector", "confidence_level"], config
+        )
+        self.connector_auto = get_config_variable(
+            "CONNECTOR_AUTO", ["connector", "auto"], config
+        )
+        # Force log level to uppercase string (e.g. 'INFO')
+        raw_log_level = get_config_variable(
+            "CONNECTOR_LOG_LEVEL", ["connector", "log_level"], config, default="INFO"
+        )
+        self.connector_log_level = (
+            str(raw_log_level).upper() if raw_log_level else "INFO"
+        )
+        self.whoisfreaks_api_key = get_config_variable(
+            "WHOISFREAKS_API_KEY", ["whoisfreaks", "api_key"], config
+        )
+
+        self._validate()
+
+    def _validate(self) -> None:
+        """Validates that all required configuration values are present."""
+        missing = []
+        if not self.opencti_url or self.opencti_url == "ChangeMe":
+            missing.append("OPENCTI_URL / opencti.url")
+        if not self.opencti_token or self.opencti_token == "ChangeMe":
+            missing.append("OPENCTI_TOKEN / opencti.token")
+        if not self.connector_id or self.connector_id == "ChangeMe":
+            missing.append("CONNECTOR_ID / connector.id")
+        if not self.whoisfreaks_api_key or self.whoisfreaks_api_key == "ChangeMe":
+            missing.append("WHOISFREAKS_API_KEY / whoisfreaks.api_key")
+
+        if missing:
+            print(
+                f"[ERROR] Missing or default configuration values for: {', '.join(missing)}"
+            )
+            print("[ERROR] Please update config.yml or pass environment variables.")
+            sys.exit(1)

--- a/internal-enrichment/whoisfreaks/src/main.py
+++ b/internal-enrichment/whoisfreaks/src/main.py
@@ -1,0 +1,179 @@
+import sys
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+from pycti import OpenCTIConnectorHelper
+
+from configVariables import ConfigVariables
+from client import WhoisFreaksClient
+from builder import WhoisFreaksStixBuilder
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger(__name__)
+
+
+class WhoisFreaksConnector:
+    """
+    OpenCTI Internal Enrichment Connector for WhoisFreaks.
+    Enriches Domain-Name and IPv4/IPv6 Observables with WHOIS, DNS, SSL, and Geolocation data.
+    """
+
+    def __init__(self):
+        logger.info("[WhoisFreaks Connector] Initializing configuration...")
+        self.config = ConfigVariables()
+
+        logging.getLogger().setLevel(self.config.connector_log_level)
+
+        self.helper = OpenCTIConnectorHelper(
+            {
+                "opencti": {
+                    "url": self.config.opencti_url,
+                    "token": self.config.opencti_token,
+                },
+                "connector": {
+                    "name": self.config.connector_name,
+                    "id": self.config.connector_id,
+                    "type": self.config.connector_type,
+                    "scope": self.config.connector_scope,
+                    "auto": self.config.connector_auto,
+                    "log_level": self.config.connector_log_level,
+                    "confidence_level": self.config.connector_confidence_level,
+                },
+            }
+        )
+
+        self.client = WhoisFreaksClient(api_key=self.config.whoisfreaks_api_key)
+        self.builder = WhoisFreaksStixBuilder(author_name="WhoisFreaks")
+
+    def _enrich_domain(self, domain_name: str) -> List[Any]:
+        """Executes all WhoisFreaks lookups for Domain-Name entities."""
+        bundles = []
+
+        lookups = [
+            (self.client.live_whois_lookup, self.builder.build_whois_bundle),
+            (self.client.live_dns_lookup, self.builder.build_dns_bundle),
+            (self.client.ssl_lookup, self.builder.build_ssl_bundle),
+            (self.client.subdomains_lookup, self.builder.build_subdomains_bundle),
+        ]
+
+        for fetch_fn, build_fn in lookups:
+            resp = fetch_fn(domain_name)
+            if resp:
+                bundle = build_fn(domain_name, resp)
+                if bundle:
+                    bundles.append(bundle)
+
+        return bundles
+
+    def _enrich_ip(self, ip_address: str) -> List[Any]:
+        """Executes all WhoisFreaks lookups for IP entities."""
+        bundles = []
+
+        lookups = [
+            (
+                self.client.ip_geolocation_lookup,
+                self.builder.build_ip_geolocation_bundle,
+            ),
+            (self.client.ip_reputation_lookup, self.builder.build_ip_reputation_bundle),
+            (self.client.reverse_dns_lookup, self.builder.build_dns_bundle),
+        ]
+
+        for fetch_fn, build_fn in lookups:
+            resp = fetch_fn(ip_address)
+            if resp:
+                bundle = build_fn(ip_address, resp)
+                if bundle:
+                    bundles.append(bundle)
+
+        return bundles
+
+    def _get_entity_info(self, entity_id: str) -> Tuple[Optional[str], Optional[str]]:
+        """Reads entity from OpenCTI and returns entity type and observable value."""
+        opencti_entity = self.helper.api.stix_cyber_observable.read(id=entity_id)
+        if not opencti_entity:
+            opencti_entity = self.helper.api.stix_domain_object.read(id=entity_id)
+
+        if not opencti_entity:
+            return None, None
+
+        obs_type = opencti_entity.get("entity_type")
+        obs_val = (
+            opencti_entity.get("observable_value")
+            or opencti_entity.get("value")
+            or opencti_entity.get("name")
+        )
+        return obs_type, obs_val
+
+    def process_message(self, msg: Dict[str, Any]) -> str:
+        """Callback executed whenever an enrichment task is received from RabbitMQ."""
+        entity_id = msg.get("entity_id")
+        observable_type, observable_value = self._get_entity_info(entity_id)
+
+        if not observable_type or not observable_value:
+            logger.error(
+                f"[WhoisFreaks Connector] Invalid or missing entity for ID: {entity_id}"
+            )
+            return "Entity or value missing"
+
+        logger.info(
+            f"[WhoisFreaks Connector] Processing enrichment for {observable_type}: '{observable_value}'"
+        )
+
+        work_id = self.helper.api.work.initiate_work(
+            connector_id=self.config.connector_id,
+            friendly_name=f"WhoisFreaks enrichment for {observable_value}",
+        )
+
+        try:
+            if observable_type == "Domain-Name":
+                bundles = self._enrich_domain(observable_value)
+            elif observable_type in ["IPv4-Addr", "IPv6-Addr"]:
+                bundles = self._enrich_ip(observable_value)
+            else:
+                logger.warning(
+                    f"[WhoisFreaks Connector] Unsupported type: {observable_type}"
+                )
+                self.helper.api.work.to_processed(
+                    work_id, "Unsupported observable type"
+                )
+                return "Unsupported observable type"
+
+            if bundles:
+                for bundle in bundles:
+                    self.helper.send_stix2_bundle(
+                        bundle=bundle.serialize(),
+                        work_id=work_id,
+                    )
+
+                message = f"Successfully enriched {observable_value} with {len(bundles)} STIX bundles."
+                logger.info(f"[WhoisFreaks Connector] {message}")
+                self.helper.api.work.to_processed(work_id, message)
+                return message
+
+            message = f"No threat intelligence data found on WhoisFreaks for {observable_value}."
+            logger.info(f"[WhoisFreaks Connector] {message}")
+            self.helper.api.work.to_processed(work_id, message)
+            return message
+
+        except Exception as e:
+            error_msg = f"Error during processing of {observable_value}: {str(e)}"
+            logger.exception(f"[WhoisFreaks Connector] {error_msg}")
+            self.helper.api.work.to_processed(work_id, error_msg, in_error=True)
+            return error_msg
+
+    def start(self):
+        """Starts the connector worker and listens to RabbitMQ queue."""
+        logger.info("[WhoisFreaks Connector] Starting connector listener loop...")
+        self.helper.listen(self.process_message)
+
+
+if __name__ == "__main__":
+    try:
+        connector = WhoisFreaksConnector()
+        connector.start()
+    except Exception as e:
+        logger.fatal(f"[WhoisFreaks Connector] Unhandled startup failure: {str(e)}")
+        sys.exit(1)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.

PR TITLE FORMAT (enforced by CI):
  type(scope?)!?: description (#123)
  - type: feat | fix | chore | docs | style | refactor | perf | test | build | ci | revert
  - scope: optional, e.g. connector name
  - description: must start with a lowercase letter
  - (#123): required linked issue number
  Example: feat(alienvault): add pagination support (#42)
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

This PR introduces the official WhoisFreaks Internal Enrichment Connector for OpenCTI under internal-enrichment/whoisfreaks.

Features Implemented
WHOIS Intelligence: Live WHOIS lookup mapping Registrars and Registrants into STIX 2.1 Identity objects.

DNS Resolution: Live DNS parser generating Domain-Name and IPv4-Addr/IPv6-Addr observables connected via resolves-to and related-to STIX relationships.

SSL/TLS Certificates: Extracts X.509 metadata into X509-Certificate observables.

IP Geolocation & Reputation: IP lookup translating coordinates and country metadata into STIX Location SDOs (located-at).

Subdomain Mapping: Maps parent-child domain relationships.

Checklist
[x] Code auto-formatted with black and compliant with flake8.

[x] Tested with OpenCTI Platform v6.x.

[x] Dockerfile and Docker Compose stack verified locally.

[x] Sample environment file (.env.sample) included without hardcoded secrets.

[x] README.md added under internal-enrichment/whoisfreaks/.
