### PR TITLE
fix(shodan-internetdb): run() should register process_message, not _process_message

### DIFF
--- a/internal-enrichment/shodan-internetdb/src/shodan_internetdb/connector.py
+++ b/internal-enrichment/shodan-internetdb/src/shodan_internetdb/connector.py
@@ -110,4 +110,4 @@ class ShodanInternetDBConnector:
         Start the connector
         :return: None
         """
-        self.helper.listen(message_callback=self._process_message)
+        self.helper.listen(message_callback=self.process_message)


### PR DESCRIPTION
Fixes #6780.

## Problem

`ShodanInternetDBConnector.run()` registers `self._process_message` as the SDK message callback instead of the public `self.process_message` wrapper:

```python
def run(self) -> None:
    self.helper.listen(message_callback=self._process_message)
```

`_process_message` raises typed exceptions for every expected/handled case (404 not found, invalid IPv4, TLP violation, entity not in scope, API error). `process_message` exists specifically to catch those exceptions, log them as a `WARNING`, and return a string so the SDK treats the message as successfully processed — but it's never actually used as the callback.

## Impact

The most common outcome for this connector — Shodan InternetDB returning 404 for an IP it has no data on — propagates as an uncaught exception to the SDK, which reports it as a real work failure (`inError: true`) and writes an extra Elasticsearch document with the full stack trace. On deployments enriching IPv4 observables automatically, this inflates connector error-rate metrics/alerts with what is actually expected, normal behavior, and adds unnecessary Elasticsearch write load.

Observed in our own OpenCTI deployment: after ruling out an unrelated TLP misconfiguration on our side, the connector's error rate stayed pinned around ~75-85% purely from `ShodanInternetDbNotFoundError` propagating through this path.

## Fix

One-line change, using the wrapper that was already written for this purpose:

```python
def run(self) -> None:
    self.helper.listen(message_callback=self.process_message)
```

No behavior change for the success path; only affects how already-anticipated exceptions are reported.
