### PR TITLE
fix(import-file-stix): pre-generate stixmarx cache to fix /.stixmarx PermissionError (#7152)

### DIFF
--- a/Dockerfile_ubi9
+++ b/Dockerfile_ubi9
@@ -8,6 +8,13 @@ RUN set -eux; \
 
 ENV PYTHONDONTWRITEBYTECODE=1
 
+# Provide a dedicated HOME so tools that build per-user caches/config under "~"
+# (e.g. POST_INSTALL steps) have a valid writable location at build time and a
+# readable one at runtime for arbitrary non-root UIDs (OpenShift/Kubernetes).
+# HOME defaulting to "/" would otherwise fail with a PermissionError.
+ENV HOME=/opt/opencti-connector
+RUN mkdir -p "$HOME"
+
 ARG CONNECTOR_TYPE
 ENV CONNECTOR_TYPE=${CONNECTOR_TYPE}
 
@@ -23,6 +30,9 @@ RUN set -eux; \
     microdnf -y --setopt=install_weak_deps=0 install python3.12-pip git-core; \
     pip3.12 install --no-cache-dir -r /opt/connector/src/requirements.txt; \
     if [ -n "${POST_INSTALL}" ]; then ${POST_INSTALL}; fi; \
+    # Make anything created under HOME at build time (e.g. POST_INSTALL caches)
+    # world-readable so the connector can read it as an arbitrary non-root UID.
+    chmod -R a+rX "$HOME"; \
     microdnf -y remove python3.12-pip git-core ; \
     microdnf clean all;
 

--- a/internal-import-file/import-file-stix/.build.env
+++ b/internal-import-file/import-file-stix/.build.env
@@ -1,2 +1,2 @@
-CONNECTOR_CMD="import-file-stix.py"
-
+CONNECTOR_CMD="main.py"
+POST_INSTALL="python3.12 /opt/connector/src/stixmarx_warmup.py"

--- a/internal-import-file/import-file-stix/Dockerfile
+++ b/internal-import-file/import-file-stix/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.12-alpine
 ENV CONNECTOR_TYPE=INTERNAL_IMPORT_FILE
+# stixmarx (pulled in by stix2-elevator) builds a "~/.stixmarx" cache on first
+# import. Use a dedicated HOME (not /tmp, which may be shadowed by a mounted
+# volume) and pre-generate the cache at build time as world-readable, so the
+# connector runs as any non-root UID, even on a read-only root filesystem.
+ENV HOME=/opt/opencti-connector-import-file-stix
 
 # Copy the connector
 COPY src /opt/opencti-connector-import-file-stix
@@ -9,6 +14,9 @@ COPY src /opt/opencti-connector-import-file-stix
 RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev gfortran musl-dev g++ openblas openblas-dev && \
     cd /opt/opencti-connector-import-file-stix && \
     pip3 install --no-cache-dir -r requirements.txt && \
+    mkdir -p "$HOME" && \
+    python3 stixmarx_warmup.py && \
+    chmod -R a+rX "$HOME" && \
     apk del git build-base gfortran musl-dev g++ openblas-dev
 
 WORKDIR /opt/opencti-connector-import-file-stix

--- a/internal-import-file/import-file-stix/Dockerfile_fips
+++ b/internal-import-file/import-file-stix/Dockerfile_fips
@@ -1,14 +1,22 @@
 FROM filigran/python-fips:latest
 ENV CONNECTOR_TYPE=INTERNAL_IMPORT_FILE
+# stixmarx (pulled in by stix2-elevator) builds a "~/.stixmarx" cache on first
+# import. Use a dedicated HOME (not /tmp, which may be shadowed by a mounted
+# volume) and pre-generate the cache at build time as world-readable, so the
+# connector runs as any non-root UID, even on a read-only root filesystem.
+ENV HOME=/opt/opencti-connector-import-file-stix
 
 # Copy the connector
 COPY src /opt/opencti-connector-import-file-stix
 
 # Install Python modules
 # hadolint ignore=DL3003
-RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev gfortran musl-dev g++ openblas openblas-dev && \
+RUN apk --no-cache add libbz2 git build-base libmagic libffi-dev libxml2-dev libxslt-dev gfortran musl-dev g++ openblas openblas-dev && \
     cd /opt/opencti-connector-import-file-stix && \
     pip3 install --no-cache-dir -r requirements.txt && \
+    mkdir -p "$HOME" && \
+    python3 stixmarx_warmup.py && \
+    chmod -R a+rX "$HOME" && \
     apk del git build-base gfortran musl-dev g++ openblas-dev
 
 WORKDIR /opt/opencti-connector-import-file-stix

--- a/internal-import-file/import-file-stix/src/stixmarx_warmup.py
+++ b/internal-import-file/import-file-stix/src/stixmarx_warmup.py
@@ -1,0 +1,12 @@
+"""Build-time warm-up: pre-generate the stixmarx "~/.stixmarx" cache.
+
+Importing stix2-elevator makes stixmarx build its cache under ``$HOME``. Doing it
+at image-build time lets the connector import stix2-elevator at runtime as any
+non-root UID without writing to the filesystem (see issue #7152).
+
+All three image variants use this script: the Alpine and FIPS Dockerfiles run it
+directly, and the shared UBI9 image runs it via the ``POST_INSTALL`` build hook
+declared in ``.build.env``.
+"""
+
+from stix2elevator import elevate  # noqa: F401  # pylint: disable=unused-import


### PR DESCRIPTION
### Proposed changes

* Warm up the `stix2-elevator`/`stixmarx` `~/.stixmarx` cache at **build time** into a dedicated world-readable `HOME`, so the connector runs as any non-root arbitrary UID (Kubernetes/OpenShift), even on a read-only root filesystem. Fixes the startup crash `PermissionError: [Errno 13] Permission denied: '/.stixmarx'`.
* **Alpine (`Dockerfile`) & FIPS (`Dockerfile_fips`)** — set `ENV HOME=/opt/opencti-connector-import-file-stix` and warm the cache via the new `src/stixmarx_warmup.py` script, then `chmod -R a+rX "$HOME"`.
* **Shared `Dockerfile_ubi9`** — kept connector-agnostic (used by all UBI9 connectors): only provides a generic writable/readable `HOME` (`/opt/opencti-connector`) + `chmod -R a+rX "$HOME"`. The stixmarx warm-up is injected per-connector via the `POST_INSTALL` build hook in `.build.env`.
* **`src/stixmarx_warmup.py`** (new) — single canonical warm-up used by all three variants (run directly by Alpine/FIPS, and via `POST_INSTALL` on UBI9).
* **FIPS `libbz2`** — the `filigran/python-fips` base image is missing `libbz2.so.1`, breaking the `stix2-elevator`/`numpy` import; added `libbz2` to the apk install.
* **`.build.env`** — fixed stale `CONNECTOR_CMD` (`import-file-stix.py` -> `main.py`) and added the `POST_INSTALL` hook.

### Related issues

* Closes #7152

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
