### PR TITLE
ci: retry connector image builds with backoff on transient registry errors (#7162)

### DIFF
--- a/.circleci/templates/dynamic.yml.j2
+++ b/.circleci/templates/dynamic.yml.j2
@@ -16,26 +16,6 @@ jobs:
           command: |
             echo "Processing {{top_dir}}/{{sub_dir}}"
             set -x
-            build_with_retry() {
-              max_attempts=5
-              attempt=1
-              delay=15
-              while true; do
-                if "$@"; then
-                  return 0
-                fi
-                if [ "$attempt" -ge "$max_attempts" ]; then
-                  echo "build/push failed after $attempt attempts"
-                  return 1
-                fi
-                jitter=$((RANDOM % 5))
-                sleep_for=$((delay + jitter))
-                echo "build/push attempt $attempt failed, retrying in ${sleep_for}s..."
-                sleep "$sleep_for"
-                attempt=$((attempt + 1))
-                delay=$((delay * 2))
-              done
-            }
             cd {{top_dir}}/{{sub_dir}}
             docker run --privileged --rm tonistiigi/binfmt --install linux/amd64,linux/arm64
             CIRCLE_TAG=${CIRCLE_TAG:-latest}
@@ -74,7 +54,7 @@ jobs:
             find . -name pyproject.toml -exec sed "s|connectors-sdk.*$|connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@$RELEASE_REF#subdirectory=connectors-sdk\",|" -i {} \;
                 {% endif %}
             {% endif -%}
-            build_with_retry docker buildx build --pull . \
+            docker buildx build --pull . \
              {% for tag in tags -%}
              --tag {{repo}}/connector-{{sub_dir}}:{{tag}} \
              --tag ghcr.io/opencti-platform/{{repo}}/connector-{{sub_dir}}:{{tag}} \
@@ -83,7 +63,7 @@ jobs:
              --push
 
             {% if param['images'][image_key] is defined and param['images'][image_key]['fips'] == true -%}
-            build_with_retry docker buildx build --pull -f Dockerfile_fips . \
+            docker buildx build --pull -f Dockerfile_fips . \
              {% for tag in tags -%}
              --tag {{repo}}/connector-{{sub_dir}}:{{tag}}-fips \
              --tag ghcr.io/opencti-platform/{{repo}}/connector-{{sub_dir}}:{{tag}}-fips \

--- a/.circleci/templates/dynamic.yml.j2
+++ b/.circleci/templates/dynamic.yml.j2
@@ -16,6 +16,26 @@ jobs:
           command: |
             echo "Processing {{top_dir}}/{{sub_dir}}"
             set -x
+            build_with_retry() {
+              max_attempts=5
+              attempt=1
+              delay=15
+              while true; do
+                if "$@"; then
+                  return 0
+                fi
+                if [ "$attempt" -ge "$max_attempts" ]; then
+                  echo "build/push failed after $attempt attempts"
+                  return 1
+                fi
+                jitter=$((RANDOM % 5))
+                sleep_for=$((delay + jitter))
+                echo "build/push attempt $attempt failed, retrying in ${sleep_for}s..."
+                sleep "$sleep_for"
+                attempt=$((attempt + 1))
+                delay=$((delay * 2))
+              done
+            }
             cd {{top_dir}}/{{sub_dir}}
             docker run --privileged --rm tonistiigi/binfmt --install linux/amd64,linux/arm64
             CIRCLE_TAG=${CIRCLE_TAG:-latest}
@@ -54,7 +74,7 @@ jobs:
             find . -name pyproject.toml -exec sed "s|connectors-sdk.*$|connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@$RELEASE_REF#subdirectory=connectors-sdk\",|" -i {} \;
                 {% endif %}
             {% endif -%}
-            docker buildx build --pull . \
+            build_with_retry docker buildx build --pull . \
              {% for tag in tags -%}
              --tag {{repo}}/connector-{{sub_dir}}:{{tag}} \
              --tag ghcr.io/opencti-platform/{{repo}}/connector-{{sub_dir}}:{{tag}} \
@@ -63,7 +83,7 @@ jobs:
              --push
 
             {% if param['images'][image_key] is defined and param['images'][image_key]['fips'] == true -%}
-            docker buildx build --pull -f Dockerfile_fips . \
+            build_with_retry docker buildx build --pull -f Dockerfile_fips . \
              {% for tag in tags -%}
              --tag {{repo}}/connector-{{sub_dir}}:{{tag}}-fips \
              --tag ghcr.io/opencti-platform/{{repo}}/connector-{{sub_dir}}:{{tag}}-fips \

--- a/.github/actions/build-connector-image/action.yml
+++ b/.github/actions/build-connector-image/action.yml
@@ -229,44 +229,30 @@ runs:
           io.opencti.build.run_id=${{ github.run_id }}
           io.opencti.build.run_url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-    - name: Build and push
+    - name: Build and push (with retry)
       id: build
-      continue-on-error: true
-      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-      with:
-        context: ${{ inputs.connector_path }}
-        file: ${{ steps.resolve.outputs.dockerfile }}
-        build-args: ${{ steps.resolve.outputs.build_args }}
-        pull: true
-        push: ${{ inputs.push == 'true' }}
-        platforms: ${{ inputs.platforms }}
-        tags: ${{ steps.docker-tags.outputs.tags }}
-        labels: ${{ steps.oci-labels.outputs.labels }}
-        cache-from: type=registry,ref=ghcr.io/opencti-platform/opencti/cache/connector-${{ inputs.connector_name }}:buildcache${{ steps.resolve.outputs.cache_suffix }}
-        cache-to: ${{ inputs.push == 'true' && format('type=registry,ref=ghcr.io/opencti-platform/opencti/cache/connector-{0}:buildcache{1},mode=max', inputs.connector_name, steps.resolve.outputs.cache_suffix) || '' }}
-
-    - name: Retry build and push
-      id: build-retry
-      if: steps.build.outcome == 'failure'
-      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-      with:
-        context: ${{ inputs.connector_path }}
-        file: ${{ steps.resolve.outputs.dockerfile }}
-        build-args: ${{ steps.resolve.outputs.build_args }}
-        pull: true
-        push: ${{ inputs.push == 'true' }}
-        platforms: ${{ inputs.platforms }}
-        tags: ${{ steps.docker-tags.outputs.tags }}
-        labels: ${{ steps.oci-labels.outputs.labels }}
-        cache-from: type=registry,ref=ghcr.io/opencti-platform/opencti/cache/connector-${{ inputs.connector_name }}:buildcache${{ steps.resolve.outputs.cache_suffix }}
-        cache-to: ${{ inputs.push == 'true' && format('type=registry,ref=ghcr.io/opencti-platform/opencti/cache/connector-{0}:buildcache{1},mode=max', inputs.connector_name, steps.resolve.outputs.cache_suffix) || '' }}
+      shell: bash
+      env:
+        CONTEXT: ${{ inputs.connector_path }}
+        DOCKERFILE: ${{ steps.resolve.outputs.dockerfile }}
+        BUILD_ARGS: ${{ steps.resolve.outputs.build_args }}
+        PLATFORMS: ${{ inputs.platforms }}
+        PUSH: ${{ inputs.push }}
+        PULL: "true"
+        TAGS: ${{ steps.docker-tags.outputs.tags }}
+        LABELS: ${{ steps.oci-labels.outputs.labels }}
+        CACHE_FROM: type=registry,ref=ghcr.io/opencti-platform/opencti/cache/connector-${{ inputs.connector_name }}:buildcache${{ steps.resolve.outputs.cache_suffix }}
+        CACHE_TO: ${{ inputs.push == 'true' && format('type=registry,ref=ghcr.io/opencti-platform/opencti/cache/connector-{0}:buildcache{1},mode=max', inputs.connector_name, steps.resolve.outputs.cache_suffix) || '' }}
+        DIGEST_OUT: ${{ runner.temp }}/digest-${{ inputs.connector_name }}
+      run: |
+        bash "${{ github.action_path }}/../../scripts/buildx_with_retry.sh"
 
     - name: Export digest
       if: inputs.push == 'true'
       shell: bash
       run: |
         mkdir -p "${{ inputs.digests_dir }}"
-        DIGEST="${{ steps.build-retry.outputs.digest || steps.build.outputs.digest }}"
+        DIGEST="$(cat "${{ runner.temp }}/digest-${{ inputs.connector_name }}")"
         echo "$DIGEST" > "${{ inputs.digests_dir }}/${{ inputs.connector_name }}"
         echo "📋 Digest: $DIGEST"
 
@@ -312,33 +298,19 @@ runs:
           io.opencti.build.run_id=${{ github.run_id }}
           io.opencti.build.run_url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-    - name: Build and push FIPS image
+    - name: Build and push FIPS image (with retry)
       if: inputs.fips == 'true' && inputs.platforms == 'linux/amd64'
       id: build-fips
-      continue-on-error: true
-      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-      with:
-        context: ${{ inputs.connector_path }}
-        file: ${{ inputs.connector_path }}/Dockerfile_fips
-        pull: true
-        push: ${{ inputs.push == 'true' }}
-        platforms: linux/amd64
-        tags: ${{ steps.fips-tags.outputs.tags }}
-        labels: ${{ steps.fips-oci-labels.outputs.labels }}
-        cache-from: type=registry,ref=ghcr.io/opencti-platform/opencti/cache/connector-${{ inputs.connector_name }}:buildcache-fips
-        cache-to: ${{ inputs.push == 'true' && format('type=registry,ref=ghcr.io/opencti-platform/opencti/cache/connector-{0}:buildcache-fips,mode=max', inputs.connector_name) || '' }}
-
-    - name: Retry FIPS build and push
-      if: inputs.fips == 'true' && inputs.platforms == 'linux/amd64' && steps.build-fips.outcome == 'failure'
-      id: build-fips-retry
-      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-      with:
-        context: ${{ inputs.connector_path }}
-        file: ${{ inputs.connector_path }}/Dockerfile_fips
-        pull: true
-        push: ${{ inputs.push == 'true' }}
-        platforms: linux/amd64
-        tags: ${{ steps.fips-tags.outputs.tags }}
-        labels: ${{ steps.fips-oci-labels.outputs.labels }}
-        cache-from: type=registry,ref=ghcr.io/opencti-platform/opencti/cache/connector-${{ inputs.connector_name }}:buildcache-fips
-        cache-to: ${{ inputs.push == 'true' && format('type=registry,ref=ghcr.io/opencti-platform/opencti/cache/connector-{0}:buildcache-fips,mode=max', inputs.connector_name) || '' }}
+      shell: bash
+      env:
+        CONTEXT: ${{ inputs.connector_path }}
+        DOCKERFILE: ${{ inputs.connector_path }}/Dockerfile_fips
+        PLATFORMS: linux/amd64
+        PUSH: ${{ inputs.push }}
+        PULL: "true"
+        TAGS: ${{ steps.fips-tags.outputs.tags }}
+        LABELS: ${{ steps.fips-oci-labels.outputs.labels }}
+        CACHE_FROM: type=registry,ref=ghcr.io/opencti-platform/opencti/cache/connector-${{ inputs.connector_name }}:buildcache-fips
+        CACHE_TO: ${{ inputs.push == 'true' && format('type=registry,ref=ghcr.io/opencti-platform/opencti/cache/connector-{0}:buildcache-fips,mode=max', inputs.connector_name) || '' }}
+      run: |
+        bash "${{ github.action_path }}/../../scripts/buildx_with_retry.sh"

--- a/.github/scripts/buildx_with_retry.sh
+++ b/.github/scripts/buildx_with_retry.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Build (and optionally push) a connector image with docker buildx, retrying
+# transient failures (e.g. registry 5xx/timeouts) with exponential backoff.
+#
+# Mirrors the retry behaviour of the CircleCI pipeline
+# (.circleci/templates/dynamic.yml.j2) so both CIs are equally resilient.
+#
+# Required environment variables:
+#   CONTEXT      - Build context directory
+#   DOCKERFILE   - Path to the Dockerfile
+#   PLATFORMS    - Target platform(s), e.g. "linux/amd64"
+#   TAGS         - Newline-separated list of image tags
+#
+# Optional environment variables:
+#   PUSH         - "true" to push, anything else to build only (default: false)
+#   PULL         - "true" to always pull base images (default: true)
+#   BUILD_ARGS   - Newline-separated list of KEY=VALUE build args
+#   LABELS       - Newline-separated list of KEY=VALUE OCI labels
+#   CACHE_FROM   - buildx --cache-from value (skipped when empty)
+#   CACHE_TO     - buildx --cache-to value (skipped when empty)
+#   PROVENANCE   - buildx --provenance value (default: false, matches
+#                  docker/build-push-action so per-arch images stay
+#                  single-manifest for the imagetools merge)
+#   DIGEST_OUT   - File path to write the resulting image digest to
+#   MAX_ATTEMPTS - Maximum number of attempts (default: 5)
+#   INITIAL_DELAY- Initial backoff delay in seconds (default: 15)
+set -euo pipefail
+
+: "${CONTEXT:?CONTEXT is required}"
+: "${DOCKERFILE:?DOCKERFILE is required}"
+: "${PLATFORMS:?PLATFORMS is required}"
+: "${TAGS:?TAGS is required}"
+
+PUSH="${PUSH:-false}"
+PULL="${PULL:-true}"
+PROVENANCE="${PROVENANCE:-false}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-5}"
+INITIAL_DELAY="${INITIAL_DELAY:-15}"
+
+METADATA_FILE="$(mktemp)"
+
+# Assemble the buildx argument list.
+args=(build "$CONTEXT" --file "$DOCKERFILE" --platform "$PLATFORMS")
+args+=(--provenance "$PROVENANCE" --metadata-file "$METADATA_FILE")
+
+if [ "$PULL" = "true" ]; then
+  args+=(--pull)
+fi
+if [ "$PUSH" = "true" ]; then
+  args+=(--push)
+fi
+
+while IFS= read -r tag; do
+  [ -n "$tag" ] && args+=(--tag "$tag")
+done <<< "$TAGS"
+
+if [ -n "${BUILD_ARGS:-}" ]; then
+  while IFS= read -r ba; do
+    [ -n "$ba" ] && args+=(--build-arg "$ba")
+  done <<< "$BUILD_ARGS"
+fi
+
+if [ -n "${LABELS:-}" ]; then
+  while IFS= read -r label; do
+    [ -n "$label" ] && args+=(--label "$label")
+  done <<< "$LABELS"
+fi
+
+if [ -n "${CACHE_FROM:-}" ]; then
+  args+=(--cache-from "$CACHE_FROM")
+fi
+if [ -n "${CACHE_TO:-}" ]; then
+  args+=(--cache-to "$CACHE_TO")
+fi
+
+attempt=1
+delay="$INITIAL_DELAY"
+while true; do
+  echo "🐳 docker buildx (attempt ${attempt}/${MAX_ATTEMPTS})"
+  if docker buildx "${args[@]}"; then
+    break
+  fi
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "❌ buildx failed after ${attempt} attempts"
+    rm -f "$METADATA_FILE"
+    exit 1
+  fi
+  jitter=$((RANDOM % 5))
+  sleep_for=$((delay + jitter))
+  echo "⚠️  buildx attempt ${attempt} failed, retrying in ${sleep_for}s..."
+  sleep "$sleep_for"
+  attempt=$((attempt + 1))
+  delay=$((delay * 2))
+done
+
+if [ -n "${DIGEST_OUT:-}" ]; then
+  DIGEST="$(jq -r '.["containerimage.digest"] // empty' "$METADATA_FILE")"
+  echo "$DIGEST" > "$DIGEST_OUT"
+  echo "📋 Digest: ${DIGEST:-(none)}"
+fi
+
+rm -f "$METADATA_FILE"

--- a/.github/scripts/buildx_with_retry.sh
+++ b/.github/scripts/buildx_with_retry.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 # Build (and optionally push) a connector image with docker buildx, retrying
-# transient failures (e.g. registry 5xx/timeouts) with exponential backoff.
-#
-# Mirrors the retry behaviour of the CircleCI pipeline
-# (.circleci/templates/dynamic.yml.j2) so both CIs are equally resilient.
+# transient failures (e.g. registry 5xx/timeouts, rate limiting) with
+# exponential backoff.
 #
 # Required environment variables:
 #   CONTEXT      - Build context directory


### PR DESCRIPTION
## Description

Adds automatic **multi-attempt retry with exponential backoff** around the connector docker image build/push in the **GitHub Actions** pipeline, to survive transient GHCR registry errors (notably rate limiting) without manual reruns.

### Motivation

UBI9 build jobs on GitHub Actions had to be **manually rerun** because of a transient registry rate limit:

```
ERROR: failed to push ghcr.io/.../connector-virustotal-livehunt-rules:rolling-ubi9-amd64:
toomanyrequests: retry-after: 2.487659ms, allowed: 2000/minute
```

Previously, **GitHub Actions** had only a single *immediate* retry via `docker/build-push-action` (no backoff), which does not help when the registry needs the rate-limit window to elapse.

> Note: this was only observed on GitHub Actions, so the change is intentionally scoped to that pipeline. CircleCI is left untouched.

## Changes

- **GitHub Actions**:
  - New shared script `.github/scripts/buildx_with_retry.sh` implementing a retry loop around `docker buildx build` — 5 attempts, exponential backoff (15s -> 30s -> 60s -> 120s) with jitter.
  - `.github/actions/build-connector-image/action.yml`: replace the single `docker/build-push-action` build + retry (main and FIPS) with the shared retry script.
  - `--provenance=false` set explicitly (matches `docker/build-push-action` default) so per-arch images stay single-manifest for the imagetools merge; digest captured via `--metadata-file` and exported for the merge step.

Closes #7162
