### PR TITLE
fix(misp): fix not subscriptable object in process_events (#7261)

### DIFF
--- a/external-import/misp/src/connector/use_cases/convert_event.py
+++ b/external-import/misp/src/connector/use_cases/convert_event.py
@@ -449,32 +449,41 @@ class EventConverter:
             # Extract relationships from event's objects references
             for object in event.Event.Object or []:
                 for object_reference in object.ObjectReference or []:
-                    ref_src = object_reference.source_uuid
-                    ref_target = object_reference.referenced_uuid
-                    if ref_src and ref_target:
-                        # ! Seems to always return None as MISP uuids are different from generated STIX ids
-                        src_result = find_type_by_uuid(ref_src, stix_objects)
-                        target_result = find_type_by_uuid(ref_target, stix_objects)
-                        if src_result and target_result:
-                            stix_objects.append(
-                                stix2.Relationship(
-                                    id=pycti.StixCoreRelationship.generate_id(
+                    try:
+                        ref_src = object_reference.source_uuid
+                        ref_target = object_reference.referenced_uuid
+                        if ref_src and ref_target:
+                            # ! Seems to always return None as MISP uuids are different from generated STIX ids
+                            src_result = find_type_by_uuid(ref_src, stix_objects)
+                            target_result = find_type_by_uuid(ref_target, stix_objects)
+                            if src_result and target_result:
+                                stix_objects.append(
+                                    stix2.Relationship(
+                                        id=pycti.StixCoreRelationship.generate_id(
+                                            relationship_type="related-to",
+                                            source_ref=src_result["entity"]["id"],
+                                            target_ref=target_result["entity"]["id"],
+                                        ),
                                         relationship_type="related-to",
+                                        created_by_ref=event_author["id"],
+                                        description=(
+                                            f"Original Relationship: {object_reference.relationship_type}\n"
+                                            f"Comment: {object_reference.comment}"
+                                        ),
                                         source_ref=src_result["entity"]["id"],
                                         target_ref=target_result["entity"]["id"],
-                                    ),
-                                    relationship_type="related-to",
-                                    created_by_ref=event_author["id"],
-                                    description=(
-                                        f"Original Relationship: {object_reference['relationship_type']}\n"
-                                        f"Comment: {object_reference['comment']}"
-                                    ),
-                                    source_ref=src_result["entity"]["id"],
-                                    target_ref=target_result["entity"]["id"],
-                                    object_marking_refs=event_markings,
-                                    allow_custom=True,
+                                        object_marking_refs=event_markings,
+                                        allow_custom=True,
+                                    )
                                 )
-                            )
+                    except Exception as e:
+                        self.logger.warning(
+                            f"{LOG_PREFIX} Failed to process object reference, skipping it",
+                            {
+                                "object_reference": str(object_reference),
+                                "error": str(e),
+                            },
+                        )
 
         # Prepare the bundle
         bundle_objects = []

--- a/external-import/misp/src/connector/use_cases/convert_event.py
+++ b/external-import/misp/src/connector/use_cases/convert_event.py
@@ -478,8 +478,9 @@ class EventConverter:
                                 )
                     except Exception as e:
                         self.logger.warning(
-                            f"{LOG_PREFIX} Failed to process object reference, skipping it",
+                            "Failed to process object reference, skipping it",
                             {
+                                "prefix": LOG_PREFIX,
                                 "object_reference": str(object_reference),
                                 "error": str(e),
                             },

--- a/external-import/misp/tests/tests_connector/test_event_converter.py
+++ b/external-import/misp/tests/tests_connector/test_event_converter.py
@@ -1,6 +1,11 @@
+from unittest.mock import MagicMock
+
 import pytest
+from api_client.models import EventRestSearchListItem
+from connector.use_cases import convert_event
 from connector.use_cases.convert_event import (
     DEFAULT_THREAT_LEVEL_SCORE_MAPPING,
+    EventConverter,
     event_threat_level_to_opencti_score,
 )
 
@@ -56,3 +61,123 @@ def test_default_threat_level_score_mapping_matches_legacy_behavior():
         "3": 30,
         "4": 50,
     }
+
+
+def _make_event_with_object_reference() -> EventRestSearchListItem:
+    """Build an event with an Object containing an ObjectReference, which is
+    the payload that used to crash `EventConverter.process` with a
+    `TypeError: 'ObjectItemObjectReference' object is not subscriptable`.
+    """
+    return EventRestSearchListItem.model_validate(
+        {
+            "Event": {
+                "id": "1",
+                "uuid": "00000000-0000-0000-0000-000000000001",
+                "info": "Test event",
+                "date": "2026-01-15",
+                "timestamp": "1768521600",
+                "threat_level_id": "2",
+                "Orgc": {"name": "TestOrg"},
+                "Object": [
+                    {
+                        "id": "10",
+                        "uuid": "10000000-0000-0000-0000-000000000000",
+                        "name": "source-object",
+                        "meta-category": "misc",
+                        "ObjectReference": [
+                            {
+                                "source_uuid": "10000000-0000-0000-0000-000000000000",
+                                "referenced_uuid": "20000000-0000-0000-0000-000000000000",
+                                "relationship_type": "related-to",
+                                "comment": "Test comment",
+                            }
+                        ],
+                    },
+                    {
+                        "id": "20",
+                        "uuid": "20000000-0000-0000-0000-000000000000",
+                        "name": "target-object",
+                        "meta-category": "misc",
+                    },
+                ],
+            }
+        }
+    )
+
+
+def test_process_object_reference_uses_attribute_access(monkeypatch):
+    """Regression test for issue #7261: `EventConverter.process` must read
+    `relationship_type`/`comment` from `ObjectItemObjectReference` using
+    attribute access, not dictionary-style subscript access, since it is a
+    typed (pydantic) object, not a dict.
+    """
+    # Given an event with an Object Reference between two objects that
+    # resolve to STIX entities
+    event = _make_event_with_object_reference()
+
+    logger = MagicMock()
+    converter = EventConverter(
+        logger=logger,
+        external_reference_base_url="http://test.com",
+    )
+
+    fake_source = {
+        "entity": {"id": "identity--10000000-0000-4000-8000-000000000000"},
+        "type": "identity",
+    }
+    fake_target = {
+        "entity": {"id": "identity--20000000-0000-4000-8000-000000000000"},
+        "type": "identity",
+    }
+
+    def fake_find_type_by_uuid(uuid, stix_objects):
+        if uuid == "10000000-0000-0000-0000-000000000000":
+            return fake_source
+        if uuid == "20000000-0000-0000-0000-000000000000":
+            return fake_target
+        return None
+
+    monkeypatch.setattr(convert_event, "find_type_by_uuid", fake_find_type_by_uuid)
+
+    # When processing the event
+    _, _, stix_objects = converter.process(event)
+
+    # Then a relationship is created with the relationship_type/comment
+    # correctly read via attribute access, and no exception is raised
+    relationships = [
+        obj
+        for obj in stix_objects
+        if obj.get("type") == "relationship"
+        and obj["source_ref"] == fake_source["entity"]["id"]
+        and obj["target_ref"] == fake_target["entity"]["id"]
+    ]
+    assert len(relationships) == 1
+    assert "Original Relationship: related-to" in relationships[0]["description"]
+    assert "Comment: Test comment" in relationships[0]["description"]
+
+
+def test_process_object_reference_error_is_caught_and_logged(monkeypatch):
+    """A malformed/unexpected object reference must not interrupt the whole
+    event processing: the error is logged and the event conversion
+    continues instead of raising.
+    """
+    # Given an event with an object reference, but `find_type_by_uuid`
+    # raising an unexpected error while resolving it
+    event = _make_event_with_object_reference()
+
+    logger = MagicMock()
+    converter = EventConverter(
+        logger=logger,
+        external_reference_base_url="http://test.com",
+    )
+
+    def broken_find_type_by_uuid(uuid, stix_objects):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(convert_event, "find_type_by_uuid", broken_find_type_by_uuid)
+
+    # When processing the event
+    # Then no exception propagates and the error is logged as a warning
+    author, markings, stix_objects = converter.process(event)
+
+    assert logger.warning.called

--- a/external-import/misp/tests/tests_connector/test_event_converter.py
+++ b/external-import/misp/tests/tests_connector/test_event_converter.py
@@ -178,6 +178,6 @@ def test_process_object_reference_error_is_caught_and_logged(monkeypatch):
 
     # When processing the event
     # Then no exception propagates and the error is logged as a warning
-    author, markings, stix_objects = converter.process(event)
+    converter.process(event)
 
     assert logger.warning.called


### PR DESCRIPTION
### Proposed changes

* Fix `TypeError: 'ObjectItemObjectReference' object is not subscriptable` in `EventConverter.process` by reading `relationship_type`/`comment` via attribute access instead of dict-style subscript access, since `ObjectItemObjectReference` is a typed pydantic model.
* Wrap the per-object-reference processing in a `try/except` so a single malformed/unexpected object reference is logged as a warning and skipped, instead of aborting the whole batch of MISP events.
* Add regression tests covering both the attribute-access fix and the new error-isolation behavior.

### Related issues

* Close #7261

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] ~~I added/update the relevant documentation (either on github or on notion)~~ (not needed)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Root cause: `object_reference` is a pydantic model (`ObjectItemObjectReference`), not a dict, so `object_reference['relationship_type']` raised. Also added exception handling around this code path per the issue's suggestion, so a single bad object reference doesn't crash the whole event batch.

Validated with the full misp connector test suite (138 tests passing), `black`/`isort`/`flake8`, and the custom STIX-ID pylint plugin (10/10).
