### PR TITLE
fix(import-ttps-file-navigator): connector_logger is not callable in contextual import (#7181)

### DIFF
--- a/internal-import-file/import-ttps-file-navigator/src/main.py
+++ b/internal-import-file/import-ttps-file-navigator/src/main.py
@@ -87,7 +87,7 @@ class ImportTTPsFileNavigator:
         entity_id = data.get("entity_id", None)
 
         if entity_id:
-            self.helper.connector_logger("Contextual import.")
+            self.helper.connector_logger.info("Contextual import.")
             stix_entities = self._update_bundle(technique_entities, entity_id)
             bundle_json = self.helper.stix2_create_bundle(stix_entities)
 


### PR DESCRIPTION
### Proposed changes

* Fixes a `TypeError: 'AppLogger' object is not callable` that occurs systematically during a **contextual import** of a MITRE ATT&CK Navigator layer (i.e. when the import is triggered with an associated `entity_id` from the OpenCTI UI).

### Related issues

* closes #7181

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
