### PR TITLE
docs: add AGENTS.md guidance for AI coding agents across connector types (#7122)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,25 @@ This is the **OpenCTI connectors** monorepo, containing 200+ Python-based connec
 - **Build System:** CircleCI with dynamic pipeline generation
 - **Testing:** pytest with isolated virtual environments per connector
 
+## Deep-Dive Documentation & Agent Instructions
+
+This file is a repo-wide quick reference. For connector-type-specific implementation
+details (scheduling, event handling, TLP/playbook rules, dedup strategy, etc.), read
+the canonical docs in [`docs/`](../docs) — start with
+[`docs/01-common-implementation.md`](../docs/01-common-implementation.md), then the
+spec for the type you're touching: [`02-external-import`](../docs/02-external-import-specifications.md),
+[`03-internal-enrichment`](../docs/03-internal-enrichment-specifications.md),
+[`04-stream`](../docs/04-stream-specifications.md), and
+[`05-code-quality-standards`](../docs/05-code-quality-standards.md) (applies to all
+types). There is no dedicated spec yet for `internal-import-file`/`internal-export-file`.
+
+There is also a repo-root [`AGENTS.md`](../AGENTS.md) plus one nested inside each
+connector-type directory (`external-import/AGENTS.md`, `internal-enrichment/AGENTS.md`,
+`stream/AGENTS.md`, `internal-import-file/AGENTS.md`, `internal-export-file/AGENTS.md`).
+These distill the docs above into actionable rules and are picked up automatically by
+Copilot and other AI agents based on which folder you're working in — keep them in
+sync with `docs/` if either changes.
+
 ## Critical Build & Validation Requirements
 
 ### Code Formatting (ALWAYS REQUIRED)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,121 @@
+# AGENTS.md — OpenCTI Connectors Monorepo
+
+This file guides **any AI coding agent** (GitHub Copilot, Claude, Cursor, Codex, etc.)
+working in this repository. Humans should read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+This is a distilled, actionable summary. **The canonical, in-depth human
+documentation lives in [`docs/`](./docs)** — read the relevant file there before
+implementing non-trivial logic, and keep this file in sync if you update it:
+
+| Doc                                                                        | Covers                                                             |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| [`docs/01-common-implementation.md`](./docs/01-common-implementation.md)     | Env setup, directory layout, config, connectors-sdk, logging, state |
+| [`docs/02-external-import-specifications.md`](./docs/02-external-import-specifications.md) | Scheduling, work management, deduplication                          |
+| [`docs/03-internal-enrichment-specifications.md`](./docs/03-internal-enrichment-specifications.md) | Event-driven enrichment, TLP handling, playbooks                    |
+| [`docs/04-stream-specifications.md`](./docs/04-stream-specifications.md)     | Live stream listening, event types, sync                            |
+| [`docs/05-code-quality-standards.md`](./docs/05-code-quality-standards.md)   | Style, linting, STIX compliance, testing, Docker, metadata           |
+
+> **Gap:** there is currently no dedicated spec doc for `internal-import-file` or
+> `internal-export-file` connectors. Their `AGENTS.md` files are distilled from
+> `templates/` and existing connector code instead — treat them as lower-confidence.
+
+Each connector-type directory also has its own nested `AGENTS.md` with rules specific
+to that architecture. Read **this file plus the one for the folder you're editing**:
+`external-import/AGENTS.md`, `internal-enrichment/AGENTS.md`, `stream/AGENTS.md`,
+`internal-import-file/AGENTS.md`, `internal-export-file/AGENTS.md`.
+
+## Repository shape
+
+200+ Python 3.11/3.12 connectors integrating OpenCTI with external tools, grouped by
+type: `external-import/` (pull, scheduled), `internal-enrichment/` (event-driven,
+enriches existing entities), `stream/` (real-time sync), `internal-import-file/` /
+`internal-export-file/` (file conversion). Shared code lives in `connectors-sdk/` and
+`shared/`. New connectors are scaffolded with `templates/create_connector_dir.sh`.
+
+Standard connector layout:
+```
+<type>/<connector-name>/
+├── __metadata__/connector_manifest.json   # title, description, container_type, use_cases...
+├── src/connector/{connector.py, converter_to_stix.py, settings.py}
+├── src/main.py
+├── tests/
+├── config.yml.sample / .env.sample
+├── Dockerfile / docker-compose.yml
+└── README.md
+```
+
+## Configuration (Pydantic + connectors-sdk)
+
+Define settings in `src/connector/settings.py` using `BaseConnectorSettings` /
+`BaseConfigModel` from `connectors-sdk`. Config is auto-discovered: `config.yml` takes
+precedence over `.env`, both are overridden by environment variables. Env var names are
+`SECTION_FIELD` in uppercase (e.g. `my_connector.api_key` → `MY_CONNECTOR_API_KEY`).
+Never hardcode secrets — use `.env.sample`/`config.yml.sample` as templates only.
+
+## STIX objects: deterministic IDs are CRITICAL
+
+**Never let `stix2` auto-generate an object ID.** OpenCTI deduplicates via a
+deterministic `standard_id` derived from each entity's "ID Contributing Properties"
+(e.g. `name` for Malware, `pattern` for Indicator, `name`+`published` for Report).
+Random IDs bypass this, causing the `x_opencti_stix_ids` list to grow unboundedly on
+every re-import → memory bloat and Redis stream degradation.
+
+```python
+# Preferred: connectors-sdk models (deterministic ID built in)
+from connectors_sdk.models import IPV4Address, OrganizationAuthor, TLPMarking
+author = OrganizationAuthor(name="Example Author")
+ip = IPV4Address(value="127.0.0.1", author=author, markings=[TLPMarking(level="amber+strict")])
+stix_object = ip.to_stix2_object()
+
+# Accepted: stix2 + pycti generate_id()
+import stix2
+from pycti import Indicator
+indicator = stix2.Indicator(
+    id=Indicator.generate_id("[domain-name:value = 'evil.com']"),
+    pattern="[domain-name:value = 'evil.com']",
+    pattern_type="stix",
+)
+```
+The custom pylint plugin (`shared/pylint_plugins/check_stix_plugin`, rule
+`no_generated_id_stix`) enforces this — run it on any connector code you touch that
+creates STIX objects (see below).
+
+## Logging & error handling
+
+Always log via `self.helper.connector_logger.{debug,info,warning,error}(message, {dict of context})`
+— never f-string interpolation into the message. Wrap `main.py`'s entrypoint in
+try/except with `traceback.print_exc(); exit(1)`. Use `tenacity` for retry with
+exponential backoff and `limiter` for API rate limiting.
+
+## Formatting, linting, testing (run before every commit)
+
+```bash
+# Format (required, CI fails otherwise)
+isort --profile black --line-length 88 .
+black .
+
+# Lint
+flake8 --ignore=E,W .
+
+# STIX ID plugin — mandatory whenever you create/modify STIX objects
+cd shared/pylint_plugins/check_stix_plugin && pip install -r requirements.txt
+PYTHONPATH=. python -m pylint <path/to/connector> \
+  --disable=all --enable=no_generated_id_stix,no-value-for-parameter,unused-import \
+  --load-plugins linter_stix_id_generator
+
+# Tests (isolated venv per connector)
+bash run_test.sh ./<type>/<connector-name>/tests/test-requirements.txt
+```
+
+## Metadata & docs
+
+Update `__metadata__/connector_manifest.json` (title, description, `container_type`,
+`use_cases`, `solution_categories`, `playbook_supported`, etc.) for any new/modified
+connector, and keep `README.md` complete (config table, behavior, troubleshooting).
+Never commit real secrets in `.env.sample`/`config.yml.sample` — use `ChangeMe`.
+
+## PR conventions
+
+Conventional Commits with an issue reference (`type(scope): description (#issue)`),
+GPG-signed commits, PR title ends with the issue reference. See `CONTRIBUTING.md` and
+`.github/LABELS.md`.

--- a/external-import/AGENTS.md
+++ b/external-import/AGENTS.md
@@ -1,0 +1,93 @@
+# AGENTS.md — External Import Connectors
+
+Scope: everything under `external-import/`. Read the repo-root [`AGENTS.md`](../AGENTS.md)
+first (universal rules: STIX IDs, config, logging, formatting/linting/tests). Full spec:
+[`docs/02-external-import-specifications.md`](../docs/02-external-import-specifications.md).
+
+## What this connector type does
+
+Pulls data from an external source (API, feed, file) on a schedule and imports it into
+OpenCTI as STIX 2.1 objects. Pull-based, stateful (tracks what's been imported),
+autonomous (no user trigger needed).
+
+## Class shape
+
+```python
+class MyConnector:
+    def __init__(self, config: ConnectorSettings, helper: OpenCTIConnectorHelper):
+        self.config = config
+        self.helper = helper
+        self.client = MyClient(...)                 # external API client
+        self.converter_to_stix = ConverterToStix(...)  # STIX conversion
+
+    def _collect_intelligence(self) -> list: ...    # fetch + convert to STIX, returns list of objects
+    def process_message(self) -> None: ...          # state + work management + send bundle
+    def run(self) -> None:
+        self.helper.schedule_process(
+            message_callback=self.process_message,
+            duration_period=self.config.connector.duration_period.total_seconds(),
+        )
+```
+
+## Scheduling: use `schedule_process()`, never a manual loop
+
+Since OpenCTI 6.2.12, **do not** write `while True: ... time.sleep(...)` or implement
+Run-and-Terminate manually. `self.helper.schedule_process(...)` handles both the
+periodic scheduled mode and Run & Terminate mode (triggered by
+`connector.run_and_terminate: true` or a zero `duration_period`), including flushing
+state via `force_ping()` before exit. `duration_period` is an ISO-8601 duration
+(`PT1H`, `PT5M`...) converted to seconds via `.total_seconds()`.
+
+The scheduler also auto-checks `connector.queue_threshold` (MB) and pauses
+("Buffering" mode, visible in the OpenCTI UI) if the RabbitMQ queue is too full —
+you don't need to implement backpressure yourself.
+
+## Work management — always wrap sends in a work
+
+```python
+work_id = self.helper.api.work.initiate_work(self.helper.connect_id, friendly_name)
+# ... send bundle with work_id=work_id ...
+self.helper.api.work.to_processed(work_id, f"Imported {len(stix_objects)} objects")
+```
+Only update state (`self.helper.set_state(...)`) **after** successful completion, so a
+failed run retries with the same parameters instead of silently skipping data.
+
+## State: use timestamps/ISO-8601, resume incrementally
+
+Store `last_run_start` / `last_run_with_data` (or a cursor / processed-ID set for
+paginated APIs) — always with explicit timezone. Prefer **relative** ISO-8601
+durations for `import_from_date`-style config (e.g. `P30D`) over absolute dates —
+they keep configs portable and don't degrade as the platform ages.
+
+## Bundle rules
+
+- Always include the **author** and **TLP marking** objects in every bundle sent.
+- Use `cleanup_inconsistent_bundle=True` on `send_stix2_bundle(...)` — but then *every*
+  bundle must carry its own author/markings, or you'll get `MISSING_REFERENCE_ERROR`.
+- Batch large datasets (200k+ entities): ~500 objects/batch, **one `work` per batch**,
+  update state after each batch so a mid-run failure resumes instead of restarting.
+- Keep single bundles under ~10,000 objects.
+
+## Deduplication — beyond generateId
+
+Besides the root rule (always use deterministic IDs), know the platform's upsert
+semantics: incoming data only overwrites an existing entity if its **Confidence Level**
+is ≥ the existing one's. Streams/feeds can't set a confidence level per-object, so a
+high-confidence source will always win — be deliberate about the confidence you send.
+
+## Rate limiting
+
+```python
+from limiter import Limiter
+from tenacity import retry, stop_after_attempt, wait_exponential_jitter
+
+self.rate_limiter = Limiter(rate=10, capacity=20, bucket="my_connector")
+
+@retry(stop=stop_after_attempt(3), wait=wait_exponential_jitter(initial=1, max=60, jitter=1))
+def _request(self, endpoint): ...
+```
+
+## Reference implementation
+
+A full working example is in [`docs/02-external-import-specifications.md#complete-example`](../docs/02-external-import-specifications.md#complete-example)
+and the scaffold at [`templates/external-import`](../templates/external-import).

--- a/internal-enrichment/AGENTS.md
+++ b/internal-enrichment/AGENTS.md
@@ -1,0 +1,87 @@
+# AGENTS.md — Internal Enrichment Connectors
+
+Scope: everything under `internal-enrichment/`. Read the repo-root [`AGENTS.md`](../AGENTS.md)
+first (universal rules: STIX IDs, config, logging, formatting/linting/tests). Full spec:
+[`docs/03-internal-enrichment-specifications.md`](../docs/03-internal-enrichment-specifications.md).
+
+## What this connector type does
+
+Enriches entities that **already exist** in OpenCTI with extra context/relationships
+from an external source. Event-driven (triggered on entity create/update), push-based
+(OpenCTI sends the entity to the connector), stateless (each request independent),
+scope-based (only processes configured entity types).
+
+## Class shape
+
+```python
+class MyEnrichmentConnector:
+    def __init__(self, config, helper):
+        self.config = config
+        self.helper = helper
+        self.client = MyClient(...)
+        self.converter_to_stix = ConverterToStix(...)
+        self.stix_objects_list = []           # existing bundle, set per-request
+
+    def entity_in_scope(self, data: dict) -> bool: ...
+    def extract_and_check_markings(self, opencti_entity: dict) -> None: ...
+    def _collect_intelligence(self, value: str, obs_id: str) -> list: ...
+    def process_message(self, data: dict) -> str: ...
+    def run(self) -> None:
+        self.helper.listen(message_callback=self.process_message)
+```
+
+## Order of operations matters — TLP check ALWAYS first
+
+**Never call an external (especially paid/quota-limited) API before validating TLP.**
+Check the entity's TLP against `config.max_tlp_level` via `self.helper.check_max_tlp(...)`
+before doing anything else in `process_message`. This is both a data-handling rule and
+a quota-protection measure — skipping it means potentially leaking sensitive entities
+to a third-party API and burning quota on entities you'd reject anyway.
+
+## Scope validation
+
+```python
+scopes = self.helper.connect_scope.lower().replace(" ", "").split(",")
+entity_type = data["entity_id"].split("--")[0].lower()
+return entity_type in scopes
+```
+`scope` in config (`connector.scope`) determines which entity types **trigger** the
+connector — it does not filter what the connector is allowed to return.
+
+## Playbook compatibility is mandatory
+
+Connectors **must**:
+1. Always return a bundle — even on error or when the entity is out of scope.
+2. Include the original entity in that bundle (`data["stix_objects"]`, untouched if you
+   have nothing to add).
+3. Set `playbook_compatible=True` when constructing `OpenCTIConnectorHelper` — only if
+   a bundle is always sent.
+4. Set `"playbook_supported": true` in `__metadata__/connector_manifest.json`.
+
+```python
+if not self.entity_in_scope(data):
+    if not data.get("event_type"):
+        self._send_bundle(self.stix_objects_list)   # return original, unchanged
+        return "Entity not in scope, returned original bundle"
+    raise ValueError(f"{opencti_entity['entity_type']} is not a supported entity type")
+```
+On any exception during enrichment, catch it, send the **original** bundle back, and
+return an error string — don't let the exception propagate and drop the bundle.
+
+## `auto: false` for quota-based/paid sources
+
+If the external API is metered or paid, set `connector.auto: false` in the manifest and
+sample config so enrichment must be manually triggered (or driven by a Playbook with
+controlled targeting) instead of firing automatically on every new observable.
+
+## Bundle composition
+
+Original entity/bundle + enriched or new related entities + relationships linking them
++ author + markings. Send via `self.helper.stix2_create_bundle(...)` /
+`self.helper.send_stix2_bundle(...)` — never mutate objects directly via the API client
+outside this flow (it bypasses confidence-level checks and deduplication).
+
+## Reference implementation
+
+Full example in [`docs/03-internal-enrichment-specifications.md#complete-example`](../docs/03-internal-enrichment-specifications.md#complete-example)
+and the scaffold at [`templates/internal-enrichment`](../templates/internal-enrichment).

--- a/internal-export-file/AGENTS.md
+++ b/internal-export-file/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md — Internal Export File Connectors
+
+Scope: everything under `internal-export-file/`. Read the repo-root
+[`AGENTS.md`](../AGENTS.md) first (universal rules: STIX IDs, config, logging,
+formatting/linting/tests).
+
+> **No dedicated spec doc exists yet** for this connector type (unlike
+> external-import/internal-enrichment/stream, which have `docs/02-04`). The rules
+> below are distilled from [`templates/internal-export-file`](../templates/internal-export-file).
+> Several existing connectors here (e.g. `export-file-csv`) predate the connectors-sdk
+> and use the legacy `get_config_variable` pattern — **don't copy that pattern for new
+> connectors**; follow the template instead, which uses `ConnectorSettings`/Pydantic
+> like every other connector type.
+
+## What this connector type does
+
+Triggered when a user requests an export from the OpenCTI UI. The connector receives
+the export request, generates a file (CSV, STIX, PDF, etc.), and pushes it back into
+OpenCTI via a direct API call — it does not send a STIX bundle back through the
+worker queue like other connector types do.
+
+## Class shape
+
+```python
+class MyExportConnector:
+    def __init__(self, config, helper):
+        self.config = config
+        self.helper = helper
+
+    def process_message(self, data: dict) -> str:
+        entity_id = data.get("entity_id")
+        entity_type = data["entity_type"]
+        file_name = data["file_name"]
+        export_type = data["export_type"]
+        file_markings = data["file_markings"]
+        export_scope = data["export_scope"]       # "query" | "selection" | "single"
+        access_filter = data.get("access_filter")
+
+        # ... build the export content (json_bundle, csv bytes, etc.) ...
+
+        self.helper.api.stix_cyber_observable.push_list_export(
+            entity_id, entity_type, file_name, file_markings, json_bundle, list_filters,
+        )
+        return "Export done"
+
+    def run(self) -> None:
+        self.helper.listen(message_callback=self.process_message)
+```
+
+## Message payload (`data` dict)
+
+| Key             | Meaning                                                                 |
+| ----------------- | -------------------------------------------------------------------- |
+| `entity_id`      | Root entity being exported (absent for global/query exports)           |
+| `entity_type`    | Determines which `push_list_export` client to call (see below)         |
+| `file_name`      | Name to give the generated file                                        |
+| `export_type`    | Requested format/flavor (connector-specific)                           |
+| `file_markings`  | Markings to attach to the generated file                               |
+| `export_scope`   | `"query"`, `"selection"`, or `"single"` — what set of entities to export |
+| `access_filter`  | Filter to apply when resolving the entities to export                  |
+
+## Pushing the result back — pick the right client by `entity_type`
+
+- `self.helper.api.stix_cyber_observable.push_list_export(...)` — observables
+- `self.helper.api.stix_domain_object.push_list_export(...)` — domain objects
+- `self.helper.api.stix_core_object.push_list_export(...)` — generic core objects
+
+For `export_scope == "selection"`, resolve the entities via
+`self.helper.api_impersonate.stix2.export_selected(entities_list, export_type, access_filter)`
+before pushing.
+
+## Still applies from the root rules
+
+Structured logging via `self.helper.connector_logger`, no hardcoded secrets, formatting/
+linting/tests before commit. STIX ID determinism applies if you construct STIX objects
+as part of building the export (e.g. `export-file-stix`).
+
+## Reference implementation
+
+[`templates/internal-export-file`](../templates/internal-export-file) for the current
+(connectors-sdk based) scaffold to copy from.

--- a/internal-import-file/AGENTS.md
+++ b/internal-import-file/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md — Internal Import File Connectors
+
+Scope: everything under `internal-import-file/`. Read the repo-root
+[`AGENTS.md`](../AGENTS.md) first (universal rules: STIX IDs, config, logging,
+formatting/linting/tests).
+
+> **No dedicated spec doc exists yet** for this connector type (unlike
+> external-import/internal-enrichment/stream, which have `docs/02-04`). The rules
+> below are distilled from [`templates/internal-import-file`](../templates/internal-import-file)
+> and real connectors (e.g. `import-file-stix`) — treat as lower-confidence than the
+> documented types, and prefer reading a couple of existing connectors in this folder
+> before writing new logic.
+
+## What this connector type does
+
+Triggered when a user uploads a file into OpenCTI whose MIME type (or STIX type)
+matches the connector's `scope`. The connector fetches the raw file content, parses/
+converts it, and sends the result back as a STIX bundle — mechanically identical to
+internal-enrichment (same `helper.listen()` push model), but the payload is a file
+rather than an existing entity.
+
+## Class shape
+
+```python
+class MyImportConnector:
+    def __init__(self, config, helper):
+        self.config = config
+        self.helper = helper
+
+    def process_message(self, data: dict) -> str:
+        file_fetch = data["file_fetch"]
+        file_uri = self.helper.opencti_url + file_fetch
+        entity_id = data.get("entity_id")            # set only for contextual import
+        bypass_validation = data["bypass_validation"]
+
+        file_content = self.helper.api.fetch_opencti_file(file_uri)
+        # ... parse / convert file_content to a STIX bundle ...
+        return self.helper.send_stix2_bundle(
+            file_content,
+            bypass_validation=bypass_validation,
+            file_name=data["file_id"],
+            entity_id=entity_id,
+            file_markings=data.get("file_markings", []),
+        )
+
+    def run(self) -> None:
+        self.helper.listen(message_callback=self.process_message)
+```
+
+## Message payload (`data` dict)
+
+| Key                 | Meaning                                                              |
+| ------------------- | --------------------------------------------------------------------- |
+| `file_fetch`        | Path to append to `self.helper.opencti_url` to download the file      |
+| `file_mime`         | MIME type of the uploaded file — branch conversion logic on this      |
+| `file_id`           | Pass through as `file_name` when sending the resulting bundle          |
+| `entity_id`         | Present for **contextual import** (import directly into a container: Report, Case, etc.) — absent otherwise |
+| `bypass_validation` | Pass straight through to `send_stix2_bundle(bypass_validation=...)`    |
+| `file_markings`     | Markings to attach to the imported file/bundle                        |
+
+## Contextual import
+
+When `entity_id` is set, merge the parsed objects into the target container's
+`object_refs` instead of creating a standalone bundle (see `import-file-stix`'s
+`_update_container` for the reference pattern: read the container, append new object
+refs, re-attach).
+
+## Still applies from the root rules
+
+- Any STIX object you construct while parsing the file must use a deterministic ID
+  (connectors-sdk model or `stix2` + `pycti.generate_id()`).
+- `connector.scope` here means MIME type(s) / STIX object type(s) that trigger the
+  connector — set it precisely so unrelated uploads aren't routed to you.
+
+## Reference implementation
+
+[`templates/internal-import-file`](../templates/internal-import-file) for the scaffold;
+`internal-import-file/import-file-stix/src/connector/connector.py` for a real,
+non-trivial example (STIX 1.2→2.1 elevation, contextual import).

--- a/stream/AGENTS.md
+++ b/stream/AGENTS.md
@@ -1,0 +1,85 @@
+# AGENTS.md — Stream Connectors
+
+Scope: everything under `stream/`. Read the repo-root [`AGENTS.md`](../AGENTS.md) first
+(universal rules: STIX IDs, config, logging, formatting/linting/tests). Full spec:
+[`docs/04-stream-specifications.md`](../docs/04-stream-specifications.md).
+
+## What this connector type does
+
+Listens to a real-time OpenCTI live stream and synchronizes create/update/delete
+events to an external system (SIEM, ticketing, messaging, data warehouse). Real-time,
+event-driven, stateless per event.
+
+## Class shape
+
+```python
+class MyStreamConnector:
+    def __init__(self, config, helper):
+        self.config = config
+        self.helper = helper
+        self.client = MyExternalClient(...)
+
+    def check_stream_id(self) -> None: ...      # validate config before listening
+    def process_message(self, msg) -> None: ...  # route by msg.event
+    def run(self) -> None:
+        self.helper.listen_stream(message_callback=self.process_message)
+```
+
+## Stream must exist before the connector runs
+
+A Live Stream is created in the OpenCTI UI (**Data → Data Sharing → Live Streams**),
+which yields a `live_stream_id` (config: `connector.live_stream_id`, env:
+`CONNECTOR_LIVE_STREAM_ID`). Validate it's set and not `"ChangeMe"` in
+`check_stream_id()`, raising `ValueError` otherwise — call this before `listen_stream`.
+
+## Event types
+
+`msg.event` is one of `"create"`, `"update"`, `"delete"`; `msg.data` carries the STIX
+entity representation. Route to dedicated handlers (`_handle_create/_update/_delete`)
+rather than one large branch — keeps transformation logic per event type testable.
+
+## Error handling: don't let one bad event kill the listener
+
+```python
+except ConnectionError:
+    ...  # log, don't raise — message will be redelivered
+except ValueError:
+    ...  # invalid data — log and skip this message, don't raise
+except Exception:
+    ...  # log unexpected errors — still don't raise
+```
+Raising from `process_message` stops the stream consumer for that event but the
+connector should keep processing subsequent events. For events that must not be
+silently dropped, write to a dead-letter store (e.g. append to a JSONL file) instead
+of only logging.
+
+## Idempotency is required
+
+Events can be redelivered (retries, reconnects). Before creating in the external
+system, check whether the entity already exists there (e.g. by OpenCTI ID) and update
+instead of duplicating:
+
+```python
+existing = self.client.get_entity_by_opencti_id(entity_data["id"])
+if existing:
+    return self._handle_update(entity_data)
+```
+
+## Data transformation
+
+Map OpenCTI/STIX fields to the external system's schema in a dedicated
+`_transform_entity()` (dispatch by `entity_type`), including TLP extraction
+(`objectMarking` → `definition_type == "TLP"`) so you can filter/route by
+sensitivity (e.g. send `TLP:RED` only to a secure channel).
+
+## Rate limiting & monitoring
+
+Apply your own token-bucket or `limiter`-based throttling before calling the external
+system (stream connectors don't get the external-import scheduler's backpressure), and
+log periodic metrics (`events_processed`, `events_failed`) so operators can see
+throughput and failure rate over time.
+
+## Reference implementation
+
+Full example in [`docs/04-stream-specifications.md#complete-example`](../docs/04-stream-specifications.md#complete-example)
+and the scaffold at [`templates/stream`](../templates/stream).


### PR DESCRIPTION
### Proposed changes

* Add a root `AGENTS.md` covering repo shape, Pydantic config conventions,
  deterministic STIX ID rules, logging/error handling, and the
  formatting/linting/testing/PR commands agents must run.
* Add per-connector-type `AGENTS.md` files (`external-import/`,
  `internal-enrichment/`, `stream/`, `internal-import-file/`,
  `internal-export-file/`) distilling the canonical specs in `docs/` into
  actionable, folder-scoped rules for AI coding agents.
* Cross-link `docs/` and the new `AGENTS.md` files from
  `.github/copilot-instructions.md` so both stay in sync going forward.

### Related issues

* Closes #7122

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Docs-only change, no code/tests affected. Flagged in the root `AGENTS.md` that
`internal-import-file`/`internal-export-file` have no dedicated spec doc yet in
`docs/`, so those two `AGENTS.md` files are distilled from `templates/` and
existing connector code instead — lower confidence than the other three.
