### PR TITLE
fix(deps): bump pytest to 9.0.3 to fix vulnerable tmpdir handling (#7109)

### DIFF
--- a/external-import/citalid/tests/test-requirements.txt
+++ b/external-import/citalid/tests/test-requirements.txt
@@ -1,2 +1,2 @@
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3

--- a/external-import/malcore/tests/test-requirements.txt
+++ b/external-import/malcore/tests/test-requirements.txt
@@ -1,2 +1,2 @@
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3

--- a/external-import/maltiverse/tests/test-requirements.txt
+++ b/external-import/maltiverse/tests/test-requirements.txt
@@ -1,2 +1,2 @@
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3

--- a/external-import/rst-report-hub/tests/test-requirements.txt
+++ b/external-import/rst-report-hub/tests/test-requirements.txt
@@ -1,2 +1,2 @@
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3

--- a/external-import/rst-threat-feed/tests/test-requirements.txt
+++ b/external-import/rst-threat-feed/tests/test-requirements.txt
@@ -1,2 +1,2 @@
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3

--- a/external-import/zerofox/tests/test-requirements.txt
+++ b/external-import/zerofox/tests/test-requirements.txt
@@ -1,3 +1,3 @@
 # Main dependencies need to be installed
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3

--- a/internal-enrichment/greynoise/tests/test-requirements.txt
+++ b/internal-enrichment/greynoise/tests/test-requirements.txt
@@ -1,2 +1,2 @@
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3

--- a/internal-enrichment/malbeacon/tests/test-requirements.txt
+++ b/internal-enrichment/malbeacon/tests/test-requirements.txt
@@ -1,2 +1,2 @@
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3

--- a/internal-enrichment/yara/tests/test-requirements.txt
+++ b/internal-enrichment/yara/tests/test-requirements.txt
@@ -1,3 +1,3 @@
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3
 

--- a/stream/jira/tests/test-requirements.txt
+++ b/stream/jira/tests/test-requirements.txt
@@ -1,2 +1,2 @@
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3

--- a/stream/misp-intel/tests/test-requirements.txt
+++ b/stream/misp-intel/tests/test-requirements.txt
@@ -1,3 +1,3 @@
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3
 pytest-mock==3.14.1


### PR DESCRIPTION
### Proposed changes

* Bump `pytest` from `8.4.2` to `9.0.3` in all affected connectors' `tests/test-requirements.txt` files to resolve the Dependabot moderate severity alert (vulnerable tmpdir handling).

### Related issues

* Fixes #7109

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This only updates test dependency pins; no connector runtime code is affected. The 11 files updated correspond to Dependabot alerts #666, #665, #652, #651, #650, #649, #648, #647, #646, #488 and #485.