### PR TITLE
fix(google-ti-feeds): fix indicator/observable score defaulting to 50 for benign IOCs (#7138)

### DIFF
--- a/external-import/google-ti-feeds/connector/src/custom/mappers/gti_iocs/gti_file_to_stix_file.py
+++ b/external-import/google-ti-feeds/connector/src/custom/mappers/gti_iocs/gti_file_to_stix_file.py
@@ -227,8 +227,8 @@ class GTIFileToSTIXFile(BaseMapper):
         """Get score from file attributes.
 
         Priority order:
-        1. contributing_factors.mandiant_confidence_score
-        2. threat_score.value
+        1. threat_score.value
+        2. contributing_factors.mandiant_confidence_score
 
         Returns:
             int | None: The score if available, None otherwise

--- a/external-import/google-ti-feeds/connector/src/custom/mappers/gti_iocs/gti_ip_to_stix_ip.py
+++ b/external-import/google-ti-feeds/connector/src/custom/mappers/gti_iocs/gti_ip_to_stix_ip.py
@@ -252,8 +252,8 @@ class GTIIPToSTIXIP(BaseMapper):
         """Get score from IP attributes.
 
         Priority order:
-        1. contributing_factors.mandiant_confidence_score
-        2. threat_score.value
+        1. threat_score.value
+        2. contributing_factors.mandiant_confidence_score
 
         Returns:
             int | None: The score if available, None otherwise

--- a/external-import/google-ti-feeds/connector/src/custom/mappers/gti_iocs/gti_url_to_stix_url.py
+++ b/external-import/google-ti-feeds/connector/src/custom/mappers/gti_iocs/gti_url_to_stix_url.py
@@ -206,8 +206,8 @@ class GTIUrlToSTIXUrl(BaseMapper):
         """Get score from URL attributes.
 
         Priority order:
-        1. contributing_factors.mandiant_confidence_score
-        2. threat_score.value
+        1. threat_score.value
+        2. contributing_factors.mandiant_confidence_score
 
         Returns:
             int | None: The score if available, None otherwise

--- a/external-import/google-ti-feeds/connector/src/stix/octi/models/domain_model.py
+++ b/external-import/google-ti-feeds/connector/src/stix/octi/models/domain_model.py
@@ -34,7 +34,7 @@ class OctiDomainModel:
         custom_properties = kwargs.pop("custom_properties", {})
         if organization_id:
             custom_properties["x_opencti_created_by_ref"] = organization_id
-        if score:
+        if score is not None:
             custom_properties["x_opencti_score"] = score
         if create_indicator:
             custom_properties["x_opencti_create_indicator"] = create_indicator

--- a/external-import/google-ti-feeds/connector/src/stix/octi/models/file_model.py
+++ b/external-import/google-ti-feeds/connector/src/stix/octi/models/file_model.py
@@ -40,7 +40,7 @@ class OctiFileModel:
         custom_properties = kwargs.pop("custom_properties", {})
         if organization_id:
             custom_properties["x_opencti_created_by_ref"] = organization_id
-        if score:
+        if score is not None:
             custom_properties["x_opencti_score"] = score
         if additional_names:
             custom_properties["x_opencti_additional_names"] = additional_names

--- a/external-import/google-ti-feeds/connector/src/stix/octi/models/indicator_model.py
+++ b/external-import/google-ti-feeds/connector/src/stix/octi/models/indicator_model.py
@@ -58,7 +58,7 @@ class OctiIndicatorModel:
 
         """
         custom_properties = kwargs.pop("custom_properties", {})
-        if score:
+        if score is not None:
             custom_properties["x_opencti_score"] = score
         if platforms:
             custom_properties["x_mitre_platforms"] = platforms

--- a/external-import/google-ti-feeds/connector/src/stix/octi/models/ipv4_address_model.py
+++ b/external-import/google-ti-feeds/connector/src/stix/octi/models/ipv4_address_model.py
@@ -34,7 +34,7 @@ class OctiIPv4AddressModel:
         custom_properties = kwargs.pop("custom_properties", {})
         if organization_id:
             custom_properties["x_opencti_created_by_ref"] = organization_id
-        if score:
+        if score is not None:
             custom_properties["x_opencti_score"] = score
         if create_indicator:
             custom_properties["x_opencti_create_indicator"] = create_indicator

--- a/external-import/google-ti-feeds/connector/src/stix/octi/models/ipv6_address_model.py
+++ b/external-import/google-ti-feeds/connector/src/stix/octi/models/ipv6_address_model.py
@@ -34,7 +34,7 @@ class OctiIPv6AddressModel:
         custom_properties = kwargs.pop("custom_properties", {})
         if organization_id:
             custom_properties["x_opencti_created_by_ref"] = organization_id
-        if score:
+        if score is not None:
             custom_properties["x_opencti_score"] = score
         if create_indicator:
             custom_properties["x_opencti_create_indicator"] = create_indicator

--- a/external-import/google-ti-feeds/connector/src/stix/octi/models/software_model.py
+++ b/external-import/google-ti-feeds/connector/src/stix/octi/models/software_model.py
@@ -44,7 +44,7 @@ class OctiSoftwareModel:
         custom_properties = kwargs.pop("custom_properties", {})
         if organization_id:
             custom_properties["x_opencti_created_by_ref"] = organization_id
-        if score:
+        if score is not None:
             custom_properties["x_opencti_score"] = score
         if create_indicator:
             custom_properties["x_opencti_create_indicator"] = create_indicator

--- a/external-import/google-ti-feeds/connector/src/stix/octi/models/url_model.py
+++ b/external-import/google-ti-feeds/connector/src/stix/octi/models/url_model.py
@@ -34,7 +34,7 @@ class OctiUrlModel:
         custom_properties = kwargs.pop("custom_properties", {})
         if organization_id:
             custom_properties["x_opencti_created_by_ref"] = organization_id
-        if score:
+        if score is not None:
             custom_properties["x_opencti_score"] = score
         if create_indicator:
             custom_properties["x_opencti_create_indicator"] = create_indicator

--- a/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_domain_to_stix_domain.py
+++ b/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_domain_to_stix_domain.py
@@ -417,7 +417,7 @@ def test_gti_domain_to_stix_with_all_data(
     _then_stix_domain_has_correct_properties(
         domain_observable, domain_with_all_data, mock_organization, mock_tlp_marking
     )
-    _then_stix_objects_have_score(domain_observable, indicator, 95)
+    _then_stix_objects_have_score(domain_observable, indicator, 85)
     _then_stix_indicator_has_type(indicator, IndicatorTypeOV("MALICIOUS"))
     _then_stix_indicator_has_correct_timestamps(indicator, domain_with_all_data)
 
@@ -742,14 +742,21 @@ def _then_stix_domain_has_correct_properties(
     assert tlp_marking.id in domain_observable.object_marking_refs  # noqa: S101
 
 
+def _get_opencti_score(obj: Any) -> int | None:
+    """Extract x_opencti_score from a raw pydantic model or a converted STIX2 object."""
+    score = getattr(obj, "x_opencti_score", None)
+    if score is not None:
+        return score
+    custom_properties = getattr(obj, "custom_properties", None) or {}
+    return custom_properties.get("x_opencti_score")
+
+
 def _then_stix_objects_have_score(
     domain_observable: Any, indicator: Any, expected_score: int
 ) -> None:
     """Assert that STIX objects have score."""
-    if hasattr(domain_observable, "score"):
-        assert domain_observable.score == expected_score  # noqa: S101
-    if hasattr(indicator, "score"):
-        assert indicator.score == expected_score  # noqa: S101
+    assert _get_opencti_score(domain_observable) == expected_score  # noqa: S101
+    assert _get_opencti_score(indicator) == expected_score  # noqa: S101
 
 
 def _then_stix_indicator_has_type(

--- a/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_domain_to_stix_domain.py
+++ b/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_domain_to_stix_domain.py
@@ -141,6 +141,23 @@ def domain_with_threat_score() -> GTIDomainData:
 
 
 @pytest.fixture
+def domain_with_zero_score() -> GTIDomainData:
+    """Fixture for domain data with a genuine zero threat score (fully benign, e.g. youtube.com)."""
+    return GTIDomainDataFactory.build(
+        id="benign.example.com",
+        attributes=DomainModelFactory.build(
+            gti_assessment=GTIAssessmentFactory.build(
+                contributing_factors=ContributingFactorsFactory.build(
+                    mandiant_confidence_score=None
+                ),
+                threat_score=ThreatScoreFactory.build(value=0),
+                verdict=None,
+            ),
+        ),
+    )
+
+
+@pytest.fixture
 def domain_with_malicious_verdict() -> GTIDomainData:
     """Fixture for domain data with malicious verdict."""
     return GTIDomainDataFactory.build(
@@ -327,6 +344,33 @@ def test_gti_domain_to_stix_with_threat_score(
     _then_stix_objects_created_successfully(stix_objects)
     domain_observable, indicator, relationship = stix_objects
     _then_stix_objects_have_score(domain_observable, indicator, 70)
+
+
+# Scenario: Convert GTI domain with a genuine zero threat score to STIX objects
+@pytest.mark.order(1)
+def test_gti_domain_to_stix_with_zero_score(
+    domain_with_zero_score: GTIDomainData,
+    mock_organization: Identity,
+    mock_tlp_marking: MarkingDefinition,
+) -> None:
+    """Test conversion of GTI domain with a genuine zero threat score to STIX objects.
+
+    Regression test: `if score:` previously treated a real score of 0 as falsy,
+    dropping x_opencti_score entirely and letting OpenCTI fall back to its own
+    default score of 50 instead of the real value.
+    """
+    # Given a GTI domain with a genuine zero threat score
+    mapper = _given_gti_domain_mapper(
+        domain_with_zero_score, mock_organization, mock_tlp_marking
+    )
+
+    # When converting to STIX
+    stix_objects = _when_convert_to_stix(mapper)
+
+    # Then the STIX objects should have a score of 0, not a missing score
+    _then_stix_objects_created_successfully(stix_objects)
+    domain_observable, indicator, relationship = stix_objects
+    _then_stix_objects_have_score(domain_observable, indicator, 0)
 
 
 # Scenario: Convert GTI domain with malicious verdict to STIX objects
@@ -560,6 +604,32 @@ def test_get_score_with_threat_score(
 
     # Then threat score should be returned
     assert score == 70  # noqa: S101
+
+
+# Scenario: Extract score with a genuine zero threat score
+@pytest.mark.order(1)
+def test_get_score_with_zero_threat_score(
+    mock_organization: Identity, mock_tlp_marking: MarkingDefinition
+) -> None:
+    """Test _get_score method returns 0, not None, for a genuine zero threat score."""
+    # Given a domain with a real threat score of 0 and no mandiant score
+    domain_data = GTIDomainDataFactory.build(
+        attributes=DomainModelFactory.build(
+            gti_assessment=GTIAssessmentFactory.build(
+                contributing_factors=ContributingFactorsFactory.build(
+                    mandiant_confidence_score=None
+                ),
+                threat_score=ThreatScoreFactory.build(value=0),
+            )
+        )
+    )
+    mapper = _given_gti_domain_mapper(domain_data, mock_organization, mock_tlp_marking)
+
+    # When getting score
+    score = mapper._get_score()
+
+    # Then the real zero score should be returned, not None
+    assert score == 0  # noqa: S101
 
 
 # Scenario: Extract score with mandiant confidence score available fallback

--- a/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_file_to_stix_file.py
+++ b/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_file_to_stix_file.py
@@ -484,7 +484,7 @@ def test_gti_file_to_stix_with_all_data(
     _then_stix_file_has_correct_properties(
         file_observable, file_with_all_data, mock_organization, mock_tlp_marking
     )
-    _then_stix_objects_have_score(file_observable, indicator, 90)
+    _then_stix_objects_have_score(file_observable, indicator, 85)
     _then_stix_indicator_has_type(indicator, IndicatorTypeOV("MALICIOUS"))
     _then_stix_indicator_has_correct_timestamps(indicator, file_with_all_data)
     _then_stix_file_has_hashes(file_observable, file_with_all_data)
@@ -946,14 +946,21 @@ def _then_stix_file_has_correct_properties(
     _then_stix_file_has_correct_ctime(file_observable, gti_file)
 
 
+def _get_opencti_score(obj: Any) -> int | None:
+    """Extract x_opencti_score from a raw pydantic model or a converted STIX2 object."""
+    score = getattr(obj, "x_opencti_score", None)
+    if score is not None:
+        return score
+    custom_properties = getattr(obj, "custom_properties", None) or {}
+    return custom_properties.get("x_opencti_score")
+
+
 def _then_stix_objects_have_score(
     file_observable: Any, indicator: Any, expected_score: int
 ) -> None:
     """Assert that STIX objects have score."""
-    if hasattr(file_observable, "score"):
-        assert file_observable.score == expected_score  # noqa: S101
-    if hasattr(indicator, "score"):
-        assert indicator.score == expected_score  # noqa: S101
+    assert _get_opencti_score(file_observable) == expected_score  # noqa: S101
+    assert _get_opencti_score(indicator) == expected_score  # noqa: S101
 
 
 def _then_stix_indicator_has_type(

--- a/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_file_to_stix_file.py
+++ b/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_file_to_stix_file.py
@@ -168,6 +168,26 @@ def file_with_threat_score() -> GTIFileData:
 
 
 @pytest.fixture
+def file_with_zero_score() -> GTIFileData:
+    """GTI file data with a genuine zero threat score (fully benign, e.g. a signed system binary)."""
+    return GTIFileDataFactory.build(
+        id="1111111111111111111111111111111111111111111111111111111111111111",
+        attributes=FileModelFactory.build(
+            sha256="1111111111111111111111111111111111111111111111111111111111111111",
+            sha1="1111111111111111111111111111111111111111",
+            md5="11111111111111111111111111111111",
+            gti_assessment=GTIAssessmentFactory.build(
+                threat_score=ThreatScoreFactory.build(value=0),
+                contributing_factors=ContributingFactorsFactory.build(
+                    mandiant_confidence_score=None
+                ),
+                verdict=None,
+            ),
+        ),
+    )
+
+
+@pytest.fixture
 def file_with_malicious_verdict() -> GTIFileData:
     """GTI file data with malicious verdict."""
     return GTIFileDataFactory.build(
@@ -396,6 +416,33 @@ def test_gti_file_to_stix_with_threat_score(
     _then_stix_objects_have_score(file_observable, indicator, 75)
 
 
+# Scenario: Convert GTI file with a genuine zero threat score to STIX objects
+@pytest.mark.order(1)
+def test_gti_file_to_stix_with_zero_score(
+    file_with_zero_score: GTIFileData,
+    mock_organization: Identity,
+    mock_tlp_marking: MarkingDefinition,
+) -> None:
+    """Test conversion of GTI file with a genuine zero threat score to STIX objects.
+
+    Regression test: `if score:` previously treated a real score of 0 as falsy,
+    dropping x_opencti_score entirely and letting OpenCTI fall back to its own
+    default score of 50 instead of the real value.
+    """
+    # Given a GTI file with a genuine zero threat score
+    mapper = _given_gti_file_mapper(
+        file_with_zero_score, mock_organization, mock_tlp_marking
+    )
+
+    # When converting to STIX
+    stix_objects = _when_convert_to_stix(mapper)
+
+    # Then the STIX objects should have a score of 0, not a missing score
+    _then_stix_objects_created_successfully(stix_objects)
+    file_observable, indicator, relationship = stix_objects
+    _then_stix_objects_have_score(file_observable, indicator, 0)
+
+
 # Scenario: Convert GTI file with malicious verdict to STIX objects
 @pytest.mark.order(1)
 def test_gti_file_to_stix_with_malicious_verdict(
@@ -608,6 +655,32 @@ def test_get_score_with_threat_score(
 
     # Then threat score should be returned
     assert score == 70  # noqa: S101
+
+
+# Scenario: Extract score with a genuine zero threat score
+@pytest.mark.order(1)
+def test_get_score_with_zero_threat_score(
+    mock_organization: Identity, mock_tlp_marking: MarkingDefinition
+) -> None:
+    """Test _get_score method returns 0, not None, for a genuine zero threat score."""
+    # Given a file with a real threat score of 0 and no mandiant score
+    file_data = GTIFileDataFactory.build(
+        attributes=FileModelFactory.build(
+            gti_assessment=GTIAssessmentFactory.build(
+                contributing_factors=ContributingFactorsFactory.build(
+                    mandiant_confidence_score=None
+                ),
+                threat_score=ThreatScoreFactory.build(value=0),
+            )
+        )
+    )
+    mapper = _given_gti_file_mapper(file_data, mock_organization, mock_tlp_marking)
+
+    # When getting score
+    score = mapper._get_score()
+
+    # Then the real zero score should be returned, not None
+    assert score == 0  # noqa: S101
 
 
 # Scenario: Extract score with mandiant confidence score available fallback

--- a/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_ip_to_stix_ip.py
+++ b/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_ip_to_stix_ip.py
@@ -166,6 +166,23 @@ def ip_with_threat_score() -> GTIIPData:
 
 
 @pytest.fixture
+def ip_with_zero_score() -> GTIIPData:
+    """Fixture for ip data with a genuine zero threat score (fully benign, e.g. youtube.com)."""
+    return GTIIPDataFactory.build(
+        id="198.51.100.50",
+        attributes=IPModelFactory.build(
+            gti_assessment=GTIAssessmentFactory.build(
+                contributing_factors=ContributingFactorsFactory.build(
+                    mandiant_confidence_score=None
+                ),
+                threat_score=ThreatScoreFactory.build(value=0),
+                verdict=None,
+            ),
+        ),
+    )
+
+
+@pytest.fixture
 def ip_with_malicious_verdict() -> GTIIPData:
     """Fixture for IP data with malicious verdict."""
     return GTIIPDataFactory.build(
@@ -377,6 +394,33 @@ def test_gti_ip_to_stix_with_threat_score(
     _then_stix_objects_created_successfully(stix_objects)
     ip_observable, indicator, relationship = stix_objects
     _then_stix_objects_have_score(ip_observable, indicator, 70)
+
+
+# Scenario: Convert GTI ip with a genuine zero threat score to STIX objects
+@pytest.mark.order(1)
+def test_gti_ip_to_stix_with_zero_score(
+    ip_with_zero_score: GTIIPData,
+    mock_organization: Identity,
+    mock_tlp_marking: MarkingDefinition,
+) -> None:
+    """Test conversion of GTI ip with a genuine zero threat score to STIX objects.
+
+    Regression test: `if score:` previously treated a real score of 0 as falsy,
+    dropping x_opencti_score entirely and letting OpenCTI fall back to its own
+    default score of 50 instead of the real value.
+    """
+    # Given a GTI ip with a genuine zero threat score
+    mapper = _given_gti_ip_mapper(
+        ip_with_zero_score, mock_organization, mock_tlp_marking
+    )
+
+    # When converting to STIX
+    stix_objects = _when_convert_to_stix(mapper)
+
+    # Then the STIX objects should have a score of 0, not a missing score
+    _then_stix_objects_created_successfully(stix_objects)
+    ip_observable, indicator, relationship = stix_objects
+    _then_stix_objects_have_score(ip_observable, indicator, 0)
 
 
 # Scenario: Convert GTI IP with malicious verdict to STIX objects
@@ -658,6 +702,32 @@ def test_get_score_with_threat_score(
 
     # Then threat score should be returned
     assert score == 70  # noqa: S101
+
+
+# Scenario: Extract score with a genuine zero threat score
+@pytest.mark.order(1)
+def test_get_score_with_zero_threat_score(
+    mock_organization: Identity, mock_tlp_marking: MarkingDefinition
+) -> None:
+    """Test _get_score method returns 0, not None, for a genuine zero threat score."""
+    # Given a ip with a real threat score of 0 and no mandiant score
+    ip_data = GTIIPDataFactory.build(
+        attributes=IPModelFactory.build(
+            gti_assessment=GTIAssessmentFactory.build(
+                contributing_factors=ContributingFactorsFactory.build(
+                    mandiant_confidence_score=None
+                ),
+                threat_score=ThreatScoreFactory.build(value=0),
+            )
+        )
+    )
+    mapper = _given_gti_ip_mapper(ip_data, mock_organization, mock_tlp_marking)
+
+    # When getting score
+    score = mapper._get_score()
+
+    # Then the real zero score should be returned, not None
+    assert score == 0  # noqa: S101
 
 
 # Scenario: Extract score with mandiant confidence score available fallback

--- a/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_ip_to_stix_ip.py
+++ b/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_ip_to_stix_ip.py
@@ -465,7 +465,7 @@ def test_gti_ip_to_stix_with_all_data(
     _then_stix_ipv4_has_correct_properties(
         ip_observable, ip_with_all_data, mock_organization, mock_tlp_marking
     )
-    _then_stix_objects_have_score(ip_observable, indicator, 95)
+    _then_stix_objects_have_score(ip_observable, indicator, 85)
     _then_stix_indicator_has_type(indicator, IndicatorTypeOV("MALICIOUS"))
     _then_stix_indicator_has_correct_timestamps(indicator, ip_with_all_data)
 
@@ -918,14 +918,21 @@ def _then_stix_ipv6_has_correct_properties(
     assert tlp_marking.id in ip_observable.object_marking_refs  # noqa: S101
 
 
+def _get_opencti_score(obj: Any) -> int | None:
+    """Extract x_opencti_score from a raw pydantic model or a converted STIX2 object."""
+    score = getattr(obj, "x_opencti_score", None)
+    if score is not None:
+        return score
+    custom_properties = getattr(obj, "custom_properties", None) or {}
+    return custom_properties.get("x_opencti_score")
+
+
 def _then_stix_objects_have_score(
     ip_observable: Any, indicator: Any, expected_score: int
 ) -> None:
     """Assert that STIX objects have score."""
-    if hasattr(ip_observable, "score"):
-        assert ip_observable.score == expected_score  # noqa: S101
-    if hasattr(indicator, "score"):
-        assert indicator.score == expected_score  # noqa: S101
+    assert _get_opencti_score(ip_observable) == expected_score  # noqa: S101
+    assert _get_opencti_score(indicator) == expected_score  # noqa: S101
 
 
 def _then_stix_indicator_has_type(

--- a/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_url_to_stix_url.py
+++ b/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_url_to_stix_url.py
@@ -460,7 +460,7 @@ def test_gti_url_to_stix_with_all_data(
     _then_stix_url_has_correct_properties(
         url_observable, url_with_all_data, mock_organization, mock_tlp_marking
     )
-    _then_stix_objects_have_score(url_observable, indicator, 95)
+    _then_stix_objects_have_score(url_observable, indicator, 85)
     _then_stix_indicator_has_type(indicator, IndicatorTypeOV("MALICIOUS"))
     _then_stix_indicator_has_correct_timestamps(indicator, url_with_all_data)
     _then_stix_url_has_value(url_observable, "https://original.example.com/malware")
@@ -875,14 +875,21 @@ def _then_stix_url_has_correct_properties(
     assert tlp_marking.id in url_observable.object_marking_refs  # noqa: S101
 
 
+def _get_opencti_score(obj: Any) -> int | None:
+    """Extract x_opencti_score from a raw pydantic model or a converted STIX2 object."""
+    score = getattr(obj, "x_opencti_score", None)
+    if score is not None:
+        return score
+    custom_properties = getattr(obj, "custom_properties", None) or {}
+    return custom_properties.get("x_opencti_score")
+
+
 def _then_stix_objects_have_score(
     url_observable: Any, indicator: Any, expected_score: int
 ) -> None:
     """Assert that STIX objects have score."""
-    if hasattr(url_observable, "score"):
-        assert url_observable.score == expected_score  # noqa: S101
-    if hasattr(indicator, "score"):
-        assert indicator.score == expected_score  # noqa: S101
+    assert _get_opencti_score(url_observable) == expected_score  # noqa: S101
+    assert _get_opencti_score(indicator) == expected_score  # noqa: S101
 
 
 def _then_stix_indicator_has_type(

--- a/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_url_to_stix_url.py
+++ b/external-import/google-ti-feeds/tests/custom/mappers/gti_iocs/test_gti_url_to_stix_url.py
@@ -157,6 +157,23 @@ def url_with_threat_score() -> GTIURLData:
 
 
 @pytest.fixture
+def url_with_zero_score() -> GTIURLData:
+    """Fixture for url data with a genuine zero threat score (fully benign, e.g. youtube.com)."""
+    return GTIURLDataFactory.build(
+        id="https://benign.example.com/path",
+        attributes=URLModelFactory.build(
+            gti_assessment=GTIAssessmentFactory.build(
+                contributing_factors=ContributingFactorsFactory.build(
+                    mandiant_confidence_score=None
+                ),
+                threat_score=ThreatScoreFactory.build(value=0),
+                verdict=None,
+            ),
+        ),
+    )
+
+
+@pytest.fixture
 def url_with_malicious_verdict() -> GTIURLData:
     """Fixture for URL data with malicious verdict."""
     return GTIURLDataFactory.build(
@@ -370,6 +387,33 @@ def test_gti_url_to_stix_with_threat_score(
     _then_stix_objects_created_successfully(stix_objects)
     url_observable, indicator, relationship = stix_objects
     _then_stix_objects_have_score(url_observable, indicator, 70)
+
+
+# Scenario: Convert GTI url with a genuine zero threat score to STIX objects
+@pytest.mark.order(1)
+def test_gti_url_to_stix_with_zero_score(
+    url_with_zero_score: GTIURLData,
+    mock_organization: Identity,
+    mock_tlp_marking: MarkingDefinition,
+) -> None:
+    """Test conversion of GTI url with a genuine zero threat score to STIX objects.
+
+    Regression test: `if score:` previously treated a real score of 0 as falsy,
+    dropping x_opencti_score entirely and letting OpenCTI fall back to its own
+    default score of 50 instead of the real value.
+    """
+    # Given a GTI url with a genuine zero threat score
+    mapper = _given_gti_url_mapper(
+        url_with_zero_score, mock_organization, mock_tlp_marking
+    )
+
+    # When converting to STIX
+    stix_objects = _when_convert_to_stix(mapper)
+
+    # Then the STIX objects should have a score of 0, not a missing score
+    _then_stix_objects_created_successfully(stix_objects)
+    url_observable, indicator, relationship = stix_objects
+    _then_stix_objects_have_score(url_observable, indicator, 0)
 
 
 # Scenario: Convert GTI URL with malicious verdict to STIX objects
@@ -604,6 +648,32 @@ def test_get_score_with_threat_score(
 
     # Then threat score should be returned
     assert score == 70  # noqa: S101
+
+
+# Scenario: Extract score with a genuine zero threat score
+@pytest.mark.order(1)
+def test_get_score_with_zero_threat_score(
+    mock_organization: Identity, mock_tlp_marking: MarkingDefinition
+) -> None:
+    """Test _get_score method returns 0, not None, for a genuine zero threat score."""
+    # Given a url with a real threat score of 0 and no mandiant score
+    url_data = GTIURLDataFactory.build(
+        attributes=URLModelFactory.build(
+            gti_assessment=GTIAssessmentFactory.build(
+                contributing_factors=ContributingFactorsFactory.build(
+                    mandiant_confidence_score=None
+                ),
+                threat_score=ThreatScoreFactory.build(value=0),
+            )
+        )
+    )
+    mapper = _given_gti_url_mapper(url_data, mock_organization, mock_tlp_marking)
+
+    # When getting score
+    score = mapper._get_score()
+
+    # Then the real zero score should be returned, not None
+    assert score == 0  # noqa: S101
 
 
 # Scenario: Extract score with mandiant confidence score available fallback


### PR DESCRIPTION
### Proposed changes

* Fix `if score:` → `if score is not None:` in all 7 `Octi*Model.create()` methods (`indicator_model.py`, `domain_model.py`, `ipv4_address_model.py`, `ipv6_address_model.py`, `url_model.py`, `file_model.py`, `software_model.py`) so a real GTI score of `0` is stored instead of silently dropped.
* Fix the masked `_then_stix_objects_have_score()` test helper in `tests/custom/mappers/gti_iocs/test_gti_{ip,domain,url,file}_to_stix_*.py` to assert on the real `x_opencti_score` value instead of a `hasattr(obj, "score")` check that was never true.

### Related issues

* Closes https://github.com/OpenCTI-Platform/connectors/issues/7138

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Verified against the live GTI API with both a fully-benign indicator (`threat_score.value == 0`,
confirming the score was previously dropped and OpenCTI showed its platform default of 50) and a
malicious indicator (a real non-zero score, confirming `threat_score` correctly remains priority 1
over `contributing_factors.mandiant_confidence_score` — unchanged by this PR). No config/doc
changes needed since this only affects internal STIX object construction.