### PR TITLE
fix(email-intel-imap): preserve line breaks in plain text email content (#6880)

### DIFF
--- a/external-import/email-intel-imap/src/email_intel_imap/converter.py
+++ b/external-import/email-intel-imap/src/email_intel_imap/converter.py
@@ -1,4 +1,5 @@
 import base64
+import html
 import logging
 from typing import Generator, Literal
 
@@ -36,6 +37,26 @@ class ConnectorConverter(BaseConverter):
         )
         self.attachments_mime_types = attachments_mime_types
 
+    @staticmethod
+    def _get_html_body(entity: MailMessage) -> str:
+        """
+        Return the email body as HTML, ready to be stored in the Report content.
+
+        `imap_tools` only fills `entity.html` when the message has a `text/html` part.
+        For `text/plain` messages we fall back to `entity.text`, which is a raw string:
+        its line breaks would be collapsed by the HTML renderer of the Report content
+        field. Escape the body and materialize its newlines as `<br>` so that it is
+        rendered the way it was sent.
+        """
+        if entity.html:
+            return entity.html
+        if not entity.text:
+            # `x_opencti_content` is a required string: never return None, otherwise the
+            # whole Report would be skipped for an email with an empty body.
+            return ""
+        normalized_text = entity.text.replace("\r\n", "\n").replace("\r", "\n")
+        return html.escape(normalized_text, quote=False).replace("\n", "<br>\n")
+
     def to_stix_objects(
         self, entity: MailMessage
     ) -> Generator[stix2.Report, None, None]:
@@ -64,7 +85,7 @@ class ConnectorConverter(BaseConverter):
                 name=name,
                 published=entity.date,
                 report_types=[REPORT_TYPE_THREAT_REPORT],
-                x_opencti_content=entity.html or entity.text,
+                x_opencti_content=self._get_html_body(entity),
                 x_opencti_files=[
                     OpenCTIFile(
                         name=attachment.filename,

--- a/external-import/email-intel-imap/tests/email_intel_imap/test_converter.py
+++ b/external-import/email-intel-imap/tests/email_intel_imap/test_converter.py
@@ -209,3 +209,55 @@ def test_converter_to_stix_with_attachment__mime_type_not_in_config(
     assert (
         "x_opencti_files" not in list(converter.to_stix_objects(entity=mocked_email))[0]
     )
+
+
+def test_converter_to_stix_plain_text_body(converter: ConnectorConverter) -> None:
+    """A text/plain email body keeps its line breaks and is HTML-escaped."""
+    mocked_email = Mock(
+        subject="Plain Text Report",
+        date=datetime.datetime(2025, 4, 16, 10, 10, 10),
+        html="",
+        text="line 1\r\nline 2\r\n<<< 3 & 4 >>>",
+        attachments=[],
+        from_="em@il.com",
+    )
+
+    report = list(converter.to_stix_objects(entity=mocked_email))[0]
+
+    assert report.x_opencti_content == (
+        "line 1<br>\nline 2<br>\n&lt;&lt;&lt; 3 &amp; 4 &gt;&gt;&gt;"
+    )
+
+
+def test_converter_to_stix_html_body_is_kept_as_is(
+    converter: ConnectorConverter,
+) -> None:
+    """A text/html email body is left untouched."""
+    mocked_email = Mock(
+        subject="HTML Report",
+        date=datetime.datetime(2025, 4, 16, 10, 10, 10),
+        html="<p>Test<br>Content</p>",
+        text="ignored plain text",
+        attachments=[],
+        from_="em@il.com",
+    )
+
+    report = list(converter.to_stix_objects(entity=mocked_email))[0]
+
+    assert report.x_opencti_content == "<p>Test<br>Content</p>"
+
+
+def test_converter_to_stix_empty_body(converter: ConnectorConverter) -> None:
+    """An email without any body is still converted into a Report."""
+    mocked_email = Mock(
+        subject="Empty Report",
+        date=datetime.datetime(2025, 4, 16, 10, 10, 10),
+        html="",
+        text="",
+        attachments=[],
+        from_="em@il.com",
+    )
+
+    report = list(converter.to_stix_objects(entity=mocked_email))[0]
+
+    assert report.x_opencti_content == ""


### PR DESCRIPTION
### Proposed changes

* Add a `_get_html_body()` helper in `converter.py` that returns `entity.html` unchanged when an HTML part is present, and otherwise HTML-escapes `entity.text` and converts newlines to `<br>` tags before storing it in `x_opencti_content`.
* Plain text email bodies were previously stored as-is, so their raw newlines were collapsed by the HTML renderer of the Report **Content** tab (Option B of the issue).
* HTML-escaping is applied to the plain text fallback so that characters such as `<`, `>` and `&` are rendered literally instead of being interpreted as markup.
* Add unit tests covering the HTML part passthrough, the plain text fallback (line breaks + escaping) and the empty body case.

### Related issues

* Closes #6880
* Follow-up of #6548, which introduced the plain text fallback.

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Emails that contain a `text/html` part are unaffected: the HTML part is returned untouched, so there is no behaviour change for them.

Option B (`<br>` tags) was chosen over Option A (`<pre>`) because the Report Content editor renders `<pre>` in a monospace block with no wrapping, which degrades readability for long lines and URLs, whereas `<br>` integrates with the existing rich text rendering.

Tested locally on a Docker deployment: a `text/plain` only email was injected into the monitored IMAP mailbox and the resulting Report Content tab shows the line breaks, the blank line and the literally rendered `<b>` tag as expected. Unit tests: 33 passed.
