### PR TITLE
chore(sekoia-intel): use python 3.12 base image (#7249)

### DIFF
--- a/stream/sekoia-intel/Dockerfile
+++ b/stream/sekoia-intel/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python:3.12-alpine
 ENV CONNECTOR_TYPE=STREAM
 
 # Copy the connector

--- a/stream/sekoia-intel/README.md
+++ b/stream/sekoia-intel/README.md
@@ -39,7 +39,7 @@ Key features:
 
 ### Requirements
 
-- Python 3.11.x (not compatible with 3.12 and above)
+- Python 3.12.x
 - OpenCTI Platform >= 6.8.x
 - pycti >= 6.8.x
 - stix-shifter >= 7.1.x


### PR DESCRIPTION
### Proposed changes

* Bump `stream/sekoia-intel` from `python:3.11-alpine` to `python:3.12-alpine`.
* This connector was pinned to Python 3.11 because of past dependency constraints (notably `stix-shifter`). Those constraints no longer apply: the image builds and the connector imports cleanly on 3.12.
* Part of the stack that unpins the remaining 3.11 connectors so the CircleCI executor can move to `cimg/python:3.12` (last PR of the stack).

### Related issues

* Closes #7249
* Part of #2906

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Validation performed locally:
* `docker build` succeeds on `python:3.12-alpine`
* the connector entrypoint module imports successfully inside the 3.12 image
* unit tests pass under Python 3.12 (where the connector has tests)

> [!NOTE]
> Any `connector-linter` (VC3xx/VC5xx) errors reported on this PR are pre-existing on `master` and unrelated to this change — they are surfaced only because the linter runs on connectors touched by the PR.

> [!WARNING]
> Labeled **do not merge** — this stack is opened to validate CI on Python 3.12.
