### PR TITLE
chore(ci): add crowdstrike-recon to ubi9 image build support (#7057)

### DIFF
--- a/.github/ubi9-connectors.json
+++ b/.github/ubi9-connectors.json
@@ -2,6 +2,7 @@
   "external-import/alienvault",
   "external-import/cisa-known-exploited-vulnerabilities",
   "external-import/crowdstrike",
+  "external-import/crowdstrike-recon",
   "external-import/cpe",
   "external-import/cve",
   "external-import/group-ib",


### PR DESCRIPTION
### Proposed changes

* Added `external-import/crowdstrike-recon` to `.github/ubi9-connectors.json` so the CrowdStrike Recon connector is also built as a UBI9 (Red Hat Universal Base Image 9) image in CI, in addition to its existing Alpine-based image.

### Related issues

* Closes #7057

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This is a one-line addition to a manually maintained CI build list — no code or documentation changes are involved.