### PR TITLE
fix(infoblox): add missing WORKDIR so the entrypoint finds main.py (#7198)

### DIFF
--- a/external-import/infoblox/Dockerfile
+++ b/external-import/infoblox/Dockerfile
@@ -13,4 +13,5 @@ RUN apk update && apk upgrade && \
     rm -rf /var/cache/apk/*
 
 # Expose and entrypoint
+WORKDIR /opt/opencti-connector-infoblox
 ENTRYPOINT ["python3", "main.py"]


### PR DESCRIPTION
### Proposed changes

* The Dockerfile copies the connector source into `/opt/opencti-connector-infoblox` and `cd`s into it for the `pip install` step, but never sets `WORKDIR` for the final image. The `python:3.12-alpine` base image has no default working directory, so at runtime the container starts with `cwd=/`, and `ENTRYPOINT ["python3", "main.py"]` can't resolve the relative `main.py` path.

Every other connector in this repo sets `WORKDIR` explicitly before its `ENTRYPOINT` (see `crowdstrike-recon/Dockerfile` for comparison) — infoblox is the one missing it.

## Fix

Add `WORKDIR /opt/opencti-connector-infoblox` before the `ENTRYPOINT` line, matching the pattern used by every other connector in the repo.

### Related issues

* Closes #7198

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
