### PR TITLE
fix(urlscan): honor config labels and duration_period (#6555)

### DIFF
--- a/external-import/urlscan/README.md
+++ b/external-import/urlscan/README.md
@@ -14,24 +14,9 @@ We provide an example of [`docker-compose.yml`](docker-compose.yml) file that co
 
 If you are using it independently, remember that the connector will try to connect to the RabbitMQ on the port configured in the OpenCTI platform.
 
-## Configuration
+## Configuration variables
 
-| Parameter                        | Docker envvar                    | Mandatory | Description                                                                                        |
-|----------------------------------|----------------------------------|-----------|----------------------------------------------------------------------------------------------------|
-| `opencti_url`                    | `OPENCTI_URL`                    | Yes       | The URL of the OpenCTI platform.                                                                   |
-| `opencti_token`                  | `OPENCTI_TOKEN`                  | Yes       | The default admin token configured in the OpenCTI platform parameters file.                        |
-| `connector_id`                   | `CONNECTOR_ID`                   | Yes       | A valid arbitrary `UUIDv4` that must be unique for this connector.                                 |
-| `connector_name`                 | `CONNECTOR_NAME`                 | Yes       | The name of the connector, can be just "ThreatMatch"                                               |
-| `connector_scope`                | `CONNECTOR_SCOPE`                | Yes       | Must be `threatmatch`, not used in this connector.                                                 |
-| `connector_update_existing_data` | `CONNECTOR_UPDATE_EXISTING_DATA` | Yes       | If an entity already exists, update its attributes with information provided by this connector.    |
-| `connector_log_level`            | `CONNECTOR_LOG_LEVEL`            | Yes       | The log level for this connector, could be `debug`, `info`, `warn` or `error` (less verbose).      |
-| `connector_create_indicators`    | `CONNECTOR_CREATE_INDICATORS`    | No        | Create indicators for each observable processed.                                                   |
-| `connector_tlp`                  | `CONNECTOR_TLP`                  | No        | The TLP to apply to any indicators and observables, this could be `white`,`green`,`amber` or `red` |
-| `connector_labels`               | `CONNECTOR_LABELS`               | No        | Comma delimited list of labels to apply to each observable.                                        |
-| `connector_interval`             | `CONNECTOR_INTERVAL`             | No        | An interval (in seconds) for data gathering from Urlscan.                                          |
-| `connector_lookback`             | `CONNECTOR_LOOKBACK`             | No        | How far to look back in days if the connector has never run or the last run is older than this value. Default is 3. You should not go above 7. |
-| `urlscan_url`                    | `URLSCAN_URL`                    | Yes       | The Urlscan URL.                                                                                    |
-| `urlscan_api_key`                | `URLSCAN_API_KEY`                | Yes       | The Urlscan client secret.                                                                          |
-| `urlscan_default_x_opencti_score`| `URLSCAN_DEFAULT_X_OPENCTI_SCORE`| No        | The default x_opencti_score to use across observable/indicator types. Default is 50.                |
-| `urlscan_x_opencti_score_domain` | `URLSCAN_X_OPENCTI_SCORE_DOMAIN` | No        | The x_opencti_score to use across Domain-Name observable and indicators. Defaults to default score. |
-| `urlscan_x_opencti_score_url`    | `URLSCAN_X_OPENCTI_URL`          | No        | The x_opencti_score to use across Url observable and indicators. Defaults to default score.         |
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
+
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._

--- a/external-import/urlscan/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/urlscan/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -4,21 +4,23 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 
 ### Type: `object`
 
-| Property | Type | Required | Possible values | Default | Description |
-| -------- | ---- | -------- | --------------- | ------- | ----------- |
-| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
-| URLSCAN_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The Urlscan API key. |
-| CONNECTOR_NAME | `string` |  | string | `"Urlscan"` | The name of the connector. |
-| CONNECTOR_SCOPE | `array` |  | string | `["urlscan"]` | The scope of the connector, e.g. 'urlscan'. |
-| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
-| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
-| CONNECTOR_INTERVAL | `integer` |  | integer | `86400` | Interval between two runs of the connector, in seconds. |
-| CONNECTOR_LOOKBACK | `integer` |  | integer | `3` | How far to look back in days if the connector has never run or its last run is older than this value. |
-| URLSCAN_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"https://urlscan.io/api/v1/pro/phishfeed?format=json"` | The Urlscan feed URL to query. |
-| URLSCAN_CREATE_INDICATORS | `boolean` |  | boolean | `true` | Whether to create indicators for imported observables. |
-| URLSCAN_UPDATE_EXISTING_DATA | `boolean` |  | boolean | `true` | Whether to update data already ingested into the platform. |
-| URLSCAN_DEFAULT_TLP | `string` |  | string | `"white"` | Default TLP marking applied to imported data. |
-| URLSCAN_DEFAULT_X_OPENCTI_SCORE | `integer` |  | integer | `50` | Default x_opencti_score applied to imported data. |
-| URLSCAN_X_OPENCTI_SCORE_DOMAIN | `integer` |  | integer | `null` | Optional x_opencti_score for domain-name observables. |
-| URLSCAN_X_OPENCTI_SCORE_URL | `integer` |  | integer | `null` | Optional x_opencti_score for url observables. |
+| Property | Type | Required | Possible values | Deprecated | Default | Description |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| URLSCAN_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The Urlscan API key. |
+| CONNECTOR_NAME | `string` |  | string |  | `"Urlscan"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string |  | `["urlscan"]` | The scope of the connector, e.g. 'urlscan'. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` |  | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` |  | `"EXTERNAL_IMPORT"` |  |
+| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | `"P1D"` | The period of time to await between two runs of the connector. |
+| CONNECTOR_LOOKBACK | `integer` |  | integer |  | `3` | How far to look back in days if the connector has never run or its last run is older than this value. |
+| URLSCAN_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | `"https://urlscan.io/api/v1/pro/phishfeed?format=json"` | The Urlscan feed URL to query. |
+| URLSCAN_CREATE_INDICATORS | `boolean` |  | boolean |  | `true` | Whether to create indicators for imported observables. |
+| URLSCAN_UPDATE_EXISTING_DATA | `boolean` |  | boolean |  | `true` | Whether to update data already ingested into the platform. |
+| URLSCAN_DEFAULT_TLP | `string` |  | string |  | `"white"` | Default TLP marking applied to imported data. |
+| URLSCAN_DEFAULT_X_OPENCTI_SCORE | `integer` |  | integer |  | `50` | Default x_opencti_score applied to imported data. |
+| URLSCAN_X_OPENCTI_SCORE_DOMAIN | `integer` |  | integer |  | `null` | Optional x_opencti_score for domain-name observables. |
+| URLSCAN_X_OPENCTI_SCORE_URL | `integer` |  | integer |  | `null` | Optional x_opencti_score for url observables. |
+| URLSCAN_LABELS | `array` |  | string |  | `["Phishing", "phishfeed"]` | list of labels to apply to each observable. |
+| CONNECTOR_INTERVAL | `integer` |  | integer | ⛔️ | `null` | Use CONNECTOR_DURATION_PERIOD instead. |

--- a/external-import/urlscan/__metadata__/connector_config_schema.json
+++ b/external-import/urlscan/__metadata__/connector_config_schema.json
@@ -46,10 +46,17 @@
       "default": "EXTERNAL_IMPORT",
       "type": "string"
     },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "P1D",
