### PR TITLE
fix(opencti): align UBI9 CONNECTOR_CMD with actual entrypoint (#7154)

### DIFF
--- a/external-import/opencti/.build.env
+++ b/external-import/opencti/.build.env
@@ -1,1 +1,1 @@
-CONNECTOR_CMD="connector.py"
+CONNECTOR_CMD="main.py"


### PR DESCRIPTION
### Proposed changes

* update `external-import/opencti/.build.env` to set `CONNECTOR_CMD="main.py"`
* align UBI9 startup behavior with the actual connector entrypoint file

### Related issues

* Close #7154

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] ~~I added/update the relevant documentation (either on github or on notion)~~ not necessary
- [x] ~~Where necessary I refactored code to improve the overall quality~~ not necessary

### Further comments

This change fixes the UBI9 runtime failure where the default command targeted a non-existing `connector.py` file.