### PR TITLE
chore(ci): improve bulk release visibility and manifest workflow (#7075)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,8 @@ jobs:
                 echo "Manifest changed. Committing changes..."
                 git add .
                 # Add custom flag to avoid triggering workflows
-                git commit -m "chore(manifest): build and update manifest [ci build-manifest]"
+                # https://circleci.com/docs/guides/orchestrate/skip-build/
+                git commit -m "chore(manifest): build and update manifest [skip ci]"
                 # Push quietly to prevent showing the token in log
                 if git push -q https://${GITHUB_TOKEN}@github.com/OpenCTI-Platform/connectors.git ${CIRCLE_BRANCH}; then
                   echo "Manifest changes pushed successfully."

--- a/.github/scripts/bulk_release.py
+++ b/.github/scripts/bulk_release.py
@@ -43,6 +43,10 @@ Outputs (written to $GITHUB_OUTPUT when set, and always printed as a summary):
     skipped         JSON array of connector names skipped (already released)
     skipped_count   number of skipped connectors
     has_connectors  "true" if at least one connector will be released
+
+A resolution table (pending + skipped, with the reason each connector was
+skipped) is also appended to $GITHUB_STEP_SUMMARY when set, so it's visible
+in the Job Summary for both dry runs and real dispatches.
 """
 
 import argparse
@@ -301,6 +305,44 @@ def print_plan(plan: ReleasePlan) -> None:
             print(f"    = {build_tag(connector.name, plan.version)}", file=sys.stderr)
 
 
+def write_step_summary(plan: ReleasePlan, github_step_summary: str | None) -> None:
+    """Append a resolution table (pending + skipped, with reasons) to the Job
+    Summary. Written here — rather than in the workflow — so it's always
+    present regardless of dry-run vs. real dispatch, and stays in sync with
+    the single source of truth for *why* a connector was skipped.
+    """
+    if not github_step_summary:
+        return
+
+    total = len(plan.pending) + len(plan.skipped)
+    lines = [
+        f"### 🔖 Bulk release resolution — version `{plan.version}`",
+        "",
+        f"{total} connector(s) targeted: {len(plan.pending)} to release, "
+        f"{len(plan.skipped)} skipped.",
+        "",
+        "| Connector | Target | Status | Reason |",
+        "|-----------|--------|--------|--------|",
+    ]
+    for connector in plan.pending:
+        lines.append(
+            f"| {connector.name} | {build_tag(connector.name, plan.version)} "
+            "| ✅ to release | — |"
+        )
+    for connector in plan.skipped:
+        lines.append(
+            f"| {connector.name} | {build_tag(connector.name, plan.version)} "
+            "| ⏭️ skipped | Already released — tag "
+            f"`{build_tag(connector.name, plan.version)}` exists |"
+        )
+    if not plan.pending and not plan.skipped:
+        lines.append("| _(none)_ | | | |")
+    lines.append("")
+
+    with open(github_step_summary, "a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
 def emit_outputs(plan: ReleasePlan, github_output: str | None) -> None:
     """Write GitHub Actions job outputs (and echo them for local runs)."""
     connectors = json.dumps([c.name for c in plan.pending], separators=(",", ":"))
@@ -377,6 +419,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=os.environ.get("GITHUB_OUTPUT"),
         help="Path to write matrix outputs (defaults to $GITHUB_OUTPUT).",
     )
+    parser.add_argument(
+        "--github-step-summary",
+        default=os.environ.get("GITHUB_STEP_SUMMARY"),
+        help="Path to append the resolution table to (defaults to "
+        "$GITHUB_STEP_SUMMARY).",
+    )
     return parser
 
 
@@ -406,6 +454,7 @@ def run(args: argparse.Namespace) -> int:
     plan = build_plan(connectors, version, released_tags)
 
     print_plan(plan)
+    write_step_summary(plan, args.github_step_summary)
     emit_outputs(plan, args.github_output)
     return 0
 

--- a/.github/workflows/build-all-connectors.yml
+++ b/.github/workflows/build-all-connectors.yml
@@ -53,6 +53,14 @@ jobs:
       contents: read
     secrets: inherit
 
+  build-manifest:
+    needs: [resolve-build-mode, lint, tests]
+    uses: ./.github/workflows/build-manifest.yml
+    permissions:
+      contents: write
+      actions: read
+    secrets: inherit
+
   build-alpine:
     needs: [resolve-build-mode, lint, tests]
     uses: ./.github/workflows/build-alpine.yml

--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -13,11 +13,8 @@ name: Build Manifest
     #   - lts/**
 
 on:
-  push:
-    branches:
-      - master
-      - 'release/*'
-      - 'lts/*'
+  workflow_call:
+
 
 concurrency:
   group: build-manifest-${{ github.event.pull_request.head.ref || github.ref }}
@@ -53,62 +50,19 @@ jobs:
         with:
           python-version: "3.12"
 
-#       - id: gate
-#         name: Verify upstream workflows succeeded for this commit
-#         shell: bash
-#         run: |
-#           set -euo pipefail
-
-#           SHA="${{ github.event.workflow_run.head_sha }}"
-#           API_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&per_page=100"
-#           RESPONSE="$(curl --silent --show-error --fail \
-#             -H "Accept: application/vnd.github+json" \
-#             -H "Authorization: Bearer ${PUSH_TOKEN}" \
-#             "${API_URL}")"
-
-#           STATUS="$(printf '%s' "${RESPONSE}" | python3 -c '
-# import json
-# import sys
-
-# required = {"Lint & Format", "Tests Connectors"}
-# data = json.load(sys.stdin)
-# ok = set()
-
-# for run in data.get("workflow_runs", []):
-#     name = run.get("name")
-#     if name in required and run.get("status") == "completed" and run.get("conclusion") == "success":
-#         ok.add(name)
-
-# missing = sorted(required - ok)
-# print("ok" if not missing else "missing:" + ",".join(missing))
-# ')"
-
-#           if [ "${STATUS}" != "ok" ]; then
-#             echo "Skipping: required workflows not all successful for this SHA (${STATUS})."
-#             echo "should_run=false" >> "${GITHUB_OUTPUT}"
-#             exit 0
-#           fi
-
-#           echo "TARGET_BRANCH=${{ github.event.workflow_run.head_branch }}" >> "${GITHUB_ENV}"
-#           echo "RELEASE_REF=${{ github.event.workflow_run.head_branch }}" >> "${GITHUB_ENV}"
-#           echo "should_run=true" >> "${GITHUB_OUTPUT}"
-
       - name: Build connectors schemas
-        # if: ${{ steps.gate.outputs.should_run == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
           bash ./shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.sh
 
       - name: Build global manifest
-        # if: ${{ steps.gate.outputs.should_run == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
           bash ./shared/tools/composer/generate_global_manifest/generate_global_manifest.sh
 
     #   - name: Commit manifest if changed
-    #     if: ${{ steps.gate.outputs.should_run == 'true' }}
     #     shell: bash
     #     run: |
     #       set -euo pipefail
@@ -121,11 +75,6 @@ jobs:
     #       if [ -z "${GITHUB_GPG_SECRET_KEY:-}" ] || [ -z "${GITHUB_GPG_SIGNING_KEY:-}" ]; then
     #         echo "Missing GPG secrets; cannot create signed commit."
     #         exit 1
-    #       fi
-
-    #       if git log -1 --pretty=%B | grep -q '\[ci build-manifest\]'; then
-    #         echo "Skipping due to [ci build-manifest] flag."
-    #         exit 0
     #       fi
 
     #       if git diff --quiet -- manifest.json; then
@@ -143,7 +92,7 @@ jobs:
     #       git config commit.gpgsign true
 
     #       git add .
-    #       git commit -m "chore(manifest): build and update manifest [ci build-manifest]"
+    #       git commit -m "chore(manifest): build and update manifest [skip ci]"
 
     #       git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
     #       if git push -q origin "${TARGET_BRANCH}"; then

--- a/.github/workflows/release-bulk-connectors.yml
+++ b/.github/workflows/release-bulk-connectors.yml
@@ -79,9 +79,9 @@ on:
           CalVer tag push.
         required: false
         type: boolean
-        default: false
+        default: true
       dry_run:
-        description: "Dry run — resolve and preview connectors without dispatching releases."
+        description: "Dry run — Do not publish any tags or GitHub Releases, only test release process"
         required: false
         type: boolean
         default: true
@@ -181,7 +181,7 @@ jobs:
           python .github/scripts/bulk_release.py "${ARGS[@]}"
 
       - name: Dispatch per-connector releases
-        if: ${{ steps.trigger.outputs.dry_run != 'true' && steps.resolve.outputs.has_connectors == 'true' }}
+        if: ${{ steps.resolve.outputs.has_connectors == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONNECTORS_JSON: ${{ steps.resolve.outputs.connectors }}
@@ -189,6 +189,7 @@ jobs:
           MANIFEST_ONLY: ${{ steps.trigger.outputs.manifest_only }}
           REF: ${{ github.ref_name }}
           REPO: ${{ github.repository }}
+          DRY_RUN: ${{ steps.trigger.outputs.dry_run }}
         run: |
           set -euo pipefail
 
@@ -214,7 +215,7 @@ jobs:
                  --ref "$REF" \
                  -f connector_name="$name" \
                  -f version="$VERSION" \
-                 -f dry_run=false \
+                 -f dry_run="$DRY_RUN" \
                  -f manifest_only="$MANIFEST_ONLY"; then
               echo "| $name | $target_label | ✅ dispatched |" >> "$GITHUB_STEP_SUMMARY"
               ok=$((ok + 1))
@@ -237,10 +238,4 @@ jobs:
           if [ "$failed" -gt 0 ]; then
             exit 1
           fi
-
-      - name: Dry run notice
-        if: ${{ steps.trigger.outputs.dry_run == 'true' }}
-        run: |
-          echo "🔎 Dry run — connectors resolved and previewed above; no releases dispatched."
-          echo "Re-run with dry_run=false to dispatch the per-connector release workflows."
 

--- a/.github/workflows/release-bulk-connectors.yml
+++ b/.github/workflows/release-bulk-connectors.yml
@@ -170,6 +170,14 @@ jobs:
             ARGS+=("--include-released")
           fi
 
+          # bulk_release.py writes the resolved version, and the full
+          # pending/skipped table (with skip reasons), to $GITHUB_STEP_SUMMARY
+          # itself — this runs for both dry runs and real dispatches, unlike
+          # the dispatch step below which only runs on a real dispatch. This
+          # is also the only place the *actual* resolved version is visible:
+          # the run-name is rendered before this job starts, so it only ever
+          # has access to the raw `inputs.version` (possibly empty), never
+          # the value auto-computed here.
           python .github/scripts/bulk_release.py "${ARGS[@]}"
 
       - name: Dispatch per-connector releases

--- a/shared/tools/composer/generate_manifest_fragment/connector_manifest_schema.json
+++ b/shared/tools/composer/generate_manifest_fragment/connector_manifest_schema.json
@@ -33,9 +33,9 @@
   "properties": {
     "id": {
       "type": "string",
-      "description": "Unique identifier for the connector, derived from the slug.",
-      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
-      "examples": ["misp", "export-file-csv", "crowdstrike"]
+      "description": "Unique identifier for the connector, derived from the slug and version.",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*-[0-9]+\\.[0-9]{1,6}\\.?[0-9]*$",
+      "examples": ["misp-7.260601.0", "export-file-csv-7.260601.0", "crowdstrike-7.260601.0"]
     },
     "title": {
       "type": "string",

--- a/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
+++ b/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
@@ -172,7 +172,7 @@ def build_fragment(connector_dir: Path, version: str) -> dict:
     )
 
     fragment = {
-        "id": slug,
+        "id": f"{slug}-{version}",
         "title": manifest["title"],
         "slug": slug,
         "description": manifest["description"],


### PR DESCRIPTION
### Proposed changes

* Append the connector version to the `id` field in generated manifest fragments (`{slug}-{version}` instead of just `{slug}`) and update the JSON schema pattern accordingly, so multiple versions of the same connector's manifest fragment can coexist without id collisions.
* Write a resolution summary table (pending + skipped connectors, with skip reasons) to `$GITHUB_STEP_SUMMARY` in `bulk_release.py` for every run (dry or real), since the auto-computed CalVer version and skip reasons are only known once the job resolves them and can't be shown in the workflow run-name.
* Convert `build-manifest.yml` into a reusable `workflow_call` workflow invoked from `build-all-connectors.yml` with explicit `needs: [resolve-build-mode, lint, tests]` ordering, removing the old manual "gate" step that polled the GitHub API for upstream workflow success, and grant the caller `contents: write` + `actions: read` permissions so the manifest commit-back keeps working.
* Change the automated manifest commit message from `[ci build-manifest]` to `[skip ci]` in `.circleci/config.yml` so manifest-only commits no longer retrigger the CI pipeline.
* Fix `release-bulk-connectors.yml` to always dispatch per-connector `release-connector.yml` runs, forwarding the resolved `dry_run` flag to each dispatch instead of gating the whole dispatch step on it, so a bulk dry run now previews real per-connector dispatches (each running in dry-run mode) instead of skipping dispatch entirely.

### Related issues

* Closes #7075

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Two changes are worth calling out as more involved:

1. **Manifest fragment `id` versioning**: `generate_manifest_fragment.py` now emits `id: "{slug}-{version}"` instead of `id: "{slug}"`, with the JSON schema pattern updated to match. This avoids id collisions when a connector's manifest fragment is regenerated across versions/releases.
2. **`build-manifest` reusable workflow refactor**: previously ran standalone on push with a manual polling "gate" step. It's now a `workflow_call` reusable workflow invoked directly from `build-all-connectors.yml` with `needs:` ordering, so ordering is enforced natively instead of by polling. The caller grants `contents: write` + `actions: read` so the nested manifest-commit job retains needed permissions.