### PR TITLE
fix(connectors-sdk): ListFromString parser doesn't filter empty values (#7012)

### DIFF
--- a/connectors-sdk/connectors_sdk/settings/annotated_types.py
+++ b/connectors-sdk/connectors_sdk/settings/annotated_types.py
@@ -41,8 +41,8 @@ ListFromString = Annotated[
     BeforeValidator(parse_comma_separated_list),
     """Annotated list[str] that:
 - Validates: Accepts a comma-separated string (e.g., "a,b,c") or a list[str].
-  If a string is provided, it is split on commas and whitespace is trimmed for
-  each item.
+  If a string is provided, it is split on commas, whitespace is trimmed for
+  each item, and empty items are discarded.
 
 Components
 - BeforeValidator(parse_comma_separated_list): Converts input strings to list[str]

--- a/connectors-sdk/connectors_sdk/settings/annotated_types.py
+++ b/connectors-sdk/connectors_sdk/settings/annotated_types.py
@@ -22,15 +22,17 @@ def parse_comma_separated_list(value: str | list[str]) -> list[str]:
     - value: Either a string (e.g., "a,b,c") or a list[str].
 
     Returns:
-    - A list of strings. For string inputs, the string is split on commas and each
-      token is stripped of leading/trailing whitespace.
+    - A list of strings. For string inputs, the string is split on commas, each
+      token is stripped of leading/trailing whitespace, and empty tokens are
+      discarded.
 
     Examples:
     - "a, b ,c" -> ["a", "b", "c"]
+    - "a, ,c" -> ["a", "c"]
     - ["a", "b"] -> ["a", "b"]
     """
     if isinstance(value, str):
-        return [string.strip() for string in value.split(",") if value]
+        return [stripped for string in value.split(",") if (stripped := string.strip())]
     return value
 
 

--- a/connectors-sdk/tests/test_settings/test_annotated_types.py
+++ b/connectors-sdk/tests/test_settings/test_annotated_types.py
@@ -31,6 +31,21 @@ from pydantic import TypeAdapter
             [],
             id="empty_string",  # empty string -> empty list
         ),
+        pytest.param(
+            "a, ,c",
+            ["a", "c"],
+            id="blank_item_between_commas",
+        ),
+        pytest.param(
+            "a,,c",
+            ["a", "c"],
+            id="consecutive_commas",
+        ),
+        pytest.param(
+            ",a,",
+            ["a"],
+            id="leading_and_trailing_commas",
+        ),
     ],
 )
 def test_parse_comma_separated_list_handles_string(
@@ -51,6 +66,11 @@ def test_list_from_string_accepts_string_input() -> None:
 def test_list_from_string_accepts_list_input() -> None:
     value = TypeAdapter(ListFromString).validate_python(["a", "b"])
     assert value == ["a", "b"]
+
+
+def test_list_from_string_discards_empty_items() -> None:
+    value = TypeAdapter(ListFromString).validate_python("scope1, ,scope3")
+    assert value == ["scope1", "scope3"]
 
 
 def test_list_from_string_dumps_valid_json() -> None:


### PR DESCRIPTION
Closes #7012

### Proposed changes

* `parse_comma_separated_list` filtered each split token on the truthiness of the whole input string (`if value`) rather than the stripped token, so blank segments survived: `CONNECTOR_SCOPE="scope1, ,scope3"` validated to `["scope1", "", "scope3"]`. The comprehension now keeps a token only when it is non-empty after stripping.
* Behaviour for `"a, b , c"`, already-list inputs and the empty string is unchanged.

### Related issues

* close #7012

### Checklist

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Regression coverage was added to the existing parametrized case list in `tests/test_settings/test_annotated_types.py` (blank item between commas, consecutive commas, leading/trailing commas) plus a `ListFromString` validation test using the reporter's exact input. Those four cases fail on the current parser and pass with the fix; `tests/test_settings` is green (40 passed).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
