### PR TITLE
fix(servicenow): resolve crash on composer deployment from unhandled int(None) (#7264)

### DIFF
--- a/external-import/servicenow/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/servicenow/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -15,12 +15,8 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
 | CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"P1D"` | Duration between two scheduled runs of the connector (ISO 8601 format). |
-| CONNECTOR_QUEUE_THRESHOLD | `integer` |  | `0 < x ` | `null` | Connector queue max size in Mbytes. Default to 500. |
+| CONNECTOR_QUEUE_THRESHOLD | `integer` |  | `0 < x ` | `500` | Connector queue max size in Mbytes. Default to 500. |
 | CONNECTOR_RUN_AND_TERMINATE | `boolean` |  | boolean | `null` | Connector run-and-terminate flag. |
-| CONNECTOR_SEND_TO_QUEUE | `boolean` |  | boolean | `null` | Connector send-to-queue flag. |
-| CONNECTOR_SEND_TO_DIRECTORY | `boolean` |  | boolean | `null` | Connector send-to-directory flag. |
-| CONNECTOR_SEND_TO_DIRECTORY_PATH | `string` |  | string | `null` | Connector send-to-directory path. |
-| CONNECTOR_SEND_TO_DIRECTORY_RETENTION | `integer` |  | `0 < x ` | `null` | Connector send-to-directory retention in days. |
 | SERVICENOW_API_VERSION | `string` |  | `v1` `v2` | `"v2"` | ServiceNow API version used for REST requests. |
 | SERVICENOW_API_LEAKY_BUCKET_RATE | `integer` |  | `0 < x ` | `10` | Bucket refill rate (in tokens per second). Controls the rate at which API calls are allowed. For example, a rate of 10 means that 10 calls can be made per second, if the bucket is not empty. |
 | SERVICENOW_API_LEAKY_BUCKET_CAPACITY | `integer` |  | `0 < x ` | `10` | Maximum bucket capacity (in tokens). Defines the number of calls that can be made immediately in a burst. Once the bucket is empty, it refills at the rate defined by 'api_leaky_bucket_rate'. |

--- a/external-import/servicenow/__metadata__/connector_config_schema.json
+++ b/external-import/servicenow/__metadata__/connector_config_schema.json
@@ -55,7 +55,7 @@
       "type": "string"
     },
     "CONNECTOR_QUEUE_THRESHOLD": {
-      "default": null,
+      "default": 500,
       "description": "Connector queue max size in Mbytes. Default to 500.",
       "exclusiveMinimum": 0,
       "type": "integer"
@@ -64,27 +64,6 @@
       "default": null,
       "description": "Connector run-and-terminate flag.",
       "type": "boolean"
-    },
-    "CONNECTOR_SEND_TO_QUEUE": {
-      "default": null,
-      "description": "Connector send-to-queue flag.",
-      "type": "boolean"
-    },
-    "CONNECTOR_SEND_TO_DIRECTORY": {
-      "default": null,
-      "description": "Connector send-to-directory flag.",
-      "type": "boolean"
-    },
-    "CONNECTOR_SEND_TO_DIRECTORY_PATH": {
-      "default": null,
-      "description": "Connector send-to-directory path.",
-      "type": "string"
-    },
-    "CONNECTOR_SEND_TO_DIRECTORY_RETENTION": {
-      "default": null,
-      "description": "Connector send-to-directory retention in days.",
-      "exclusiveMinimum": 0,
-      "type": "integer"
     },
     "SERVICENOW_INSTANCE_NAME": {
       "description": "Corresponds to server instance name (will be used for API requests).",

--- a/external-import/servicenow/src/config.yml.sample
+++ b/external-import/servicenow/src/config.yml.sample
@@ -14,10 +14,6 @@ connector:
   #duration_period: 'ChangeMe' # Default: 'PT24H' (ISO8601 format in String, start with P...)
   #queue_threshold: ChangeMe # Default: 500 MBytes, Float accepted
   #run_and_terminate: ChangeMe # Default: False, True run connector once
-  #send_to_queue: ChangeMe # Default: True
-  #send_to_directory: ChangeMe # Default: False
-  #send_to_directory_path: 'ChangeMe' # if CONNECTOR_SEND_TO_DIRECTORY is True, you must specify a path
-  #send_to_directory_retention: ChangeMe # Default: 7, in days
 
 servicenow:
   # ServiceNow definition parameters - REQUIRED

--- a/external-import/servicenow/src/connector/settings.py
+++ b/external-import/servicenow/src/connector/settings.py
@@ -48,8 +48,8 @@ class _ConnectorConfig(BaseExternalImportConnectorConfig):
         default=timedelta(hours=24),
         description="Duration between two scheduled runs of the connector (ISO 8601 format).",
     )
-    queue_threshold: Optional[PositiveInt] = Field(
-        default=None,
+    queue_threshold: PositiveInt = Field(
+        default=500,
         description="Connector queue max size in Mbytes. Default to 500.",
     )
     run_and_terminate: Optional[bool] = Field(

--- a/external-import/servicenow/src/connector/settings.py
+++ b/external-import/servicenow/src/connector/settings.py
@@ -56,22 +56,6 @@ class _ConnectorConfig(BaseExternalImportConnectorConfig):
         default=None,
         description="Connector run-and-terminate flag.",
     )
-    send_to_queue: Optional[bool] = Field(
-        default=None,
-        description="Connector send-to-queue flag.",
-    )
-    send_to_directory: Optional[bool] = Field(
-        default=None,
-        description="Connector send-to-directory flag.",
-    )
-    send_to_directory_path: Optional[str] = Field(
-        default=None,
-        description="Connector send-to-directory path.",
-    )
-    send_to_directory_retention: Optional[PositiveInt] = Field(
-        default=None,
-        description="Connector send-to-directory retention in days.",
-    )
 
 
 class _ServiceNowConfig(BaseConfigModel):


### PR DESCRIPTION
### Proposed changes

* Remove the `send_to_queue`, `send_to_directory`, `send_to_directory_path` and `send_to_directory_retention` `Optional` fields from `_ConnectorConfig` in `src/connector/settings.py`. These are historical pycti helper passthroughs that don't need to be exposed in this connector's settings/manifest at all.
* Root cause: `pycti.OpenCTIConnectorHelper.__init__` casts `CONNECTOR_SEND_TO_DIRECTORY_RETENTION` to `int` via `get_config_variable(..., isNumber=True)`. Because these fields defaulted to `None` and `to_helper_config()` dumps them as an explicit `null` (present key with `None` value), pycti used that `None` instead of falling back to its own default, and crashed with `TypeError: int() argument must be ... not 'NoneType'`. Removing the fields means the keys are absent from the helper config dict entirely, so pycti now falls back to its own safe defaults (e.g. 7 days retention).
* Fix `queue_threshold`: it was typed `Optional[PositiveInt]` with `default=None`, even though its own description documents a default of `500`. Any deployment that didn't explicitly set `CONNECTOR_QUEUE_THRESHOLD` would crash, since `PositiveInt` validation rejects `None` (Pydantic) and the same downstream `int(None)` pattern also applies. Set `default=500` and drop `Optional`, matching the documented behavior.
* Regenerate `__metadata__/connector_config_schema.json` and `__metadata__/CONNECTOR_CONFIG_DOC.md` via the standard `make connector_config_schema` pipeline to drop `CONNECTOR_SEND_TO_QUEUE`, `CONNECTOR_SEND_TO_DIRECTORY`, `CONNECTOR_SEND_TO_DIRECTORY_PATH`, `CONNECTOR_SEND_TO_DIRECTORY_RETENTION`, and to update `CONNECTOR_QUEUE_THRESHOLD`'s default.
* Update `src/config.yml.sample` to remove the corresponding commented-out sample lines.

### Related issues

* Closes #7264
* Related to #7278 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

`run_and_terminate` is intentionally kept as `Optional[bool] = None`: pycti doesn't cast it with `isNumber=True`/`int()`, so a `None` value there doesn't trigger this crash.

Validated with the connector's own test suite (`bash run_test.sh ./external-import/servicenow/tests/test-requirements.txt`, 15 passed) against master's `connectors-sdk`, plus a manual reproduction confirming the helper config dict no longer contains the offending keys and `pycti.get_config_variable` falls back to its default (7) instead of crashing.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
