### PR TITLE
fix(greynoise-feed): uncaught ValueError when parsing last_seen with unexpected date format (#7270)

### DIFF
--- a/external-import/greynoise-feed/src/connector/connector.py
+++ b/external-import/greynoise-feed/src/connector/connector.py
@@ -190,9 +190,8 @@ class GreyNoiseFeedConnector:
                 first_seen = parse(
                     ip["internet_scanner_intelligence"]["last_seen_timestamp"]
                 ).strftime("%Y-%m-%dT%H:%M:%SZ")
-                last_seen = datetime.strptime(
-                    ip["internet_scanner_intelligence"]["last_seen_timestamp"],
-                    "%Y-%m-%dT%H:%M:%SZ",
+                last_seen = datetime.fromisoformat(
+                    ip["internet_scanner_intelligence"]["last_seen_timestamp"]
                 ) + timedelta(hours=23)
                 last_seen = last_seen.strftime("%Y-%m-%dT%H:%M:%SZ")
             # Generate ExternalReference
@@ -332,11 +331,12 @@ class GreyNoiseFeedConnector:
                         last_seen_str = ip.get("internet_scanner_intelligence", {}).get(
                             "last_seen_timestamp", ""
                         )
-                        # Parse the timestamp string (format: "2026-01-26 19:59:37") to a timezone-aware datetime
+                        # Parse the timestamp string (e.g. "2026-01-26 19:59:37" or
+                        # "2026-01-26T19:59:37Z") to a timezone-aware datetime
                         try:
-                            last_seen_dt = datetime.strptime(
-                                last_seen_str, "%Y-%m-%d %H:%M:%S"
-                            ).replace(tzinfo=pytz.UTC)
+                            last_seen_dt = datetime.fromisoformat(last_seen_str)
+                            if last_seen_dt.tzinfo is None:
+                                last_seen_dt = last_seen_dt.replace(tzinfo=pytz.UTC)
                         except ValueError:
                             # Skip entries with an unparsable timestamp
                             skip_count += 1
@@ -378,10 +378,16 @@ class GreyNoiseFeedConnector:
                             last_seen_str = ip.get(
                                 "internet_scanner_intelligence", {}
                             ).get("last_seen_timestamp", "")
-                            # Parse the timestamp string (format: "2026-01-26 19:59:37") to a timezone-aware datetime
-                            last_seen_dt = datetime.strptime(
-                                last_seen_str, "%Y-%m-%d %H:%M:%S"
-                            ).replace(tzinfo=pytz.UTC)
+                            # Parse the timestamp string (e.g. "2026-01-26 19:59:37" or
+                            # "2026-01-26T19:59:37Z") to a timezone-aware datetime
+                            try:
+                                last_seen_dt = datetime.fromisoformat(last_seen_str)
+                                if last_seen_dt.tzinfo is None:
+                                    last_seen_dt = last_seen_dt.replace(tzinfo=pytz.UTC)
+                            except ValueError:
+                                # Skip entries with an unparsable timestamp
+                                skip_count += 1
+                                continue
                             if last_seen_dt > most_recent_last_seen:
                                 ips_list.append(ip)
                                 added_count += 1


### PR DESCRIPTION
### Proposed changes

* Replace strict `datetime.strptime(..., "%Y-%m-%dT%H:%M:%SZ")` / `"%Y-%m-%d %H:%M:%S"` parsing of the GreyNoise API `last_seen_timestamp` field with `datetime.fromisoformat()`, which handles both the `"YYYY-MM-DD HH:MM:SS"` and `"YYYY-MM-DDTHH:MM:SSZ"` ISO 8601 variants on Python 3.11+.
* Wrap the second pagination loop's timestamp parsing in a `try/except ValueError` to skip unparsable entries instead of crashing the whole batch, matching the behavior already used in the first page's loop.

### Related issues

* Fixes #7270

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

No existing test suite for `greynoise-feed` (no `tests/` directory), so verification was done via `isort`, `black`, `flake8 --ignore=E,W`, and a `py_compile` syntax check — all pass. Manually verified `datetime.fromisoformat()` correctly parses both `"2026-01-26 19:59:37"` and `"2026-01-26T19:59:37Z"` on Python 3.12.