### PR TITLE
ci(circleci): use cimg/python 3.12 executor (#7254)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
     environment:
       BUILD_TAGS: <<parameters.tags>>
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
   ci_notifications:
     docker:
       - image: "cimg/base:stable"
@@ -189,7 +189,7 @@ jobs:
             fi
   test:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
     working_directory: ~/repo
     parallelism: 4
     parameters:


### PR DESCRIPTION
### Proposed changes

* Move the CircleCI executors from `cimg/python:3.11` to `cimg/python:3.12` (the `ci_environment` executor and the `test` job).
* The pin to 3.11 existed only because a handful of connectors could not build on Python 3.12 (`stix-shifter` dependency constraints). The preceding PRs in this stack move all of them to `python:3.12-alpine`, so the pin is no longer needed.
* All other `cimg/python` references in the config were already on 3.12, so this aligns the whole pipeline.

### Related issues

* Closes #7254
* Part of #2906

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Validation performed locally:
* `ci-requirements.txt` and `.circleci/scripts/requirements.txt` install cleanly on Python 3.12
* `.circleci/scripts/generate_ci.py` runs successfully under Python 3.12 and generates `dynamic.yml`
* every connector previously pinned to 3.11 builds on `python:3.12-alpine` (earlier PRs in this stack)

> [!WARNING]
> Labeled **do not merge** — this stack is opened to validate CI on Python 3.12.
