### PR TITLE
fix(crowdstrike-recon): connector gets permanently stuck after a PAGINATION_LIMIT_EXCEEDED error from query_notifications (#7190)

### DIFF
--- a/external-import/crowdstrike-recon/README.md
+++ b/external-import/crowdstrike-recon/README.md
@@ -51,7 +51,7 @@ This connector fetches those notifications via the CrowdStrike Recon API and con
 | Malware            | Malware families detected in breach items                  |
 | Relationship       | `related-to` links between Incidents and observables       |
 
-Each Incident also includes an attached Markdown file (`alert.md`) with the full alert details.
+The full alert details (rule metadata, breach summary, typosquatting WHOIS data, dark web post/reply content, etc.) are rendered as Markdown directly in the Incident's `description` field.
 
 ## Installation
 
@@ -208,6 +208,12 @@ The connector persists its state between runs using OpenCTI's connector state me
 
 On first run (no existing state), the connector imports alerts from `now - IMPORT_START_DATE` (default: 10 days back).
 
+### Pagination limits
+
+CrowdStrike's Recon notification search enforces an undocumented ceiling on the combination of `offset` and `limit` used for pagination (exceeding it fails with a `PAGINATION_LIMIT_EXCEEDED` error). To stay safely under it, the connector fetches at most **9,900 notifications per run** (99 pages of 100).
+
+If the backlog since the last saved `last_alert_date` is larger than that, the connector does not fail: it processes the first 9,900, saves its state at the most recent notification fetched during that run, and the **next scheduled run** continues from there. A very large backlog — for example after extended downtime, or a first run with a long `CROWDSTRIKE_RECON_IMPORT_START_DATE` — is therefore caught up gradually over several runs rather than all at once. Keep this in mind when choosing `CONNECTOR_DURATION_PERIOD` if you expect a large initial backlog.
+
 ### FQL Filtering
 
 The connector builds CrowdStrike FQL (Falcon Query Language) filter strings from the configured filter parameters. Filters are combined with AND logic. For example, with `filter_topic=SA_BRAND` and `filter_priority=high,medium`, the FQL filter would be:
@@ -221,8 +227,7 @@ topic:['SA_BRAND']+priority:['high','medium']+created_date:>'2026-05-01T00:00:00
 Each Incident created in OpenCTI includes:
 
 - **Name**: `{rule_name} : {title}` (title derived from notification content)
-- **Description**: Alert metadata summary (Markdown)
-- **Attached file**: `alert.md` — Full Markdown report with detailed information per notification type
+- **Description**: Full Markdown report with detailed information per notification type (rule metadata, breach summary, typosquatting WHOIS data, dark web post/reply content, etc.) — not a summary, and not an attached file
 - **Severity**: Mapped from CrowdStrike `rule_priority`
 - **Incident type**: The CrowdStrike notification `item_type` (e.g. `typosquatting_domain`, `exposed_data`, `post`)
 
@@ -240,6 +245,7 @@ Log output includes:
 - Number of notifications retrieved per run
 - STIX bundle creation and sending progress
 - State updates with `last_alert_date`
+- Warning when the per-run pagination cap is reached (see [Pagination limits](#pagination-limits)) — the remaining backlog is picked up on the next scheduled run, not lost
 
 ## Additional information
 

--- a/external-import/crowdstrike-recon/src/connector/converter_to_stix.py
+++ b/external-import/crowdstrike-recon/src/connector/converter_to_stix.py
@@ -322,7 +322,6 @@ class ConverterToStix:
         incident_type = item_type or "alert"
         incident_labels = []
         inc_sco_sdo_refs = []
-        attachment_files = []
 
         if item_type == "typosquatting_domain":
             typosquatting = notification.get("typosquatting") or {}
@@ -451,7 +450,6 @@ class ConverterToStix:
             custom_properties={
                 "severity": notification.get("rule_priority"),
                 "incident_type": incident_type,
-                "x_opencti_files": attachment_files,
             },
         )
         stix_objects.append(stix_incident)

--- a/external-import/crowdstrike-recon/src/crowdstrike_client/api_client.py
+++ b/external-import/crowdstrike-recon/src/crowdstrike_client/api_client.py
@@ -2,14 +2,33 @@ from falconpy import Recon as CrowdstrikeRecon
 from pycti import OpenCTIConnectorHelper
 
 
+class CrowdstrikeReconPaginationLimitError(RuntimeError):
+    """Raised when the CrowdStrike Recon API rejects a request because the
+    offset/limit combination exceeds its (undocumented) pagination ceiling
+    for ``query_notifications`` (``PAGINATION_LIMIT_EXCEEDED``).
+    """
+
+
 class CrowdstrikeReconClient:
 
     # CrowdStrike's get_notifications_detailed accepts a batch of IDs, so detail
     # lookups are chunked to avoid one HTTP request per notification.
     _DETAIL_CHUNK_SIZE = 100
-    # Safety guard so a misbehaving API (e.g. a missing/zero ``total``) cannot
-    # turn pagination into an unbounded loop.
-    _MAX_PAGES = 1000
+
+    # CrowdStrike's Recon notification search enforces an undocumented ceiling
+    # on offset + limit: exceeding it fails with a 400 error whose
+    # ``message_key`` is ``PAGINATION_LIMIT_EXCEEDED``. We believe that ceiling
+    # to be 10,000 (the same limit reported on several other Falcon Query API
+    # endpoints), but it is not officially documented for this endpoint, so we
+    # stay comfortably below it rather than assume the exact boundary: 99
+    # pages * 100 = 9,900.
+    #
+    # Hitting this cap is an expected outcome whenever there is a large
+    # backlog, not a failure: the connector saves its progress at the end of
+    # every run using the most recent notification's ``created_date`` (see
+    # ``connector.py``), so the next scheduled run picks up exactly where
+    # this one left off instead of ever requesting past the ceiling.
+    _MAX_PAGES_PER_RUN = 99
 
     def __init__(
         self,
@@ -91,11 +110,28 @@ class CrowdstrikeReconClient:
         """
         Raise on a non-2xx falconpy response so auth / permission / rate-limit
         failures are surfaced instead of being silently treated as "no data".
+
+        A ``PAGINATION_LIMIT_EXCEEDED`` response raises
+        ``CrowdstrikeReconPaginationLimitError`` specifically (without logging
+        it here as a generic error), so callers that know how to recover from
+        it -- see ``query_notifications`` -- can do so quietly.
         """
         result = result or {}
         status_code = result.get("status_code")
         if status_code is None or status_code >= 300:
-            errors = (result.get("body") or {}).get("errors")
+            errors = (result.get("body") or {}).get("errors") or []
+
+            if any(
+                isinstance(error, dict)
+                and error.get("message_key") == "PAGINATION_LIMIT_EXCEEDED"
+                for error in errors
+            ):
+                raise CrowdstrikeReconPaginationLimitError(
+                    f"CrowdStrike Recon API '{operation}' rejected the "
+                    f"offset/limit combination as exceeding its pagination "
+                    f"limit: {errors}"
+                )
+
             self.helper.connector_logger.error(
                 "[API CLIENT] CrowdStrike Recon API request failed",
                 meta={
@@ -112,7 +148,8 @@ class CrowdstrikeReconClient:
     def query_notifications(self, from_date) -> list[str]:
         """
         Query notification IDs from the CrowdStrike Recon API with optional FQL filters.
-        Handles pagination to retrieve all matching notification IDs.
+        Handles pagination to retrieve all matching notification IDs, up to
+        ``_MAX_PAGES_PER_RUN`` pages per call (see its docstring for why).
 
         :return: List of notification IDs.
         """
@@ -129,7 +166,7 @@ class CrowdstrikeReconClient:
                 meta={"filter": fql_filter},
             )
 
-        for _ in range(self._MAX_PAGES):
+        for _ in range(self._MAX_PAGES_PER_RUN):
             kwargs = {
                 "limit": limit,
                 "offset": offset,
@@ -139,7 +176,23 @@ class CrowdstrikeReconClient:
                 kwargs["filter"] = fql_filter
 
             result = self.cs.query_notifications(**kwargs)
-            self._raise_for_status(result, "query_notifications")
+            try:
+                self._raise_for_status(result, "query_notifications")
+            except CrowdstrikeReconPaginationLimitError:
+                # We already cap ourselves below the ceiling we believe
+                # CrowdStrike enforces (see _MAX_PAGES_PER_RUN); this is a
+                # backstop in case the real ceiling is lower than assumed.
+                # Either way it is not fatal: keep what has already been
+                # collected this run and let the next scheduled run continue
+                # from the last notification's date.
+                self.helper.connector_logger.warning(
+                    "[API CLIENT] CrowdStrike Recon pagination limit "
+                    "reached; stopping this run's collection early. The "
+                    "next scheduled run will continue from the last "
+                    "notification's date.",
+                    meta={"offset": offset, "limit": limit},
+                )
+                break
 
             body = result.get("body") or {}
             resources = body.get("resources") or []
@@ -162,9 +215,10 @@ class CrowdstrikeReconClient:
             offset += limit
         else:
             self.helper.connector_logger.warning(
-                "[API CLIENT] Reached pagination safety limit while querying "
-                "notifications; results may be truncated",
-                meta={"max_pages": self._MAX_PAGES},
+                "[API CLIENT] Reached the per-run pagination cap while "
+                "querying notifications; more notifications remain and "
+                "will be fetched on the next scheduled run.",
+                meta={"max_pages_per_run": self._MAX_PAGES_PER_RUN},
             )
 
         return notification_ids

--- a/external-import/crowdstrike-recon/tests/test_api_client.py
+++ b/external-import/crowdstrike-recon/tests/test_api_client.py
@@ -163,6 +163,60 @@ def test_query_notifications_raises_on_api_error():
         client.query_notifications(from_date="2026-05-01T00:00:00Z")
 
 
+def test_query_notifications_stops_gracefully_on_pagination_limit_exceeded():
+    """PAGINATION_LIMIT_EXCEEDED must not raise: it is an expected outcome
+    once a run's backlog is larger than the per-run cap, so whatever has
+    already been collected is returned and the run still saves progress
+    (issue #7190)."""
+    client = _client()
+    page1 = {
+        "status_code": 200,
+        "body": {
+            "resources": [f"id-{i}" for i in range(100)],
+            "meta": {"pagination": {"total": 50000}},
+        },
+    }
+    limit_exceeded = {
+        "status_code": 400,
+        "body": {
+            "errors": [
+                {
+                    "code": 400,
+                    "message": (
+                        "The provided limit and offset exceed the "
+                        "pagination limit"
+                    ),
+                    "message_key": "PAGINATION_LIMIT_EXCEEDED",
+                }
+            ]
+        },
+    }
+    client.cs.query_notifications.side_effect = [page1, limit_exceeded]
+
+    ids = client.query_notifications(from_date="2026-05-01T00:00:00Z")
+
+    assert len(ids) == 100
+    assert client.cs.query_notifications.call_count == 2
+    client.helper.connector_logger.warning.assert_called()
+
+
+def test_query_notifications_caps_pages_per_run():
+    """Without a per-run cap, a large backlog with an unreliable ``total``
+    would paginate until CrowdStrike itself rejects the request. We stop
+    comfortably before that instead (issue #7190)."""
+    client = _client()
+    client.cs.query_notifications.return_value = {
+        "status_code": 200,
+        "body": {"resources": [f"id-{i}" for i in range(100)], "meta": {}},
+    }
+
+    ids = client.query_notifications(from_date="2026-05-01T00:00:00Z")
+
+    assert client.cs.query_notifications.call_count == client._MAX_PAGES_PER_RUN
+    assert len(ids) == client._MAX_PAGES_PER_RUN * 100
+    client.helper.connector_logger.warning.assert_called()
+
+
 def test_get_notifications_details_batches_requests():
     client = _client()
     client.cs.get_notifications_detailed.return_value = {

--- a/external-import/crowdstrike-recon/tests/test_api_client.py
+++ b/external-import/crowdstrike-recon/tests/test_api_client.py
@@ -183,8 +183,7 @@ def test_query_notifications_stops_gracefully_on_pagination_limit_exceeded():
                 {
                     "code": 400,
                     "message": (
-                        "The provided limit and offset exceed the "
-                        "pagination limit"
+                        "The provided limit and offset exceed the " "pagination limit"
                     ),
                     "message_key": "PAGINATION_LIMIT_EXCEEDED",
                 }


### PR DESCRIPTION
### Proposed changes

* Cap `query_notifications` pagination at 99 pages per run (9,900 notifications) instead of the previous 1000-page cap, staying comfortably under CrowdStrike's undocumented ~10,000 offset+limit ceiling instead of hitting a 400 `PAGINATION_LIMIT_EXCEEDED` and failing the whole run.
* Hitting this per-run cap is treated as a normal end-of-page condition: `last_alert_date` is saved based on what was collected, so the next scheduled run continues from there — a large backlog is caught up over several runs instead of getting stuck forever.
* Reactively catch `PAGINATION_LIMIT_EXCEEDED` (via a dedicated `CrowdstrikeReconPaginationLimitError`) as a backstop in case the real ceiling turns out to be lower than the ~10,000 assumed.
* Remove dead code in `converter_to_stix.py`: `attachment_files` / the `x_opencti_files` custom property were always empty and never populated — the full alert Markdown is actually written directly to the Incident's `description` field.
* Update the README: document the new per-run pagination/catch-up behavior, and correct the outdated claim that each Incident gets an attached `alert.md` file.
* Add unit tests covering the per-run pagination cap and graceful handling of `PAGINATION_LIMIT_EXCEEDED`.

### Related issues

* Closes #7190

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
