### PR TITLE
fix(threatmatch): update unit tests after connectors_sdk update (#7100)

### DIFF
--- a/external-import/threatmatch/tests/threatmatch/conftest.py
+++ b/external-import/threatmatch/tests/threatmatch/conftest.py
@@ -32,6 +32,7 @@ def fixture_config_dict() -> dict[str, Any]:
             "import_iocs": True,
             "tlp_level": "amber",
             "threat_actor_as_intrusion_set": True,
+            "interval": None,
         },
     }
 

--- a/external-import/threatmatch/tests/threatmatch/test_config.py
+++ b/external-import/threatmatch/tests/threatmatch/test_config.py
@@ -14,7 +14,7 @@ def test_config() -> None:
     config = ConnectorSettings().model_dump(exclude_none=True)
 
     assert config["opencti"]["url"] == HttpUrl("http://test-opencti-url/")
-    assert config["opencti"]["token"] == "test-opencti-token"
+    assert config["opencti"]["token"].get_secret_value() == "test-opencti-token"
 
     assert config["connector"]["id"] == "threatmatch-connector-id"
     assert config["connector"]["type"] == "EXTERNAL_IMPORT"


### PR DESCRIPTION
### Proposed changes

- align threatmatch config tests with connectors-sdk serialization updates
- assert secret token using SecretStr accessor and include deprecated interval key in expected helper config

### Related issues

- close #7100

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

- this change is limited to unit tests and does not alter runtime connector behavior