### PR TITLE
feat(connectors-sdk): add labels field to Infrastructure model (#7256)

### DIFF
--- a/connectors-sdk/connectors_sdk/models/infrastructure.py
+++ b/connectors-sdk/connectors_sdk/models/infrastructure.py
@@ -19,6 +19,10 @@ class Infrastructure(BaseIdentifiedEntity):
         default=None,
         description="A description that provides more details and context about the Infrastructure.",
     )
+    labels: list[str] | None = Field(
+        default=None,
+        description="Labels of the Infrastructure.",
+    )
     aliases: list[str] | None = Field(
         default=None,
         description="Alternative names used to identify this Infrastructure.",
@@ -46,6 +50,7 @@ class Infrastructure(BaseIdentifiedEntity):
             id=PyctiInfrastructure.generate_id(name=self.name),
             name=self.name,
             description=self.description,
+            labels=self.labels,
             aliases=self.aliases,
             infrastructure_types=self.infrastructure_types,
             first_seen=self.first_seen,

--- a/connectors-sdk/tests/test_models/test_infrastructure.py
+++ b/connectors-sdk/tests/test_models/test_infrastructure.py
@@ -31,6 +31,7 @@ def test_infrastructure_to_stix2_object_returns_valid_stix_object(
     infrastructure = Infrastructure(
         name="Test infrastructure",
         description="Test description",
+        labels=["Test label"],
         aliases=["Test alias"],
         infrastructure_types=["command-and-control"],
         first_seen="2023-01-01T00:00:00Z",
@@ -51,6 +52,7 @@ def test_infrastructure_to_stix2_object_returns_valid_stix_object(
         id=PyctiInfrastructure.generate_id(name="Test infrastructure"),
         name="Test infrastructure",
         description="Test description",
+        labels=["Test label"],
         aliases=["Test alias"],
         infrastructure_types=["command-and-control"],
         first_seen="2023-01-01T00:00:00Z",


### PR DESCRIPTION
### Proposed changes

* Add optional `labels: list[str] | None` field to the `Infrastructure` model in `connectors-sdk`
* Pass `labels` through to the generated STIX2.1 `Infrastructure` object in `to_stix2_object()`
* Update unit tests to cover the new field

### Related issues

* Close #7256

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Follows the same `labels` field pattern already used in other connectors-sdk models (`vulnerability.py`, `attack_pattern.py`, `incident.py`).