### PR TITLE
docs(recorded-future): clarify analyst notes only import primary entities (#7279)

### DIFF
--- a/external-import/recorded-future/README.md
+++ b/external-import/recorded-future/README.md
@@ -212,8 +212,8 @@ _insikt_only: True_
 Each Analyst Note is converted into a STIX2 report. The report contains STIX2 SDOs that are converted as per below
 
 - Note Title and Content -> STIX2 report content
-- Topic-> STIX2 report labels
-- Validation Urls -> STIX2 report external references
+- Topic -> STIX2 report labels
+- Validation URLs -> STIX2 report external references
 - Note Entities -> Indicator, Observables, Threat Actors or other corresponding SDOs
 - Detection Rules -> Indicators
 
@@ -235,7 +235,21 @@ For Note entities, the following Recorded Future Entity types are supported:
 - Campaign
 - Threat Actor
 
-The context have been added now following the relationships below:
+> **Note — Primary vs Related entities.**
+>
+> In the Recorded Future portal, an Analyst Note separates its entities into two categories:
+>
+> - Primary Entities: "Entities directly involved or targeted in the reported activity".
+> - Related Entities: "Associated, but not directly involved in the reported activity".
+>
+> This connector **only imports the Primary Entities**. The Related entities are intentionally
+> not ingested, because entities that are merely *associated* — not directly involved —
+> carry a high risk of false positives.
+>
+> As a result, a Report created in OpenCTI may contain fewer entities than the same note shows
+> in the Recorded Future portal — this is expected behavior, not a bug.
+
+The context has been added following the relationships below:
 
 ![mapping relationships](./__docs__/media/mapping-relationships.png)
 
@@ -298,7 +312,7 @@ For example, if you want to perform an investigation on an indicator:
 
 Risk Lists and Analyst Notes can be retrieved simultaneously by the connector.
 
-Give a value for the `risk_list_interval` (config.yml for local deployment) or `RECORDED_FUTURE_RISK_LIST_INTERVAL` (docker-compose.yml file for deployment with Docker containers) allows you to pull Risk Lists at regular intervals. NB: Risk Lists are updated every 12 hours by RecordedFuture, so there is no benefit in fetching them more frequently than that.
+Give a value for the `risk_list_interval` (config.yml for local deployment) or `RECORDED_FUTURE_RISK_LIST_INTERVAL` (docker-compose.yml file for deployment with Docker containers) allows you to pull Risk Lists at regular intervals. NB: Risk Lists are updated every 12 hours by Recorded Future, so there is no benefit in fetching them more frequently than that.
 
 #### Verification
 
@@ -324,7 +338,7 @@ Give a value for the `threat_maps_interval` (config.yml for local deployment) or
 
 The connector will import all Malware and Threat Actors with their context.
 
-Threat Actors will be registered as in `Intrusion Set`.
+Threat Actors will be registered as `Intrusion Set`.
 
 Example of result for an Intrusion Set:
 
@@ -370,7 +384,7 @@ Check your Alerting Rules activation
 
 And if you want to have priority alerts, you need to check the box
 
-![priority alerts](./__docs__/media/rf-priority-alerts.png)]
+![priority alerts](./__docs__/media/rf-priority-alerts.png)
 
 #### Initial population
 

--- a/external-import/recorded-future/README.md
+++ b/external-import/recorded-future/README.md
@@ -338,7 +338,7 @@ Give a value for the `threat_maps_interval` (config.yml for local deployment) or
 
 The connector will import all Malware and Threat Actors with their context.
 
-Threat Actors will be registered as `Intrusion Set`.
+Threat Actors will be registered as `Intrusion Set` entities.
 
 Example of result for an Intrusion Set:
 

--- a/external-import/recorded-future/README.md
+++ b/external-import/recorded-future/README.md
@@ -312,7 +312,7 @@ For example, if you want to perform an investigation on an indicator:
 
 Risk Lists and Analyst Notes can be retrieved simultaneously by the connector.
 
-Give a value for the `risk_list_interval` (config.yml for local deployment) or `RECORDED_FUTURE_RISK_LIST_INTERVAL` (docker-compose.yml file for deployment with Docker containers) allows you to pull Risk Lists at regular intervals. NB: Risk Lists are updated every 12 hours by Recorded Future, so there is no benefit in fetching them more frequently than that.
+Setting `risk_list_interval` (config.yml for local deployment) or `RECORDED_FUTURE_RISK_LIST_INTERVAL` (docker-compose.yml for deployment with Docker containers) allows you to pull Risk Lists at regular intervals. NB: Risk Lists are updated every 12 hours by Recorded Future, so there is no benefit in fetching them more frequently than that.
 
 #### Verification
 

--- a/external-import/recorded-future/README.md
+++ b/external-import/recorded-future/README.md
@@ -249,7 +249,7 @@ For Note entities, the following Recorded Future Entity types are supported:
 > As a result, a Report created in OpenCTI may contain fewer entities than the same note shows
 > in the Recorded Future portal — this is expected behavior, not a bug.
 
-The context has been added following the relationships below:
+The connector creates the following relationships between imported entities:
 
 ![mapping relationships](./__docs__/media/mapping-relationships.png)
 


### PR DESCRIPTION
### Proposed changes

* Add a note in the "Analyst notes" section explaining that the connector imports only the note's Primary Entities and intentionally excludes the Related (context) entities shown in the RF portal, to avoid false positives.
Sets user expectations that an OpenCTI Report may contain fewer entities than the corresponding note in the portal (expected behavior, not a bug).


### Related issues

* Closes #7279

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
