### PR TITLE
fix(connectors-sdk): revert annotated_types.py changes from PR #7101 (#7213)

### DIFF
--- a/connectors-sdk/connectors_sdk/settings/annotated_types.py
+++ b/connectors-sdk/connectors_sdk/settings/annotated_types.py
@@ -6,6 +6,7 @@ from typing import Annotated
 from pydantic import (
     BeforeValidator,
     PlainSerializer,
+    SerializationInfo,
     TypeAdapter,
 )
 
@@ -34,17 +35,58 @@ def parse_comma_separated_list(value: str | list[str]) -> list[str]:
     return value
 
 
+def serialize_list_of_strings(
+    value: list[str], info: SerializationInfo
+) -> str | list[str]:
+    """Serialize a list[str] as a comma-separated string when the Pydantic
+    serialization context requests "pycti" mode; otherwise, return the list
+    unchanged.
+
+    This serializer is intended for use with Pydantic v2 `PlainSerializer` and
+    is typically activated only during JSON serialization (`when_used="json"`),
+    so the in-memory Python value remains a `list[str]` while the JSON output
+    can be a single string when required by external systems.
+
+    Parameters
+    - value: The value to serialize. Expected to be a list of strings.
+    - info: Serialization context provided by Pydantic. If `info.context`
+      contains `{"mode": "pycti"}`, the list will be joined into a single
+      comma-separated string.
+
+    Returns:
+    - A comma-separated string if context mode is "pycti" and `value` is a list.
+    - The original value `value` unchanged in all other cases.
+
+    Notes:
+    - Joining does not insert spaces; e.g., ["a", "b", "c"] -> "a,b,c".
+    - If any element contains commas, those commas are not escaped.
+
+    Examples:
+    - info.context={"mode": "pycti"} and value=["e1", "e2"] -> "e1,e2"
+    - info.context is None or mode != "pycti" -> ["e1", "e2"]
+    """
+    if info.context and info.context.get("mode") == "pycti":
+        return ",".join(value)  # [ "e1", "e2", "e3" ] -> "e1,e2,e3"
+    return value
+
+
 ListFromString = Annotated[
     list[str],  # Final type
     BeforeValidator(parse_comma_separated_list),
+    PlainSerializer(serialize_list_of_strings, when_used="json"),
     """Annotated list[str] that:
 - Validates: Accepts a comma-separated string (e.g., "a,b,c") or a list[str].
   If a string is provided, it is split on commas and whitespace is trimmed for
   each item.
+- Serializes (JSON): When the Pydantic serialization context includes
+  {"mode": "pycti"}, the list is serialized as a single comma-separated string
+  (e.g., ["a","b"] -> "a,b"). Otherwise, it serializes as a JSON array by default.
 
 Components
 - BeforeValidator(parse_comma_separated_list): Converts input strings to list[str]
   early in validation.
+- PlainSerializer(serialize_list_of_strings, when_used="json"): Produces the "pycti"
+  string form only for JSON serialization.
 
 Examples
 - Validation:
@@ -55,6 +97,12 @@ Examples
 
     Model.model_validate({"tags": "a, b , c"}).tags  # -> ["a", "b", "c"]
     Model.model_validate({"tags": ["x", "y"]}).tags  # -> ["x", "y"]
+
+- Serialization:
+    m = Model.model_validate({"tags": ["e1", "e2"]})
+    m.model_dump()                               # -> {'tags': ['e1', 'e2']}
+    m.model_dump_json()                          # -> {"tags":["e1","e2"]}
+    m.model_dump_json(context={"mode": "pycti"}) # -> {"tags":"e1,e2"}
 """,
 ]
 
@@ -124,5 +172,6 @@ Examples
     m = Model.model_validate({"start_date": datetime(2023, 10, 01, 0, 0, tzinfo=timezone.utc)})
     m.model_dump()                               # -> {'start_date': datetime(2023, 10, 01, 0, 0, tzinfo=timezone.utc)}
     m.model_dump_json()                          # -> {"start_date": "2023-10-01T00:00:00+00:00"}
