### PR TITLE
intel471 v1.1.12

### DIFF
--- a/external-import/intel471_v2/src/requirements.txt
+++ b/external-import/intel471_v2/src/requirements.txt
@@ -2,6 +2,6 @@ pycti==7.260728.0
 stix2~=3.0.1
 APScheduler~=3.11.0
 Titan-Client==1.20.0.15
-verity471[stix]==1.1.7
+verity471[stix]==1.1.12
 pydantic >=2.8.2, <3
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk


### PR DESCRIPTION
Proposed changes

- Bump verity471[stix] to 1.1.12 to pick up the latest Verity471 API changes (optional/required field updates across Intel Reports, Data Leak Sites, Forums, Watchers, Messaging Services, and new default page sizes).


Checklist

- I consider the submitted work as finished
- I have signed my commits using GPG key.
- I tested the code for its functionality using different use cases
- I added/update the relevant documentation (either on github or on notion)
- Where necessary I refaerall quality
- 
Further comments

Dependency bump only — no connector code changes required.