### PR TITLE
fix(microsoft-sentinel-incidents): check OAuth token response status (#7265)

### DIFF
--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/client_api.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/client_api.py
@@ -1,4 +1,3 @@
-import json
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -36,24 +35,40 @@ class ConnectorClient:
         self.session = requests.Session()
 
     def set_oauth_token(self):
+        url = f"https://login.microsoftonline.com/{self.tenant_id}/oauth2/v2.0/token"
+        oauth_data = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret.get_secret_value(),
+            "grant_type": "client_credentials",
+            "scope": "https://api.loganalytics.io/.default",
+        }
         try:
-            url = (
-                f"https://login.microsoftonline.com/{self.tenant_id}/oauth2/v2.0/token"
-            )
-            oauth_data = {
-                "client_id": self.client_id,
-                "client_secret": self.client_secret.get_secret_value(),
-                "grant_type": "client_credentials",
-                "scope": "https://api.loganalytics.io/.default",
-            }
             response = requests.post(url, data=oauth_data)
-            response_json = json.loads(response.text)
-
-            oauth_token = response_json["access_token"]
-
-            self.session.headers.update({"Authorization": "Bearer " + oauth_token})
         except Exception as e:
-            raise ValueError("[ERROR] Failed generating oauth token {" + str(e) + "}")
+            raise ValueError(f"[ERROR] Failed requesting oauth token: {e}")
+
+        # Check the HTTP status first. On an auth failure Azure AD replies with
+        # a 400/401 whose JSON body carries the actionable message
+        # (``error`` / ``error_description`` with an ``AADSTS...`` code), e.g.
+        # "AADSTS7000215: Invalid client secret provided". Surface that instead
+        # of later crashing on a missing ``access_token`` key.
+        if not response.ok:
+            try:
+                error_body = response.json()
+            except ValueError:
+                error_body = {}
+            error = error_body.get("error", "unknown_error")
+            description = error_body.get(
+                "error_description", response.text or "no response body"
+            )
+            raise ValueError(
+                "[ERROR] Failed generating oauth token "
+                f"(HTTP {response.status_code}): {error} - {description}"
+            )
+
+        # 2xx from the token endpoint always contains the access token.
+        oauth_token = response.json()["access_token"]
+        self.session.headers.update({"Authorization": "Bearer " + oauth_token})
 
     def retries_builder(self) -> None:
         """

--- a/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/client_api.py
+++ b/external-import/microsoft-sentinel-incidents/src/microsoft_sentinel_incidents_connector/client_api.py
@@ -3,7 +3,13 @@ from typing import TYPE_CHECKING
 
 import requests
 from requests.adapters import HTTPAdapter
-from requests.exceptions import ConnectionError, HTTPError, RetryError, Timeout
+from requests.exceptions import (
+    ConnectionError,
+    HTTPError,
+    RequestException,
+    RetryError,
+    Timeout,
+)
 from urllib3.util.retry import Retry
 
 if TYPE_CHECKING:
@@ -44,8 +50,8 @@ class ConnectorClient:
         }
         try:
             response = requests.post(url, data=oauth_data)
-        except Exception as e:
-            raise ValueError(f"[ERROR] Failed requesting oauth token: {e}")
+        except RequestException as e:
+            raise ValueError(f"[ERROR] Failed requesting oauth token: {e}") from e
 
         # Check the HTTP status first. On an auth failure Azure AD replies with
         # a 400/401 whose JSON body carries the actionable message


### PR DESCRIPTION
## Proposed changes

`ConnectorClient.set_oauth_token()` read `response_json["access_token"]` without checking the HTTP status of the token request. On any authentication failure, the Azure AD token endpoint returns an HTTP 400/401 with a JSON error envelope (`error` / `error_description` carrying an `AADSTS...` code) and no `access_token`. The code therefore raised `KeyError: 'access_token'`, which the surrounding `try/except` re-raised as the opaque `ValueError: [ERROR] Failed generating oauth token {'access_token'}` — discarding the real Azure AD error and making misconfigurations (invalid/expired secret, wrong tenant/client id, missing permissions/consent) impossible to diagnose.

This PR makes `set_oauth_token()`:

- Check the HTTP status **before** parsing the token out of the body.
- On failure, surface the Azure AD `error` / `error_description` and status code, e.g. `[ERROR] Failed generating oauth token (HTTP 401): invalid_client - AADSTS7000215: Invalid client secret provided...`.
- Only read `access_token` on a successful (2xx) response.
- Keep a dedicated `try/except` around `requests.post` for transport errors (DNS, timeout, connection).
- Remove the now-unused `import json`.

**Before**
​```
ValueError: [ERROR] Failed generating oauth token {'access_token'}
​```

**After**
​```
ValueError: [ERROR] Failed generating oauth token (HTTP 401): invalid_client - AADSTS7000215: Invalid client secret provided...
​```

### Related issues

* closes #7265 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
