### PR TITLE
fix(ci): support LTS version format MAJOR.YYMMDD.PATCH-lts.N in release tooling (#6019)

### DIFF
--- a/.github/scripts/bulk_release.py
+++ b/.github/scripts/bulk_release.py
@@ -61,8 +61,10 @@ import _matrix_common as common
 # Default CalVer major, matching release-connector.yml (MAJOR=7).
 DEFAULT_MAJOR = 7
 
-# CalVer format MAJOR.YYMMDD.PATCH — identical to release-connector.yml.
-VERSION_RE = re.compile(r"^[0-9]+\.[0-9]{6}\.[0-9]+$")
+# CalVer format MAJOR.YYMMDD.PATCH with an optional "-lts.N" suffix for LTS
+# releases (e.g. 7.260706.0 or 7.260706.0-lts.1) — identical to
+# release-connector.yml and the global tag patterns in build-all-connectors.yml.
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]{6}\.[0-9]+(-lts\.[0-9]+)?$")
 
 
 class BulkReleaseError(Exception):
@@ -90,11 +92,16 @@ def compute_calver(
 
 
 def validate_version(version: str) -> str:
-    """Validate a CalVer string against the release-connector.yml format."""
+    """Validate a CalVer string against the release-connector.yml format.
+
+    Accepts a plain CalVer (``MAJOR.YYMMDD.PATCH``) or an LTS variant with a
+    ``-lts.N`` suffix (e.g. ``7.260706.0-lts.1``).
+    """
     if not VERSION_RE.match(version):
         raise BulkReleaseError(
-            f"Invalid CalVer version '{version}'. "
-            "Expected format: MAJOR.YYMMDD.PATCH (e.g. 7.260706.0)."
+            f"Invalid CalVer version '{version}'. Expected format: "
+            "MAJOR.YYMMDD.PATCH or MAJOR.YYMMDD.PATCH-lts.N "
+            "(e.g. 7.260706.0 or 7.260706.0-lts.1)."
         )
     return version
 
@@ -375,7 +382,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--github-output",
         default=os.environ.get("GITHUB_OUTPUT"),
-        help="Path to write matrix outputs (defaults to $GITHUB_OUTPUT).",
+        help="Path to write resolved outputs (defaults to $GITHUB_OUTPUT).",
     )
     return parser
 

--- a/.github/workflows/release-bulk-connectors.yml
+++ b/.github/workflows/release-bulk-connectors.yml
@@ -49,9 +49,9 @@ on:
       # contain '/', unlike per-connector tags `{name}/{version}` matched by
       # release-connector.yml's own '*/*' filter (glob '*' does not match
       # '/', so the two patterns can never collide).
-      # NOTE: bulk_release.py currently only validates the plain
-      # MAJOR.YYMMDD.PATCH format; an `-lts.N`-suffixed platform tag would
-      # match this trigger but fail version validation in the resolve step.
+      # LTS platform tags (e.g. 7.260706.0-lts.1) also match this pattern and
+      # are supported: bulk_release.py validates both MAJOR.YYMMDD.PATCH and the
+      # `-lts.N` variant, so an LTS tag produces LTS per-connector releases.
       - '*.*.*'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -210,8 +210,8 @@ jobs:
             VERSION="${{ github.ref_name }}"
             VERSION="${VERSION##*/}"
 
-            if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]{6}\.[0-9]+$'; then
-              echo "::error::Invalid CalVer version '${VERSION}' from tag '${{ github.ref_name }}'. Expected format: MAJOR.YYMMDD.PATCH (e.g. 7.260630.0)"
+            if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]{6}\.[0-9]+(-lts\.[0-9]+)?$'; then
+              echo "::error::Invalid CalVer version '${VERSION}' from tag '${{ github.ref_name }}'. Expected format: MAJOR.YYMMDD.PATCH or MAJOR.YYMMDD.PATCH-lts.N (e.g. 7.260630.0 or 7.260630.0-lts.1)"
               exit 1
             fi
 
@@ -221,8 +221,8 @@ jobs:
             INPUT_VERSION="${{ inputs.version }}"
 
             if [ -n "$INPUT_VERSION" ]; then
-              if ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]{6}\.[0-9]+$'; then
-                echo "::error::Invalid CalVer version: '$INPUT_VERSION'. Expected format: MAJOR.YYMMDD.PATCH (e.g. 7.260603.0)"
+              if ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]{6}\.[0-9]+(-lts\.[0-9]+)?$'; then
+                echo "::error::Invalid CalVer version: '$INPUT_VERSION'. Expected format: MAJOR.YYMMDD.PATCH or MAJOR.YYMMDD.PATCH-lts.N (e.g. 7.260603.0 or 7.260603.0-lts.1)"
                 exit 1
               fi
               VERSION="$INPUT_VERSION"

--- a/shared/tools/composer/generate_manifest_fragment/connector_manifest_schema.json
+++ b/shared/tools/composer/generate_manifest_fragment/connector_manifest_schema.json
@@ -170,7 +170,7 @@
     "version": {
       "type": "string",
       "description": "Current version of the connector.",
-      "pattern": "^[0-9]+\\.[0-9]{1,6}\\.[0-9]+$",
+      "pattern": "^[0-9]+\\.[0-9]{1,6}\\.[0-9]+(-lts\\.[0-9]+)?$",
       "examples": ["6.5.1", "1.0.0"]
     },
     "image_name": {


### PR DESCRIPTION
### Proposed changes
* Update the CalVer regex in `.github/scripts/bulk_release.py` to accept an optional `-lts.N` suffix (`^[0-9]+\.[0-9]{6}\.[0-9]+(-lts\.[0-9]+)?$`), so LTS tags like `7.260706.0-lts.1` validate alongside standard `7.260706.0` versions.
* Refresh the `validate_version` docstring and error message to document both the `MAJOR.YYMMDD.PATCH` and `MAJOR.YYMMDD.PATCH-lts.N` formats, and reword the `--github-output` help text ("matrix outputs" -> "resolved outputs").
* Update the two shell CalVer validation regexes in `.github/workflows/release-connector.yml` (the tag `ref_name` path and the `workflow_dispatch` `inputs.version` path) to allow the `-lts.N` suffix, with error messages updated to mention the LTS format.
* Clarify the comment in `.github/workflows/release-bulk-connectors.yml` to note that LTS platform tags (e.g. `7.260706.0-lts.1`) match the `*.*.*` trigger and are supported because `bulk_release.py` validates both formats.

### Related issues
* Closes #7075

### Checklist
- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments
This aligns the version validation in `bulk_release.py` and `release-connector.yml` with the global LTS tag patterns already used elsewhere in the release tooling, so LTS releases flow through the release and bulk-release workflows without manual intervention. Documentation box is checked because inline docstrings and workflow comments were updated as part of this change.

Tested on personal fork: https://github.com/jabesq/connectors/actions/runs/30103227176