### PR TITLE
fix(doppel): harden alert polling and replay updates (#7168)

### DIFF
--- a/external-import/doppel/README.md
+++ b/external-import/doppel/README.md
@@ -56,20 +56,20 @@ Below are the parameters you'll need to set for running the connector properly:
 | Parameter       | config.yml `connector` | Docker environment variable | Default | Mandatory | Description                                                                              |
 |-----------------|------------------------|-----------------------------|---------|-----------|------------------------------------------------------------------------------------------|
 | Connector ID    | `id`                   | `CONNECTOR_ID`              | /       | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
-| Connector Name  | `name`                 | `CONNECTOR_NAME`            | /       | Yes       | Name of the connector.                                                                   |
+| Connector Name  | `name`                 | `CONNECTOR_NAME`            | Doppel Threat Intelligence | No | Name of the connector.                                                        |
 | Connector Scope | `scope`                | `CONNECTOR_SCOPE`           | doppel  | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
-| Log Level       | `log_level`            | `CONNECTOR_LOG_LEVEL`       | info    | No        | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
-| Duration Period | `duration_period`      | `CONNECTOR_DURATION_PERIOD` | PT1H    | Yes       | The period of time between two connector runs (ISO 8601 duration format).                |
+| Log Level       | `log_level`            | `CONNECTOR_LOG_LEVEL`       | error   | No        | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
+| Duration Period | `duration_period`      | `CONNECTOR_DURATION_PERIOD` | PT1H    | No        | The period of time between two connector runs (ISO 8601 duration format).                |
 
 ### Connector extra parameters environment variables
 
 | Parameter               | config.yml                     | Docker environment variable      | Role |  Default | Mandatory | Description                           |
 |-------------------------|--------------------------------|----------------------------------|---------|---------|-----------|---------------------------------------|
-| API base URL            | doppel.api_base_url            | `DOPPEL_API_BASE_URL`            |    Connectivity: Defines the network entry point for all API requests.      | https://api.doppel.com/v1        | Yes       | Doppel API base URL                   |
+| API base URL            | doppel.api_base_url            | `DOPPEL_API_BASE_URL`            |    Connectivity: Defines the network entry point for all API requests.      | https://api.doppel.com/v1        | No        | Doppel API base URL                   |
 | API key                 | doppel.api_key                 | `DOPPEL_API_KEY`                 |    Authentication: Provides the primary security credentials for service access.      |         | Yes       | Doppel API key                        |
 | User API key                 | doppel.user_api_key       | `DOPPEL_USER_API_KEY`            |     Authorization: Used for user-specific identity.     |         | No        | Doppel User API key                   |
 | Organization Code       | doppel.organization_code       | `DOPPEL_ORGANIZATION_CODE`       |     Scope: Identifies the specific organizational workspace for multi-tenant keys.     |         | No        | Organization Code for Doppel API Keys |
-| Alerts endpoint         | doppel.alerts_endpoint         | `DOPPEL_ALERTS_ENDPOINT`         |     Routing: Specifies the API resource path for alert ingestion.     | /alerts | Yes       | API endpoint for fetching alerts      |
+| Alerts endpoint         | doppel.alerts_endpoint         | `DOPPEL_ALERTS_ENDPOINT`         |     Routing: Specifies the API resource path for alert ingestion.     | /alerts | No        | API endpoint for fetching alerts      |
 | Historical polling days | doppel.historical_polling_days | `DOPPEL_HISTORICAL_POLLING_DAYS` |     Synchronization: Determines the time-window for initial data fetching.     | 30      | No        | Days of data to fetch on first run    |
 | Max retries             | doppel.max_retries             | `DOPPEL_MAX_RETRIES`             |     Resilience: Configures automated error recovery from transient failures.     | 3       | No        | Retry attempts on API errors          |
 | Retry delay (seconds)   | doppel.retry_delay             | `DOPPEL_RETRY_DELAY`             |     Rate Management: Controls the frequency of requests during error recovery.     | 30      | No        | Delay between retry attempts          |
@@ -82,33 +82,30 @@ Below are the parameters you'll need to set for running the connector properly:
 
 ### Docker Deployment
 
-Before building the Docker container, you need to set the version of pycti in `requirements.txt` equal to whatever version of OpenCTI you're running. Example, `pycti==6.5.1`. If you don't, it will take the latest version, but sometimes the OpenCTI SDK fails to initialize.
+Use a connector image tag matching the OpenCTI platform version. If you build the
+image yourself, check out the matching connectors release before using the provided
+`Dockerfile`; its `pycti` dependency is already pinned to that release.
 
-Build a Docker Image using the provided `Dockerfile`.
-
-Example:
-
-3. Register connector in the **main** OpenCTI `docker-compose.yml`:
+Register the connector in the **main** OpenCTI `docker-compose.yml`:
 
 ```yaml
   connector-doppel:
-    image: opencti/connector-doppel:latest
+    image: opencti/connector-doppel:<opencti-version>
     environment:
       - OPENCTI_URL=http://opencti:8080
       - OPENCTI_TOKEN=changeme
       - CONNECTOR_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
       - CONNECTOR_NAME=Doppel Threat Intelligence
-      - CONNECTOR_SCOPE=Indicator
+      - CONNECTOR_SCOPE=doppel
       - CONNECTOR_LOG_LEVEL=info
       - CONNECTOR_DURATION_PERIOD=PT1H
-      - DOPPEL_API_BASE_URL=https://api.doppel.com
+      - DOPPEL_API_BASE_URL=https://api.doppel.com/v1
       - DOPPEL_API_KEY=changeme
-      - DOPPEL_USER_API_KEY=changeme
-      - DOPPEL_ORGANIZATION_CODE=changeme
-      - DOPPEL_ALERTS_ENDPOINT=/v1/alerts
+      - DOPPEL_ALERTS_ENDPOINT=/alerts
       - DOPPEL_HISTORICAL_POLLING_DAYS=30
       - DOPPEL_MAX_RETRIES=3
       - DOPPEL_RETRY_DELAY=30
+      - DOPPEL_PAGE_SIZE=100
       - DOPPEL_TLP_LEVEL=clear
       - DOPPEL_ENABLE_GROUPING_CASE=false
       - DOPPEL_ENABLE_RFT_CASE=false
@@ -163,6 +160,10 @@ Find the "Doppel" connector, and click on the refresh button to reset the connec
     full URL value.
 - Bundles and sends the STIX objects to OpenCTI
 - Includes platform, score, brand, audit logs, notes, etc. as `custom_properties`
+- Reprocessing an alert refreshes Doppel-owned mutable data on existing
+  Indicators (description, score, external reference, revoked state) and RFT
+  cases (description, priority, severity, external reference, revoked state).
+  External references added by users are preserved.
 - On first run, fetches up to `HISTORICAL_POLLING_DAYS`; subsequent runs are delta-based
 
 ## Debugging

--- a/external-import/doppel/README.md
+++ b/external-import/doppel/README.md
@@ -161,8 +161,10 @@ Find the "Doppel" connector, and click on the refresh button to reset the connec
 - Bundles and sends the STIX objects to OpenCTI
 - Includes platform, score, brand, audit logs, notes, etc. as `custom_properties`
 - Reprocessing an alert refreshes Doppel-owned mutable data on existing
-  Indicators (description, score, external reference, revoked state) and RFT
-  cases (description, priority, severity, external reference, revoked state).
+  Indicators (description, score, external reference) and RFT cases
+  (description, priority, severity, external reference). Queue transitions are
+  represented by labels and do not revoke these objects; obsolete
+  `revoked-false-positive` labels from earlier connector versions are removed.
   External references added by users are preserved.
 - On first run, fetches up to `HISTORICAL_POLLING_DAYS`; subsequent runs are delta-based
 

--- a/external-import/doppel/README.md
+++ b/external-import/doppel/README.md
@@ -150,6 +150,9 @@ Find the "Doppel" connector, and click on the refresh button to reset the connec
 ## Behavior
 
 - Fetches alerts from Doppel API paginated by `last_activity_timestamp`
+- Identifies every outbound Doppel API request with
+  `x-doppel-client: opencti/7.260901.0` and
+  `User-Agent: doppel-opencti/7.260901.0` for usage attribution.
 - Converts each alert into a STIX 2.1 Observable with a value-appropriate type:
   - `domains` alerts become `Domain-Name` observables. URL schemes, paths,
     queries, and fragments added by the Doppel API are removed from the domain

--- a/external-import/doppel/src/config.yml.sample
+++ b/external-import/doppel/src/config.yml.sample
@@ -21,3 +21,5 @@ doppel:
   max_retries: 3
   retry_delay: 30
   page_size: 100
+  enable_grouping_case: false
+  enable_rft_case: false

--- a/external-import/doppel/src/doppel/client_api.py
+++ b/external-import/doppel/src/doppel/client_api.py
@@ -2,7 +2,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any
 
 import requests
-from doppel.constants import RETRYABLE_REQUEST_ERRORS
+from doppel.constants import DOPPEL_ATTRIBUTION_HEADERS, RETRYABLE_REQUEST_ERRORS
 from tenacity import (
     retry,
     retry_if_exception,
@@ -26,6 +26,7 @@ class ConnectorClient:
 
         self.session = requests.Session()
         headers = {
+            **DOPPEL_ATTRIBUTION_HEADERS,
             "x-api-key": self.config.doppel.api_key,
             "accept": "application/json",
         }

--- a/external-import/doppel/src/doppel/client_api.py
+++ b/external-import/doppel/src/doppel/client_api.py
@@ -124,7 +124,9 @@ class ConnectorClient:
         """
         Retrieve alerts from api
         """
-        url = f"{self.config.doppel.api_base_url}{self.config.doppel.alerts_endpoint}"
+        base_url = str(self.config.doppel.api_base_url).rstrip("/")
+        alerts_endpoint = self.config.doppel.alerts_endpoint.lstrip("/")
+        url = f"{base_url}/{alerts_endpoint}"
 
         # Dynamically set retry settings
         self._request_data.retry.wait = wait_fixed(self.config.doppel.retry_delay)
@@ -152,12 +154,15 @@ class ConnectorClient:
             "[DoppelConnector] Fetched first page of alerts",
             {"url": url, "params": params, "metadata": metadata},
         )
+        total_pages = metadata.get("total_pages", 0)
         with ThreadPoolExecutor(max_workers=10) as executor:
             futures = [
                 executor.submit(
-                    self._get_alerts, url, params, page, metadata["total_pages"]
+                    self._get_alerts, url, params, current_page, total_pages
                 )
-                for page in range(1, metadata["total_pages"] + 1)
+                # Doppel pagination is zero-indexed and total_pages is a count,
+                # so the final valid page is total_pages - 1.
+                for current_page in range(page + 1, total_pages)
             ]
             for future in as_completed(futures):
                 res.extend(future.result())

--- a/external-import/doppel/src/doppel/constants.py
+++ b/external-import/doppel/src/doppel/constants.py
@@ -13,6 +13,7 @@ DOPPEL_ALERT_TYPES_EXCEPT_DOMAIN_AND_TELCO = [
     "ecommerce",
     "crypto",
     "email",
+    "suspicious_emails",
     "paid_ads",
     "darkweb",
 ]

--- a/external-import/doppel/src/doppel/converter_to_stix.py
+++ b/external-import/doppel/src/doppel/converter_to_stix.py
@@ -661,8 +661,7 @@ class ConverterToStix:
                     "value": calculate_priority(alert.get("score", 0)),
                 }
             )
-            if alert.get("severity") is not None:
-                updates.append({"key": "severity", "value": alert["severity"]})
+            updates.append({"key": "severity", "value": alert.get("severity") or ""})
 
         return updates
 

--- a/external-import/doppel/src/doppel/converter_to_stix.py
+++ b/external-import/doppel/src/doppel/converter_to_stix.py
@@ -347,7 +347,7 @@ class ConverterToStix:
     def _find_rft_cases_by_alert_id(self, alert_id: str, entity_value: str) -> list:
         """
         Find RFT cases by alert_id stored in x_opencti_workflow_id.
-        Used for revocation during reversion workflow.
+        Used to refresh existing cases across queue-state transitions.
 
         :param alert_id: Doppel alert ID
         :return: List of RFT case objects or empty list
@@ -637,13 +637,15 @@ class ConverterToStix:
     def _source_owned_field_updates(
         self,
         alert: dict,
-        revoked: bool,
         include_score: bool = True,
         include_case_fields: bool = False,
     ) -> list[dict]:
         """Build patches for mutable fields sourced from the Doppel alert."""
         updates = [
-            {"key": "revoked", "value": revoked},
+            # Queue state is workflow metadata, not a STIX validity verdict.
+            # Keep connector-managed objects active and repair objects that older
+            # connector versions revoked during normal lifecycle transitions.
+            {"key": "revoked", "value": False},
             {"key": "description", "value": build_description(alert)},
         ]
         if include_score:
@@ -772,34 +774,22 @@ class ConverterToStix:
     def _handle_indicators_existing(
         self, existing_indicators, alert, observables, stix_objects
     ):
-        """When an indicator for given alert data already exists.
-
-        Here we need to consider both the cases - actioned (TakenDown/Actioned) + Non-Actioned(Rest all)
-            If actioned - Update indicator with latest data.
-            If non-actioned - Revoke the indicator as part of reversion workflow and update indicator with latest data.
-        """
+        """Refresh an existing indicator without treating queue state as revocation."""
 
         alert_id = alert.get("id")
         for indicator in existing_indicators:
-
-            in_taken_down_state = in_takedown_state(alert.get("queue_state"))
-
-            # If taken_down/actioned = False
-            # If any other state = True
-            revoke_indicator = not in_taken_down_state
-
             self.helper.connector_logger.info(
-                "[DoppelConverter] Updating indicator revoke status",
+                "[DoppelConverter] Refreshing existing indicator",
                 meta={
                     "alert_id": alert_id,
                     "indicator_standard_id": indicator["standard_id"],
-                    "revoked": revoke_indicator,
+                    "queue_state": alert.get("queue_state"),
                 },
             )
 
             self.helper.api.indicator.update_field(
                 id=indicator["id"],
-                input=self._source_owned_field_updates(alert, revoked=revoke_indicator),
+                input=self._source_owned_field_updates(alert),
             )
             self._refresh_external_references(indicator["id"], alert)
             # Add Note.
@@ -963,27 +953,16 @@ class ConverterToStix:
     def _handle_rft_cases_existing(
         self, existing_rft_cases, alert, observables, stix_objects
     ):
-        """When an RFT case for given alert data already exists.
-
-        Here we need to consider both the cases - actioned (TakenDown/Actioned) + Non-Actioned(Rest all)
-            If actioned - Update RFT case with latest data.
-            If non-actioned - Revoke the RFT case as part of reversion workflow and update RFT case with latest data.
-        """
+        """Refresh an existing RFT case across Doppel queue transitions."""
 
         alert_id = alert.get("id")
         for rft_case in existing_rft_cases:
-            in_taken_down_state = in_takedown_state(alert.get("queue_state"))
-
-            # If taken_down/actioned => Revoke = False
-            # If any other state => Revoke = True
-            revoke_rft_case = not in_taken_down_state
-
             self.helper.connector_logger.info(
-                "[DoppelConverter] Updating RFT case revoke status",
+                "[DoppelConverter] Refreshing existing RFT case",
                 meta={
                     "alert_id": alert_id,
                     "case_ref": rft_case.get("standard_id") or rft_case.get("id"),
-                    "revoked": revoke_rft_case,
+                    "queue_state": alert.get("queue_state"),
                 },
             )
 
@@ -991,7 +970,6 @@ class ConverterToStix:
                 id=rft_case["id"],
                 input=self._source_owned_field_updates(
                     alert,
-                    revoked=revoke_rft_case,
                     # Case-RFT rejects x_opencti_score as an incompatible
                     # attribute; its score-derived mutable field is priority.
                     include_score=False,
@@ -1067,10 +1045,7 @@ class ConverterToStix:
             )
 
     def _handle_note_addition(self, obj, alert, observables, stix_objects):
-        """Handle update of note content when indicator already exists.
-
-        Whenever we have an indicator already present for given alert data and if we find that the indicator is revoked but alert is in actioned/taken down state - we will update the note content to reflect the current status of the alert.
-        """
+        """Add a note describing the current Doppel queue state."""
         ### Adding Note with details about update in Doppel queue state.
         self.helper.connector_logger.info(
             "[DoppelConverter] Note addition",
@@ -1080,7 +1055,7 @@ class ConverterToStix:
         alert_id = alert.get("id")
         queue_state = alert.get("queue_state")
         observable_id = observables[0].get("id")
-        note_content = f"Doppel alert queue state updated to {alert.get('queue_state')}. Setting revoked to {not in_takedown_state(queue_state)}."
+        note_content = f"Doppel alert queue state updated to {queue_state}."
 
         # API-returned objects expose their STIX id as "standard_id"; newly-created
         # serialized dicts expose it as "id". Prefer standard_id so the ref is always
@@ -1143,16 +1118,8 @@ class ConverterToStix:
                     labels_to_remove = self._get_labels_to_remove(
                         target_obj_type,
                         target_object,
-                        include_revoked_false_positive=in_takedown_state(
-                            alert.get("queue_state")
-                        ),
+                        remove_legacy_revoked_false_positive=True,
                     )
-                    # When the alert is no longer in takedown state the entity is
-                    # revoked as a false positive, so it should gain the
-                    # "revoked-false-positive" label; an actioned/taken-down
-                    # entity should have it removed.
-                    if not in_takedown_state(alert.get("queue_state")):
-                        new_labels.append("revoked-false-positive")
 
                     for label_name in labels_to_remove or []:
                         self.helper.api.stix_domain_object.remove_label(
@@ -1185,17 +1152,8 @@ class ConverterToStix:
                     labels_to_remove = self._get_labels_to_remove(
                         target_obj_type,
                         target_object,
-                        include_revoked_false_positive=in_takedown_state(
-                            alert.get("queue_state")
-                        ),
+                        remove_legacy_revoked_false_positive=True,
                     )
-
-                    # When the alert is no longer in takedown state the entity is
-                    # revoked as a false positive, so it should gain the
-                    # "revoked-false-positive" label; an actioned/taken-down
-                    # entity should have it removed.
-                    if not in_takedown_state(alert.get("queue_state")):
-                        new_labels.append("revoked-false-positive")
 
                     for label_name in labels_to_remove or []:
                         self.helper.api.stix_domain_object.remove_label(
@@ -1213,7 +1171,7 @@ class ConverterToStix:
             )
 
     def _get_labels_to_remove(
-        self, target_obj_type, obj, include_revoked_false_positive=False
+        self, target_obj_type, obj, remove_legacy_revoked_false_positive=False
     ):
         """Return labels added by Doppel Alert."""
         managed_prefixes = (
@@ -1243,7 +1201,7 @@ class ConverterToStix:
             for label in (obj or {}).get("objectLabel", [])
             if label.get("value", "").startswith(managed_prefixes)
             or (
-                include_revoked_false_positive
+                remove_legacy_revoked_false_positive
                 and label.get("value") == "revoked-false-positive"
             )
         ]

--- a/external-import/doppel/src/doppel/converter_to_stix.py
+++ b/external-import/doppel/src/doppel/converter_to_stix.py
@@ -680,11 +680,10 @@ class ConverterToStix:
                     else None
                 )
                 if not external_reference_id:
-                    self.helper.connector_logger.warning(
-                        "[DoppelConverter] External reference upsert returned no id",
-                        meta={"alert_id": alert.get("id"), "object_id": object_id},
+                    raise RuntimeError(
+                        "OpenCTI external reference upsert returned no id "
+                        f"for Doppel alert {alert.get('id')}"
                     )
-                    continue
                 self.helper.api.stix_domain_object.add_external_reference(
                     id=object_id,
                     external_reference_id=external_reference_id,
@@ -698,6 +697,7 @@ class ConverterToStix:
                         "error": str(e),
                     },
                 )
+                raise
 
     def _handle_grouping_case_creation(self, alert, observables, stix_objects):
         """

--- a/external-import/doppel/src/doppel/converter_to_stix.py
+++ b/external-import/doppel/src/doppel/converter_to_stix.py
@@ -633,6 +633,71 @@ class ConverterToStix:
             if existing:
                 self._handle_labels(alert, "Observable", existing)
 
+    def _source_owned_field_updates(
+        self,
+        alert: dict,
+        revoked: bool,
+        include_score: bool = True,
+        include_case_fields: bool = False,
+    ) -> list[dict]:
+        """Build patches for mutable fields sourced from the Doppel alert."""
+        updates = [
+            {"key": "revoked", "value": revoked},
+            {"key": "description", "value": build_description(alert)},
+        ]
+        if include_score:
+            custom_properties = build_custom_properties(alert, self.author.id)
+            updates.append(
+                {
+                    "key": "x_opencti_score",
+                    "value": custom_properties["x_opencti_score"],
+                }
+            )
+
+        if include_case_fields:
+            updates.append(
+                {
+                    "key": "priority",
+                    "value": calculate_priority(alert.get("score", 0)),
+                }
+            )
+            if alert.get("severity") is not None:
+                updates.append({"key": "severity", "value": alert["severity"]})
+
+        return updates
+
+    def _refresh_external_references(self, object_id: str, alert: dict) -> None:
+        """Upsert Doppel references and attach them without removing user references."""
+        for reference in build_external_references(alert):
+            try:
+                external_reference = self.helper.api.external_reference.create(
+                    **reference, update=True
+                )
+                external_reference_id = (
+                    external_reference.get("id")
+                    if isinstance(external_reference, dict)
+                    else None
+                )
+                if not external_reference_id:
+                    self.helper.connector_logger.warning(
+                        "[DoppelConverter] External reference upsert returned no id",
+                        meta={"alert_id": alert.get("id"), "object_id": object_id},
+                    )
+                    continue
+                self.helper.api.stix_domain_object.add_external_reference(
+                    id=object_id,
+                    external_reference_id=external_reference_id,
+                )
+            except Exception as e:
+                self.helper.connector_logger.warning(
+                    "[DoppelConverter] Failed to refresh external reference",
+                    meta={
+                        "alert_id": alert.get("id"),
+                        "object_id": object_id,
+                        "error": str(e),
+                    },
+                )
+
     def _handle_grouping_case_creation(self, alert, observables, stix_objects):
         """
         Handle creation of grouping case and relationships with observables
@@ -735,8 +800,9 @@ class ConverterToStix:
 
             self.helper.api.indicator.update_field(
                 id=indicator["id"],
-                input={"key": "revoked", "value": revoke_indicator},
+                input=self._source_owned_field_updates(alert, revoked=revoke_indicator),
             )
+            self._refresh_external_references(indicator["id"], alert)
             # Add Note.
             _ = self._handle_note_addition(indicator, alert, observables, stix_objects)
 
@@ -924,8 +990,16 @@ class ConverterToStix:
 
             self.helper.api.stix_domain_object.update_field(
                 id=rft_case["id"],
-                input={"key": "revoked", "value": revoke_rft_case},
+                input=self._source_owned_field_updates(
+                    alert,
+                    revoked=revoke_rft_case,
+                    # Case-RFT rejects x_opencti_score as an incompatible
+                    # attribute; its score-derived mutable field is priority.
+                    include_score=False,
+                    include_case_fields=True,
+                ),
             )
+            self._refresh_external_references(rft_case["id"], alert)
 
             # Add Note.
             _ = self._handle_note_addition(rft_case, alert, observables, stix_objects)
@@ -1068,7 +1142,11 @@ class ConverterToStix:
                 indicator_id = target_object.get("id")
                 if indicator_id:
                     labels_to_remove = self._get_labels_to_remove(
-                        target_obj_type, target_object
+                        target_obj_type,
+                        target_object,
+                        include_revoked_false_positive=in_takedown_state(
+                            alert.get("queue_state")
+                        ),
                     )
                     # When the alert is no longer in takedown state the entity is
                     # revoked as a false positive, so it should gain the
@@ -1076,8 +1154,6 @@ class ConverterToStix:
                     # entity should have it removed.
                     if not in_takedown_state(alert.get("queue_state")):
                         new_labels.append("revoked-false-positive")
-                    else:
-                        labels_to_remove.append("revoked-false-positive")
 
                     for label_name in labels_to_remove or []:
                         self.helper.api.stix_domain_object.remove_label(
@@ -1108,7 +1184,11 @@ class ConverterToStix:
                 RFT_case_id = target_object.get("id")
                 if RFT_case_id:
                     labels_to_remove = self._get_labels_to_remove(
-                        target_obj_type, target_object
+                        target_obj_type,
+                        target_object,
+                        include_revoked_false_positive=in_takedown_state(
+                            alert.get("queue_state")
+                        ),
                     )
 
                     # When the alert is no longer in takedown state the entity is
@@ -1117,8 +1197,6 @@ class ConverterToStix:
                     # entity should have it removed.
                     if not in_takedown_state(alert.get("queue_state")):
                         new_labels.append("revoked-false-positive")
-                    else:
-                        labels_to_remove.append("revoked-false-positive")
 
                     for label_name in labels_to_remove or []:
                         self.helper.api.stix_domain_object.remove_label(
@@ -1135,7 +1213,9 @@ class ConverterToStix:
                 meta={"alert_id": alert.get("id"), "error": str(e)},
             )
 
-    def _get_labels_to_remove(self, target_obj_type, obj):
+    def _get_labels_to_remove(
+        self, target_obj_type, obj, include_revoked_false_positive=False
+    ):
         """Return labels added by Doppel Alert."""
         managed_prefixes = (
             "queue_state:",
@@ -1163,6 +1243,10 @@ class ConverterToStix:
             label["value"]
             for label in (obj or {}).get("objectLabel", [])
             if label.get("value", "").startswith(managed_prefixes)
+            or (
+                include_revoked_false_positive
+                and label.get("value") == "revoked-false-positive"
+            )
         ]
 
         return labels

--- a/external-import/doppel/src/doppel/converter_to_stix.py
+++ b/external-import/doppel/src/doppel/converter_to_stix.py
@@ -9,6 +9,7 @@ from doppel.stix_helpers import (
     build_description,
     build_external_references,
     build_labels,
+    calculate_opencti_score,
     calculate_priority,
     in_takedown_state,
 )
@@ -646,11 +647,10 @@ class ConverterToStix:
             {"key": "description", "value": build_description(alert)},
         ]
         if include_score:
-            custom_properties = build_custom_properties(alert, self.author.id)
             updates.append(
                 {
                     "key": "x_opencti_score",
-                    "value": custom_properties["x_opencti_score"],
+                    "value": calculate_opencti_score(alert.get("score")),
                 }
             )
 

--- a/external-import/doppel/src/doppel/stix_helpers.py
+++ b/external-import/doppel/src/doppel/stix_helpers.py
@@ -46,16 +46,6 @@ def in_takedown_state(queue_state) -> bool:
     return _normalize_queue_state(queue_state) in {"actioned", "taken_down"}
 
 
-def is_reverted_state(queue_state) -> bool:
-    """Check if alert is reverted from takedown"""
-    return _normalize_queue_state(queue_state) in {
-        "archived",
-        "needs_confirmation",
-        "doppel_review",
-        "monitoring",
-    }
-
-
 def build_external_references(alert) -> list:
     """
     Build external references for observables/indicators

--- a/external-import/doppel/src/doppel/stix_helpers.py
+++ b/external-import/doppel/src/doppel/stix_helpers.py
@@ -19,7 +19,7 @@ def calculate_priority(score) -> str:
 def calculate_opencti_score(score) -> int:
     """Scale a Doppel score to OpenCTI's integer score representation."""
     try:
-        return int(float(score) * 100) if score is not None else 0
+        return round(float(score) * 100) if score is not None else 0
     except (ValueError, TypeError):
         return 0
 

--- a/external-import/doppel/src/doppel/stix_helpers.py
+++ b/external-import/doppel/src/doppel/stix_helpers.py
@@ -16,6 +16,14 @@ def calculate_priority(score) -> str:
         return "P4"
 
 
+def calculate_opencti_score(score) -> int:
+    """Scale a Doppel score to OpenCTI's integer score representation."""
+    try:
+        return int(float(score) * 100) if score is not None else 0
+    except (ValueError, TypeError):
+        return 0
+
+
 def _normalize_queue_state(queue_state) -> str:
     """
     Normalize a Doppel queue state for robust comparison.
@@ -150,16 +158,9 @@ def build_custom_properties(alert, author_id) -> dict:
     :return: Dict of custom properties
     """
     custom_properties = {}
-    raw_score = alert.get("score")
-    try:
-        # Source API returns a score like 0.34
-        # It has to be scaled to 34 in OpenCTI (multiplied by 100)
-        score = int(float(raw_score) * 100) if raw_score is not None else 0
-    except (ValueError, TypeError):
-        score = 0
 
     custom_properties["x_opencti_created_by_ref"] = author_id
-    custom_properties["x_opencti_score"] = score
+    custom_properties["x_opencti_score"] = calculate_opencti_score(alert.get("score"))
     custom_properties["x_opencti_workflow_id"] = alert.get(
         "id"
     )  # Store alert_id for lookup

--- a/external-import/doppel/tests/test_client_api.py
+++ b/external-import/doppel/tests/test_client_api.py
@@ -1,0 +1,85 @@
+from unittest.mock import MagicMock
+
+import pytest
+from doppel.client_api import ConnectorClient
+
+
+@pytest.fixture
+def client():
+    helper = MagicMock()
+    config = MagicMock()
+    # Pydantic's HttpUrl serializes a path-like base URL with a trailing slash.
+    config.doppel.api_base_url = "https://api.doppel.test/v1/"
+    config.doppel.alerts_endpoint = "/alerts"
+    config.doppel.api_key = "test-api-key"
+    config.doppel.user_api_key = None
+    config.doppel.organization_code = None
+    config.doppel.retry_delay = 0
+    config.doppel.max_retries = 1
+
+    return ConnectorClient(helper=helper, config=config)
+
+
+def _response(payload):
+    response = MagicMock()
+    response.json.return_value = payload
+    return response
+
+
+@pytest.mark.parametrize(
+    ("total_pages", "expected_pages"),
+    [
+        (0, [0]),
+        (1, [0]),
+        (3, [0, 1, 2]),
+    ],
+)
+def test_get_alerts_fetches_each_zero_indexed_page_once(
+    client, total_pages, expected_pages
+):
+    def request_data(_url, params):
+        page = params["page"]
+        return _response(
+            {
+                "alerts": [{"id": f"alert-{page}"}] if total_pages else [],
+                "metadata": {"total_pages": total_pages},
+            }
+        )
+
+    client._request_data = MagicMock(side_effect=request_data)
+    client._request_data.retry = MagicMock()
+
+    alerts = client.get_alerts("2026-08-03T00:00:00Z")
+
+    requested_pages = sorted(
+        call.kwargs["params"]["page"] for call in client._request_data.call_args_list
+    )
+    assert requested_pages == expected_pages
+    assert {call.args[0] for call in client._request_data.call_args_list} == {
+        "https://api.doppel.test/v1/alerts"
+    }
+    assert sorted(alert["id"] for alert in alerts) == [
+        f"alert-{page}" for page in expected_pages if total_pages
+    ]
+
+
+def test_get_alerts_continues_from_requested_start_page(client):
+    def request_data(_url, params):
+        page = params["page"]
+        return _response(
+            {
+                "alerts": [{"id": f"alert-{page}"}],
+                "metadata": {"total_pages": 4},
+            }
+        )
+
+    client._request_data = MagicMock(side_effect=request_data)
+    client._request_data.retry = MagicMock()
+
+    alerts = client.get_alerts("2026-08-03T00:00:00Z", page=2)
+
+    requested_pages = sorted(
+        call.kwargs["params"]["page"] for call in client._request_data.call_args_list
+    )
+    assert requested_pages == [2, 3]
+    assert sorted(alert["id"] for alert in alerts) == ["alert-2", "alert-3"]

--- a/external-import/doppel/tests/test_client_api.py
+++ b/external-import/doppel/tests/test_client_api.py
@@ -26,6 +26,11 @@ def _response(payload):
     return response
 
 
+def test_client_sets_attribution_headers(client):
+    assert client.session.headers["x-doppel-client"] == "opencti/7.260901.0"
+    assert client.session.headers["User-Agent"] == "doppel-opencti/7.260901.0"
+
+
 @pytest.mark.parametrize(
     ("total_pages", "expected_pages"),
     [

--- a/external-import/doppel/tests/test_converter_to_stix.py
+++ b/external-import/doppel/tests/test_converter_to_stix.py
@@ -822,13 +822,22 @@ def test_existing_indicator_refreshes_source_owned_fields_and_reference(converte
     )
 
 
-def test_existing_rft_case_refreshes_source_owned_fields_and_reference(converter):
+@pytest.mark.parametrize(
+    ("severity", "expected_severity"),
+    [
+        ("high", "high"),
+        (None, ""),
+    ],
+)
+def test_existing_rft_case_refreshes_source_owned_fields_and_reference(
+    converter, severity, expected_severity
+):
     converter.enable_rft_case = True
     alert = _domains_alert(
         alert_id="alert_rft_refresh",
         queue_state="taken_down",
         score=0.91,
-        severity="high",
+        severity=severity,
         notes="Takedown completed",
         source="Doppel",
         doppel_link="https://app.doppel.com/alerts/alert_rft_refresh",
@@ -855,7 +864,7 @@ def test_existing_rft_case_refreshes_source_owned_fields_and_reference(converter
     assert "**Product**: domains" in description_update["value"]
     assert "**Notes**: Takedown completed" in description_update["value"]
     assert {"key": "priority", "value": "P1"} in field_patch
-    assert {"key": "severity", "value": "high"} in field_patch
+    assert {"key": "severity", "value": expected_severity} in field_patch
     assert not any(update["key"] == "x_opencti_score" for update in field_patch)
     assert not any(update["key"] == "modified" for update in field_patch)
 

--- a/external-import/doppel/tests/test_converter_to_stix.py
+++ b/external-import/doppel/tests/test_converter_to_stix.py
@@ -853,6 +853,37 @@ def test_existing_indicator_refreshes_source_owned_fields_and_reference(converte
 
 
 @pytest.mark.parametrize(
+    ("reference_result", "reference_error", "expected_message"),
+    [
+        ({}, None, "returned no id"),
+        (None, RuntimeError("OpenCTI unavailable"), "OpenCTI unavailable"),
+    ],
+)
+def test_existing_indicator_external_reference_failure_aborts_replay(
+    converter, reference_result, reference_error, expected_message
+):
+    """A partial refresh must be retried instead of advancing connector state."""
+    alert = _domains_alert(
+        alert_id="alert_reference_retry",
+        queue_state="actioned",
+    )
+    existing_indicator = {
+        "id": "internal-indicator-id",
+        "standard_id": "indicator--e5a6f272-3595-4673-9097-f5be0df2a926",
+        "objectLabel": [],
+    }
+    converter.helper.api.indicator.list.return_value = [existing_indicator]
+    converter.helper.api.stix_cyber_observable.read.return_value = None
+    converter.helper.api.external_reference.create.return_value = reference_result
+    converter.helper.api.external_reference.create.side_effect = reference_error
+
+    with pytest.raises(RuntimeError, match=expected_message):
+        converter.convert_alerts_to_stix([alert])
+
+    converter.helper.api.stix_domain_object.add_external_reference.assert_not_called()
+
+
+@pytest.mark.parametrize(
     ("severity", "expected_severity"),
     [
         ("high", "high"),

--- a/external-import/doppel/tests/test_converter_to_stix.py
+++ b/external-import/doppel/tests/test_converter_to_stix.py
@@ -15,6 +15,10 @@ def mock_helper():
     helper.api.stix_domain_object = MagicMock()
     helper.api.indicator = MagicMock()
     helper.api.case_rft = MagicMock()
+    helper.api.external_reference = MagicMock()
+    helper.api.external_reference.create.return_value = {
+        "id": "external-reference--11111111-1111-4111-8111-111111111111"
+    }
 
     # Simple bundle creation bypass
     helper.stix2_create_bundle.side_effect = lambda objects: objects
@@ -157,11 +161,9 @@ def test_convert_alerts_to_stix_existing_indicator_reversion(converter):
     # When
     converter.convert_alerts_to_stix([alert])
 
-    # Then verify that the update_field API was called to revoke the indicator
-    converter.helper.api.indicator.update_field.assert_called_with(
-        id="e5a6f272-3595-4673-9097-f5be0df2a926",
-        input={"key": "revoked", "value": True},
-    )
+    # Then verify that the source-owned fields include the revoked state.
+    field_patch = converter.helper.api.indicator.update_field.call_args.kwargs["input"]
+    assert {"key": "revoked", "value": True} in field_patch
 
 
 def test_convert_alerts_to_stix_with_optional_cases_enabled(converter):
@@ -382,10 +384,8 @@ def test_indicator_found_via_name_search_fallback(converter):
     converter.convert_alerts_to_stix([alert])
 
     # Existing indicator path updates revoked=False (actioned state).
-    converter.helper.api.indicator.update_field.assert_called_with(
-        id="indicator--e5a6f272-3595-4673-9097-f5be0df2a926",
-        input={"key": "revoked", "value": False},
-    )
+    field_patch = converter.helper.api.indicator.update_field.call_args.kwargs["input"]
+    assert {"key": "revoked", "value": False} in field_patch
 
 
 def test_rft_case_new_creation(converter):
@@ -431,10 +431,10 @@ def test_rft_case_existing_revoked_on_reversion(converter):
 
     converter.convert_alerts_to_stix([alert])
 
-    converter.helper.api.stix_domain_object.update_field.assert_called_with(
-        id="case-rft--11111111-1111-4111-8111-111111111111",
-        input={"key": "revoked", "value": True},
-    )
+    field_patch = converter.helper.api.stix_domain_object.update_field.call_args.kwargs[
+        "input"
+    ]
+    assert {"key": "revoked", "value": True} in field_patch
 
 
 def test_rft_case_found_via_name_search_fallback(converter):
@@ -455,10 +455,10 @@ def test_rft_case_found_via_name_search_fallback(converter):
     converter.convert_alerts_to_stix([alert])
 
     # Existing (actioned) -> revoked=False.
-    converter.helper.api.stix_domain_object.update_field.assert_called_with(
-        id="case-rft--22222222-2222-4222-8222-222222222222",
-        input={"key": "revoked", "value": False},
-    )
+    field_patch = converter.helper.api.stix_domain_object.update_field.call_args.kwargs[
+        "input"
+    ]
+    assert {"key": "revoked", "value": False} in field_patch
 
 
 def test_grouping_case_existing_updates_labels(converter):
@@ -574,6 +574,25 @@ def test_reverted_indicator_gains_revoked_false_positive_label(converter):
     )
 
 
+def test_reverted_indicator_does_not_churn_existing_false_positive_label(converter):
+    alert = _domains_alert(alert_id="alert_rfp_keep", queue_state="resolved")
+    existing_indicator = {
+        "id": "e5a6f272-3595-4673-9097-f5be0df2a926",
+        "standard_id": "indicator--e5a6f272-3595-4673-9097-f5be0df2a926",
+        "objectLabel": [{"value": "revoked-false-positive"}],
+    }
+    converter.helper.api.indicator.list.return_value = [existing_indicator]
+    converter.helper.api.stix_cyber_observable.read.return_value = None
+
+    converter.convert_alerts_to_stix([alert])
+
+    remove_calls = converter.helper.api.stix_domain_object.remove_label.call_args_list
+    assert not any(
+        call.kwargs.get("label_name") == "revoked-false-positive"
+        for call in remove_calls
+    )
+
+
 def test_takedown_indicator_removes_revoked_false_positive_label(converter):
     """An actioned/taken-down indicator must REMOVE the revoked-false-positive label."""
     alert = _domains_alert(alert_id="alert_rfp_rm", queue_state="actioned")
@@ -589,6 +608,26 @@ def test_takedown_indicator_removes_revoked_false_positive_label(converter):
 
     remove_calls = converter.helper.api.stix_domain_object.remove_label.call_args_list
     assert any(
+        call.kwargs.get("label_name") == "revoked-false-positive"
+        for call in remove_calls
+    )
+
+
+def test_takedown_indicator_does_not_remove_absent_false_positive_label(converter):
+    """Avoid a noisy API error when the false-positive label is already absent."""
+    alert = _domains_alert(alert_id="alert_rfp_absent", queue_state="actioned")
+    existing_indicator = {
+        "id": "e5a6f272-3595-4673-9097-f5be0df2a926",
+        "standard_id": "indicator--e5a6f272-3595-4673-9097-f5be0df2a926",
+        "objectLabel": [{"value": "queue_state:taken_down"}],
+    }
+    converter.helper.api.indicator.list.return_value = [existing_indicator]
+    converter.helper.api.stix_cyber_observable.read.return_value = None
+
+    converter.convert_alerts_to_stix([alert])
+
+    remove_calls = converter.helper.api.stix_domain_object.remove_label.call_args_list
+    assert not any(
         call.kwargs.get("label_name") == "revoked-false-positive"
         for call in remove_calls
     )
@@ -722,3 +761,103 @@ def test_create_case_rft_id_is_deterministic_without_created_at(converter):
     first = _case_id(converter.convert_alerts_to_stix([alert]))
     second = _case_id(converter.convert_alerts_to_stix([alert]))
     assert first == second
+
+
+def test_existing_indicator_refreshes_source_owned_fields_and_reference(converter):
+    alert = _domains_alert(
+        alert_id="alert_indicator_refresh",
+        queue_state="actioned",
+        score=0.42,
+        notes="Updated analyst context",
+        source="Doppel",
+        doppel_link="https://app.doppel.com/alerts/alert_indicator_refresh",
+        last_activity_timestamp="2026-08-03T10:15:00Z",
+        audit_logs=[
+            {
+                "timestamp": "2026-08-03T10:15:00Z",
+                "type": "queue_state",
+                "value": "actioned",
+                "changed_by": "analyst@example.com",
+            }
+        ],
+    )
+    existing_indicator = {
+        "id": "internal-indicator-id",
+        "standard_id": "indicator--e5a6f272-3595-4673-9097-f5be0df2a926",
+        "objectLabel": [],
+    }
+    converter.helper.api.indicator.list.return_value = [existing_indicator]
+    converter.helper.api.stix_cyber_observable.read.return_value = None
+
+    converter.convert_alerts_to_stix([alert])
+
+    field_patch = converter.helper.api.indicator.update_field.call_args.kwargs["input"]
+    assert {"key": "revoked", "value": False} in field_patch
+    description_update = next(
+        update for update in field_patch if update["key"] == "description"
+    )
+    assert "**Product**: domains" in description_update["value"]
+    assert "**Notes**: Updated analyst context" in description_update["value"]
+    assert {"key": "x_opencti_score", "value": 42} in field_patch
+    assert not any(update["key"] == "modified" for update in field_patch)
+
+    converter.helper.api.external_reference.create.assert_called_with(
+        source_name="Doppel",
+        url="https://app.doppel.com/alerts/alert_indicator_refresh",
+        external_id="alert_indicator_refresh",
+        description=(
+            "2026-08-03T10:15:00Z: queue_state - actioned " "(by analyst@example.com)"
+        ),
+        update=True,
+    )
+    converter.helper.api.stix_domain_object.add_external_reference.assert_called_with(
+        id="internal-indicator-id",
+        external_reference_id=(
+            "external-reference--11111111-1111-4111-8111-111111111111"
+        ),
+    )
+
+
+def test_existing_rft_case_refreshes_source_owned_fields_and_reference(converter):
+    converter.enable_rft_case = True
+    alert = _domains_alert(
+        alert_id="alert_rft_refresh",
+        queue_state="taken_down",
+        score=0.91,
+        severity="high",
+        notes="Takedown completed",
+        source="Doppel",
+        doppel_link="https://app.doppel.com/alerts/alert_rft_refresh",
+        last_activity_timestamp="2026-08-03T11:30:00Z",
+    )
+    existing_case = {
+        "id": "internal-rft-id",
+        "standard_id": "case-rft--11111111-1111-4111-8111-111111111111",
+        "objectLabel": [],
+    }
+    converter.helper.api.stix_cyber_observable.read.return_value = None
+    converter.helper.api.indicator.list.return_value = []
+    converter.helper.api.case_rft.list.return_value = [existing_case]
+
+    converter.convert_alerts_to_stix([alert])
+
+    field_patch = converter.helper.api.stix_domain_object.update_field.call_args.kwargs[
+        "input"
+    ]
+    assert {"key": "revoked", "value": False} in field_patch
+    description_update = next(
+        update for update in field_patch if update["key"] == "description"
+    )
+    assert "**Product**: domains" in description_update["value"]
+    assert "**Notes**: Takedown completed" in description_update["value"]
+    assert {"key": "priority", "value": "P1"} in field_patch
+    assert {"key": "severity", "value": "high"} in field_patch
+    assert not any(update["key"] == "x_opencti_score" for update in field_patch)
+    assert not any(update["key"] == "modified" for update in field_patch)
+
+    converter.helper.api.stix_domain_object.add_external_reference.assert_called_with(
+        id="internal-rft-id",
+        external_reference_id=(
+            "external-reference--11111111-1111-4111-8111-111111111111"
+        ),
+    )

--- a/external-import/doppel/tests/test_converter_to_stix.py
+++ b/external-import/doppel/tests/test_converter_to_stix.py
@@ -162,7 +162,9 @@ def test_convert_alerts_to_stix_existing_indicator_reversion(converter):
     converter.convert_alerts_to_stix([alert])
 
     # Then verify that the source-owned fields include the revoked state.
-    field_patch = converter.helper.api.indicator.update_field.call_args.kwargs["input"]
+    update_call = converter.helper.api.indicator.update_field.call_args
+    assert update_call.kwargs["id"] == mock_indicator["id"]
+    field_patch = update_call.kwargs["input"]
     assert {"key": "revoked", "value": True} in field_patch
 
 
@@ -384,7 +386,9 @@ def test_indicator_found_via_name_search_fallback(converter):
     converter.convert_alerts_to_stix([alert])
 
     # Existing indicator path updates revoked=False (actioned state).
-    field_patch = converter.helper.api.indicator.update_field.call_args.kwargs["input"]
+    update_call = converter.helper.api.indicator.update_field.call_args
+    assert update_call.kwargs["id"] == matching_indicator["id"]
+    field_patch = update_call.kwargs["input"]
     assert {"key": "revoked", "value": False} in field_patch
 
 
@@ -431,9 +435,9 @@ def test_rft_case_existing_revoked_on_reversion(converter):
 
     converter.convert_alerts_to_stix([alert])
 
-    field_patch = converter.helper.api.stix_domain_object.update_field.call_args.kwargs[
-        "input"
-    ]
+    update_call = converter.helper.api.stix_domain_object.update_field.call_args
+    assert update_call.kwargs["id"] == existing_case["id"]
+    field_patch = update_call.kwargs["input"]
     assert {"key": "revoked", "value": True} in field_patch
 
 
@@ -455,9 +459,9 @@ def test_rft_case_found_via_name_search_fallback(converter):
     converter.convert_alerts_to_stix([alert])
 
     # Existing (actioned) -> revoked=False.
-    field_patch = converter.helper.api.stix_domain_object.update_field.call_args.kwargs[
-        "input"
-    ]
+    update_call = converter.helper.api.stix_domain_object.update_field.call_args
+    assert update_call.kwargs["id"] == matching_case["id"]
+    field_patch = update_call.kwargs["input"]
     assert {"key": "revoked", "value": False} in field_patch
 
 

--- a/external-import/doppel/tests/test_converter_to_stix.py
+++ b/external-import/doppel/tests/test_converter_to_stix.py
@@ -124,24 +124,23 @@ def test_convert_alerts_to_stix_domains_product_with_ip(converter):
     assert "based-on" in serialized_bundle
 
 
-def test_convert_alerts_to_stix_existing_indicator_reversion(converter):
-    """
-    Scenario 3: Test reversion state updates against an already existing indicator.
-    Covers: _find_indicators_by_alert_id_or_entity_value,
-            _handle_indicators_existing, setting revoked=True,
-            and managed prefix label cleanups via _handle_labels.
-    """
-    # Given an alert moving to an un-actioned/reverted state
+@pytest.mark.parametrize(
+    "queue_state",
+    ["monitoring", "doppel_review", "needs_confirmation", "actioned", "taken_down"],
+)
+def test_existing_indicator_stays_active_across_revival_lifecycle(
+    converter, queue_state
+):
+    """Doppel workflow transitions must not revoke an existing STIX Indicator."""
     alert = {
-        "id": "alert_revert_789",
+        "id": "alert_revival_789",
         "product": "domains",
-        "entity": "reverted-domain.com",
-        "queue_state": "resolved",  # Not a takedown state -> triggers reversion
+        "entity": "revived-domain.com",
+        "queue_state": queue_state,
         "score": 0.4,
         "created_at": "2026-06-11T09:00:00Z",
     }
 
-    # Mocking that the indicator already exists in OpenCTI.
     # Real pycti API responses return "id" as an internal OpenCTI UUID (no "--"),
     # not a STIX identifier — only "standard_id" is the valid STIX id.
     mock_indicator = {
@@ -161,11 +160,20 @@ def test_convert_alerts_to_stix_existing_indicator_reversion(converter):
     # When
     converter.convert_alerts_to_stix([alert])
 
-    # Then verify that the source-owned fields include the revoked state.
+    # The Indicator remains valid while queue labels carry the Doppel lifecycle.
     update_call = converter.helper.api.indicator.update_field.call_args
     assert update_call.kwargs["id"] == mock_indicator["id"]
     field_patch = update_call.kwargs["input"]
-    assert {"key": "revoked", "value": True} in field_patch
+    assert {"key": "revoked", "value": False} in field_patch
+    added_labels = converter.helper.api.stix_domain_object.add_label.call_args_list
+    assert any(
+        call.kwargs.get("label_name") == f"queue_state:{queue_state}"
+        for call in added_labels
+    )
+    assert not any(
+        call.kwargs.get("label_name") == "revoked-false-positive"
+        for call in added_labels
+    )
 
 
 def test_convert_alerts_to_stix_with_optional_cases_enabled(converter):
@@ -449,14 +457,17 @@ def test_rft_case_new_not_takedown_is_skipped(converter):
     assert "case-rft" not in str(result)
 
 
-def test_rft_case_existing_revoked_on_reversion(converter):
-    """Covers _handle_rft_cases_existing revoke + note + RFTCase labels."""
+def test_rft_case_stays_active_during_revival(converter):
+    """RFT cases remain valid while Doppel workflow labels are refreshed."""
     converter.enable_rft_case = True
-    alert = _domains_alert(alert_id="alert_rft_exist", queue_state="resolved")
+    alert = _domains_alert(alert_id="alert_rft_exist", queue_state="doppel_review")
     existing_case = {
         "id": "case-rft--11111111-1111-4111-8111-111111111111",
         "standard_id": "case-rft--11111111-1111-4111-8111-111111111111",
-        "objectLabel": [{"value": "queue_state:taken_down"}],
+        "objectLabel": [
+            {"value": "queue_state:monitoring"},
+            {"value": "revoked-false-positive"},
+        ],
     }
     converter.helper.api.stix_cyber_observable.read.return_value = None
     converter.helper.api.indicator.list.return_value = []
@@ -467,7 +478,12 @@ def test_rft_case_existing_revoked_on_reversion(converter):
     update_call = converter.helper.api.stix_domain_object.update_field.call_args
     assert update_call.kwargs["id"] == existing_case["id"]
     field_patch = update_call.kwargs["input"]
-    assert {"key": "revoked", "value": True} in field_patch
+    assert {"key": "revoked", "value": False} in field_patch
+    remove_calls = converter.helper.api.stix_domain_object.remove_label.call_args_list
+    assert any(
+        call.kwargs.get("label_name") == "revoked-false-positive"
+        for call in remove_calls
+    )
 
 
 def test_rft_case_found_via_name_search_fallback(converter):
@@ -588,9 +604,9 @@ def test_existing_rft_case_creates_related_to_relationship(converter):
     )
 
 
-def test_reverted_indicator_gains_revoked_false_positive_label(converter):
-    """Reverting (not-takedown) must ADD the revoked-false-positive label."""
-    alert = _domains_alert(alert_id="alert_rfp_add", queue_state="resolved")
+def test_revival_does_not_add_revoked_false_positive_label(converter):
+    """A normal workflow transition must not be inferred as a false positive."""
+    alert = _domains_alert(alert_id="alert_rfp_add", queue_state="doppel_review")
     existing_indicator = {
         "id": "e5a6f272-3595-4673-9097-f5be0df2a926",
         "standard_id": "indicator--e5a6f272-3595-4673-9097-f5be0df2a926",
@@ -602,33 +618,18 @@ def test_reverted_indicator_gains_revoked_false_positive_label(converter):
     converter.convert_alerts_to_stix([alert])
 
     add_calls = converter.helper.api.stix_domain_object.add_label.call_args_list
-    assert any(
+    assert not any(
         call.kwargs.get("label_name") == "revoked-false-positive" for call in add_calls
     )
 
 
-def test_reverted_indicator_does_not_churn_existing_false_positive_label(converter):
-    alert = _domains_alert(alert_id="alert_rfp_keep", queue_state="resolved")
-    existing_indicator = {
-        "id": "e5a6f272-3595-4673-9097-f5be0df2a926",
-        "standard_id": "indicator--e5a6f272-3595-4673-9097-f5be0df2a926",
-        "objectLabel": [{"value": "revoked-false-positive"}],
-    }
-    converter.helper.api.indicator.list.return_value = [existing_indicator]
-    converter.helper.api.stix_cyber_observable.read.return_value = None
-
-    converter.convert_alerts_to_stix([alert])
-
-    remove_calls = converter.helper.api.stix_domain_object.remove_label.call_args_list
-    assert not any(
-        call.kwargs.get("label_name") == "revoked-false-positive"
-        for call in remove_calls
-    )
-
-
-def test_takedown_indicator_removes_revoked_false_positive_label(converter):
-    """An actioned/taken-down indicator must REMOVE the revoked-false-positive label."""
-    alert = _domains_alert(alert_id="alert_rfp_rm", queue_state="actioned")
+@pytest.mark.parametrize(
+    "queue_state",
+    ["monitoring", "doppel_review", "needs_confirmation", "actioned", "taken_down"],
+)
+def test_replay_removes_legacy_revoked_false_positive_label(converter, queue_state):
+    """Every lifecycle state cleans up the obsolete connector-managed label."""
+    alert = _domains_alert(alert_id="alert_rfp_cleanup", queue_state=queue_state)
     existing_indicator = {
         "id": "e5a6f272-3595-4673-9097-f5be0df2a926",
         "standard_id": "indicator--e5a6f272-3595-4673-9097-f5be0df2a926",
@@ -646,9 +647,9 @@ def test_takedown_indicator_removes_revoked_false_positive_label(converter):
     )
 
 
-def test_takedown_indicator_does_not_remove_absent_false_positive_label(converter):
+def test_revival_does_not_remove_absent_false_positive_label(converter):
     """Avoid a noisy API error when the false-positive label is already absent."""
-    alert = _domains_alert(alert_id="alert_rfp_absent", queue_state="actioned")
+    alert = _domains_alert(alert_id="alert_rfp_absent", queue_state="doppel_review")
     existing_indicator = {
         "id": "e5a6f272-3595-4673-9097-f5be0df2a926",
         "standard_id": "indicator--e5a6f272-3595-4673-9097-f5be0df2a926",

--- a/external-import/doppel/tests/test_converter_to_stix.py
+++ b/external-import/doppel/tests/test_converter_to_stix.py
@@ -251,6 +251,7 @@ def test_standard_observables_use_opencti_custom_metadata(
         "ecommerce",
         "crypto",
         "email",
+        "suspicious_emails",
         "paid_ads",
         "darkweb",
     ],
@@ -277,6 +278,34 @@ def test_other_product_type_creates_url_observable_and_indicator(converter, prod
     assert indicators[0]["pattern"] == (
         "[url:value = 'http://social.example/profile/fake']"
     )
+
+
+def test_suspicious_email_tags_are_mapped_to_opencti_labels(converter):
+    """Suspicious-email alerts must not be dropped before their tags are mapped."""
+    entity = "http://<calendar-37348e36-99eb-4cf3-a252-fbd1e7058f9f@google.com>"
+    alert = _domains_alert(alert_id="TET-2075433")
+    alert.update(
+        {
+            "product": "suspicious_emails",
+            "entity": entity,
+            "tags": [{"name": "Link"}, {"name": "Payload"}],
+        }
+    )
+    converter.helper.api.stix_cyber_observable.read.return_value = None
+    converter.helper.api.indicator.list.return_value = []
+
+    result = converter.convert_alerts_to_stix([alert])
+
+    observable = next(
+        obj for obj in result if isinstance(obj, dict) and obj.get("type") == "url"
+    )
+    indicator = next(
+        obj
+        for obj in result
+        if isinstance(obj, dict) and obj.get("type") == "indicator"
+    )
+    assert {"Link", "Payload"} <= set(observable["x_opencti_labels"])
+    assert {"Link", "Payload"} <= set(indicator["labels"])
 
 
 @pytest.mark.parametrize(

--- a/external-import/doppel/tests/test_stix_helpers.py
+++ b/external-import/doppel/tests/test_stix_helpers.py
@@ -46,7 +46,7 @@ def test_build_custom_properties():
 
 @pytest.mark.parametrize(
     ("score", "expected"),
-    [(0.42, 42), ("0.91", 91), (None, 0), ("invalid", 0)],
+    [(0.29, 29), (0.42, 42), ("0.91", 91), (None, 0), ("invalid", 0)],
 )
 def test_calculate_opencti_score(score, expected):
     assert calculate_opencti_score(score) == expected

--- a/external-import/doppel/tests/test_stix_helpers.py
+++ b/external-import/doppel/tests/test_stix_helpers.py
@@ -4,6 +4,7 @@ from doppel.stix_helpers import (
     build_description,
     build_external_references,
     build_labels,
+    calculate_opencti_score,
     in_takedown_state,
     is_reverted_state,
 )
@@ -41,6 +42,14 @@ def test_build_custom_properties():
         ],
         "x_opencti_description": "**Brand**: Brand Test\n\n**Product**: domains\n\n**Notes**: Note Test\n\n**Uploaded By**: Test uploader\n\n**Screenshot URL**: https://test.com/\n\n**Message**: Message test\n\n**Source**: Test Upload\n\n**Assignee**: Assignee Test\n\n**Country**: US\n\n**Hosting Provider**: Test Hosting\n\n**Contact Email**: contact@test.com\n\n**MX Records**: test.com. (pref: 10)\n\n**Nameservers**: NS.TEST.COM\n",
     }
+
+
+@pytest.mark.parametrize(
+    ("score", "expected"),
+    [(0.42, 42), ("0.91", 91), (None, 0), ("invalid", 0)],
+)
+def test_calculate_opencti_score(score, expected):
+    assert calculate_opencti_score(score) == expected
 
 
 # Scenario: If external references are correctly formatted

--- a/external-import/doppel/tests/test_stix_helpers.py
+++ b/external-import/doppel/tests/test_stix_helpers.py
@@ -6,7 +6,6 @@ from doppel.stix_helpers import (
     build_labels,
     calculate_opencti_score,
     in_takedown_state,
-    is_reverted_state,
 )
 
 # --------------------------
@@ -122,31 +121,6 @@ def test_in_takedown_state_true(queue_state):
 )
 def test_in_takedown_state_false(queue_state):
     assert in_takedown_state(queue_state) is False
-
-
-# Scenario: reverted states are detected regardless of spelling/whitespace
-@pytest.mark.parametrize(
-    "queue_state",
-    [
-        "archived",
-        "needs_confirmation",
-        "needs confirmation",  # space-separated variant
-        "DOPPEL_REVIEW",
-        "doppel review",
-        "monitoring",
-    ],
-)
-def test_is_reverted_state_true(queue_state):
-    assert is_reverted_state(queue_state) is True
-
-
-# Scenario: takedown / invalid states are not treated as reverted
-@pytest.mark.parametrize(
-    "queue_state",
-    ["actioned", "taken_down", "resolved", "", None, 12345],
-)
-def test_is_reverted_state_false(queue_state):
-    assert is_reverted_state(queue_state) is False
 
 
 # ---------------------------------------------------------

--- a/internal-enrichment/doppel-alert-takedown/README.md
+++ b/internal-enrichment/doppel-alert-takedown/README.md
@@ -96,6 +96,9 @@ The connector is also playbook compatible and can be added as a step in a playbo
 
 For each in-scope observable (URL or Domain-Name), the connector:
 
+- identifies every outbound Doppel API request with
+  `x-doppel-client: opencti/7.260901.0` and
+  `User-Agent: doppel-opencti/7.260901.0` for usage attribution;
 - maps the OpenCTI observable type to the Doppel `entity_type`
   (`url` → `url`, `domain-name` → `domain`);
 - creates a Doppel alert with the configured tags;

--- a/internal-enrichment/doppel-alert-takedown/src/doppel_client/api_client.py
+++ b/internal-enrichment/doppel-alert-takedown/src/doppel_client/api_client.py
@@ -1,4 +1,5 @@
 import requests
+from doppel_client.constants import DOPPEL_ATTRIBUTION_HEADERS
 from pycti import OpenCTIConnectorHelper
 from pydantic import HttpUrl
 
@@ -32,6 +33,7 @@ class DoppelClient:
         self.session = requests.Session()
         self.session.headers.update(
             {
+                **DOPPEL_ATTRIBUTION_HEADERS,
                 "Content-Type": "application/json",
                 "x-api-key": api_key,
                 "x-user-api-key": user_api_key,

--- a/internal-enrichment/doppel-alert-takedown/src/doppel_client/constants.py
+++ b/internal-enrichment/doppel-alert-takedown/src/doppel_client/constants.py
@@ -1,5 +1,3 @@
-import requests
-
 # OpenCTI connector releases track the pinned pycti version. Bump this value
 # whenever the connector is released against a new OpenCTI version.
 DOPPEL_CLIENT_VERSION = "7.260901.0"
@@ -7,21 +5,3 @@ DOPPEL_ATTRIBUTION_HEADERS = {
     "x-doppel-client": f"opencti/{DOPPEL_CLIENT_VERSION}",
     "User-Agent": f"doppel-opencti/{DOPPEL_CLIENT_VERSION}",
 }
-
-RETRYABLE_REQUEST_ERRORS = (
-    requests.Timeout,
-    requests.ConnectionError,
-)
-
-DOPPEL_ALERT_TYPES_EXCEPT_DOMAIN_AND_TELCO = [
-    # 'domains',
-    # 'telco',
-    "social_media",
-    "mobile_apps",
-    "ecommerce",
-    "crypto",
-    "email",
-    "suspicious_emails",
-    "paid_ads",
-    "darkweb",
-]

--- a/internal-enrichment/doppel-alert-takedown/tests/test_main.py
+++ b/internal-enrichment/doppel-alert-takedown/tests/test_main.py
@@ -76,3 +76,7 @@ def test_connector_is_instantiated(mock_opencti_connector_helper):
 
     assert connector.config == settings
     assert connector.helper == helper
+    assert connector.client.session.headers["x-doppel-client"] == "opencti/7.260901.0"
+    assert connector.client.session.headers["User-Agent"] == (
+        "doppel-opencti/7.260901.0"
+    )


### PR DESCRIPTION
### Proposed changes

* Normalize the configured Doppel API URL and fetch every zero-indexed alert page exactly once.
* Refresh Doppel-owned fields and external-reference details on existing Indicators and RFT cases while preserving user-added references.
* Treat Doppel queue transitions as workflow labels rather than STIX revocation, keep existing Indicators and RFT cases active through revival monitoring, and remove the obsolete `revoked-false-positive` label on replay.
* Keep managed-label replacement idempotent and align the sample configuration and deployment documentation with supported settings.

### Related issues

* Fixes #7168
* Follow-up reliability hardening after #7025

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Test plan

- [x] Doppel unit suite: 83 tests passed
- [x] Black, isort, and Flake8 checks passed
- [x] Connector image built with `pycti==7.260803.0`
- [x] Live Docker Desktop/OpenCTI replay refreshed existing Indicator and RFT fields and external references
- [x] Regression coverage for `monitoring → doppel_review → needs_confirmation → actioned → taken_down`

### Further comments

Doppel reports zero-indexed pages with `total_pages` as a count. Reprocessing intentionally updates only connector-owned mutable fields; external references added by OpenCTI users are not removed. New Indicators and RFT cases are still created only for `actioned` or `taken_down` alerts, while an existing object remains active if the alert later enters revival monitoring.

Made with [Cursor](https://cursor.com)

## Linear
- [INT-341](https://linear.app/doppel/issue/INT-341/harden-opencti-alert-polling-and-replay-updates)