### PR TITLE
fix(stream-importer): Ensure S3 paths always end in '/' (#0)

### DIFF
--- a/external-import/stream-importer/src/importer/connector.py
+++ b/external-import/stream-importer/src/importer/connector.py
@@ -67,6 +67,9 @@ class StreamImporterConnector(ExternalImportConnector):
             if "/" in os.environ.get("MINIO_DST_PATH")
             else (os.environ.get("MINIO_DST_PATH"), "")
         )
+        # Ensure S3 paths always end in '/'
+        self.minio_src_path = self.minio_src_path.rstrip("/") + "/"
+        self.minio_dst_path = self.minio_dst_path.rstrip("/") + "/"
         # Reject the unsafe ``src bucket == dst bucket AND dst_path is
         # empty`` configuration up front. The ``bucket_exists`` /
         # ``make_bucket`` plumbing below cannot defend this case

--- a/external-import/stream-importer/src/importer/connector.py
+++ b/external-import/stream-importer/src/importer/connector.py
@@ -67,9 +67,11 @@ class StreamImporterConnector(ExternalImportConnector):
             if "/" in os.environ.get("MINIO_DST_PATH")
             else (os.environ.get("MINIO_DST_PATH"), "")
         )
-        # Ensure S3 paths always end in '/'
-        self.minio_src_path = self.minio_src_path.rstrip("/") + "/"
-        self.minio_dst_path = self.minio_dst_path.rstrip("/") + "/"
+        # Ensure S3 paths always end in '/' (but keep empty path as "")
+        if self.minio_src_path:
+            self.minio_src_path = self.minio_src_path.rstrip("/") + "/"
+        if self.minio_dst_path:
+            self.minio_dst_path = self.minio_dst_path.rstrip("/") + "/"
         # Reject the unsafe ``src bucket == dst bucket AND dst_path is
         # empty`` configuration up front. The ``bucket_exists`` /
         # ``make_bucket`` plumbing below cannot defend this case


### PR DESCRIPTION
When no trailing is specified, the minio calls return no data.  Force the slash to always be present to prevent.

### Proposed changes

* Ensure s3 paths always end in a `/`

### Related issues

### Checklist

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
