### PR TITLE
test(all): update connector_config_schema.json tests (#6342)

### DIFF
--- a/external-import/abuseipdb-ipblacklist/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/abuseipdb-ipblacklist/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | ABUSEIPDB_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Your AbuseIPDB API key. |
 | ABUSEIPDB_SCORE | `integer` | ✅ | integer |  | Minimum confidence score threshold for IP addresses. |
 | CONNECTOR_NAME | `string` |  | string | `"AbuseIPDB IP Blacklist"` | The name of the connector. |

--- a/external-import/abuseipdb-ipblacklist/__metadata__/connector_config_schema.json
+++ b/external-import/abuseipdb-ipblacklist/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "AbuseIPDB IP Blacklist",

--- a/external-import/alienvault/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/alienvault/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | ALIENVAULT_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The OTX Key. |
 | CONNECTOR_NAME | `string` |  | string |  | `"AlienVault"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string |  | `["alienvault"]` | The scope of the connector. |

--- a/external-import/alienvault/__metadata__/connector_config_schema.json
+++ b/external-import/alienvault/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "AlienVault",

--- a/external-import/anyrun-feed/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/anyrun-feed/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | ANYRUN_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | ANY.RUN TI Feeds API key. See 'Generate your API key' section in the README file. |
 | CONNECTOR_NAME | `string` |  | string |  | `"ANY.RUN TI Feed"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string |  | `["anyrun-feed"]` | The scope of the connector. |

--- a/external-import/anyrun-feed/__metadata__/connector_config_schema.json
+++ b/external-import/anyrun-feed/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ANY.RUN TI Feed",

--- a/external-import/arcsight-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/arcsight-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | ARCSIGHT_INCIDENTS_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the ArcSight ESM Manager (e.g. https://arcsight.example.com:8443). |
 | ARCSIGHT_INCIDENTS_USERNAME | `string` | ✅ | string |  | ArcSight ESM user name. |
 | ARCSIGHT_INCIDENTS_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | ArcSight ESM user password. |

--- a/external-import/arcsight-incidents/__metadata__/connector_config_schema.json
+++ b/external-import/arcsight-incidents/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ArcSight Incidents",

--- a/external-import/checkfirst-import-connector/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/checkfirst-import-connector/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CHECKFIRST_API_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL for the API endpoint (e.g., https://api.example.com). |
 | CHECKFIRST_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | API key for authentication (sent in Api-Key header). |
 | CONNECTOR_NAME | `string` |  | string | `"Checkfirst Import Connector"` | The name of the connector. |

--- a/external-import/checkfirst-import-connector/__metadata__/connector_config_schema.json
+++ b/external-import/checkfirst-import-connector/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Checkfirst Import Connector",

--- a/external-import/citalid/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/citalid/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | CITALID_CUSTOMER_SUB_DOMAIN_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | URL of your Citalid instance (customer subdomain). |
 | CITALID_USER | `string` | ✅ | string |  |  | Username with access to the Citalid instance. |
 | CITALID_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Password for the Citalid user. |

--- a/external-import/citalid/__metadata__/connector_config_schema.json
+++ b/external-import/citalid/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Citalid",

--- a/external-import/cofense-threathq/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/cofense-threathq/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | COFENSE_THREATHQ_TOKEN_USER | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Token user for Cofense ThreatHQ API authentication. |
 | COFENSE_THREATHQ_TOKEN_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Token password for Cofense ThreatHQ API authentication. |
 | CONNECTOR_NAME | `string` |  | string | `"CofenseThreathq"` | The name of the connector. |

--- a/external-import/cofense-threathq/__metadata__/connector_config_schema.json
+++ b/external-import/cofense-threathq/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "CofenseThreathq",

--- a/external-import/comlaude/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/comlaude/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | COMLAUDE_USERNAME | `string` | ✅ | string |  | ComLaude API username. |
 | COMLAUDE_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | ComLaude API password. |
 | COMLAUDE_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | ComLaude API key. |

--- a/external-import/comlaude/__metadata__/connector_config_schema.json
+++ b/external-import/comlaude/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Comlaude",

--- a/external-import/corelight-investigator/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/corelight-investigator/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CORELIGHT_INVESTIGATOR_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Corelight Investigator API base URL (region specific, e.g. https://eu.api.investigator.corelight.com). |
 | CORELIGHT_INVESTIGATOR_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Corelight Investigator API key (sent as an Authorization bearer header). |
 | CONNECTOR_NAME | `string` |  | string | `"Corelight Investigator"` | The name of the connector. |

--- a/external-import/corelight-investigator/__metadata__/connector_config_schema.json
+++ b/external-import/corelight-investigator/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Corelight Investigator",

--- a/external-import/cpe/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/cpe/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CPE_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | API Key for the NIST NVD API. |
 | CONNECTOR_NAME | `string` |  | string | `"Common Platform Enumeration"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["software"]` | The scope of the connector. |

--- a/external-import/cpe/__metadata__/connector_config_schema.json
+++ b/external-import/cpe/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Common Platform Enumeration",

--- a/external-import/crowdstrike-recon/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/crowdstrike-recon/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CROWDSTRIKE_RECON_API_BASE_URL | `string` | ✅ | string |  | API base URL. |
 | CROWDSTRIKE_RECON_CLIENT_ID | `string` | ✅ | string |  | CrowdStrike Falcon Client ID. |
 | CROWDSTRIKE_RECON_CLIENT_SECRET | `string` | ✅ | string |  | CrowdStrike Falcon Client Secret. |

--- a/external-import/crowdstrike-recon/__metadata__/connector_config_schema.json
+++ b/external-import/crowdstrike-recon/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "CrowdStrike Recon",

--- a/external-import/crowdstrike/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/crowdstrike/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | CROWDSTRIKE_CLIENT_ID | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | CrowdStrike API client ID for authentication. |
 | CROWDSTRIKE_CLIENT_SECRET | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | CrowdStrike API client secret for authentication. |
 | CONNECTOR_NAME | `string` |  | string |  | `"CrowdStrike"` | The name of the connector. |

--- a/external-import/crowdstrike/__metadata__/connector_config_schema.json
+++ b/external-import/crowdstrike/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "CrowdStrike",

--- a/external-import/ctm360-threatcover/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/ctm360-threatcover/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CTM360_THREATCOVER_DISCOVERY_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | CTM360 ThreatCover TAXII discovery URL (e.g. https://<tenant>.ctm360.com/taxii2/). |
 | CTM360_THREATCOVER_COLLECTION | `string` | ✅ | string |  | TAXII collection to poll (the ThreatCover 'Observables' collection id or title). |
 | CONNECTOR_NAME | `string` |  | string | `"CTM360 ThreatCover"` | The name of the connector. |

--- a/external-import/ctm360-threatcover/__metadata__/connector_config_schema.json
+++ b/external-import/ctm360-threatcover/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "CTM360 ThreatCover",

--- a/external-import/cybelangel/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/cybelangel/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CYBELANGEL_CLIENT_ID | `string` | ✅ | string |  | CybelAngel OAuth2 client ID. |
 | CYBELANGEL_CLIENT_SECRET | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | CybelAngel OAuth2 client secret. |
 | CONNECTOR_NAME | `string` |  | string | `"CybelAngel"` | The name of the connector. |

--- a/external-import/cybelangel/__metadata__/connector_config_schema.json
+++ b/external-import/cybelangel/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "CybelAngel",

--- a/external-import/disarm-framework/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/disarm-framework/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"DisarmFramework"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["marking-definition", "identity", "attack-pattern", "course-of-action", "intrusion-set", "campaign", "malware", "tool", "report", "narrative", "event", "channel"]` | The scope of the connector. Only these object types will be imported on OpenCTI. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/external-import/disarm-framework/__metadata__/connector_config_schema.json
+++ b/external-import/disarm-framework/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "DisarmFramework",

--- a/external-import/dragos/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/dragos/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | DRAGOS_API_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Dragos API token. |
 | DRAGOS_API_SECRET | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Dragos API secret. |
 | CONNECTOR_NAME | `string` |  | string | `"Dragos"` | The name of the connector. |

--- a/external-import/dragos/__metadata__/connector_config_schema.json
+++ b/external-import/dragos/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Dragos",

--- a/external-import/elastic-security-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/elastic-security-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | ELASTIC_SECURITY_URL | `string` | ✅ | string |  | The Elasticsearch URL (for alerts) or Kibana URL (for cases). |
 | ELASTIC_SECURITY_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The Elasticsearch API Key. |
 | CONNECTOR_NAME | `string` |  | string | `"Elastic Security Incidents"` | The name of the connector. |

--- a/external-import/elastic-security-incidents/__metadata__/connector_config_schema.json
+++ b/external-import/elastic-security-incidents/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Elastic Security Incidents",

--- a/external-import/flare/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/flare/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | FLARE_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Flare API key. |
 | CONNECTOR_NAME | `string` |  | string |  | `"Flare"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string |  | `["Flare"]` | The scope of the connector. |

--- a/external-import/flare/__metadata__/connector_config_schema.json
+++ b/external-import/flare/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Flare",

--- a/external-import/fortisiem-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/fortisiem-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | FORTISIEM_INCIDENTS_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the FortiSIEM Supervisor (e.g. https://fortisiem.example.com). |
 | FORTISIEM_INCIDENTS_USERNAME | `string` | ✅ | string |  | FortiSIEM REST API user name. |
 | FORTISIEM_INCIDENTS_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | FortiSIEM REST API user password. |

--- a/external-import/fortisiem-incidents/__metadata__/connector_config_schema.json
+++ b/external-import/fortisiem-incidents/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "FortiSIEM Incidents",

--- a/external-import/google-dtm/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/google-dtm/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | GOOGLE_DTM_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Google DTM API Key |
 | CONNECTOR_NAME | `string` |  | string | `"Google DTM"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["google-dtm"]` | The scope of the connector, e.g. 'google-dtm'. |

--- a/external-import/google-dtm/__metadata__/connector_config_schema.json
+++ b/external-import/google-dtm/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Google DTM",

--- a/external-import/google-secops-siem-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/google-secops-siem-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | GOOGLE_SECOPS_SIEM_INCIDENTS_PROJECT_ID | `string` | ✅ | string |  | GCP project ID. |
 | GOOGLE_SECOPS_SIEM_INCIDENTS_PROJECT_REGION | `string` | ✅ | string |  | Region (e.g. 'us', 'eu', 'asia'). |
 | GOOGLE_SECOPS_SIEM_INCIDENTS_PROJECT_INSTANCE | `string` | ✅ | string |  | Instance UUID. |

--- a/external-import/google-secops-siem-incidents/__metadata__/connector_config_schema.json
+++ b/external-import/google-secops-siem-incidents/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Google SecOps",

--- a/external-import/hunt-io/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/hunt-io/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | HUNT_IO_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Authentication key for accessing the Hunt.io API. Obtain this from your Hunt.io account settings |
 | CONNECTOR_NAME | `string` |  | string |  | `"Hunt IO"` | Display name for this connector instance in the OpenCTI platform |
 | CONNECTOR_SCOPE | `array` |  | string |  | `["Hunt IO"]` | Entity types or categories this connector will handle. Used for filtering and organization within OpenCTI |

--- a/external-import/hunt-io/__metadata__/connector_config_schema.json
+++ b/external-import/hunt-io/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Hunt IO",

--- a/external-import/ibm-xti/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/ibm-xti/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | IBM_XTI_TAXII_SERVER_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the IBM X-Force PTI TAXII Server. |
 | IBM_XTI_TAXII_USER | `string` | ✅ | string |  | Your TAXII Server username. |
 | IBM_XTI_TAXII_PASS | `string` | ✅ | string |  | Your TAXII Server password. |

--- a/external-import/ibm-xti/__metadata__/connector_config_schema.json
+++ b/external-import/ibm-xti/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "IBMXTIConnector",

--- a/external-import/infoblox/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/infoblox/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | INFOBLOX_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API key used to authenticate against the Infoblox TIDE API. |
 | CONNECTOR_NAME | `string` |  | string |  | `"Infoblox"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string |  | `["infoblox"]` | The scope of the connector. |

--- a/external-import/infoblox/__metadata__/connector_config_schema.json
+++ b/external-import/infoblox/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Infoblox",

--- a/external-import/intel471_v2/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/intel471_v2/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | INTEL471_API_USERNAME | `string` | ✅ | string |  | Titan API username |
 | INTEL471_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Titan API key |
 | CONNECTOR_NAME | `string` |  | string | `"Intel471 v2"` | The name of the connector. |

--- a/external-import/intel471_v2/__metadata__/connector_config_schema.json
+++ b/external-import/intel471_v2/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Intel471 v2",

--- a/external-import/ipsum/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/ipsum/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"IPsum"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["ipsum"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/external-import/ipsum/__metadata__/connector_config_schema.json
+++ b/external-import/ipsum/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "IPsum",

--- a/external-import/logrhythm-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/logrhythm-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | LOGRHYTHM_INCIDENTS_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the LogRhythm API gateway (e.g. https://logrhythm.example.com:8501). |
 | LOGRHYTHM_INCIDENTS_API_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | LogRhythm API token (Bearer) used for authentication. |
 | CONNECTOR_NAME | `string` |  | string | `"LogRhythm Incidents"` | The name of the connector. |

--- a/external-import/logrhythm-incidents/__metadata__/connector_config_schema.json
+++ b/external-import/logrhythm-incidents/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "LogRhythm Incidents",

--- a/external-import/malcore/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/malcore/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | MALCORE_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Malcore API Key |
 | CONNECTOR_NAME | `string` |  | string |  | `"Malcore"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string |  | `[]` | The scope of the connector. |

--- a/external-import/malcore/__metadata__/connector_config_schema.json
+++ b/external-import/malcore/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Malcore",

--- a/external-import/malpedia/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/malpedia/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"Malpedia"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["malpedia"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/external-import/malpedia/__metadata__/connector_config_schema.json
+++ b/external-import/malpedia/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Malpedia",

--- a/external-import/maltiverse/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/maltiverse/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | MALTIVERSE_USER | `string` | ✅ | string |  |  | Maltiverse account username/email. |
 | MALTIVERSE_PASSWD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Maltiverse account password. |
 | MALTIVERSE_FEEDS | `string` | ✅ | string |  |  | Comma-separated list of feed/collection IDs to fetch. |

--- a/external-import/maltiverse/__metadata__/connector_config_schema.json
+++ b/external-import/maltiverse/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Maltiverse",

--- a/external-import/microsoft-defender-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/microsoft-defender-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | MICROSOFT_DEFENDER_INCIDENTS_TENANT_ID | `string` | ✅ | string |  | Azure Tenant ID for Microsoft Graph API authentication. |
 | MICROSOFT_DEFENDER_INCIDENTS_CLIENT_ID | `string` | ✅ | string |  | Azure App Client ID for Microsoft Graph API authentication. |
 | MICROSOFT_DEFENDER_INCIDENTS_CLIENT_SECRET | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Azure App Client Secret for Microsoft Graph API authentication. |

--- a/external-import/microsoft-defender-incidents/__metadata__/connector_config_schema.json
+++ b/external-import/microsoft-defender-incidents/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Microsoft Defender Incidents",

--- a/external-import/microsoft-sentinel-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/microsoft-sentinel-incidents/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | MICROSOFT_SENTINEL_INCIDENTS_TENANT_ID | `string` | ✅ | string |  | Your Azure App Tenant ID, see the screenshot to help you find this information. |
 | MICROSOFT_SENTINEL_INCIDENTS_CLIENT_ID | `string` | ✅ | string |  | Your Azure App Client ID, see the screenshot to help you find this information. |
 | MICROSOFT_SENTINEL_INCIDENTS_CLIENT_SECRET | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Your Azure App Client secret, See the screenshot to help you find this information. |

--- a/external-import/microsoft-sentinel-incidents/__metadata__/connector_config_schema.json
+++ b/external-import/microsoft-sentinel-incidents/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Microsoft Sentinel Incidents",

--- a/external-import/misp-feed/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/misp-feed/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"Misp Feed"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["misp-feed"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/external-import/misp-feed/__metadata__/connector_config_schema.json
+++ b/external-import/misp-feed/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Misp Feed",

--- a/external-import/misp/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/misp/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | MISP_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | MISP instance URL |
 | MISP_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | MISP instance API key. |
 | CONNECTOR_NAME | `string` |  | string | `"MISP"` | The name of the connector. |

--- a/external-import/misp/__metadata__/connector_config_schema.json
+++ b/external-import/misp/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "MISP",

--- a/external-import/mitre-atlas/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/mitre-atlas/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"MITRE ATLAS"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["identity", "attack-pattern", "course-of-action", "relationship", "x-mitre-collection", "x-mitre-matrix", "x-mitre-tactic"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/external-import/mitre-atlas/__metadata__/connector_config_schema.json
+++ b/external-import/mitre-atlas/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "MITRE ATLAS",

--- a/external-import/mokn/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/mokn/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | MOKN_CONSOLE_URL | `string` | ✅ | string |  | MokN console base URL. |
 | MOKN_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | MokN API key. |
 | CONNECTOR_NAME | `string` |  | string | `"MokN"` | The name of the connector. |

--- a/external-import/mokn/__metadata__/connector_config_schema.json
+++ b/external-import/mokn/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "MokN",

--- a/external-import/montysecurity-c2-tracker/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/montysecurity-c2-tracker/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"MontysecurityC2TrackerConnector"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["montysecurity-c2-tracker"]` | The scope of the connector, e.g. 'flashpoint'. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/external-import/montysecurity-c2-tracker/__metadata__/connector_config_schema.json
+++ b/external-import/montysecurity-c2-tracker/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "MontysecurityC2TrackerConnector",

--- a/external-import/phishunt/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/phishunt/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"Phishunt"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["phishunt"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/external-import/phishunt/__metadata__/connector_config_schema.json
+++ b/external-import/phishunt/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Phishunt",

--- a/external-import/promptintel/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/promptintel/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | PROMPTINTEL_API_KEY | `string` | ✅ | string |  | API key for authenticating with PromptIntel. |
 | CONNECTOR_NAME | `string` |  | string | `"PromptIntel"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["promptintel"]` | The scope of the connector. |

--- a/external-import/promptintel/__metadata__/connector_config_schema.json
+++ b/external-import/promptintel/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "PromptIntel",

--- a/external-import/proofpoint-et-reputation/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/proofpoint-et-reputation/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | PROOFPOINT_ET_REPUTATION_API_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | API token for authentication with the ProofPoint ET Reputation API. |
 | CONNECTOR_NAME | `string` |  | string | `"ProofPoint ET Reputation"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["IPv4-Addr", "Domain-Name"]` | The scope of the connector. |

--- a/external-import/proofpoint-et-reputation/__metadata__/connector_config_schema.json
+++ b/external-import/proofpoint-et-reputation/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ProofPoint ET Reputation",

--- a/external-import/proofpoint-tap/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/proofpoint-tap/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | PROOFPOINT_TAP_API_PRINCIPAL_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Proofpoint API principal key for authentication. |
 | PROOFPOINT_TAP_API_SECRET_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Proofpoint API secret key for authentication. |
 | CONNECTOR_NAME | `string` |  | string |  | `"ProofPointTAP"` | The name of the connector. |

--- a/external-import/proofpoint-tap/__metadata__/connector_config_schema.json
+++ b/external-import/proofpoint-tap/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ProofPointTAP",

--- a/external-import/recorded-future-asi/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/recorded-future-asi/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | RECORDED_FUTURE_ASI_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | API key for authentication. |
 | RECORDED_FUTURE_ASI_PROJECT_ID | `string` | ✅ | string |  | ASI project ID to fetch exposures from. |
 | CONNECTOR_NAME | `string` |  | string | `"Recorded Future ASI Exposures"` | The name of the connector. |

--- a/external-import/recorded-future-asi/__metadata__/connector_config_schema.json
+++ b/external-import/recorded-future-asi/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Recorded Future ASI Exposures",

--- a/external-import/red-flag-domains/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/red-flag-domains/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"Red Flag Domains"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["red-flag-domains"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/external-import/red-flag-domains/__metadata__/connector_config_schema.json
+++ b/external-import/red-flag-domains/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Red Flag Domains",

--- a/external-import/rst-report-hub/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/rst-report-hub/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | RST_REPORT_HUB_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Your API Key for accessing RST Cloud. |
 | CONNECTOR_NAME | `string` |  | string | `"RstReportHub"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `[]` | The scope of the connector. |

--- a/external-import/rst-report-hub/__metadata__/connector_config_schema.json
+++ b/external-import/rst-report-hub/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "RstReportHub",

--- a/external-import/rst-threat-feed/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/rst-threat-feed/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | RST_THREAT_FEED_APIKEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Your API Key for accessing RST Cloud. |
 | CONNECTOR_NAME | `string` |  | string |  | `"RstThreatFeed"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string |  | `[]` | The scope of the connector. |

--- a/external-import/rst-threat-feed/__metadata__/connector_config_schema.json
+++ b/external-import/rst-threat-feed/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "RstThreatFeed",

--- a/external-import/servicenow/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/servicenow/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | SERVICENOW_INSTANCE_NAME | `string` | ✅ | string |  | Corresponds to server instance name (will be used for API requests). |
 | SERVICENOW_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Secure identifier used to validate access to ServiceNow APIs. |
 | CONNECTOR_NAME | `string` |  | string | `"ServiceNow"` | Name of the connector. |

--- a/external-import/servicenow/__metadata__/connector_config_schema.json
+++ b/external-import/servicenow/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ServiceNow",

--- a/external-import/shadowserver/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/shadowserver/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | SHADOWSERVER_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Shadowserver API key. |
 | SHADOWSERVER_API_SECRET | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Shadowserver API secret. |
 | CONNECTOR_NAME | `string` |  | string |  | `"Shadowserver"` | The name of the connector. |

--- a/external-import/shadowserver/__metadata__/connector_config_schema.json
+++ b/external-import/shadowserver/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Shadowserver",

--- a/external-import/sigmahq/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/sigmahq/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"SigmaHQ"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["sigmahq"]` | The scope of the connector |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/external-import/sigmahq/__metadata__/connector_config_schema.json
+++ b/external-import/sigmahq/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "SigmaHQ",

--- a/external-import/silobreaker/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/silobreaker/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | SILOBREAKER_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API key for the Silobreaker API. |
 | SILOBREAKER_API_SHARED | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The shared secret for the Silobreaker API. |
 | CONNECTOR_NAME | `string` |  | string | `"Silobreaker"` | The name of the connector. |

--- a/external-import/silobreaker/__metadata__/connector_config_schema.json
+++ b/external-import/silobreaker/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Silobreaker",

--- a/external-import/socprime/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/socprime/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | SOCPRIME_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | API key used to authenticate against the SOC Prime TDM API. |
 | CONNECTOR_NAME | `string` |  | string |  | `"SocPrime"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string |  | `["socprime"]` | The scope of the connector. |

--- a/external-import/socprime/__metadata__/connector_config_schema.json
+++ b/external-import/socprime/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "SocPrime",

--- a/external-import/socradar/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/socradar/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -17,4 +17,4 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` |  | `"EXTERNAL_IMPORT"` |  |
 | CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | `"PT10M"` | The period of time to await between two runs of the connector. |
 | RADAR_RUN_INTERVAL | `integer` |  | integer | ⛔️ | `null` | Use CONNECTOR_DURATION_PERIOD instead. |
-| RADAR_COLLECTIONS_UUID | `object` |  | object | ⛔️ | `null` | Use RADAR_FEED_LISTS instead. |
+| RADAR_COLLECTIONS_UUID | `string` |  | string | ⛔️ | `null` | Use RADAR_FEED_LISTS instead. |

--- a/external-import/socradar/__metadata__/connector_config_schema.json
+++ b/external-import/socradar/__metadata__/connector_config_schema.json
@@ -82,10 +82,22 @@
       "description": "Use CONNECTOR_DURATION_PERIOD instead."
     },
     "RADAR_COLLECTIONS_UUID": {
-      "additionalProperties": true,
+      "contentMediaType": "application/json",
+      "contentSchema": {
+        "additionalProperties": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object"
+        },
+        "type": "object"
+      },
       "default": null,
       "deprecated": true,
-      "type": "object",
+      "type": "string",
       "description": "Use RADAR_FEED_LISTS instead."
     }
   },

--- a/external-import/socradar/src/connector/settings.py
+++ b/external-import/socradar/src/connector/settings.py
@@ -74,7 +74,7 @@ class RadarConfig(BaseConfigModel):
         new_namespaced_var="duration_period",
         new_value_factory=lambda x: timedelta(seconds=int(x)),
     )
-    collections_uuid: dict | None = DeprecatedField(
+    collections_uuid: Json[dict[str, dict[str, list[str]]]] | None = DeprecatedField(
         default=None,
         deprecated="Use 'RADAR_FEED_LISTS' instead.",
         new_namespaced_var="feed_lists",

--- a/external-import/sublime/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/sublime/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | SUBLIME_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Sublime Security API authentication token. |
 | CONNECTOR_NAME | `string` |  | string | `"Sublime Security"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["sublime"]` | The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only). |

--- a/external-import/sublime/__metadata__/connector_config_schema.json
+++ b/external-import/sublime/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Sublime Security",

--- a/external-import/swimlane/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/swimlane/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | SWIMLANE_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the Swimlane instance (e.g. https://swimlane.example.com). |
 | SWIMLANE_API_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Swimlane API token (Personal Access Token) used for authentication. |
 | SWIMLANE_APPLICATION_ID | `string` | ✅ | string |  | ID of the Swimlane application whose records are imported. |

--- a/external-import/swimlane/__metadata__/connector_config_schema.json
+++ b/external-import/swimlane/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Swimlane",

--- a/external-import/teamt5/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/teamt5/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"Team T5 External Import Connector"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `[]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/external-import/teamt5/__metadata__/connector_config_schema.json
+++ b/external-import/teamt5/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Team T5 External Import Connector",

--- a/external-import/tenable-vuln-management/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/tenable-vuln-management/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | TENABLE_VULN_MANAGEMENT_API_ACCESS_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Tenable API access key. |
 | TENABLE_VULN_MANAGEMENT_API_SECRET_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Tenable API secret key. |
 | CONNECTOR_NAME | `string` |  | string |  | `"TenableVulnManagement"` | The name of the connector. |

--- a/external-import/tenable-vuln-management/__metadata__/connector_config_schema.json
+++ b/external-import/tenable-vuln-management/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "TenableVulnManagement",

--- a/external-import/thehive/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/thehive/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | THEHIVE_URL | `string` | ✅ | string |  |  | The URL of the TheHive instance. |
 | THEHIVE_API_KEY | `string` | ✅ | string |  |  | The API key to authenticate to TheHive. |
 | THEHIVE_ORGANIZATION_NAME | `string` | ✅ | string |  |  | The name of the organization in TheHive, used to create the identity in OpenCTI. |

--- a/external-import/thehive/__metadata__/connector_config_schema.json
+++ b/external-import/thehive/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "TheHive",

--- a/external-import/tweetfeed/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/tweetfeed/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"TweetFeed"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `[]` | The scope of the connector |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/external-import/tweetfeed/__metadata__/connector_config_schema.json
+++ b/external-import/tweetfeed/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "TweetFeed",

--- a/external-import/urlhaus/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/urlhaus/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string |  | `"Urlhaus"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string |  | `[]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` |  | `"error"` | The minimum level of logs to display. |

--- a/external-import/urlhaus/__metadata__/connector_config_schema.json
+++ b/external-import/urlhaus/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Urlhaus",

--- a/external-import/urlscan/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/urlscan/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | URLSCAN_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The Urlscan API key. |
 | CONNECTOR_NAME | `string` |  | string |  | `"Urlscan"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string |  | `["urlscan"]` | The scope of the connector, e.g. 'urlscan'. |

--- a/external-import/urlscan/__metadata__/connector_config_schema.json
+++ b/external-import/urlscan/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Urlscan",

--- a/external-import/valhalla/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/valhalla/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"Valhalla"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["valhalla"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/external-import/valhalla/__metadata__/connector_config_schema.json
+++ b/external-import/valhalla/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Valhalla",

--- a/external-import/vulncheck/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/vulncheck/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | VULNCHECK_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API key used to authenticate against the VulnCheck API. |
 | CONNECTOR_NAME | `string` |  | string |  | `"VulnCheck"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string |  | `["vulnerability", "malware", "threat-actor", "infrastructure", "location", "ip-addr", "indicator", "external-reference", "attack-pattern", "course-of-action", "x-mitre-data-source", "report"]` | Comma-separated STIX object types to import, e.g. `vulnerability,malware,threat-actor,infrastructure,location,ip-addr,indicator,external-reference,attack-pattern,course-of-action,x-mitre-data-source,report` (add `software` only if prepared for the volume — see [Data Volume](#data-volume)). |

--- a/external-import/vulncheck/__metadata__/connector_config_schema.json
+++ b/external-import/vulncheck/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "VulnCheck",

--- a/external-import/vxvault/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/vxvault/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string |  | `"VX Vault URL list"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string |  | `["vxvault"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` |  | `"error"` | The minimum level of logs to display. |

--- a/external-import/vxvault/__metadata__/connector_config_schema.json
+++ b/external-import/vxvault/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "VX Vault URL list",

--- a/external-import/wiz/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/wiz/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"Wiz Cloud Threat Landscape"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `[]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/external-import/wiz/__metadata__/connector_config_schema.json
+++ b/external-import/wiz/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Wiz Cloud Threat Landscape",

--- a/external-import/zerofox-alerts/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/zerofox-alerts/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | ZEROFOX_ALERTS_API_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | ZeroFox Personal Access Token (PAT) for authentication. |
 | CONNECTOR_NAME | `string` |  | string | `"ZeroFox Alerts"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["zerofox-alerts"]` | The scope of the connector. |

--- a/external-import/zerofox-alerts/__metadata__/connector_config_schema.json
+++ b/external-import/zerofox-alerts/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ZeroFox Alerts",

--- a/external-import/zerofox/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/zerofox/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | ZEROFOX_USERNAME | `string` | ✅ | string |  |  | The username used to authenticate against the ZeroFox API. |
 | ZEROFOX_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The password used to authenticate against the ZeroFox API. |
 | CONNECTOR_NAME | `string` |  | string |  | `"ZeroFox"` | The name of the connector. |

--- a/external-import/zerofox/__metadata__/connector_config_schema.json
+++ b/external-import/zerofox/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ZeroFox",

--- a/external-import/zvelo/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/zvelo/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | ZVELO_CLIENT_ID | `string` | ✅ | string |  | Zvelo OAuth client ID. |
 | ZVELO_CLIENT_SECRET | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Zvelo OAuth client secret. |
 | CONNECTOR_NAME | `string` |  | string | `"Zvelo"` | The name of the connector. |

--- a/external-import/zvelo/__metadata__/connector_config_schema.json
+++ b/external-import/zvelo/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Zvelo",

--- a/internal-enrichment/censys-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/censys-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CENSYS_ENRICHMENT_ORGANISATION_ID | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Censys organisation ID. |
 | CENSYS_ENRICHMENT_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Censys API token. |
 | CONNECTOR_NAME | `string` |  | string | `"Censys Enrichment"` | The name of the connector. |

--- a/internal-enrichment/censys-enrichment/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/censys-enrichment/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Censys Enrichment",

--- a/internal-enrichment/criminal-ip/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/criminal-ip/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CRIMINAL_IP_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Criminal IP API key. |
 | CONNECTOR_NAME | `string` |  | string | `"Criminal IP"` | The name of the connector |
 | CONNECTOR_SCOPE | `array` |  | string | `["IPv4-Addr", "Domain-Name"]` | The scope of the connector. |

--- a/internal-enrichment/criminal-ip/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/criminal-ip/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Criminal IP",

--- a/internal-enrichment/dnstwist/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/dnstwist/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"DNSTwist"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["Domain-Name"]` | The scope of observables the connector will enrich. Currently, only 'Domain-Name' is supported. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/internal-enrichment/dnstwist/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/dnstwist/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "DNSTwist",

--- a/internal-enrichment/domaintools/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/domaintools/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | DOMAINTOOLS_API_USERNAME | `string` | ✅ | string |  | The username required for the authentication on DomainTools API. |
 | DOMAINTOOLS_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The password required for the authentication on DomainTools API. |
 | CONNECTOR_NAME | `string` |  | string | `"Domaintools"` | The name of the connector. |

--- a/internal-enrichment/domaintools/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/domaintools/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Domaintools",

--- a/internal-enrichment/doppel-alert-takedown/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/doppel-alert-takedown/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | DOPPEL_ALERT_TAKEDOWN_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Doppel API key, sent as the `x-api-key` header. |
 | DOPPEL_ALERT_TAKEDOWN_USER_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Doppel user API key, sent as the `x-user-api-key` header. |
 | CONNECTOR_NAME | `string` |  | string | `"Doppel Alert and Takedown"` | The name of the connector. |

--- a/internal-enrichment/doppel-alert-takedown/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/doppel-alert-takedown/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Doppel Alert and Takedown",

--- a/internal-enrichment/first-epss/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/first-epss/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"First EPSS"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["vulnerability"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/internal-enrichment/first-epss/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/first-epss/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "First EPSS",

--- a/internal-enrichment/fortisandbox/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/fortisandbox/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | FORTISANDBOX_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | FortiSandbox base URL (appliance, VM or cloud), without the /jsonrpc suffix. |
 | FORTISANDBOX_USERNAME | `string` | ✅ | string |  | FortiSandbox API username. |
 | FORTISANDBOX_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | FortiSandbox API password. |

--- a/internal-enrichment/fortisandbox/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/fortisandbox/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "FortiSandbox",

--- a/internal-enrichment/greynoise-vuln/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/greynoise-vuln/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | GREYNOISE_VULN_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The GreyNoise API key. |
 | CONNECTOR_NAME | `string` |  | string | `"GreyNoise Vulnerability Enrichment"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["vulnerability"]` | The scope of the connector. |

--- a/internal-enrichment/greynoise-vuln/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/greynoise-vuln/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "GreyNoise Vulnerability Enrichment",

--- a/internal-enrichment/greynoise/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/greynoise/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | GREYNOISE_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The GreyNoise API key. |
 | CONNECTOR_NAME | `string` |  | string | `"Greynoise"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["IPv4-Addr"]` | The scope of the connector. |

--- a/internal-enrichment/greynoise/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/greynoise/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Greynoise",

--- a/internal-enrichment/hybrid-analysis-sandbox/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/hybrid-analysis-sandbox/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | HYBRID_ANALYSIS_SANDBOX_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | Hybrid Analysis API token. |
 | CONNECTOR_NAME | `string` |  | string |  | `"Hybrid Analysis (Sandbox Windows 10 64bit)"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string |  | `["StixFile", "Artifact", "Url", "Domain-Name", "Hostname"]` | The scope of the connector. |

--- a/internal-enrichment/hybrid-analysis-sandbox/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/hybrid-analysis-sandbox/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Hybrid Analysis (Sandbox Windows 10 64bit)",

--- a/internal-enrichment/ioc-extractor/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/ioc-extractor/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"IOC Extractor"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["Report"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/internal-enrichment/ioc-extractor/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/ioc-extractor/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "IOC Extractor",

--- a/internal-enrichment/joe-sandbox/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/joe-sandbox/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | JOE_SANDBOX_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API key for Joe Sandbox |
 | CONNECTOR_NAME | `string` |  | string | `"Joe Sandbox"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["Artifact", "Url"]` | The scope of the connector, i.e., the types of entities the connector can enrich. |

--- a/internal-enrichment/joe-sandbox/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/joe-sandbox/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Joe Sandbox",

--- a/internal-enrichment/kaspersky-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/kaspersky-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | KASPERSKY_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | API key used to authenticate requests to the Kaspersky service. |
 | CONNECTOR_NAME | `string` |  | string | `"Kaspersky Enrichment"` | Name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["StixFile", "IPv4-Addr", "Domain-Name", "Hostname", "Url"]` | The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only). |

--- a/internal-enrichment/kaspersky-enrichment/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/kaspersky-enrichment/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Kaspersky Enrichment",

--- a/internal-enrichment/malbeacon/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/malbeacon/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | MALBEACON_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API key used to authenticate against the Malbeacon API. |
 | CONNECTOR_NAME | `string` |  | string | `"Malbeacon"` | The name of the internal enrichment connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["IPv4-Addr", "IPv6-Addr", "Domain-Name"]` | The scope of the connector |

--- a/internal-enrichment/malbeacon/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/malbeacon/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Malbeacon",

--- a/internal-enrichment/paloalto-wildfire/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/paloalto-wildfire/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | PALOALTO_WILDFIRE_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Palo Alto Networks WildFire API key. |
 | CONNECTOR_NAME | `string` |  | string | `"Palo Alto Networks WildFire"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["StixFile", "Artifact"]` | The scope of the connector (observable types to enrich). |

--- a/internal-enrichment/paloalto-wildfire/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/paloalto-wildfire/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Palo Alto Networks WildFire",

--- a/internal-enrichment/polyswarm-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/polyswarm-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | POLYSWARM_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | PolySwarm API key for authentication. |
 | CONNECTOR_NAME | `string` |  | string | `"PolySwarm Hash Enrichment"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["StixFile", "Artifact"]` | The scope of the connector. |

--- a/internal-enrichment/polyswarm-enrichment/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/polyswarm-enrichment/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "PolySwarm Hash Enrichment",

--- a/internal-enrichment/polyswarm-sandbox/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/polyswarm-sandbox/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | POLYSWARM_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | PolySwarm API key for authentication. |
 | CONNECTOR_NAME | `string` |  | string | `"PolySwarm Sandbox"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["Artifact"]` | The scope of the connector. |

--- a/internal-enrichment/polyswarm-sandbox/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/polyswarm-sandbox/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "PolySwarm Sandbox",

--- a/internal-enrichment/proofpoint-et-intelligence/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/proofpoint-et-intelligence/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | PROOFPOINT_ET_INTELLIGENCE_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API key used for authentication to ProofPoint ET Intelligence. |
 | CONNECTOR_NAME | `string` |  | string | `"ProofPoint ET Intelligence"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["IPv4-Addr", "Domain-Name", "StixFile"]` | The scope of the connector. |

--- a/internal-enrichment/proofpoint-et-intelligence/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/proofpoint-et-intelligence/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ProofPoint ET Intelligence",

--- a/internal-enrichment/recordedfuture-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/recordedfuture-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | RECORDED_FUTURE_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | API Token for Recorded Future. |
 | CONNECTOR_NAME | `string` |  | string | `"RecordedFutureEnrichment"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["ipv4-addr", "ipv6-addr", "domain-name", "url", "stixfile", "vulnerability"]` | The scope of the connector. |

--- a/internal-enrichment/recordedfuture-enrichment/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/recordedfuture-enrichment/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "RecordedFutureEnrichment",

--- a/internal-enrichment/reversinglabs-malware-presence/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/reversinglabs-malware-presence/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | REVERSINGLABS_TITANIUMCLOUD_USERNAME | `string` | ✅ | string |  | The username for the ReversingLabs TitaniumCloud API. |
 | REVERSINGLABS_TITANIUMCLOUD_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The password for the ReversingLabs TitaniumCloud API. |
 | CONNECTOR_NAME | `string` |  | string | `"ReversingLabs Malware Presence"` | The name of the connector. |

--- a/internal-enrichment/reversinglabs-malware-presence/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/reversinglabs-malware-presence/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ReversingLabs Malware Presence",

--- a/internal-enrichment/reversinglabs-spectra-analyze/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/reversinglabs-spectra-analyze/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Deprecated | Default | Description |
 | -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  | The API token to connect to OpenCTI. |
 | REVERSINGLABS_SPECTRA_ANALYZE_URL | `string` | ✅ | string |  |  | API base URL |
 | REVERSINGLABS_SPECTRA_ANALYZE_TOKEN | `string` | ✅ | string |  |  | API token |
 | CONNECTOR_NAME | `string` |  | string |  | `"ReversingLabs Spectra Analyze"` | Connector name. |

--- a/internal-enrichment/reversinglabs-spectra-analyze/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/reversinglabs-spectra-analyze/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ReversingLabs Spectra Analyze",

--- a/internal-enrichment/reversinglabs-spectra-intel-submission/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/reversinglabs-spectra-intel-submission/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | REVERSINGLABS_SPECTRA_INTEL_SUBMISSION_USERNAME | `string` | ✅ | string |  | ReversingLabs Spectra Intelligence username. |
 | REVERSINGLABS_SPECTRA_INTEL_SUBMISSION_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | ReversingLabs Spectra Intelligence password. |
 | CONNECTOR_NAME | `string` |  | string | `"ReversingLabs Spectra Intelligence Submission"` | The name of the connector. |

--- a/internal-enrichment/reversinglabs-spectra-intel-submission/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/reversinglabs-spectra-intel-submission/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ReversingLabs Spectra Intelligence Submission",

--- a/internal-enrichment/shadowtrackr/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/shadowtrackr/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | SHADOWTRACKR_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | API key for authentication. |
 | CONNECTOR_NAME | `string` |  | string | `"ShadowTrackr"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["IPv4-Addr", "IPv6-Addr", "Indicator"]` | The scope of the connector, e.g. 'IPv4-Addr,IPv6-Addr,Indicator'. |

--- a/internal-enrichment/shadowtrackr/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/shadowtrackr/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ShadowTrackr",

--- a/internal-enrichment/shodan-internetdb/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/shodan-internetdb/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"Shodan InternetDB"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["IPv4-Addr"]` | The scope of the connector, i.e. the observable types it enriches. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/internal-enrichment/shodan-internetdb/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/shodan-internetdb/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Shodan InternetDB",

--- a/internal-enrichment/shodan/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/shodan/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | SHODAN_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Shodan API Key |
 | CONNECTOR_NAME | `string` |  | string | `"Shodan"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["ipv4-addr", "indicator"]` | The scope of the connector. |

--- a/internal-enrichment/shodan/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/shodan/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Shodan",

--- a/internal-enrichment/silentpush-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/silentpush-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | SILENTPUSH_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | API key for authentication. |
 | CONNECTOR_NAME | `string` |  | string | `"Silent Push - Enrichment"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["Indicator", "IPv4-Addr", "IPv6-Addr", "Domain-Name", "Hostname", "URL"]` | The scope of the connector |

--- a/internal-enrichment/silentpush-enrichment/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/silentpush-enrichment/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Silent Push - Enrichment",

--- a/internal-enrichment/tagger/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/tagger/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"Tagger"` | Name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["report", "malware", "tool"]` | The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only). |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/internal-enrichment/tagger/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/tagger/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Tagger",

--- a/internal-enrichment/team-cymru-scout-search/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/team-cymru-scout-search/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | PURE_SIGNAL_SCOUT_API_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Bearer token for the Scout API |
 | CONNECTOR_NAME | `string` |  | string | `"TeamCymruScoutSearch"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["Indicator"]` | The scope of the connector. |

--- a/internal-enrichment/team-cymru-scout-search/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/team-cymru-scout-search/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "TeamCymruScoutSearch",

--- a/internal-enrichment/team-cymru-scout/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/team-cymru-scout/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | PURE_SIGNAL_SCOUT_API_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Bearer token for the Scout API |
 | CONNECTOR_NAME | `string` |  | string | `"TeamCymruScout"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["IPv4-Addr", "IPv6-Addr", "Domain-Name"]` | The scope of the connector |

--- a/internal-enrichment/team-cymru-scout/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/team-cymru-scout/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "TeamCymruScout",

--- a/internal-enrichment/urlscan-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/urlscan-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | URLSCAN_ENRICHMENT_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | URLScan API Key |
 | CONNECTOR_NAME | `string` |  | string | `"Urlscan Enrichment"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["url", "ipv4-addr", "ipv6-addr"]` | The scope of the connector. Availables: `url or hostname or domain-name` (scope-submission), `ipv4-addr` and `ipv6-addr` (scope-search) |

--- a/internal-enrichment/urlscan-enrichment/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/urlscan-enrichment/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Urlscan Enrichment",

--- a/internal-enrichment/whisper/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/whisper/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description | Examples |
 | -------- | ---- | -------- | --------------- | ------- | ----------- | -------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |  |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |  |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |  |
 | WHISPER_API_URL | `string` | ✅ | string |  | Base URL of the Whisper graph API, e.g. 'https://graph.whisper.security'. The connector POSTs Cypher to '<api_url>/api/query'. | ```https://graph.whisper.security``` |
 | WHISPER_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Whisper API key, sent in the X-API-Key header. Never logged. | ```whisper-0123456789abcdef0123456789abcdef``` |
 | CONNECTOR_NAME | `string` |  | string | `"Whisper"` | Connector display name. |  |

--- a/internal-enrichment/whisper/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/whisper/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Whisper",

--- a/internal-enrichment/yara/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/yara/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"YARA"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["Artifact"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |

--- a/internal-enrichment/yara/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/yara/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "YARA",

--- a/shared/tools/composer/generate_connectors_config_schemas/generate_connector_config_json_schema.ps1
+++ b/shared/tools/composer/generate_connectors_config_schemas/generate_connector_config_json_schema.ps1
@@ -6,6 +6,7 @@ $ErrorActionPreference = "Stop"
 
 $CONNECTOR_METADATA_DIRECTORY = "__metadata__"
 $VENV_NAME = ".temp_venv"
+$PYTHON_VERSION = "3.12"
 
 function Find-ConnectorDirectories {
     param(
@@ -116,7 +117,7 @@ function Activate-Venv {
     
     # Create isolated virtual environment in connector path
     $venvPath = Join-Path $ConnectorPath $VENV_NAME
-    & python -m venv $venvPath
+    & uv venv --python $PYTHON_VERSION $venvPath
     
     # Activate virtual environment (Windows)
     $activateScript = Join-Path $venvPath "Scripts\Activate.ps1"

--- a/shared/tools/composer/generate_connectors_config_schemas/generate_connector_config_json_schema.sh
+++ b/shared/tools/composer/generate_connectors_config_schemas/generate_connector_config_json_schema.sh
@@ -7,6 +7,7 @@ set -euo pipefail  # exit on error
 
 CONNECTOR_METADATA_DIRECTORY="__metadata__"
 VENV_NAME=".temp_venv"
+PYTHON_VERSION="3.12"
 
 find_connector_directories() {
   # Method to find all directories matching the search term
@@ -85,7 +86,8 @@ activate_venv() {
     # Method to activate isolate venv
 
     # Create isolated virtual environment in connector path
-    uv venv "$1/$VENV_NAME"
+    # Use Python 3.12, as some connectors require it (but none require 3.11 strictly)
+    uv venv --python "$PYTHON_VERSION" "$1/$VENV_NAME"
 
     # Activate virtual environment according to OS
     if [ -f "$1/$VENV_NAME/bin/activate" ]; then

--- a/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.ps1
+++ b/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.ps1
@@ -5,6 +5,7 @@ $ErrorActionPreference = "Stop"
 
 $CONNECTOR_METADATA_DIRECTORY = "__metadata__"
 $VENV_NAME = ".temp_venv"
+$PYTHON_VERSION = "3.12"
 
 function Find-RequirementsTxt {
     param(
@@ -49,7 +50,7 @@ function Activate-Venv {
     
     # Create isolated virtual environment in connector path
     $venvPath = Join-Path $ConnectorPath $VENV_NAME
-    & python -m venv $venvPath
+    & uv venv --python $PYTHON_VERSION $venvPath
     
     # Activate virtual environment (Windows)
     $activateScript = Join-Path $venvPath "Scripts\Activate.ps1"
@@ -115,20 +116,35 @@ if (-not $CIRCLE_BRANCH) {
     Write-Host "Note: Not running in CI environment. Will process all connectors with changes." -ForegroundColor Yellow
 }
 
+$RELEASE_REF = $env:RELEASE_REF
+if (-not $RELEASE_REF) {
+    $RELEASE_REF = "master"
+}
+
+$connectors_sdk_has_changed = $false
+$merge_base = $null
+if ($CIRCLE_BRANCH -eq $RELEASE_REF) {
+    $connectors_sdk_diff = & git diff HEAD~1 HEAD -- connectors-sdk
+    $connectors_sdk_has_changed = -not [string]::IsNullOrEmpty($connectors_sdk_diff)
+} else {
+    $merge_base = (& git merge-base "origin/$RELEASE_REF" HEAD).Trim()
+    $connectors_sdk_diff = & git diff $merge_base HEAD -- connectors-sdk
+    $connectors_sdk_has_changed = -not [string]::IsNullOrEmpty($connectors_sdk_diff)
+}
+
 foreach ($connector_directory in $connector_directories) {
     $connector_path = $connector_directory.FullName
     
     if (Test-Path $connector_path) {
-        # Check if directory has changed (simplified for local development)
-        $hasChanges = $true  # Default to true for local development
-        if ($CIRCLE_BRANCH) {
-            # CI environment logic
-            if ($CIRCLE_BRANCH -eq "master") {
-                $gitDiff = & git diff HEAD~1 HEAD -- $connector_path
-            } else {
-                $mergeBase = & git merge-base master HEAD
-                $gitDiff = & git diff $mergeBase HEAD $connector_path
-            }
+        # Check if directory has changed
+        $hasChanges = $false
+        if ($connectors_sdk_has_changed) {
+            $hasChanges = $true
+        } elseif ($CIRCLE_BRANCH -eq $RELEASE_REF) {
+            $gitDiff = & git diff HEAD~1 HEAD -- $connector_path
+            $hasChanges = -not [string]::IsNullOrEmpty($gitDiff)
+        } else {
+            $gitDiff = & git diff $merge_base HEAD -- $connector_path
             $hasChanges = -not [string]::IsNullOrEmpty($gitDiff)
         }
         

--- a/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.ps1
+++ b/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.ps1
@@ -124,12 +124,12 @@ if (-not $RELEASE_REF) {
 $connectors_sdk_has_changed = $false
 $merge_base = $null
 if ($CIRCLE_BRANCH -eq $RELEASE_REF) {
-    $connectors_sdk_diff = & git diff HEAD~1 HEAD -- connectors-sdk
-    $connectors_sdk_has_changed = -not [string]::IsNullOrEmpty($connectors_sdk_diff)
+    & git diff --quiet HEAD~1 HEAD -- connectors-sdk
+    $connectors_sdk_has_changed = ($LASTEXITCODE -ne 0)
 } else {
     $merge_base = (& git merge-base "origin/$RELEASE_REF" HEAD).Trim()
-    $connectors_sdk_diff = & git diff $merge_base HEAD -- connectors-sdk
-    $connectors_sdk_has_changed = -not [string]::IsNullOrEmpty($connectors_sdk_diff)
+    & git diff --quiet $merge_base HEAD -- connectors-sdk
+    $connectors_sdk_has_changed = ($LASTEXITCODE -ne 0)
 }
 
 foreach ($connector_directory in $connector_directories) {

--- a/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.sh
+++ b/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.sh
@@ -4,6 +4,8 @@ set -eo pipefail  # exit on error
 
 CONNECTOR_METADATA_DIRECTORY="__metadata__"
 VENV_NAME=".temp_venv"
+PYTHON_VERSION="3.12"
+CIRCLE_BRANCH=${CIRCLE_BRANCH:-""}
 
 find_requirements_txt() {
   # Method to find the highest requirements.txt in connector's tree
@@ -39,7 +41,8 @@ activate_venv() {
     # Method to activate isolate venv
 
     # Create isolated virtual environment in connector path
-    uv venv "$1/$VENV_NAME"
+    # Use Python 3.12, as some connectors require it (but none require 3.11 strictly)
+    uv venv --python "$PYTHON_VERSION" "$1/$VENV_NAME"
 
     # Activate virtual environment according to OS
     if [ -f "$1/$VENV_NAME/bin/activate" ]; then
@@ -100,16 +103,27 @@ connector_directories_path=$(find . -type d -name "$CONNECTOR_METADATA_DIRECTORY
 git fetch --unshallow || git fetch --depth=100
 git fetch origin "+refs/heads/*:refs/remotes/origin/*"
 
+# Detect whether connectors-sdk changed
+if [ "$CIRCLE_BRANCH" = "${RELEASE_REF:-master}" ]; then
+  connectors_sdk_has_changed=$(git diff HEAD~1 HEAD -- connectors-sdk)
+else
+  merge_base=$(git merge-base origin/"${RELEASE_REF:-master}" HEAD)
+  connectors_sdk_has_changed=$(git diff "$merge_base" HEAD -- connectors-sdk)
+fi
+
 # Loop in each connector directory with infos and regenerate JSON schema if changed
 for connector_directory_path in $connector_directories_path
 do
   if [ -d "$connector_directory_path" ]; then
-    # Only generate schema for directory that changed
-    CIRCLE_BRANCH=${CIRCLE_BRANCH:-""}
-    if [ "$CIRCLE_BRANCH" = "${RELEASE_REF:-master}" ]; then
-      directory_has_changed=$(git diff HEAD~1 HEAD -- "$connector_directory_path")
+    if [ -n "$connectors_sdk_has_changed" ]; then
+      directory_has_changed=true
     else
-      directory_has_changed=$(git diff $(git merge-base origin/"${RELEASE_REF:-master}" HEAD) HEAD "$connector_directory_path")
+      # Only generate schema for directory that changed
+      if [ "$CIRCLE_BRANCH" = "${RELEASE_REF:-master}" ]; then
+        directory_has_changed=$(git diff HEAD~1 HEAD -- "$connector_directory_path")
+      else
+        directory_has_changed=$(git diff "$merge_base" HEAD -- "$connector_directory_path")
+      fi
     fi
 
     if [ -z "$directory_has_changed" ] ; then

--- a/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.sh
+++ b/shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.sh
@@ -103,12 +103,13 @@ connector_directories_path=$(find . -type d -name "$CONNECTOR_METADATA_DIRECTORY
 git fetch --unshallow || git fetch --depth=100
 git fetch origin "+refs/heads/*:refs/remotes/origin/*"
 
-# Detect whether connectors-sdk changed
+# Detect whether connectors-sdk changed (avoid storing full diff output)
+connectors_sdk_has_changed=""
 if [ "$CIRCLE_BRANCH" = "${RELEASE_REF:-master}" ]; then
-  connectors_sdk_has_changed=$(git diff HEAD~1 HEAD -- connectors-sdk)
+  git diff --quiet HEAD~1 HEAD -- connectors-sdk || connectors_sdk_has_changed="1"
 else
   merge_base=$(git merge-base origin/"${RELEASE_REF:-master}" HEAD)
-  connectors_sdk_has_changed=$(git diff "$merge_base" HEAD -- connectors-sdk)
+  git diff --quiet "$merge_base" HEAD -- connectors-sdk || connectors_sdk_has_changed="1"
 fi
 
 # Loop in each connector directory with infos and regenerate JSON schema if changed

--- a/stream/akamai/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/akamai/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the live stream to connect to. |
 | AKAMAI_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | External API base URL. |
 | AKAMAI_CLIENT_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | EdgeGrid client token. |

--- a/stream/akamai/__metadata__/connector_config_schema.json
+++ b/stream/akamai/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Akamai Connector",

--- a/stream/arcsight/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/arcsight/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the OpenCTI live stream to connect to. |
 | ARCSIGHT_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the ArcSight ESM Manager (e.g. https://arcsight.example.com:8443). |
 | ARCSIGHT_USERNAME | `string` | ✅ | string |  | ArcSight ESM user name. |

--- a/stream/arcsight/__metadata__/connector_config_schema.json
+++ b/stream/arcsight/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ArcSight",

--- a/stream/clickhouse/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/clickhouse/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the OpenCTI live stream to connect to. |
 | CLICKHOUSE_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the ClickHouse HTTP interface (e.g. http://clickhouse:8123). |
 | CONNECTOR_NAME | `string` |  | string | `"ClickHouse"` | The name of the connector. |

--- a/stream/clickhouse/__metadata__/connector_config_schema.json
+++ b/stream/clickhouse/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "ClickHouse",

--- a/stream/crowdstrike-endpoint-security/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/crowdstrike-endpoint-security/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the live stream to connect to. |
 | CROWDSTRIKE_CLIENT_ID | `string` | ✅ | string |  | Crowdstrike client ID used to connect to the API. |
 | CROWDSTRIKE_CLIENT_SECRET | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Crowdstrike client secret used to connect to the API. |
@@ -24,5 +24,5 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | CROWDSTRIKE_ACTION_ON_DOMAIN | `string` |  | `no_action` `detect` | `"detect"` | Action to apply on domain indicators pushed to CrowdStrike. |
 | CROWDSTRIKE_ACTION_ON_HASH | `string` |  | `no_action` `allow` `detect` `prevent` | `"detect"` | Action to apply on hash indicators pushed to CrowdStrike. |
 | METRICS_ENABLE | `boolean` |  | boolean | `false` | Whether or not Prometheus metrics should be enabled. |
-| METRICS_PORT | `integer` or `string` |  | integer and/or string | `9113` | Port to use for metrics endpoint. |
+| METRICS_PORT | `integer` |  | integer | `9113` | Port to use for metrics endpoint. |
 | METRICS_ADDR | `string` |  | string | `"0.0.0.0"` | Bind IP address to use for metrics endpoint. |

--- a/stream/crowdstrike-endpoint-security/__metadata__/connector_config_schema.json
+++ b/stream/crowdstrike-endpoint-security/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "CrowdstrikeEndpointSecurity",
@@ -123,16 +125,9 @@
       "type": "boolean"
     },
     "METRICS_PORT": {
-      "anyOf": [
-        {
-          "type": "integer"
-        },
-        {
-          "type": "string"
-        }
-      ],
       "default": 9113,
-      "description": "Port to use for metrics endpoint."
+      "description": "Port to use for metrics endpoint.",
+      "type": "integer"
     },
     "METRICS_ADDR": {
       "default": "0.0.0.0",

--- a/stream/crowdstrike-endpoint-security/src/crowdstrike_connector/settings.py
+++ b/stream/crowdstrike-endpoint-security/src/crowdstrike_connector/settings.py
@@ -7,7 +7,7 @@ from connectors_sdk import (
     BaseStreamConnectorConfig,
     ListFromString,
 )
-from pydantic import Field, SecretStr, field_validator, model_validator
+from pydantic import Field, SecretStr, model_validator
 from pydantic.networks import HttpUrl
 
 
@@ -76,7 +76,7 @@ class MetricsConfig(BaseConfigModel):
         description="Whether or not Prometheus metrics should be enabled.",
         default=False,
     )
-    port: int | str = Field(
+    port: int = Field(
         description="Port to use for metrics endpoint.",
         default=9113,
     )
@@ -85,13 +85,15 @@ class MetricsConfig(BaseConfigModel):
         default="0.0.0.0",
     )
 
-    @field_validator("port", mode="before")
+    @model_validator(mode="before")
     @classmethod
-    def normalize_port(cls, v) -> int | str:
-        try:
-            return int(v)
-        except (TypeError, ValueError):
-            return v
+    def drop_metrics_network_values_when_disabled(cls, values: dict) -> dict:
+        metrics_enabled_values = {True, "true", "True", "1", 1}
+        if values.get("enable") not in metrics_enabled_values:
+            values.pop("port", None)
+            values.pop("addr", None)
+
+        return values
 
     @model_validator(mode="after")
     def validate_metrics_if_enabled(self) -> "MetricsConfig":
@@ -103,8 +105,6 @@ class MetricsConfig(BaseConfigModel):
             raise ValueError(
                 "Metrics address must be a valid IPv4 address when enabled."
             ) from e
-        if not isinstance(self.port, int):
-            raise ValueError("Metrics port must be an integer when enabled.")
         return self
 
 

--- a/stream/crowdstrike-endpoint-security/tests/tests_connector/test_settings.py
+++ b/stream/crowdstrike-endpoint-security/tests/tests_connector/test_settings.py
@@ -73,11 +73,11 @@ from crowdstrike_connector import ConnectorSettings
                 },
                 "metrics": {
                     "enable": False,
-                    "port": "ChangeMe",
-                    "addr": "ChangeMe",
+                    "port": "any value",  # discarded silently by MetricsConfig model
+                    "addr": "any value",  # discarded silently by MetricsConfig model
                 },
             },
-            id="metrics_disabled_with_placeholder_addr_and_port_is_valid",
+            id="metrics_disabled_any_addr_and_port_is_valid",
         ),
         pytest.param(
             {

--- a/stream/datadog-intel/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/datadog-intel/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the live stream to connect to. |
 | DATADOG_INTEL_INTEGRATION_API_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Datadog's API URL as provided by the integration. If your Datadog site is `https://app.datadoghq.com`, use `https://api.datadoghq.com/api/v2/security/threat-intel-feed` |
 | DATADOG_INTEL_DD_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Datadog's API key. Sent on every request as the `dd-api-key` header to authenticate against `integration_api_url` |

--- a/stream/datadog-intel/__metadata__/connector_config_schema.json
+++ b/stream/datadog-intel/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "DatadogIntelConnector",

--- a/stream/fortiedr/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/fortiedr/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the OpenCTI live stream to connect to. |
 | FORTIEDR_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the FortiEDR Central Manager (e.g. https://console.fortiedr.example.com). |
 | FORTIEDR_USERNAME | `string` | ✅ | string |  | FortiEDR REST API user name. |

--- a/stream/fortiedr/__metadata__/connector_config_schema.json
+++ b/stream/fortiedr/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "FortiEDR",

--- a/stream/fortisiem/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/fortisiem/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the OpenCTI live stream to connect to. |
 | FORTISIEM_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the FortiSIEM Supervisor (e.g. https://fortisiem.example.com). |
 | FORTISIEM_USERNAME | `string` | ✅ | string |  | FortiSIEM REST API user name. |

--- a/stream/fortisiem/__metadata__/connector_config_schema.json
+++ b/stream/fortisiem/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "FortiSIEM",

--- a/stream/google-secops-siem/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/google-secops-siem/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | ID of the live stream to connect to (created in the OpenCTI UI). |
 | SECOPS_SIEM_PROJECT_ID | `string` | ✅ | string |  | Google Cloud project ID for the SecOps SIEM instance. |
 | SECOPS_SIEM_PROJECT_INSTANCE | `string` | ✅ | string |  | Google SecOps SIEM project instance identifier. |

--- a/stream/google-secops-siem/__metadata__/connector_config_schema.json
+++ b/stream/google-secops-siem/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "GoogleSecOpsSIEM",

--- a/stream/jira/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/jira/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the live stream to connect to. |
 | JIRA_URL | `string` | ✅ | string |  | URL to Jira server (e.g., https://yourinstance.atlassian.net). |
 | JIRA_LOGIN_EMAIL | `string` | ✅ | string |  | Email for Jira account with API access. |

--- a/stream/jira/__metadata__/connector_config_schema.json
+++ b/stream/jira/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Atlassian JIRA",

--- a/stream/microsoft-defender-intel/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/microsoft-defender-intel/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the live stream to connect to. |
 | MICROSOFT_DEFENDER_INTEL_TENANT_ID | `string` | ✅ | string |  | Your Azure App Tenant ID, see connector's README to help you find this information. |
 | MICROSOFT_DEFENDER_INTEL_CLIENT_ID | `string` | ✅ | string |  | Your Azure App Client ID, see connector's README to help you find this information. |

--- a/stream/microsoft-defender-intel/__metadata__/connector_config_schema.json
+++ b/stream/microsoft-defender-intel/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Microsoft Defender Intel",

--- a/stream/redpanda/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/redpanda/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the OpenCTI live stream to connect to. |
 | REDPANDA_HTTP_PROXY_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the Redpanda HTTP Proxy / Pandaproxy (e.g. http://redpanda:8082). |
 | CONNECTOR_NAME | `string` |  | string | `"Redpanda"` | The name of the connector. |

--- a/stream/redpanda/__metadata__/connector_config_schema.json
+++ b/stream/redpanda/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Redpanda",

--- a/stream/sentinelone-intel/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/sentinelone-intel/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the live stream to connect to. |
 | SENTINELONE_INTEL_API_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of your SentinelOne management console |
 | SENTINELONE_INTEL_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API key for your SentinelOne management console |

--- a/stream/sentinelone-intel/__metadata__/connector_config_schema.json
+++ b/stream/sentinelone-intel/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "SentinelOne Intel",

--- a/stream/splunk/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/splunk/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the live stream to connect to. |
 | SPLUNK_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the Splunk instance (e.g. https://splunk:8089). |
 | SPLUNK_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Token used to authenticate against the Splunk API. |

--- a/stream/splunk/__metadata__/connector_config_schema.json
+++ b/stream/splunk/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Splunk",

--- a/stream/trellix-tie/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/trellix-tie/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | TRELLIX_TIE_DXL_CONFIG_PATH | `string` | ✅ | string |  | Path to the ePO-provisioned OpenDXL configuration file (dxlclient.config) describing the DXL brokers and client certificate. |
 | CONNECTOR_NAME | `string` |  | string | `"Trellix TIE"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["trellix-tie"]` | The scope of the connector. |

--- a/stream/trellix-tie/__metadata__/connector_config_schema.json
+++ b/stream/trellix-tie/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Trellix TIE",

--- a/stream/vectra-ai/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/vectra-ai/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the OpenCTI live stream to connect to. |
 | VECTRA_AI_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Base URL of the Vectra AI Platform (e.g. https://vectra.example.com). |
 | VECTRA_AI_API_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | API token used to authenticate against the Vectra AI API. |

--- a/stream/vectra-ai/__metadata__/connector_config_schema.json
+++ b/stream/vectra-ai/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Vectra AI Intel",

--- a/stream/zscaler/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/zscaler/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,7 +7,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the live stream to connect to. |
 | ZSCALER_USERNAME | `string` | ✅ | string |  | Zscaler account username used for authentication. |
 | ZSCALER_PASSWORD | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Zscaler account password used for authentication. |

--- a/stream/zscaler/__metadata__/connector_config_schema.json
+++ b/stream/zscaler/__metadata__/connector_config_schema.json
@@ -12,7 +12,9 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "type": "string"
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
     },
     "CONNECTOR_NAME": {
       "default": "Zscaler",

--- a/tests/tests_metadata/test_connector_config_schema.py
+++ b/tests/tests_metadata/test_connector_config_schema.py
@@ -84,6 +84,31 @@ def test_connector_config_schema_is_valid_json_schema(schema_path: str):
     assert schema.get("additionalProperties") is True
 
 
+def schemas_env_vars_definitions():
+    """Yield all top-level properties from all connector config schemas (i.e., env vars definitions)."""
+    for schema_path in get_config_schema_paths():
+        schema = load_schema(schema_path)
+        for property_name, property_schema in schema.get("properties", {}).items():
+            yield pytest.param(property_schema, id=f"{schema_path}::{property_name}")
+
+
+@pytest.mark.parametrize("property_schema", list(schemas_env_vars_definitions()))
+def test_connector_config_schema_octi_ui_compatibility_rules(property_schema: dict):
+    """Assert OCTI-specific compatibility rules on top-level properties only."""
+    # Given a config schema top-level property (i.e., an env var definition)
+    # Then property complies with OCTI expectations
+    assert "type" in property_schema
+    assert "anyOf" not in property_schema
+    assert "oneOf" not in property_schema
+
+    # TODO: remove theses assertions once OpenCTI UI is fixed
+    # OpenCTI UI does not support dicts currently
+    assert property_schema.get("type") != "dict"
+    # OpenCTI UI does not support arrays without a default currently
+    if property_schema.get("type") == "array":
+        assert "default" in property_schema
+
+
 @pytest.mark.parametrize("schema_path", get_config_schema_paths())
 def test_connector_config_schema_common_properties(schema_path: str):
     """Assert that common connector properties satisfy validity rules.

--- a/tests/tests_metadata/test_connector_config_schema.py
+++ b/tests/tests_metadata/test_connector_config_schema.py
@@ -101,9 +101,9 @@ def test_connector_config_schema_octi_ui_compatibility_rules(property_schema: di
     assert "anyOf" not in property_schema
     assert "oneOf" not in property_schema
 
-    # TODO: remove theses assertions once OpenCTI UI is fixed
-    # OpenCTI UI does not support dicts currently
-    assert property_schema.get("type") != "dict"
+    # TODO: remove these assertions once OpenCTI UI is fixed
+    # OpenCTI UI does not support objects currently
+    assert property_schema.get("type") != "object"
     # OpenCTI UI does not support arrays without a default currently
     if property_schema.get("type") == "array":
         assert "default" in property_schema


### PR DESCRIPTION
### Proposed changes

* add OCTI compatibility assertions for top-level connector schema properties (`tests/tests_metadata/test_connector_config_schema.py`)
* align schema-generation scripts (`.sh` and `.ps1`) to use Python 3.12 and trigger regeneration for all connectors when `connectors-sdk` changes

### Related issues

* Close #6342

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Please ignore the **last commit** during review: it only contains re-generated `connector_config_schema.json` and `CONNECTOR_CONFIG_DOC.md` files that CI missed after merge of #7085.
