### PR TITLE
chore(connectors): bump pycti pins and misc connector fixes (#7053)

### DIFF
--- a/external-import/ransomlook/__metadata__/connector_manifest.json
+++ b/external-import/ransomlook/__metadata__/connector_manifest.json
@@ -4,7 +4,14 @@
   "description": "RansomLook tracks ransomware victim claims, captured evidence, actors, infrastructure, notes, wallets, torrents, leaks, and technical intelligence. This connector maintains separately scoped claim and actor-profile graphs with bounded delivery and content-free operational metrics in OpenCTI.",
   "short_description": "Imports ransomware claims, evidence, and actor profiles from RansomLook.",
   "logo": "external-import/ransomlook/__metadata__/logo.png",
-  "use_cases": ["Open Source Threat Intel"],
+  "use_cases": [
+    "Adversary & Campaign Insights"
+  ],
+  "solution_categories": [
+    "Threat Intelligence Feed"
+  ],
+  "license_type": "Free",
+  "contact": null,
   "verified": false,
   "last_verified_date": null,
   "playbook_supported": false,

--- a/external-import/ransomlook/src/requirements.txt
+++ b/external-import/ransomlook/src/requirements.txt
@@ -1,5 +1,5 @@
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk
-pycti==7.260715.0
+pycti==7.260722.0
 pydantic>=2.10,<3
 requests==2.33.0
 stix2==3.0.1

--- a/internal-enrichment/doppel-alert-takedown/src/requirements.txt
+++ b/internal-enrichment/doppel-alert-takedown/src/requirements.txt
@@ -1,4 +1,4 @@
-pycti==7.260715.0
+pycti==7.260722.0
 pydantic~= 2.11.3
 requests~=2.33.0
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/malbeacon/src/__init__.py
+++ b/internal-enrichment/malbeacon/src/__init__.py
@@ -1,0 +1,3 @@
+from settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings"]

--- a/internal-enrichment/malbeacon/src/main.py
+++ b/internal-enrichment/malbeacon/src/main.py
@@ -4,7 +4,6 @@ from malbeacon_converter import MalbeaconConverter
 from malbeacon_endpoints import C2_PATH
 from models.c2_model import C2Beacon
 from pycti import OpenCTIConnectorHelper
-from settings import ConnectorSettings  # noqa
 
 
 class MalBeaconConnector:

--- a/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
+++ b/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
@@ -200,8 +200,8 @@ def build_fragment(connector_dir: Path, version: str) -> dict:
         "config_schema": config_schema,
     }
 
-    # Copy through any manifest key not explicitly handled above (e.g. 
-    # any future addition) so the fragment stays in sync with the manifest 
+    # Copy through any manifest key not explicitly handled above (e.g.
+    # any future addition) so the fragment stays in sync with the manifest
     # without code changes.
     for key, value in manifest.items():
         if key not in MANIFEST_KEYS_HANDLED_EXPLICITLY and key not in fragment:


### PR DESCRIPTION
### Proposed changes

* Bump pycti to 7.260722.0 for ransomlook and doppel-alert-takedown, and add missing `solution_categories`/`license_type` fields to ransomlook's manifest
* Fix malbeacon `main.py` so `ConnectorSettings` stays importable for schema generation (add `internal-enrichment/malbeacon/src/__init__.py`)
* Align black formatting (trailing whitespace) in composer's `generate_manifest_fragment.py`

### Related issues

* Closes #7053

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This batch bundles unrelated small connector fixes/chores together.