### PR TITLE
fix(deps): add security floors for vulnerable transitive deps (#7174)

### DIFF
--- a/external-import/cyber-campaign-collection/src/requirements.txt
+++ b/external-import/cyber-campaign-collection/src/requirements.txt
@@ -1,3 +1,5 @@
 pycti==7.260803.0
 urllib3==2.7.0
 PyGithub==2.8.1
+# Security floors for transitive dependencies (CVE remediation)
+cryptography>=46.0.7  # CVE-2026-39892

--- a/external-import/virustotal-livehunt-notifications/src/requirements.txt
+++ b/external-import/virustotal-livehunt-notifications/src/requirements.txt
@@ -4,3 +4,5 @@ python-magic~=0.4.27; sys_platform == 'linux' or sys_platform == 'darwin'
 python-magic-bin~=0.4.14; sys_platform == 'win32'
 vt-py==0.21.0
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk
+# Security floor for transitive dependency aiohttp (pulled in by vt-py) - CVE remediation
+aiohttp>=3.14.3  # CVE-2025-69223/69227/69228, CVE-2026-34513/34515/34516/34993/47265/50269/54273-54280

--- a/internal-enrichment/import-external-reference/src/requirements.txt
+++ b/internal-enrichment/import-external-reference/src/requirements.txt
@@ -4,3 +4,5 @@ html2text==2025.4.15
 pdfminer.six==20251107
 playwright==1.58.0
 cachetools
+# Security floors for transitive dependencies (CVE remediation)
+cryptography>=46.0.7  # CVE-2026-39892

--- a/internal-import-file/import-document/src/requirements.txt
+++ b/internal-import-file/import-document/src/requirements.txt
@@ -9,3 +9,6 @@ dateparser==1.4.0
 pyhumps==3.8.0
 chardet==5.2.0
 python-docx==1.1.2
+# Security floors for transitive dependencies (CVE remediation)
+cryptography>=46.0.7  # CVE-2026-39892
+lxml>=6.1.0  # CVE-2026-41066

--- a/internal-import-file/import-file-stix/src/requirements.txt
+++ b/internal-import-file/import-file-stix/src/requirements.txt
@@ -4,3 +4,5 @@ stix2-elevator==4.1.7
 typing-extensions==4.15.0
 pydantic~=2.11.3
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk
+# Security floors for transitive dependencies (CVE remediation)
+lxml>=6.1.0  # CVE-2026-41066


### PR DESCRIPTION
### Proposed changes

* Add explicit security-floor constraints (`>=`) for vulnerable transitive dependencies in the affected connectors' `requirements.txt`:
  * `cryptography>=46.0.7` — import-document, import-external-reference, cyber-campaign-collection
  * `lxml>=6.1.0` — import-document, import-file-stix
  * `aiohttp>=3.14.3` — virustotal-livehunt-notifications (pulled in by `vt-py`)

### Related issues

* Closes #7174

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

These CVEs live in **transitive** dependencies that don't appear in the connectors' `requirements.txt`, so Dependabot (which only resolves the lockfile-based `google-ti-feeds` connector) never flagged them. I used lower-bound floors (`>=`) rather than hard pins (`==`) or parent-package bumps: the parents don't cap these deps, so a floor enforces the fix deterministically without causing resolver conflicts as parents evolve.

Verification with Snyk:
- **Before:** 18 reported CVEs confirmed present on the shipped versions.
- **After (floors resolve to cryptography 50.0.0, lxml 6.1.1, aiohttp 3.14.3):** 0 remaining vulnerabilities on all three packages.
- Confirmed `aiohttp>=3.14.3` resolves cleanly alongside `vt-py==0.21.0`.
