### PR TITLE
fix(doppel): map alerts to valid STIX observables (#7025)

### DIFF
--- a/external-import/doppel/README.md
+++ b/external-import/doppel/README.md
@@ -153,7 +153,14 @@ Find the "Doppel" connector, and click on the refresh button to reset the connec
 ## Behavior
 
 - Fetches alerts from Doppel API paginated by `last_activity_timestamp`
-- Converts each alert into a STIX 2.1 Observable object
+- Converts each alert into a STIX 2.1 Observable with a value-appropriate type:
+  - `domains` alerts become `Domain-Name` observables. URL schemes, paths,
+    queries, and fragments added by the Doppel API are removed from the domain
+    value.
+  - `telco` alerts become `Phone-Number` observables.
+  - Email-address entities become `Email-Addr` observables.
+  - Other supported alert products become `Url` observables, preserving their
+    full URL value.
 - Bundles and sends the STIX objects to OpenCTI
 - Includes platform, score, brand, audit logs, notes, etc. as `custom_properties`
 - On first run, fetches up to `HISTORICAL_POLLING_DAYS`; subsequent runs are delta-based

--- a/external-import/doppel/src/doppel/converter_to_stix.py
+++ b/external-import/doppel/src/doppel/converter_to_stix.py
@@ -423,26 +423,13 @@ class ConverterToStix:
 
         # Common properties
         custom_properties = build_custom_properties(alert, self.author.id)
+        custom_properties["x_opencti_labels"].append(f"priority:{priority}")
         params = {
             "value": observable_value,
             "object_marking_refs": [self.tlp_marking.id],
             "custom_properties": custom_properties,
         }
 
-        # PhoneNumber is an OpenCTI custom observable and does not accept the
-        # same STIX properties as the standard SCO classes.
-        if obs_type != "phone":
-            labels_flat = build_labels(alert)
-            labels_flat.append(f"priority:{priority}")
-            external_references = build_external_references(alert)
-
-            params.update(
-                {
-                    "labels": labels_flat or None,
-                    "external_references": external_references or None,
-                    "allow_custom": True,
-                }
-            )
         obj = observable_class(**params)
 
         return json.loads(obj.serialize())
@@ -500,7 +487,7 @@ class ConverterToStix:
         stix_objects = [self.author, self.tlp_marking]
 
         for alert in alerts:
-            #######- --------- observables ------------#######
+            # Observables
             observables = self._handle_observable_creation(alert, stix_objects)
             if not observables:
                 self.helper.connector_logger.warning(

--- a/external-import/doppel/src/doppel/converter_to_stix.py
+++ b/external-import/doppel/src/doppel/converter_to_stix.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timezone
 from typing import Literal
+from urllib.parse import urlsplit
 
 from doppel.constants import DOPPEL_ALERT_TYPES_EXCEPT_DOMAIN_AND_TELCO
 from doppel.stix_helpers import (
@@ -26,7 +27,9 @@ from stix2 import (
     TLP_GREEN,
     TLP_RED,
     TLP_WHITE,
+    URL,
     DomainName,
+    EmailAddress,
     Grouping,
     Identity,
     Indicator,
@@ -402,13 +405,21 @@ class ConverterToStix:
 
     def _create_observable(self, obs_type: str, observable_value: str, alert: dict):
         """
-        Generic method to create STIX Cyber Observables (PhoneNumber, DomainName, IPv4Address).
+        Create a STIX Cyber Observable with the type appropriate for its value.
         """
         priority = calculate_priority(alert.get("score", 0))
         # Map types to their respective classes
-        type_map = {"phone": PhoneNumber, "domain": DomainName, "ipv4": IPv4Address}
+        type_map = {
+            "phone": PhoneNumber,
+            "domain": DomainName,
+            "email": EmailAddress,
+            "ipv4": IPv4Address,
+            "url": URL,
+        }
 
         observable_class = type_map.get(obs_type)
+        if observable_class is None:
+            raise ValueError(f"Unsupported observable type: {obs_type}")
 
         # Common properties
         custom_properties = build_custom_properties(alert, self.author.id)
@@ -418,8 +429,9 @@ class ConverterToStix:
             "custom_properties": custom_properties,
         }
 
-        # Add extra properties for Domain and IP types
-        if obs_type in ["domain", "ipv4"]:
+        # PhoneNumber is an OpenCTI custom observable and does not accept the
+        # same STIX properties as the standard SCO classes.
+        if obs_type != "phone":
             labels_flat = build_labels(alert)
             labels_flat.append(f"priority:{priority}")
             external_references = build_external_references(alert)
@@ -435,6 +447,19 @@ class ConverterToStix:
 
         return json.loads(obj.serialize())
 
+    @staticmethod
+    def _domain_value(entity: str) -> str:
+        """Return a domain value without a URL scheme, path, query, or fragment."""
+        if not entity:
+            return ""
+
+        candidate = entity.strip()
+        parsed = urlsplit(
+            candidate if "://" in candidate else f"//{candidate}",
+            allow_fragments=True,
+        )
+        return (parsed.hostname or "").rstrip(".").lower()
+
     def convert_alerts_to_stix(self, alerts: list):
         """
         Convert list of alerts to stix2 Observable objects:
@@ -446,7 +471,8 @@ class ConverterToStix:
             a. Creation
                 - For telco product type - Create PhoneNumber observable
                 - For domain product type - Create Domain observable and if IP address is present in alert data then create IP observable as well.
-                - For other product types which doesn't fall in above 2 categories - Create Domain observable
+                - For email product type with an email entity - Create Email Address observable.
+                - For other supported product types - Create URL observable.
             b. Relationship between observables
                 - For domain product type - Create resolves-to relationship between Domain and IP observables
 
@@ -541,7 +567,16 @@ class ConverterToStix:
                 stix_objects.append(phone_number_observable)
                 observables.append(phone_number_observable)
             elif product_type == "domains":
-                domain = alert.get("entity")
+                domain = self._domain_value(alert.get("entity", ""))
+                if not domain:
+                    self.helper.connector_logger.warning(
+                        "[DoppelConverter] Invalid domain entity, skipping alert",
+                        meta={
+                            "alert_id": alert.get("id"),
+                            "entity": alert.get("entity"),
+                        },
+                    )
+                    return observables
                 domain_observable = self._create_observable("domain", domain, alert)
                 stix_objects.append(domain_observable)
                 observables.append(domain_observable)
@@ -560,12 +595,16 @@ class ConverterToStix:
                     ipv4_observable = self._create_observable("ipv4", ip_address, alert)
                     stix_objects.append(ipv4_observable)
                     observables.append(ipv4_observable)
-            # We may consider to change this in future.
             elif product_type in DOPPEL_ALERT_TYPES_EXCEPT_DOMAIN_AND_TELCO:
-                domain = alert.get("entity")
-                domain_observable = self._create_observable("domain", domain, alert)
-                stix_objects.append(domain_observable)
-                observables.append(domain_observable)
+                entity = alert.get("entity", "")
+                observable_type = (
+                    "email"
+                    if product_type == "email" and "@" in entity and "://" not in entity
+                    else "url"
+                )
+                observable = self._create_observable(observable_type, entity, alert)
+                stix_objects.append(observable)
+                observables.append(observable)
             else:
                 self.helper.connector_logger.warning(
                     "[DoppelConverter] Unsupported product type, skipping alert",
@@ -645,7 +684,7 @@ class ConverterToStix:
         # First of all check do we've indicators already present or not
         # with given alert_id or alert_entity value (observable value)
         alert_id = alert.get("id")
-        entity_value = alert.get("entity", "")
+        entity_value = observables[0].get("value", alert.get("entity", ""))
 
         existing_indicators = self._find_indicators_by_alert_id_or_entity_value(
             alert_id, entity_value
@@ -742,13 +781,7 @@ class ConverterToStix:
             return []
         # else in_taken_down_state = actioned/taken_down
 
-        product_type = alert.get("product")
-
         alert_id = alert.get("id")
-        # Keep the raw entity for the indicator name (used by name-based lookups)
-        # and only escape the value embedded into the STIX pattern.
-        raw_entity_value = alert.get("entity", "")
-        entity_value = raw_entity_value.replace("\\", "\\\\").replace("'", "\\'")
 
         # Fall back to a timezone-aware "now" so STIX objects never receive a
         # None (or naive) created/modified timestamp.
@@ -758,58 +791,35 @@ class ConverterToStix:
 
         indicators = []
 
-        if product_type == "telco":
-            pattern = f"[tracking-number:value = '{entity_value}']"
-            name = raw_entity_value
-            phone_number_indicator = self._create_indicator(
-                alert, pattern, name, created_at, modified_at
-            )
-
-            stix_objects.append(phone_number_indicator)
-            indicators.append(phone_number_indicator)
-        elif product_type == "domains":
-            pattern = f"[domain-name:value = '{entity_value}']"
-            name = raw_entity_value
-
-            domain_indicator = self._create_indicator(
-                alert, pattern, name, created_at, modified_at
-            )
-
-            stix_objects.append(domain_indicator)
-            indicators.append(domain_indicator)
-
-            ip_address = (
-                alert.get("entity_content", {}).get("root_domain", {}).get("ip_address")
-            )
-
-            if ip_address:
-                raw_ip_address = ip_address
-                escaped_ip_address = raw_ip_address.replace("\\", "\\\\").replace(
-                    "'", "\\'"
+        pattern_types = {
+            "domain-name": "domain-name",
+            "email-addr": "email-addr",
+            "ipv4-addr": "ipv4-addr",
+            "phone-number": "tracking-number",
+            "url": "url",
+        }
+        for observable in observables:
+            observable_type = observable.get("type")
+            pattern_type = pattern_types.get(observable_type)
+            if not pattern_type:
+                self.helper.connector_logger.warning(
+                    "[DoppelConverter] Unsupported observable type for indicator",
+                    meta={
+                        "alert_id": alert_id,
+                        "observable_type": observable_type,
+                    },
                 )
-                pattern = f"[ipv4-addr:value = '{escaped_ip_address}']"
-                name = raw_ip_address
+                continue
 
-                ipv4_indicator = self._create_indicator(
-                    alert, pattern, name, created_at, modified_at
-                )
-
-                stix_objects.append(ipv4_indicator)
-                indicators.append(ipv4_indicator)
-        elif product_type in DOPPEL_ALERT_TYPES_EXCEPT_DOMAIN_AND_TELCO:
-            pattern = f"[domain-name:value = '{entity_value}']"
-            name = raw_entity_value
-            domain_indicator = self._create_indicator(
-                alert, pattern, name, created_at, modified_at
+            raw_value = observable.get("value", "")
+            escaped_value = raw_value.replace("\\", "\\\\").replace("'", "\\'")
+            pattern = f"[{pattern_type}:value = '{escaped_value}']"
+            indicator = self._create_indicator(
+                alert, pattern, raw_value, created_at, modified_at
             )
+            stix_objects.append(indicator)
+            indicators.append(indicator)
 
-            stix_objects.append(domain_indicator)
-            indicators.append(domain_indicator)
-        else:
-            self.helper.connector_logger.warning(
-                "[DoppelConverter] Unsupported product type, skipping alert",
-                meta={"alert_id": alert_id, "product_type": product_type},
-            )
         return indicators
 
     def _handle_indicator_observable_relationship(

--- a/external-import/doppel/tests/test_converter_to_stix.py
+++ b/external-import/doppel/tests/test_converter_to_stix.py
@@ -215,18 +215,98 @@ def _domains_alert(alert_id="alert_x", queue_state="actioned", **extra):
     return alert
 
 
-def test_other_product_type_creates_domain_observable_and_indicator(converter):
-    """Covers the DOPPEL_ALERT_TYPES_EXCEPT_DOMAIN_AND_TELCO branch (observable + indicator)."""
+@pytest.mark.parametrize(
+    "product",
+    [
+        "social_media",
+        "mobile_apps",
+        "ecommerce",
+        "crypto",
+        "email",
+        "paid_ads",
+        "darkweb",
+    ],
+)
+def test_other_product_type_creates_url_observable_and_indicator(converter, product):
+    """URL-centric products must create URL objects, not invalid Domain Names."""
     alert = _domains_alert(alert_id="alert_social_1")
-    alert["product"] = "social_media"
+    alert["product"] = product
+    alert["entity"] = "http://social.example/profile/fake"
     converter.helper.api.stix_cyber_observable.read.return_value = None
     converter.helper.api.indicator.list.return_value = []
 
     result = converter.convert_alerts_to_stix([alert])
 
-    bundle = str(result)
-    assert "domain-name" in bundle
-    assert "indicator" in bundle
+    observables = [
+        obj for obj in result if isinstance(obj, dict) and obj.get("type") == "url"
+    ]
+    indicators = [
+        obj
+        for obj in result
+        if isinstance(obj, dict) and obj.get("type") == "indicator"
+    ]
+    assert observables[0]["value"] == "http://social.example/profile/fake"
+    assert indicators[0]["pattern"] == (
+        "[url:value = 'http://social.example/profile/fake']"
+    )
+
+
+@pytest.mark.parametrize(
+    ("entity", "expected_domain"),
+    [
+        ("http://malicious.example", "malicious.example"),
+        ("https://Malicious.Example/login?target=user#form", "malicious.example"),
+        ("malicious.example", "malicious.example"),
+        ("malicious.example.", "malicious.example"),
+    ],
+)
+def test_domains_product_normalizes_api_url_to_domain(
+    converter, entity, expected_domain
+):
+    """The API's fabricated scheme must not become part of a Domain Name value."""
+    alert = _domains_alert(alert_id="alert_domain_normalized")
+    alert["entity"] = entity
+    converter.helper.api.stix_cyber_observable.read.return_value = None
+    converter.helper.api.indicator.list.return_value = []
+
+    result = converter.convert_alerts_to_stix([alert])
+
+    observables = [
+        obj
+        for obj in result
+        if isinstance(obj, dict) and obj.get("type") == "domain-name"
+    ]
+    indicators = [
+        obj
+        for obj in result
+        if isinstance(obj, dict) and obj.get("type") == "indicator"
+    ]
+    assert observables[0]["value"] == expected_domain
+    assert indicators[0]["name"] == expected_domain
+    assert indicators[0]["pattern"] == (f"[domain-name:value = '{expected_domain}']")
+
+
+def test_email_product_creates_email_address_observable_and_indicator(converter):
+    alert = _domains_alert(alert_id="alert_email")
+    alert["product"] = "email"
+    alert["entity"] = "attacker@example.com"
+    converter.helper.api.stix_cyber_observable.read.return_value = None
+    converter.helper.api.indicator.list.return_value = []
+
+    result = converter.convert_alerts_to_stix([alert])
+
+    observables = [
+        obj
+        for obj in result
+        if isinstance(obj, dict) and obj.get("type") == "email-addr"
+    ]
+    indicators = [
+        obj
+        for obj in result
+        if isinstance(obj, dict) and obj.get("type") == "indicator"
+    ]
+    assert observables[0]["value"] == "attacker@example.com"
+    assert indicators[0]["pattern"] == ("[email-addr:value = 'attacker@example.com']")
 
 
 def test_unsupported_product_type_skips_alert(converter):

--- a/external-import/doppel/tests/test_converter_to_stix.py
+++ b/external-import/doppel/tests/test_converter_to_stix.py
@@ -216,6 +216,30 @@ def _domains_alert(alert_id="alert_x", queue_state="actioned", **extra):
 
 
 @pytest.mark.parametrize(
+    ("observable_type", "value", "expected_stix_type"),
+    [
+        ("domain", "malicious.example", "domain-name"),
+        ("email", "attacker@example.com", "email-addr"),
+        ("ipv4", "192.0.2.10", "ipv4-addr"),
+        ("url", "http://social.example/profile/fake", "url"),
+    ],
+)
+def test_standard_observables_use_opencti_custom_metadata(
+    converter, observable_type, value, expected_stix_type
+):
+    alert = _domains_alert(alert_id=f"alert_{observable_type}")
+
+    observable = converter._create_observable(observable_type, value, alert)
+
+    assert observable["type"] == expected_stix_type
+    assert "labels" not in observable
+    assert "external_references" not in observable
+    assert "queue_state:actioned" in observable["x_opencti_labels"]
+    assert "priority:P2" in observable["x_opencti_labels"]
+    assert observable["x_opencti_external_references"][0]["external_id"] == alert["id"]
+
+
+@pytest.mark.parametrize(
     "product",
     [
         "social_media",


### PR DESCRIPTION
## Summary
- normalize Doppel domain alerts to valid hostname-only `Domain-Name` observables
- represent URL-oriented and email entities as STIX `Url` and `Email-Addr` observables with matching indicator patterns
- preserve labels, priorities, and references through STIX-compliant OpenCTI custom properties
- document the corrected entity mapping and add regression coverage across all supported products

## Migration note
Existing malformed objects are not automatically deleted or migrated. Customers that want to correct historical data should remove the malformed Doppel-authored objects and reset the connector state before replaying the desired historical window.

## Test plan
- [x] Connector unit tests: 70 passed with the exact `pycti==7.260728.0` image dependencies
- [x] Black and isort formatting
- [x] Flake8 and `git diff --check`
- [x] Docker image build with the connector's current requirements
- [x] End-to-end fixture import into OpenCTI platform/worker 7.260728.0 on Docker Desktop
- [x] OpenCTI API verification of `Domain-Name`, `IPv4-Addr`, `Url`, and `Email-Addr` observables and matching indicator patterns
- [x] Fresh-object verification that `x_opencti_labels` and `x_opencti_external_references` render as normal OpenCTI labels and references
- [x] Read-only Doppel tenant smoke test covering normalized domains, URL and email indicators, and a monitoring-state URL without an indicator

The deterministic fixture test covered all supported URL-oriented products, domain normalization, email entities, IPv4 enrichment, actioned/taken-down indicators, and a monitoring-state observable without an indicator.

Closes https://github.com/OpenCTI-Platform/connectors/issues/7025