### PR TITLE
fix: indicator value is not valid and add API metadata (#7144)

### DIFF
--- a/external-import/domaintools-feeds/src/client/api_client.py
+++ b/external-import/domaintools-feeds/src/client/api_client.py
@@ -35,6 +35,9 @@ class DomainToolsClient:
         Internal method to handle API requests
         :return: Response in JSON format
         """
+        params["app_name"] = "OpenCTI"
+        params["app_partner"] = "Feeds"
+        params["app_version"] = "1.0"
         try:
             response = self.session.get(api_url, params=params)
 

--- a/external-import/domaintools-feeds/src/client/api_client.py
+++ b/external-import/domaintools-feeds/src/client/api_client.py
@@ -35,8 +35,8 @@ class DomainToolsClient:
         Internal method to handle API requests
         :return: Response in JSON format
         """
-        params["app_name"] = "OpenCTI"
-        params["app_partner"] = "Feeds"
+        params["app_partner"] = "OpenCTI"
+        params["app_name"] = "Feeds"
         params["app_version"] = "1.0"
         try:
             response = self.session.get(api_url, params=params)

--- a/external-import/domaintools-feeds/src/client/api_client.py
+++ b/external-import/domaintools-feeds/src/client/api_client.py
@@ -35,6 +35,7 @@ class DomainToolsClient:
         Internal method to handle API requests
         :return: Response in JSON format
         """
+        params = params or {}
         params["app_partner"] = "OpenCTI"
         params["app_name"] = "Feeds"
         params["app_version"] = "1.0"

--- a/external-import/domaintools-feeds/src/connector/converter_to_stix.py
+++ b/external-import/domaintools-feeds/src/connector/converter_to_stix.py
@@ -140,7 +140,7 @@ class ConverterToStix:
         :return: A boolean
         """
         # Temporarily swap underscores out so validators accepts the format
-        # Since some domain do have "_"
+        # Since some domains do have "_"
         sanitized_domain = value.replace("_", "-")
 
         is_valid_domain = validators.domain(sanitized_domain)

--- a/external-import/domaintools-feeds/src/connector/converter_to_stix.py
+++ b/external-import/domaintools-feeds/src/connector/converter_to_stix.py
@@ -139,7 +139,11 @@ class ConverterToStix:
         :param value: Value in string
         :return: A boolean
         """
-        is_valid_domain = validators.domain(value)
+        # Temporarily swap underscores out so validators accepts the format
+        # Since some domain do have "_"
+        sanitized_domain = value.replace("_", "-")
+
+        is_valid_domain = validators.domain(sanitized_domain)
 
         if is_valid_domain:
             return True
@@ -200,7 +204,7 @@ class ConverterToStix:
             indicator_id = Indicator.generate_id(pattern)
 
             stix_domain_name = stix2.Indicator(
-                name=f"Indicator for {value}",
+                name=value,
                 id=indicator_id,
                 pattern_type="stix",
                 pattern=pattern,

--- a/external-import/domaintools-irisql/src/client/api_client.py
+++ b/external-import/domaintools-irisql/src/client/api_client.py
@@ -27,8 +27,8 @@ class DomainToolsClient:
         Internal method to handle API requests
         :return: Response in JSON format
         """
-        params["app_name"] = "OpenCTI"
-        params["app_partner"] = "IrisQL"
+        params["app_partner"] = "OpenCTI"
+        params["app_name"] = "IrisQL"
         params["app_version"] = "1.0"
         try:
 

--- a/external-import/domaintools-irisql/src/client/api_client.py
+++ b/external-import/domaintools-irisql/src/client/api_client.py
@@ -27,6 +27,7 @@ class DomainToolsClient:
         Internal method to handle API requests
         :return: Response in JSON format
         """
+        params = params or {}
         params["app_partner"] = "OpenCTI"
         params["app_name"] = "IrisQL"
         params["app_version"] = "1.0"

--- a/external-import/domaintools-irisql/src/client/api_client.py
+++ b/external-import/domaintools-irisql/src/client/api_client.py
@@ -27,6 +27,9 @@ class DomainToolsClient:
         Internal method to handle API requests
         :return: Response in JSON format
         """
+        params["app_name"] = "OpenCTI"
+        params["app_partner"] = "IrisQL"
+        params["app_version"] = "1.0"
         try:
 
             response = self.session.post(api_url, params=params, data=body)

--- a/external-import/domaintools-irisql/src/connector/converter_to_stix.py
+++ b/external-import/domaintools-irisql/src/connector/converter_to_stix.py
@@ -139,7 +139,11 @@ class ConverterToStix:
         :param value: Value in string
         :return: A boolean
         """
-        is_valid_domain = validators.domain(value)
+        # Temporarily swap underscores out so validators accepts the format
+        # Since some domain do have "_"
+        sanitized_domain = value.replace("_", "-")
+
+        is_valid_domain = validators.domain(sanitized_domain)
 
         if is_valid_domain:
             return True

--- a/external-import/domaintools-irisql/src/connector/converter_to_stix.py
+++ b/external-import/domaintools-irisql/src/connector/converter_to_stix.py
@@ -140,7 +140,7 @@ class ConverterToStix:
         :return: A boolean
         """
         # Temporarily swap underscores out so validators accepts the format
-        # Since some domain do have "_"
+        # Since some domains do have "_"
         sanitized_domain = value.replace("_", "-")
 
         is_valid_domain = validators.domain(sanitized_domain)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.

PR TITLE FORMAT (enforced by CI):
  type(scope?)!?: description (#123)
  - type: feat | fix | chore | docs | style | refactor | perf | test | build | ci | revert
  - scope: optional, e.g. connector name
  - description: must start with a lowercase letter
  - (#123): required linked issue number
  Example: feat(alienvault): add pagination support (#42)
-->

### Proposed changes

* update api_client.py to have metadata value
* update converter_to_stix.py to have the correct indicator  value
* update converter_to_stix.py to support "_" domain

Fixes #7144

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
