### PR TITLE
fix(zscaler): remove unused OpenCTIApiClient initialization causing startup crash (#7267)

### DIFF
--- a/stream/zscaler/src/main.py
+++ b/stream/zscaler/src/main.py
@@ -6,7 +6,6 @@ from pycti import OpenCTIConnectorHelper
 from stream_connector import ZscalerConnector
 from stream_connector.settings import ConnectorSettings
 
-
 if __name__ == "__main__":
     try:
         # Load and validate configuration via Pydantic settings

--- a/stream/zscaler/src/main.py
+++ b/stream/zscaler/src/main.py
@@ -6,7 +6,6 @@ from pycti import OpenCTIConnectorHelper
 from stream_connector import ZscalerConnector
 from stream_connector.settings import ConnectorSettings
 
-CONFIG_FILE_PATH = "/opt/opencti-connector-zscaler/config.yml"
 
 if __name__ == "__main__":
     try:
@@ -18,10 +17,7 @@ if __name__ == "__main__":
 
         # Initialize the connector with the validated settings
         connector = ZscalerConnector(
-            config_path=CONFIG_FILE_PATH,
             helper=helper,
-            opencti_url=str(config.opencti.url),
-            opencti_token=config.opencti.token,
             ssl_verify=config.zscaler.ssl_verify,
             zscaler_username=config.zscaler.username,
             zscaler_password=config.zscaler.password.get_secret_value(),

--- a/stream/zscaler/src/stream_connector/connector.py
+++ b/stream/zscaler/src/stream_connector/connector.py
@@ -34,17 +34,12 @@ class ZscalerConnector:
         self.helper.connector_logger.info("Initializing Zscaler connector...")
 
         self.opencti_url = opencti_url
-        self.opencti_token = opencti_token
         self.ssl_verify = ssl_verify
         self.zscaler_username = zscaler_username
         self.zscaler_password = zscaler_password
         self.api_key = zscaler_api_key
         self.zscaler_blacklist_name = (
             zscaler_blacklist_name  # Parameter for the blacklist
-        )
-
-        self.api = OpenCTIApiClient(
-            self.opencti_url, self.opencti_token, ssl_verify=self.ssl_verify
         )
 
         self.zscaler_base_url = "https://zsapi.zscalertwo.net/api/v1"

--- a/stream/zscaler/src/stream_connector/connector.py
+++ b/stream/zscaler/src/stream_connector/connector.py
@@ -20,10 +20,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 class ZscalerConnector:
     def __init__(
         self,
-        config_path,
         helper: OpenCTIConnectorHelper,
-        opencti_url,
-        opencti_token,
         ssl_verify,
         zscaler_username,
         zscaler_password,
@@ -33,7 +30,6 @@ class ZscalerConnector:
         self.helper = helper
         self.helper.connector_logger.info("Initializing Zscaler connector...")
 
-        self.opencti_url = opencti_url
         self.ssl_verify = ssl_verify
         self.zscaler_username = zscaler_username
         self.zscaler_password = zscaler_password

--- a/stream/zscaler/src/stream_connector/connector.py
+++ b/stream/zscaler/src/stream_connector/connector.py
@@ -5,7 +5,7 @@ import time
 import requests
 import urllib3
 import validators
-from pycti import OpenCTIApiClient, OpenCTIConnectorHelper
+from pycti import OpenCTIConnectorHelper
 from stream_connector.utils import obfuscate_api_key, sanitize_payload
 from tenacity import (
     retry,

--- a/stream/zscaler/tests/conftest.py
+++ b/stream/zscaler/tests/conftest.py
@@ -20,14 +20,11 @@ def mock_obfuscate(monkeypatch):
 
 
 @pytest.fixture
-def connector(helper_mock, mock_config, mock_session, mock_opencti_client):
-    """Provide a ZscalerConnector instance with mocked config, session and OpenCTI client"""
+def connector(helper_mock, mock_config, mock_session):
+    """Provide a ZscalerConnector instance with mocked config and session"""
 
     zscaler_connector = zscaler.ZscalerConnector(
-        config_path=None,
         helper=helper_mock,
-        opencti_url=mock_config.opencti.url,
-        opencti_token=mock_config.opencti.token,
         ssl_verify=mock_config.ssl_verify,
         zscaler_username=mock_config.zscaler.username,
         zscaler_password=mock_config.zscaler.password,
@@ -50,18 +47,6 @@ def mock_config():
     mock.zscaler.api_key = "api-key"
     mock.zscaler.blacklist_name = "blacklist"
     return mock
-
-
-@pytest.fixture
-def mock_opencti_client(monkeypatch):
-    mock_client = Mock()
-    mock_client.health_check.return_value = True
-
-    monkeypatch.setattr(
-        zscaler, "OpenCTIApiClient", lambda *args, **kwargs: mock_client
-    )
-
-    return mock_client
 
 
 @pytest.fixture

--- a/stream/zscaler/tests/test_main.py
+++ b/stream/zscaler/tests/test_main.py
@@ -68,18 +68,12 @@ def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper)
     assert helper.connect_live_stream_id == "live-stream-id"
 
 
-def test_connector_is_instantiated(mock_opencti_connector_helper, monkeypatch):
-    # ZscalerConnector builds an OpenCTIApiClient in __init__ - avoid real calls.
-    monkeypatch.setattr("stream_connector.connector.OpenCTIApiClient", MagicMock())
-
+def test_connector_is_instantiated(mock_opencti_connector_helper):
     settings = StubConnectorSettings()
     helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
 
     connector = ZscalerConnector(
-        config_path=None,
         helper=helper,
-        opencti_url=str(settings.opencti.url),
-        opencti_token=settings.opencti.token,
         ssl_verify=settings.zscaler.ssl_verify,
         zscaler_username=settings.zscaler.username,
         zscaler_password=settings.zscaler.password.get_secret_value(),


### PR DESCRIPTION
### Proposed changes

* Remove unused OpenCTIApiClient initialization

### Related issues

* closes #7267 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
