### PR TITLE
feat(vulners): send an identifying User-Agent to the Vulners API (#7124)

### DIFF
--- a/internal-enrichment/vulners/src/vulners_client/api_client.py
+++ b/internal-enrichment/vulners/src/vulners_client/api_client.py
@@ -6,9 +6,14 @@ and parses it into a dict; it does not construct any STIX objects itself.
 """
 
 import json
+from importlib.metadata import version as _package_version
 from typing import Any
 
 from vulners import VulnersApi
+
+USER_AGENT = "Vulners OpenCTI Connector {} (Vulners Python API {})".format(
+    _package_version("pycti"), _package_version("vulners")
+)
 
 
 class VulnersClient:
@@ -22,6 +27,10 @@ class VulnersClient:
         :param base_url: Vulners server URL.
         """
         self._api = VulnersApi(api_key, server_url=base_url)
+        # The SDK has no public way to set the User-Agent; Vulners attributes
+        # integration traffic by this header, so override it on the
+        # underlying HTTP client.
+        self._api._client.headers["User-Agent"] = USER_AGENT
 
     def get_bundle(
         self, bulletin_id: str, opencti_id: str | None = None

--- a/internal-enrichment/vulners/src/vulners_client/api_client.py
+++ b/internal-enrichment/vulners/src/vulners_client/api_client.py
@@ -6,13 +6,23 @@ and parses it into a dict; it does not construct any STIX objects itself.
 """
 
 import json
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _package_version
 from typing import Any
 
 from vulners import VulnersApi
 
+
+def _distribution_version(name: str) -> str:
+    """Best-effort package version for the User-Agent; never raises."""
+    try:
+        return _package_version(name)
+    except PackageNotFoundError:
+        return "unknown"
+
+
 USER_AGENT = "Vulners OpenCTI Connector {} (Vulners Python API {})".format(
-    _package_version("pycti"), _package_version("vulners")
+    _distribution_version("pycti"), _distribution_version("vulners")
 )
 
 

--- a/internal-enrichment/vulners/tests/tests_connector/test_api_client.py
+++ b/internal-enrichment/vulners/tests/tests_connector/test_api_client.py
@@ -1,6 +1,6 @@
 import re
 
-from vulners_client.api_client import VulnersClient
+from vulners_client.api_client import VulnersClient, _distribution_version
 
 _USER_AGENT_RE = re.compile(
     r"^Vulners OpenCTI Connector \S+ \(Vulners Python API \S+\)$"
@@ -34,3 +34,10 @@ def test_client_sets_identifying_user_agent(monkeypatch):
 
     assert _USER_AGENT_RE.match(user_agent) is not None
     assert "Vulners" in user_agent
+
+
+def test_distribution_version_falls_back_to_unknown():
+    """A missing distribution must not break User-Agent construction."""
+    assert (
+        _distribution_version("definitely-not-an-installed-distribution") == "unknown"
+    )

--- a/internal-enrichment/vulners/tests/tests_connector/test_api_client.py
+++ b/internal-enrichment/vulners/tests/tests_connector/test_api_client.py
@@ -7,8 +7,27 @@ _USER_AGENT_RE = re.compile(
 )
 
 
-def test_client_sets_identifying_user_agent():
+class _FakeHttpClient:
+    """Stand-in for the SDK's underlying httpx.Client, exposing only `.headers`."""
+
+    def __init__(self) -> None:
+        # Pre-seeded with a fake default UA, as the real SDK would set one.
+        self.headers = {"User-Agent": "Vulners Python API 0.0.0"}
+
+
+class _FakeVulnersApi:
+    """Stand-in for `vulners.VulnersApi`, exposing only what the client touches."""
+
+    def __init__(self, api_key: str, server_url: str) -> None:
+        self.api_key = api_key
+        self.server_url = server_url
+        self._client = _FakeHttpClient()
+
+
+def test_client_sets_identifying_user_agent(monkeypatch):
     """The underlying HTTP client's User-Agent identifies the connector to Vulners."""
+    monkeypatch.setattr("vulners_client.api_client.VulnersApi", _FakeVulnersApi)
+
     client = VulnersClient("dummy-key")
 
     user_agent = client._api._client.headers["User-Agent"]

--- a/internal-enrichment/vulners/tests/tests_connector/test_api_client.py
+++ b/internal-enrichment/vulners/tests/tests_connector/test_api_client.py
@@ -1,0 +1,17 @@
+import re
+
+from vulners_client.api_client import VulnersClient
+
+_USER_AGENT_RE = re.compile(
+    r"^Vulners OpenCTI Connector \S+ \(Vulners Python API \S+\)$"
+)
+
+
+def test_client_sets_identifying_user_agent():
+    """The underlying HTTP client's User-Agent identifies the connector to Vulners."""
+    client = VulnersClient("dummy-key")
+
+    user_agent = client._api._client.headers["User-Agent"]
+
+    assert _USER_AGENT_RE.match(user_agent) is not None
+    assert "Vulners" in user_agent


### PR DESCRIPTION
### Proposed changes

- The Vulners enrichment connector (`internal-enrichment/vulners/`) now sends an **identifying `User-Agent`** on every request to the Vulners API:

  ```
  Vulners OpenCTI Connector <pycti version> (Vulners Python API <vulners sdk version>)
  ```

- Rationale: the `vulners` Python SDK sets its own default `User-Agent` (`Vulners Python API <ver>`), so connector traffic was indistinguishable from any other consumer of that SDK. Vulners attributes integration traffic by `User-Agent` (same mechanism as its NMAP/Burp plugins), which enables per-integration usage monitoring and much faster support triage — the client and its release are visible on every request.
- Both versions are resolved at runtime via `importlib.metadata` — no hardcoded version strings to maintain. The `pycti` version doubles as the connector release marker, since connector releases are pinned to it.
- The SDK exposes no public knob for the header, so it is overridden on the SDK's underlying HTTP client right after construction (a comment in code explains the constraint). No configuration or functional changes.
- Covered by a unit test (header format asserted on the constructed client) and verified at wire level: on a real `get_bundle()` call a local capture server received `User-Agent: Vulners OpenCTI Connector 7.260619.0 (Vulners Python API 3.1.11)` (versions are those of the test venv; in the shipped image they resolve to the pinned `pycti==7.260728.0` and the installed SDK).

### Related issues

Closes #7124

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Follow-up to #6971 (connector author here). Single GPG-signed commit on top of current `master`; `isort`/`black`/`flake8` clean, full connector test suite passes.

### Review fix pass (a28dd8004)

Both Copilot findings addressed:

- Version resolution is wrapped in a `_distribution_version()` helper catching `PackageNotFoundError` with an `"unknown"` fallback, so a metadata lookup failure at import time can no longer prevent the connector from starting.
- The unit test is hermetic now: it monkeypatches `VulnersApi` with a small fake exposing only `_client.headers` and asserts the override logic, instead of instantiating the real SDK and reaching into its internals. Wire-level check re-run after the change — same identifying `User-Agent` observed on a real `get_bundle()` call.