+      "description": "The period of time to await between two runs of the connector.",
+      "format": "duration",
+      "type": "string"
+    },
     "CONNECTOR_INTERVAL": {
-      "default": 86400,
-      "description": "Interval between two runs of the connector, in seconds.",
-      "type": "integer"
+      "default": null,
+      "deprecated": true,
+      "type": "integer",
+      "description": "Use CONNECTOR_DURATION_PERIOD instead."
     },
     "CONNECTOR_LOOKBACK": {
       "default": 3,
@@ -99,6 +106,17 @@
       "default": null,
       "description": "Optional x_opencti_score for url observables.",
       "type": "integer"
+    },
+    "URLSCAN_LABELS": {
+      "default": [
+        "Phishing",
+        "phishfeed"
+      ],
+      "description": "list of labels to apply to each observable.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
     }
   },
   "required": [

--- a/external-import/urlscan/docker-compose.yml
+++ b/external-import/urlscan/docker-compose.yml
@@ -5,18 +5,19 @@ services:
     environment:
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe
-      - CONNECTOR_ID=ChangeMe
-      - CONNECTOR_NAME=Urlscan # Optional (default: 'Urlscan')
-      - CONNECTOR_SCOPE=urlscan # Optional (default: 'urlscan')
-      - CONNECTOR_LOG_LEVEL=error # Optional (default: 'error')
-      - CONNECTOR_INTERVAL=86400 # Optional (default: 86400) seconds, 1d
+      # - CONNECTOR_ID=0247889a-84b9-4210-a719-b1037358c491
+      # - CONNECTOR_NAME=Urlscan # Optional (default: 'Urlscan')
+      # - CONNECTOR_SCOPE=urlscan # Optional (default: 'urlscan')
+      # - CONNECTOR_LOG_LEVEL=error # Optional (default: 'error')
+      # - CONNECTOR_DURATION_PERIOD=P1D # Optional (default: 'P1D') ISO-8601 duration (e.g. P1D, PT5M)
       - CONNECTOR_LOOKBACK=3 # Optional (default: 3) days
-      - URLSCAN_URL=https://urlscan.io/api/v1/pro/phishfeed?format=json # Optional (default: 'https://urlscan.io/api/v1/pro/phishfeed?format=json')
+      # - URLSCAN_URL=https://urlscan.io/api/v1/pro/phishfeed?format=json # Optional (default: 'https://urlscan.io/api/v1/pro/phishfeed?format=json')
       - URLSCAN_API_KEY=ChangeMe
-      - URLSCAN_CREATE_INDICATORS=true # Optional (default: true)
-      - URLSCAN_UPDATE_EXISTING_DATA=true # Optional (default: true)
-      - URLSCAN_DEFAULT_TLP=white # Optional (default: 'white')
-      - URLSCAN_DEFAULT_X_OPENCTI_SCORE=50 # Optional (default: 50)
-      # - URLSCAN_X_OPENCTI_SCORE_DOMAIN=50 # Optional (default: null)
-      # - URLSCAN_X_OPENCTI_SCORE_URL=50 # Optional (default: null)
+      # - URLSCAN_CREATE_INDICATORS=true # Optional (default: true)
+      # - URLSCAN_UPDATE_EXISTING_DATA=true # Optional (default: true)
+      # - URLSCAN_DEFAULT_TLP=white # Optional (default: 'white')
+      # - URLSCAN_DEFAULT_X_OPENCTI_SCORE=50 # Optional (default: 50)
+      # - URLSCAN_X_OPENCTI_SCORE_DOMAIN=null # Optional (default: null)
+      # - URLSCAN_X_OPENCTI_SCORE_URL=null # Optional (default: null)
+      # - URLSCAN_LABELS=Phishing, phishfeed
     restart: always

--- a/external-import/urlscan/src/config.yml.sample
+++ b/external-import/urlscan/src/config.yml.sample
@@ -6,19 +6,20 @@ opencti:
 
 connector:
   type: 'EXTERNAL_IMPORT'
-  id: "ChangeMe"
-  name: "Urlscan" # Optional (default: 'Urlscan')
-  scope: "urlscan" # Optional (default: 'urlscan')
-  log_level: "info" # Optional (default: 'error')
-  interval: 86400 # Optional (default: 86400) seconds, 1d
-  lookback: 3 # Optional (default: 3) days
+#   id: "0247889a-84b9-4210-a719-b1037358c491"
+#   name: "Urlscan" # Optional (default: 'Urlscan')
+#   scope: "urlscan" # Optional (default: 'urlscan')
+#   log_level: "error" # Optional (default: 'error')
+#   duration_period: P1D # Optional (default: 'P1D') ISO-8601 duration (e.g. P1D, PT5M)
+#   lookback: 3 # Optional (default: 3) days
 
 urlscan:
-  url: "https://urlscan.io/api/v1/pro/phishfeed?format=json" # Optional (default: 'https://urlscan.io/api/v1/pro/phishfeed?format=json')
+#   url: "https://urlscan.io/api/v1/pro/phishfeed?format=json" # Optional (default: 'https://urlscan.io/api/v1/pro/phishfeed?format=json')
   api_key: "ChangeMe"
-  create_indicators: true # Optional (default: true)
-  update_existing_data: true # Optional (default: true)
-  default_tlp: "white" # Optional (default: 'white')
-  default_x_opencti_score: 50 # Optional (default: 50)
-  # x_opencti_score_domain: 50 # Optional (default: null)
-  # x_opencti_score_url: 50 # Optional (default: null)
+#   create_indicators: true # Optional (default: true)
+#   update_existing_data: true # Optional (default: true)
+#   default_tlp: "white" # Optional (default: 'white')
+#   default_x_opencti_score: 50 # Optional (default: 50)
+#   x_opencti_score_domain: 50 # Optional (default: null)
+#   x_opencti_score_url: 50 # Optional (default: null)
+#   labels: Phishing, phishfeed # Optional (default: ["Phishing", "phishfeed"])

--- a/external-import/urlscan/src/urlscan/connector.py
+++ b/external-import/urlscan/src/urlscan/connector.py
@@ -37,7 +37,7 @@ class UrlscanConnector:
         self._config = ConnectorSettings()
 
         self._helper = OpenCTIConnectorHelper(config=self._config.to_helper_config())
-        interval = self._config.connector.interval
+        interval = int(self._config.connector.duration_period.total_seconds())
         lookback = self._config.connector.lookback
 
         urlscan_url = str(self._config.urlscan.url)
@@ -69,7 +69,7 @@ class UrlscanConnector:
             description="Phishing indicators from Urlscan.io",
         )
 
