### PR TITLE
docs(stream): remove unused confidence settings (#6594)

### DIFF
--- a/stream/misp-intel/README.md
+++ b/stream/misp-intel/README.md
@@ -79,7 +79,6 @@ There are a number of configuration options, which are set either in `docker-com
 | Live Stream ID                 | live_stream_id            | `CONNECTOR_LIVE_STREAM_ID`              |                                              | Yes       | The Live Stream ID of the stream created in the OpenCTI interface.             |
 | Live Stream Listen Delete      | live_stream_listen_delete | `CONNECTOR_LIVE_STREAM_LISTEN_DELETE`   | true                                         | No        | Listen to delete events.                                                       |
 | Live Stream No Dependencies    | live_stream_no_dependencies| `CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES`| false                                        | No        | Set to `false` to auto-resolve dependencies.                                   |
-| Confidence Level               | confidence_level          | `CONNECTOR_CONFIDENCE_LEVEL`            | 80                                           | No        | Confidence level (0-100).                                                      |
 | Container Types                | container_types           | `CONNECTOR_CONTAINER_TYPES`             | report,grouping,case-incident,case-rfi,case-rft | No     | Comma-separated list of container types to process.                            |
 | Log Level                      | log_level                 | `CONNECTOR_LOG_LEVEL`                   | info                                         | No        | Determines the verbosity of the logs.                                          |
 

--- a/stream/pan-cortex-xsoar-intel/README.md
+++ b/stream/pan-cortex-xsoar-intel/README.md
@@ -66,7 +66,6 @@ There are a number of configuration options, which are set either in `docker-com
 | Live Stream No Dependencies    | live_stream_no_dependencies| `CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES`| true                 | No        | Set to `true` unless synchronizing between OpenCTI platforms.                  |
 | Live Stream Start Timestamp    | live_stream_start_timestamp| `CONNECTOR_LIVE_STREAM_START_TIMESTAMP`|                      | No        | Start timestamp used on connector first start.                                 |
 | Consumer Count                 | consumer_count            | `CONNECTOR_CONSUMER_COUNT`              | 5                    | No        | Number of consumer/worker threads.                                             |
-| Confidence Level               | confidence_level          | `CONNECTOR_CONFIDENCE_LEVEL`            |                      | Yes       | Default confidence level (1-4).                                                |
 | Log Level                      | log_level                 | `CONNECTOR_LOG_LEVEL`                   | info                 | No        | Determines the verbosity of the logs.                                          |
 
 ### Connector extra parameters environment variables
@@ -103,7 +102,6 @@ Configure the connector in `docker-compose.yml`:
       - CONNECTOR_SCOPE=xsoar
       - CONNECTOR_LOG_LEVEL=info
       - CONNECTOR_LIVE_STREAM_ID=ChangeMe
-      - CONNECTOR_CONFIDENCE_LEVEL=80
       - XSOAR_URL=https://api-xsoar.example.com
       - XSOAR_KEY_ID=ChangeMe
       - XSOAR_KEY=ChangeMe

--- a/stream/qradar/README.md
+++ b/stream/qradar/README.md
@@ -67,7 +67,6 @@ There are a number of configuration options, which are set either in `docker-com
 | Live Stream No Dependencies    | live_stream_no_dependencies| `CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES`| true    | No        | Set to `true` unless synchronizing between OpenCTI platforms.                  |
 | Live Stream Start Timestamp    | live_stream_start_timestamp| `CONNECTOR_LIVE_STREAM_START_TIMESTAMP`|         | No        | Start timestamp used on connector first start.                                 |
 | Consumer Count                 | consumer_count            | `CONNECTOR_CONSUMER_COUNT`              | 10      | No        | Number of consumer/worker threads.                                             |
-| Confidence Level               | confidence_level          | `CONNECTOR_CONFIDENCE_LEVEL`            |         | Yes       | Default confidence level (1-4).                                                |
 | Log Level                      | log_level                 | `CONNECTOR_LOG_LEVEL`                   | error   | No        | Determines the verbosity of the logs.                                          |
 
 ### Connector extra parameters environment variables
@@ -103,7 +102,6 @@ Configure the connector in `docker-compose.yml`:
       - CONNECTOR_SCOPE=qradar
       - CONNECTOR_LOG_LEVEL=info
       - CONNECTOR_LIVE_STREAM_ID=ChangeMe
-      - CONNECTOR_CONFIDENCE_LEVEL=80
       - QRADAR_URL=https://qradar.example.com
       - QRADAR_SSL_VERIFY=true
       - QRADAR_TOKEN=ChangeMe

--- a/stream/splunk/README.md
+++ b/stream/splunk/README.md
@@ -65,7 +65,6 @@ There are a number of configuration options, which are set either in `docker-com
 | Live Stream ID                 | live_stream_id            | `CONNECTOR_LIVE_STREAM_ID`              |         | Yes       | The Live Stream ID of the stream created in the OpenCTI interface.             |
 | Live Stream Start Timestamp    | live_stream_start_timestamp| `CONNECTOR_LIVE_STREAM_START_TIMESTAMP`|         | No        | Start timestamp used on connector first start.                                 |
 | Consumer Count                 | consumer_count            | `CONNECTOR_CONSUMER_COUNT`              | 10      | No        | Number of consumer/worker threads.                                             |
-| Confidence Level               | confidence_level          | `CONNECTOR_CONFIDENCE_LEVEL`            |         | Yes       | Default confidence level (1-4).                                                |
 | Log Level                      | log_level                 | `CONNECTOR_LOG_LEVEL`                   | info    | No        | Determines the verbosity of the logs.                                          |
 
 ### Connector extra parameters environment variables
@@ -107,7 +106,6 @@ Configure the connector in `docker-compose.yml`:
       - CONNECTOR_SCOPE=splunk
       - CONNECTOR_LOG_LEVEL=info
       - CONNECTOR_LIVE_STREAM_ID=ChangeMe
-      - CONNECTOR_CONFIDENCE_LEVEL=80
       - SPLUNK_URL=https://splunk.example.com:8089
       - SPLUNK_TOKEN=ChangeMe
       - SPLUNK_AUTH_TYPE=Bearer

--- a/stream/stream-exporter/README.md
+++ b/stream/stream-exporter/README.md
@@ -64,7 +64,6 @@ There are a number of configuration options, which are set either in `docker-com
 | Connector Scope                | scope                     | `CONNECTOR_SCOPE`                       | stream-exporter | Yes       | The scope of the connector.                                                    |
 | Live Stream Start Timestamp    | live_stream_start_timestamp| `CONNECTOR_LIVE_STREAM_START_TIMESTAMP`|                 | No        | Start timestamp on first start (default: all data).                            |
 | Consumer Count                 | consumer_count            | `CONNECTOR_CONSUMER_COUNT`              | 10              | No        | Number of consumer/worker threads.                                             |
-| Confidence Level               | confidence_level          | `CONNECTOR_CONFIDENCE_LEVEL`            |                 | Yes       | Default confidence level (1-4).                                                |
 | Log Level                      | log_level                 | `CONNECTOR_LOG_LEVEL`                   | info            | No        | Determines the verbosity of the logs.                                          |
 
 ### Connector extra parameters environment variables
@@ -103,7 +102,6 @@ Configure the connector in `docker-compose.yml`:
       - CONNECTOR_NAME=Stream Exporter
       - CONNECTOR_SCOPE=stream-exporter
       - CONNECTOR_LOG_LEVEL=info
-      - CONNECTOR_CONFIDENCE_LEVEL=80
       - MINIO_ENDPOINT=minio.example.com
       - MINIO_PORT=9000
       - MINIO_BUCKET=opencti-export


### PR DESCRIPTION
### Proposed changes

* Remove `CONNECTOR_CONFIDENCE_LEVEL` from the configuration tables of the five stream connectors where it does not affect behavior.
* Remove the same unused setting from their README deployment examples.

### Related issues

* Closes #6594

### Checklist

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The commit is GitHub-verified with an SSH signature. The repository pre-commit hooks pass for all five modified README files.
