### PR TITLE
fix(stream-exporter): add missing CONNECTOR_LIVE_STREAM_ID to README.md (#0)

### DIFF
--- a/stream/stream-exporter/README.md
+++ b/stream/stream-exporter/README.md
@@ -62,6 +62,7 @@ There are a number of configuration options, which are set either in `docker-com
 | Connector ID                   | id                        | `CONNECTOR_ID`                          |                 | Yes       | A unique `UUIDv4` identifier for this connector instance.                      |
 | Connector Name                 | name                      | `CONNECTOR_NAME`                        |                 | Yes       | Name of the connector.                                                         |
 | Connector Scope                | scope                     | `CONNECTOR_SCOPE`                       | stream-exporter | Yes       | The scope of the connector.                                                    |
+| Live Stream ID                 | live_stream_id            | `CONNECTOR_LIVE_STREAM_ID`              |                 | Yes       | The Live Stream ID of the stream created in the OpenCTI interface.             |
 | Live Stream Start Timestamp    | live_stream_start_timestamp| `CONNECTOR_LIVE_STREAM_START_TIMESTAMP`|                 | No        | Start timestamp on first start (default: all data).                            |
 | Consumer Count                 | consumer_count            | `CONNECTOR_CONSUMER_COUNT`              | 10              | No        | Number of consumer/worker threads.                                             |
 | Confidence Level               | confidence_level          | `CONNECTOR_CONFIDENCE_LEVEL`            |                 | Yes       | Default confidence level (1-4).                                                |
@@ -104,6 +105,7 @@ Configure the connector in `docker-compose.yml`:
       - CONNECTOR_SCOPE=stream-exporter
       - CONNECTOR_LOG_LEVEL=info
       - CONNECTOR_CONFIDENCE_LEVEL=80
+      - CONNECTOR_LIVE_STREAM_ID=ChangeMe
       - MINIO_ENDPOINT=minio.example.com
       - MINIO_PORT=9000
       - MINIO_BUCKET=opencti-export

--- a/stream/stream-exporter/README.md
+++ b/stream/stream-exporter/README.md
@@ -65,7 +65,7 @@ There are a number of configuration options, which are set either in `docker-com
 | Live Stream ID                 | live_stream_id            | `CONNECTOR_LIVE_STREAM_ID`              |                 | Yes       | The Live Stream ID of the stream created in the OpenCTI interface.             |
 | Live Stream Start Timestamp    | live_stream_start_timestamp| `CONNECTOR_LIVE_STREAM_START_TIMESTAMP`|                 | No        | Start timestamp on first start (default: all data).                            |
 | Consumer Count                 | consumer_count            | `CONNECTOR_CONSUMER_COUNT`              | 10              | No        | Number of consumer/worker threads.                                             |
-| Confidence Level               | confidence_level          | `CONNECTOR_CONFIDENCE_LEVEL`            |                 | Yes       | Default confidence level (1-4).                                                |
+| Confidence Level               | confidence_level          | `CONNECTOR_CONFIDENCE_LEVEL`            |                 | Yes       | Default confidence level (0 = Unknown, 100 = Fully trusted).                  |
 | Log Level                      | log_level                 | `CONNECTOR_LOG_LEVEL`                   | info            | No        | Determines the verbosity of the logs.                                          |
 
 ### Connector extra parameters environment variables


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.

PR TITLE FORMAT (enforced by CI):
  type(scope?)!?: description (#123)
  - type: feat | fix | chore | docs | style | refactor | perf | test | build | ci | revert
  - scope: optional, e.g. connector name
  - description: must start with a lowercase letter
  - (#123): required linked issue number
  Example: feat(alienvault): add pagination support (#42)
-->

### Proposed changes

* Add the missing `CONNECTOR_LIVE_STREAM_ID` to README.md for the stream-exporter connector

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