-        self._default_labels = ["Phishing", "phishfeed"]
+        self._default_labels = self._config.urlscan.labels
         self._client = UrlscanClient(urlscan_url, urlscan_api_key)
         self._loop = ConnectorLoop(
             helper=self._helper,

--- a/external-import/urlscan/src/urlscan/settings.py
+++ b/external-import/urlscan/src/urlscan/settings.py
@@ -1,13 +1,15 @@
 """Urlscan connector settings"""
 
+from datetime import timedelta
+
 from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
     BaseExternalImportConnectorConfig,
+    DeprecatedField,
     ListFromString,
 )
 from pydantic import Field, HttpUrl, SecretStr
-from pydantic.json_schema import SkipJsonSchema
 
 __all__ = [
     "ConnectorSettings",
@@ -26,13 +28,19 @@ class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
         description="The name of the connector.",
         default="Urlscan",
     )
+    id: str = Field(
+        description="The ID of the connector.",
+        default="0247889a-84b9-4210-a719-b1037358c491",
+    )
     scope: ListFromString = Field(
         description="The scope of the connector, e.g. 'urlscan'.",
         default=["urlscan"],
     )
-    interval: int = Field(
-        description="Interval between two runs of the connector, in seconds.",
-        default=86400,
+    interval: int | None = DeprecatedField(
+        default=None,
+        deprecated="Use duration_period instead",
+        new_namespaced_var="duration_period",
+        new_value_factory=lambda x: timedelta(seconds=x),
     )
     lookback: int = Field(
         description=(
@@ -41,10 +49,9 @@ class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
         ),
         default=3,
     )
-    # Override `duration_period` as scheduling is handled by the connector's own loop.
-    duration_period: SkipJsonSchema[None] = Field(
-        description="Do not use. Scheduling is handled by the connector's own loop.",
-        default=None,
+    duration_period: timedelta = Field(
+        description="The period of time to await between two runs of the connector.",
+        default=timedelta(seconds=86400),
     )
 
 
@@ -81,6 +88,10 @@ class UrlscanConfig(BaseConfigModel):
     x_opencti_score_url: int | None = Field(
         description="Optional x_opencti_score for url observables.",
         default=None,
+    )
+    labels: ListFromString = Field(
+        description="list of labels to apply to each observable.",
+        default=["Phishing", "phishfeed"],
     )
 
 


### PR DESCRIPTION
### Proposed changes

* Fixed `CONNECTOR_LABELS` (now `URLSCAN_LABELS`) being silently ignored: the connector previously hardcoded `default_labels=["Phishing", "phishfeed"]` in `connector.py` instead of reading the value from configuration. Labels are now sourced from `self._config.urlscan.labels`.
* Deprecated `connector.interval` / `CONNECTOR_INTERVAL` in favor of `connector.duration_period` / `CONNECTOR_DURATION_PERIOD`, aligning this connector with the standard scheduling pattern used across other connectors, and replaced the raw-seconds interval with a proper `timedelta`.
* Added a `DeprecatedField` for `interval` so existing deployments that still set `CONNECTOR_INTERVAL` (in seconds) keep working: the old integer value is automatically converted into a `duration_period` timedelta under the hood.
* Added a default `connector.id` value so the connector can run out-of-the-box without requiring every deployment to generate its own UUID.
* Regenerated `__metadata__/CONNECTOR_CONFIG_DOC.md` and `connector_config_schema.json` to reflect the new `CONNECTOR_DURATION_PERIOD` and `URLSCAN_LABELS` variables and the deprecation of `CONNECTOR_INTERVAL`.
* Updated `docker-compose.yml` and `src/config.yml.sample` to use `duration_period`/`labels` and commented out optional variables to match current sample conventions.
* Simplified `README.md` to link to the auto-generated `CONNECTOR_CONFIG_DOC.md` instead of maintaining a manual, now-outdated configuration table.

### Related issues

* Fixes #6555

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The `connector.interval` field is kept in the settings model but marked with `DeprecatedField(deprecated="Use duration_period instead", new_namespaced_var="duration_period", new_value_factory=lambda x: timedelta(seconds=x))`. This means: if an operator still sets `CONNECTOR_INTERVAL` (in seconds, as before), it is transparently converted into a `timedelta` and assigned to `connector.duration_period`, so no breaking change occurs for existing deployments. New deployments should set `CONNECTOR_DURATION_PERIOD` (ISO-8601 duration, e.g. `P1D`) directly. The connector still manages its own scheduling loop internally (it does not delegate to the SDK's built-in scheduler), it now just reads the interval from `duration_period.total_seconds()` instead of a raw `interval` int.