+    m.model_dump_json(context={"mode": "pycti"}) # -> {"start_date": "2023-10-01T00:00:00+00:00"}
 """,
 ]

--- a/connectors-sdk/connectors_sdk/settings/base_settings.py
+++ b/connectors-sdk/connectors_sdk/settings/base_settings.py
@@ -142,21 +142,6 @@ class _BaseConnectorConfig(BaseConfigModel, ABC):
         default="error",
     )
 
-    @field_serializer("scope", mode="wrap", when_used="json")
-    def _serialize_scope(
-        self,
-        value: Any,
-        handler: SerializerFunctionWrapHandler,
-        info: FieldSerializationInfo,
-    ) -> str | list[str]:
-        """Serialize scope as a comma-separated string when serializing for `pycti.OpenCTIConnectorHelper` only.
-        Otherwise, return the list of strings.
-        """
-        mode = info.context.get("mode") if info.context else None
-        if isinstance(value, list) and mode == "pycti":
-            return ",".join(value)  # [ "e1", "e2", "e3" ] -> "e1,e2,e3"
-        return handler(value)  # type: ignore[no-any-return] # actually return `list[str]`
-
 
 class BaseConnectorSettings(BaseConfigModel, ABC):
     """Interface class for managing and loading the global configuration for connectors.

--- a/connectors-sdk/tests/test_settings/test_annotated_types.py
+++ b/connectors-sdk/tests/test_settings/test_annotated_types.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
 import freezegun
 import pytest
@@ -7,6 +8,7 @@ from connectors_sdk.settings.annotated_types import (
     ListFromString,
     parse_comma_separated_list,
     parse_iso_string,
+    serialize_list_of_strings,
 )
 from pydantic import TypeAdapter
 
@@ -43,6 +45,20 @@ def test_parse_comma_separated_list_passthrough() -> None:
     assert parse_comma_separated_list(["a", "b"]) == ["a", "b"]
 
 
+def test_serialize_list_of_strings_handles_pycti_mode() -> None:
+    info = SimpleNamespace(context={"mode": "pycti"})
+    assert serialize_list_of_strings(["a", "b"], info) == "a,b"
+
+
+@pytest.mark.parametrize("context", [None, {}, {"mode": "other"}])
+def test_serialize_list_of_strings_handles_non_pycti_modes(
+    context: dict[str, str] | None,
+) -> None:
+    info = SimpleNamespace(context=context)
+    value = ["a", "b"]
+    assert serialize_list_of_strings(value, info) == value
+
+
 def test_list_from_string_accepts_string_input() -> None:
     value = TypeAdapter(ListFromString).validate_python("a,b,c")
     assert value == ["a", "b", "c"]
@@ -56,6 +72,30 @@ def test_list_from_string_accepts_list_input() -> None:
 def test_list_from_string_dumps_valid_json() -> None:
     value = TypeAdapter(ListFromString).dump_python(["a", "b"], mode="json")
     assert value == ["a", "b"]
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        pytest.param(
+            ["a", "b", "c"],
+            "a,b,c",
+            id="list_of_strings",
+        ),
+        pytest.param(
+            [],
+            "",
+            id="empty_list",
+        ),  # empty list -> empty string
+    ],
+)
+def test_list_from_string_dumps_valid_json_in_pycti_mode(
+    input: list[str], expected: str
+) -> None:
+    value = TypeAdapter(ListFromString).dump_python(
+        input, mode="json", context={"mode": "pycti"}
+    )
+    assert value == expected
 
 
 # DatetimeFromIsoString


### PR DESCRIPTION
### Proposed changes

* Revert the `annotated_types.py` changes introduced by #7101: restore `serialize_list_of_strings` and its `PlainSerializer(when_used="json")` on `ListFromString`, so every `list[str]` setting is serialized as a comma-separated string when dumping with `context={"mode": "pycti"}` (i.e. in `to_helper_config()`).
* Restore the associated unit tests removed by #7101 in `tests/test_settings/test_annotated_types.py`.
* Remove the `_serialize_scope` field serializer added on `_BaseConnectorConfig` as a partial replacement: a `mode="wrap"` field serializer overrides the annotated `PlainSerializer`, so it only duplicated the `ListFromString` logic for a single field while leaving every other `ListFromString` setting serialized as a JSON array.

### Related issues

* Close #7213

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

`annotated_types.py` and `test_annotated_types.py` are byte-identical to their state before #7101 (`git diff 6b864f3^ HEAD -- <files>` is empty).

Removing `_serialize_scope` is behaviour-preserving for `connector.scope`: it produced exactly the same output as `ListFromString` does on its own (`"a,b"` in pycti mode, `["a", "b"]` otherwise). Keeping both would leave the same logic duplicated in two places, with only `scope` benefitting from any future fix to `serialize_list_of_strings`.

Validation: full `connectors-sdk` suite passes (479 tests), `black` / `isort` / `flake8` clean.
