### PR TITLE
fix(cve): NVD 404 error and duplicate connector logs hide the real 'Invalid apiKey' cause (#7229)

### DIFF
--- a/external-import/cve/src/connector/cve_connector.py
+++ b/external-import/cve/src/connector/cve_connector.py
@@ -182,6 +182,25 @@ class CVEConnector:
         asyncio.run(self._async_ingest(cve_params))
 
     @staticmethod
+    def _format_exception(err: BaseException) -> str:
+        """Format an exception for logging.
+
+        `asyncio.TaskGroup` (used by the streaming ingestion pipeline) wraps
+        any failure — including ones with a clear, actionable message like
+        "[API] Error: Invalid apiKey." — into a `BaseExceptionGroup` whose
+        own `str()` is just the generic "unhandled errors in a TaskGroup
+        (N sub-exception(s))". Unwrap it (recursively, in case of nested
+        groups) so the real underlying reason ends up in the single log
+        line the connector emits for a failed run, instead of a second,
+        uninformative one.
+        """
+        if isinstance(err, BaseExceptionGroup):
+            return "; ".join(
+                CVEConnector._format_exception(sub) for sub in err.exceptions
+            )
+        return str(err)
+
+    @staticmethod
     def _update_cve_params(start_date: datetime, end_date: datetime) -> dict:
         """
         Update CVE params to handle date range
@@ -274,5 +293,6 @@ class CVEConnector:
             self.helper.connector_logger.info(msg)
             sys.exit(0)
         except Exception as e:
-            error_msg = f"[CONNECTOR] Error while processing data: {e}"
-            self.helper.connector_logger.error(error_msg, meta={"error": str(e)})
+            detail = self._format_exception(e)
+            error_msg = f"[CONNECTOR] Error while processing data: {detail}"
+            self.helper.connector_logger.error(error_msg, meta={"error": detail})

--- a/external-import/cve/src/services/client/api.py
+++ b/external-import/cve/src/services/client/api.py
@@ -21,6 +21,11 @@ class CVEClient:
         self._rate_limiter = rate_limiter
         self._headers = {"apiKey": api_key, "User-Agent": header}
         self._session: aiohttp.ClientSession | None = None
+        # Last error message from a failed request, so a caller that only
+        # sees `get_complete_collection` return None (instead of an
+        # exception) can still raise/log the real reason exactly once,
+        # instead of a second, generic, information-losing message.
+        self._last_error: str | None = None
 
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
@@ -57,7 +62,14 @@ class CVEClient:
 
     @staticmethod
     async def _extract_error_message(response: aiohttp.ClientResponse) -> str | None:
-        """Extract a meaningful API error message from JSON or text body."""
+        """Extract a meaningful API error message from JSON body, text body,
+        or response headers.
+
+        The NVD API sometimes returns an empty body (e.g. Content-Length: 0)
+        with the real explanation carried in a non-standard `message` response
+        header instead (observed for invalid/expired API keys, which NVD
+        reports as a 404 with header `message: Invalid apiKey.`).
+        """
         try:
             body = await response.json(content_type=None)
             if isinstance(body, dict):
@@ -81,6 +93,11 @@ class CVEClient:
                 return body_text.strip()
         except UnicodeDecodeError:
             return None
+
+        for key in ("message", "error", "X-Error-Message"):
+            value = response.headers.get(key)
+            if value and value.strip():
+                return value.strip()
 
         return None
 
@@ -114,7 +131,10 @@ class CVEClient:
                     if response.status == 404:
                         message = await self._extract_error_message(response)
                         if message:
-                            raise Exception(f"[API] Error: {message}")
+                            raise Exception(
+                                f"[API] Request to {api_url} failed with status "
+                                f"404: {message}"
+                            )
                         raise Exception(
                             f"[API] Request to {api_url} failed with status 404"
                         )
@@ -166,14 +186,25 @@ class CVEClient:
         )
 
     async def get_complete_collection(self, api_url: str, params: dict | None = None):
-        """Fetch a JSON collection from the given NVD API endpoint."""
+        """Fetch a JSON collection from the given NVD API endpoint.
+
+        On failure, returns None instead of raising, so tolerant callers
+        (e.g. per-CVE CPE resolution) can skip and continue. The error is
+        kept on `self._last_error` and only logged at debug level here:
+        callers that treat a None result as fatal (e.g. CVE ingestion) are
+        expected to raise using `self._last_error`, so the real explanation
+        is logged exactly once, by the top-level handler, instead of once
+        here and again as a generic message further up the call stack.
+        """
         try:
             info_msg = f"[API] HTTP Get Request to endpoint for path ({api_url})"
             self.helper.connector_logger.debug(info_msg)
 
             data = await self.request(api_url, params)
+            self._last_error = None
             return data
 
         except Exception as err:
-            self.helper.connector_logger.error(str(err), meta={"error": str(err)})
+            self._last_error = str(err)
+            self.helper.connector_logger.debug(str(err), meta={"error": str(err)})
             return None

--- a/external-import/cve/src/services/client/api.py
+++ b/external-import/cve/src/services/client/api.py
@@ -92,7 +92,7 @@ class CVEClient:
             if body_text.strip():
                 return body_text.strip()
         except UnicodeDecodeError:
-            return None
+            pass
 
         for key in ("message", "error", "X-Error-Message"):
             value = response.headers.get(key)

--- a/external-import/cve/src/services/client/vulnerability.py
+++ b/external-import/cve/src/services/client/vulnerability.py
@@ -23,7 +23,8 @@ class CVEVulnerability(CVEClient):
 
         if cve_collection is None:
             raise Exception(
-                "Attempting to retrieve data failed. Wait for connector to re-run..."
+                self._last_error
+                or "Attempting to retrieve data failed. Wait for connector to re-run..."
             )
 
         page_size = cve_collection["resultsPerPage"]
@@ -63,7 +64,8 @@ class CVEVulnerability(CVEClient):
 
                 if cve_collection is None:
                     raise Exception(
-                        "Attempting to retrieve data failed. "
+                        self._last_error
+                        or "Attempting to retrieve data failed. "
                         "Wait for connector to re-run..."
                     )
 


### PR DESCRIPTION
### Proposed changes

* Extract the real NVD error reason from response headers when the body is empty (`message` header) — this was silently lost on a `404` for an invalid API key.
* Always include the HTTP status and endpoint in the raised exception message for `404` responses, not just the extracted NVD message.
* Preserve the original error on `self._last_error` instead of swallowing it, so `get_vulnerabilities()` re-raises the real reason instead of a generic "Attempting to retrieve data failed..." message.
* Unwrap `BaseExceptionGroup` (from `asyncio.TaskGroup`) recursively when logging in `process_data()`, so the underlying message reaches the log instead of "unhandled errors in a TaskGroup (1 sub-exception)".
* Downgrade the low-level log in `get_complete_collection()` from `error` to `debug`, since the error is now logged once, with full context, at the top level.

### Further comments
The root cause was twofold: NVD reports an invalid API key as a `404` with an empty body and the actual reason in a non-standard `message` header (undocumented), and the connector's own error handling compounded this by swallowing the original exception and re-raising a generic one, which `asyncio.TaskGroup` then wrapped into an opaque `ExceptionGroup`. The fix threads the real message through each layer so it's logged exactly once, with full context.

### Related issues

* Fixes #7229 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
