### PR TITLE
fix: declare python-magic dependency for connectors importing magic (#7157)

### DIFF
--- a/external-import/malwarebazaar-recent-additions/src/requirements.txt
+++ b/external-import/malwarebazaar-recent-additions/src/requirements.txt
@@ -1,4 +1,6 @@
 pycti==7.260803.0
+python-magic~=0.4.27; sys_platform == 'linux' or sys_platform == 'darwin'
+python-magic-bin~=0.4.14; sys_platform == 'win32'
 pyzipper==0.4.0
 stix2==3.0.1
 pydantic >=2.8.2, <3

--- a/external-import/sentinelone-threats/src/requirements.txt
+++ b/external-import/sentinelone-threats/src/requirements.txt
@@ -1,1 +1,3 @@
 pycti==7.260803.0
+python-magic~=0.4.27; sys_platform == 'linux' or sys_platform == 'darwin'
+python-magic-bin~=0.4.14; sys_platform == 'win32'

--- a/external-import/urlhaus-recent-payloads/src/requirements.txt
+++ b/external-import/urlhaus-recent-payloads/src/requirements.txt
@@ -1,3 +1,5 @@
 pycti==7.260803.0
+python-magic~=0.4.27; sys_platform == 'linux' or sys_platform == 'darwin'
+python-magic-bin~=0.4.14; sys_platform == 'win32'
 pydantic >=2.8.2, <3
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/virustotal-livehunt-notifications/src/requirements.txt
+++ b/external-import/virustotal-livehunt-notifications/src/requirements.txt
@@ -1,4 +1,6 @@
 plyara~=2.2.1
 pycti==7.260803.0
+python-magic~=0.4.27; sys_platform == 'linux' or sys_platform == 'darwin'
+python-magic-bin~=0.4.14; sys_platform == 'win32'
 vt-py==0.21.0
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/cape-sandbox/src/requirements.txt
+++ b/internal-enrichment/cape-sandbox/src/requirements.txt
@@ -1,2 +1,4 @@
 pycti==7.260803.0
+python-magic~=0.4.27; sys_platform == 'linux' or sys_platform == 'darwin'
+python-magic-bin~=0.4.14; sys_platform == 'win32'
 pyzipper==0.4.0

--- a/internal-enrichment/hatching-triage-sandbox/src/requirements.txt
+++ b/internal-enrichment/hatching-triage-sandbox/src/requirements.txt
@@ -1,4 +1,6 @@
 pycti==7.260803.0
+python-magic~=0.4.27; sys_platform == 'linux' or sys_platform == 'darwin'
+python-magic-bin~=0.4.14; sys_platform == 'win32'
 git+https://github.com/hatching/triage.git#subdirectory=python
 pydantic>=2.8.2,<3
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/unpac-me/src/requirements.txt
+++ b/internal-enrichment/unpac-me/src/requirements.txt
@@ -1,1 +1,3 @@
 pycti==7.260803.0
+python-magic~=0.4.27; sys_platform == 'linux' or sys_platform == 'darwin'
+python-magic-bin~=0.4.14; sys_platform == 'win32'

--- a/internal-enrichment/virustotal-downloader/src/requirements.txt
+++ b/internal-enrichment/virustotal-downloader/src/requirements.txt
@@ -1,4 +1,6 @@
 pycti==7.260803.0
+python-magic~=0.4.27; sys_platform == 'linux' or sys_platform == 'darwin'
+python-magic-bin~=0.4.14; sys_platform == 'win32'
 pydantic>=2.10, <3
 pydantic-settings==2.10.1
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk


### PR DESCRIPTION
### Proposed changes

`pycti` no longer ships `python-magic` as a transitive dependency, so connectors that call `import magic` directly fail at runtime and during release tests with `ModuleNotFoundError: No module named 'magic'` (e.g. `Test external-import/malwarebazaar-recent-additions`).

This declares `python-magic` explicitly (with the win32 `python-magic-bin` variant) in each affected connector's `requirements.txt`, matching the pycti/shadowserver convention. All affected Dockerfiles already install the `libmagic` system library.

Affected connectors:
* external-import/malwarebazaar-recent-additions
* external-import/sentinelone-threats
* external-import/urlhaus-recent-payloads
* external-import/virustotal-livehunt-notifications
* internal-enrichment/cape-sandbox
* internal-enrichment/hatching-triage-sandbox
* internal-enrichment/unpac-me
* internal-enrichment/virustotal-downloader

### Related issues

* Closes #7157

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality