### PR TITLE
feat(pan-cortex-xdr-intel): implement settings and minimal listen_stream runtime wiring (#7183)

### DIFF
--- a/stream/pan-cortex-xdr-intel/README.md
+++ b/stream/pan-cortex-xdr-intel/README.md
@@ -1,0 +1,59 @@
+# OpenCTI Palo Alto Cortex XDR Intel Connector
+
+## Table of Contents
+
+- [OpenCTI Palo Alto Cortex XDR Intel Connector](#opencti-palo-alto-cortex-xdr-intel-connector)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Installation](#installation)
+    - [Requirements](#requirements)
+    - [Getting the Cortex XDR API base URL](#getting-the-cortex-xdr-api-base-url)
+    - [Getting the Cortex XDR API credentials](#getting-the-cortex-xdr-api-credentials)
+  - [Configuration variables](#configuration-variables)
+
+
+## Introduction
+
+Palo Alto Cortex XDR is an extended detection and response (XDR) platform that integrates endpoint,
+network, and cloud data to detect, investigate, and respond to threats across the enterprise.
+
+This connector listens to an OpenCTI live stream and synchronizes indicators as Indicators of
+Compromise (IOCs) in Palo Alto Cortex XDR.
+
+## Installation
+
+### Requirements
+
+- OpenCTI Platform >= 7.260811.0
+- A Palo Alto Cortex XDR tenant with API access enabled
+- A Cortex XDR API Key (**Advanced** security level) and its associated Key ID
+
+### Getting the Cortex XDR API base URL
+
+The connector's `api_base_url` is built from your Cortex XDR tenant's FQDN:
+
+1. In the Cortex XDR management console, go to **Settings** -> **Configurations** -> **API Keys**.
+2. Note your tenant's FQDN, displayed at the top of the API Keys page (e.g. `xdr.eu.paloaltonetworks.com`).
+3. Prefix it with `api-` and `https://` to build the base URL, i.e. `https://api-<fqdn>`.
+
+See [Get Your FQDN](https://cortex-docs.paloaltonetworks.com/xdr-5-api/get-your-fqdn) for details.
+
+### Getting the Cortex XDR API credentials
+
+1. In the Cortex XDR management console, go to **Settings** -> **Configurations** -> **API Keys** -> **New Key**.
+2. Select **Advanced** as the security level (**Standard** keys are not supported by this connector).
+3. Copy the generated **API Key** (`api_key`) and its **Key ID** (`api_key_id`); the API Key is only shown once
+   and cannot be retrieved again.
+4. Use these values, together with the base URL above, to sign every request: the Key ID is sent as the
+   `x-xdr-auth-id` header, and the Key is used to compute the `Authorization` header.
+
+See [Make Your First API Call](https://cortex-docs.paloaltonetworks.com/xdr-5-api/make-your-first-api-call)
+for further details on Cortex XDR API authentication.
+
+## Configuration variables
+
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
+
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding these variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
+

--- a/stream/pan-cortex-xdr-intel/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/pan-cortex-xdr-intel/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,20 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
+| CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the live stream to connect to. |
+| PAN_CORTEX_XDR_INTEL_API_BASE_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Cortex XDR API base URL (tenant FQDN), i.e. `https://api-<fqdn>`. |
+| PAN_CORTEX_XDR_INTEL_API_KEY_ID | `string` | ✅ | string |  | Cortex XDR API key ID, sent as the `x-xdr-auth-id` header. |
+| PAN_CORTEX_XDR_INTEL_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Cortex XDR API key (Advanced key) used to sign requests. |
+| CONNECTOR_NAME | `string` |  | string | `"Palo Alto Cortex XDR Intel"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["pan-cortex-xdr-intel"]` | The scope of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `STREAM` | `"STREAM"` |  |
+| CONNECTOR_LIVE_STREAM_LISTEN_DELETE | `boolean` |  | boolean | `true` | Whether to listen for delete events on the live stream. |
+| CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES | `boolean` |  | boolean | `true` | Whether to ignore dependencies when processing events from the live stream. |

--- a/stream/pan-cortex-xdr-intel/__metadata__/connector_config_schema.json
+++ b/stream/pan-cortex-xdr-intel/__metadata__/connector_config_schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/pan-cortex-xdr-intel_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_NAME": {
+      "default": "Palo Alto Cortex XDR Intel",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "pan-cortex-xdr-intel"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "STREAM",
+      "default": "STREAM",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_ID": {
+      "description": "The ID of the live stream to connect to.",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_LISTEN_DELETE": {
+      "default": true,
+      "description": "Whether to listen for delete events on the live stream.",
+      "type": "boolean"
+    },
+    "CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES": {
+      "default": true,
+      "description": "Whether to ignore dependencies when processing events from the live stream.",
+      "type": "boolean"
+    },
+    "PAN_CORTEX_XDR_INTEL_API_BASE_URL": {
+      "description": "Cortex XDR API base URL (tenant FQDN), i.e. `https://api-<fqdn>`. ",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "PAN_CORTEX_XDR_INTEL_API_KEY_ID": {
+      "description": "Cortex XDR API key ID, sent as the `x-xdr-auth-id` header.",
+      "type": "string"
+    },
+    "PAN_CORTEX_XDR_INTEL_API_KEY": {
+      "description": "Cortex XDR API key (Advanced key) used to sign requests.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_LIVE_STREAM_ID",
+    "PAN_CORTEX_XDR_INTEL_API_BASE_URL",
+    "PAN_CORTEX_XDR_INTEL_API_KEY_ID",
+    "PAN_CORTEX_XDR_INTEL_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/stream/pan-cortex-xdr-intel/__metadata__/connector_manifest.json
+++ b/stream/pan-cortex-xdr-intel/__metadata__/connector_manifest.json
@@ -19,7 +19,7 @@
   "support_version": ">=7.260811.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/stream/pan-cortex-xdr-intel",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-pan-cortex-xdr-intel",
   "container_type": "STREAM"

--- a/stream/pan-cortex-xdr-intel/config.yml.sample
+++ b/stream/pan-cortex-xdr-intel/config.yml.sample
@@ -1,0 +1,17 @@
+opencti:
+  url: 'http://localhost'
+  token: 'ChangeMe'
+
+connector:
+  live_stream_id: 'ChangeMe' # ID of the live stream created in the OpenCTI UI
+#   id: '6f1b7d7d-4655-42e6-bef1-ad6f176d25a0'
+#   name: 'Palo Alto Cortex XDR Intel'
+#   scope: 'pan-cortex-xdr-intel'
+#   live_stream_listen_delete: true
+#   live_stream_no_dependencies: true
+#   log_level: 'error'
+
+pan_cortex_xdr_intel:
+  api_base_url: 'ChangeMe' # Cortex XDR API base URL (tenant FQDN), e.g. 'https://api-<fqdn>'
+  api_key_id: 'ChangeMe'
+  api_key: 'ChangeMe'

--- a/stream/pan-cortex-xdr-intel/docker-compose.yml
+++ b/stream/pan-cortex-xdr-intel/docker-compose.yml
@@ -4,10 +4,14 @@ services:
     environment:
       - OPENCTI_URL=http://opencti:8080
       - OPENCTI_TOKEN=ChangeMe
-      #- CONNECTOR_ID=ChangeMe # Optional (default: random uuid)
-      #- CONNECTOR_NAME=Pan Cortex XDR Intel # Optional
-      - CONNECTOR_LIVE_STREAM_ID=ChangeMe
-      #- CONNECTOR_LOG_LEVEL=error # Optional (default: 'error')
-      # Cortex XDR specific configuration keys are not final yet:
-      # they will be introduced with the `settings.py` implementation (#7183).
+      - CONNECTOR_LIVE_STREAM_ID=ChangeMe # ID of the live stream created in the OpenCTI UI
+      # - CONNECTOR_ID=6f1b7d7d-4655-42e6-bef1-ad6f176d25a0
+      # - CONNECTOR_NAME=Palo Alto Cortex XDR Intel
+      # - CONNECTOR_SCOPE=pan-cortex-xdr-intel
+      # - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=true
+      # - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true
+      # - CONNECTOR_LOG_LEVEL=error
+      - PAN_CORTEX_XDR_INTEL_API_BASE_URL=ChangeMe # Cortex XDR API base URL (tenant FQDN), e.g. https://api-<fqdn>
+      - PAN_CORTEX_XDR_INTEL_API_KEY_ID=ChangeMe
+      - PAN_CORTEX_XDR_INTEL_API_KEY=ChangeMe
     restart: always

--- a/stream/pan-cortex-xdr-intel/docker-compose.yml
+++ b/stream/pan-cortex-xdr-intel/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   connector-pan-cortex-xdr-intel:
     image: opencti/connector-pan-cortex-xdr-intel:latest
     environment:
-      - OPENCTI_URL=http://opencti:8080
+      - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_LIVE_STREAM_ID=ChangeMe # ID of the live stream created in the OpenCTI UI
       # - CONNECTOR_ID=6f1b7d7d-4655-42e6-bef1-ad6f176d25a0

--- a/stream/pan-cortex-xdr-intel/src/connector/__init__.py
+++ b/stream/pan-cortex-xdr-intel/src/connector/__init__.py
@@ -1,3 +1,4 @@
-from .connector import Connector
+from connector.connector import Connector
+from connector.settings import ConnectorSettings
 
-__all__ = ["Connector"]
+__all__ = ["Connector", "ConnectorSettings"]

--- a/stream/pan-cortex-xdr-intel/src/connector/connector.py
+++ b/stream/pan-cortex-xdr-intel/src/connector/connector.py
@@ -1,7 +1,11 @@
-from typing import Any
+from __future__ import annotations
 
-from cortex_xdr_client import CortexXdrClient
-from pycti import OpenCTIConnectorHelper
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from connector.settings import ConnectorSettings
+    from cortex_xdr_client import CortexXdrClient
+    from pycti import OpenCTIConnectorHelper
 
 
 class Connector:
@@ -13,21 +17,32 @@ class Connector:
     Attributes:
         helper (OpenCTIConnectorHelper):
             Handle the connection and the requests between the connector, OpenCTI and the workers.
-        settings (Any):
+        settings (ConnectorSettings):
             Store the connector's configuration.
         client (CortexXdrClient):
             Provide methods to request the Cortex XDR API.
+
+    ---
+
+    Best practices
+        - `self.helper.connector_logger.[info/debug/warning/error]` is used when logging a message
     """
 
     def __init__(
         self,
         helper: OpenCTIConnectorHelper,
-        settings: Any,
+        settings: ConnectorSettings,
         client: CortexXdrClient,
     ) -> None:
         self.helper = helper
         self.settings = settings
         self.client = client
 
+    def _process_message(self, message: dict) -> None:
+        # TODO: implement IOC upsert/delete mapping from the stream message (#7184/#7185)
+        self.helper.connector_logger.info(
+            "Received stream event (baseline wiring phase)"
+        )
+
     def start(self) -> None:
-        raise NotImplementedError
+        self.helper.listen_stream(self._process_message)

--- a/stream/pan-cortex-xdr-intel/src/connector/settings.py
+++ b/stream/pan-cortex-xdr-intel/src/connector/settings.py
@@ -1,0 +1,56 @@
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseStreamConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field, HttpUrl, SecretStr
+
+
+class StreamConnectorConfig(BaseStreamConnectorConfig):
+    """
+    Override the `BaseStreamConnectorConfig` to add parameters and/or defaults
+    to the configuration for connectors of type `STREAM`.
+    """
+
+    id: str = Field(
+        description="The unique identifier of the connector.",
+        default="6f1b7d7d-4655-42e6-bef1-ad6f176d25a0",
+    )
+    name: str = Field(
+        description="The name of the connector.",
+        default="Palo Alto Cortex XDR Intel",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+        default=["pan-cortex-xdr-intel"],
+    )
+
+
+class PanCortexXdrIntelConfig(BaseConfigModel):
+    """
+    Define parameters and/or defaults for the configuration specific to the Cortex XDR API.
+    """
+
+    api_base_url: HttpUrl = Field(
+        description="Cortex XDR API base URL (tenant FQDN), i.e. `https://api-<fqdn>`. ",
+    )
+    api_key_id: str = Field(
+        description="Cortex XDR API key ID, sent as the `x-xdr-auth-id` header.",
+    )
+    api_key: SecretStr = Field(
+        description="Cortex XDR API key (Advanced key) used to sign requests.",
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """
+    Override `BaseConnectorSettings` to include `StreamConnectorConfig` and `PanCortexXdrIntelConfig`.
+    """
+
+    connector: StreamConnectorConfig = Field(
+        default_factory=StreamConnectorConfig,
+    )
+    pan_cortex_xdr_intel: PanCortexXdrIntelConfig = Field(
+        default_factory=PanCortexXdrIntelConfig
+    )

--- a/stream/pan-cortex-xdr-intel/src/cortex_xdr_client/__init__.py
+++ b/stream/pan-cortex-xdr-intel/src/cortex_xdr_client/__init__.py
@@ -1,3 +1,3 @@
-from .client import CortexXdrClient
+from cortex_xdr_client.client import CortexXdrClient
 
 __all__ = ["CortexXdrClient"]

--- a/stream/pan-cortex-xdr-intel/src/main.py
+++ b/stream/pan-cortex-xdr-intel/src/main.py
@@ -1,7 +1,8 @@
 import traceback
 
-from connector import Connector
+from connector import Connector, ConnectorSettings
 from cortex_xdr_client import CortexXdrClient
+from pycti import OpenCTIConnectorHelper
 
 if __name__ == "__main__":
     """
@@ -14,13 +15,13 @@ if __name__ == "__main__":
     It signals to the operating system and any calling processes that the program did not complete successfully.
     """
     try:
-        # TODO: settings = ConnectorSettings()
-        settings = None
-        # TODO: helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
-        helper = None
-        # TODO: configure the client from `settings` instead of placeholders
+        settings = ConnectorSettings()
+        helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
         client = CortexXdrClient(
-            api_base_url="https://ChangeMe", api_key_id="", api_key=""
+            api_base_url=settings.pan_cortex_xdr_intel.api_base_url,
+            api_key_id=settings.pan_cortex_xdr_intel.api_key_id,
+            api_key=settings.pan_cortex_xdr_intel.api_key.get_secret_value(),
         )
 
         connector = Connector(helper=helper, settings=settings, client=client)

--- a/stream/pan-cortex-xdr-intel/src/requirements.txt
+++ b/stream/pan-cortex-xdr-intel/src/requirements.txt
@@ -1,3 +1,3 @@
-pycti==7.260811.0
+pycti==7.260824.0
 pydantic >=2.8.2, <3
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/stream/pan-cortex-xdr-intel/src/requirements.txt
+++ b/stream/pan-cortex-xdr-intel/src/requirements.txt
@@ -1,2 +1,3 @@
 pycti==7.260811.0
 pydantic >=2.8.2, <3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/stream/pan-cortex-xdr-intel/tests/conftest.py
+++ b/stream/pan-cortex-xdr-intel/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/stream/pan-cortex-xdr-intel/tests/test-requirements.txt
+++ b/stream/pan-cortex-xdr-intel/tests/test-requirements.txt
@@ -1,0 +1,3 @@
+# Main dependencies needs to be installed
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/stream/pan-cortex-xdr-intel/tests/test_main.py
+++ b/stream/pan-cortex-xdr-intel/tests/test_main.py
@@ -1,0 +1,121 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from connector import Connector, ConnectorSettings
+from cortex_xdr_client import CortexXdrClient
+from pycti import OpenCTIConnectorHelper
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+    It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Palo Alto Cortex XDR Intel",
+                    "scope": "pan-cortex-xdr-intel",
+                    "log_level": "error",
+                    "live_stream_id": "test-stream-id",
+                    "live_stream_listen_delete": True,
+                    "live_stream_no_dependencies": True,
+                },
+                "pan_cortex_xdr_intel": {
+                    "api_base_url": "https://api-test.com",
+                    "api_key_id": "test-key-id",
+                    "api_key": "test-api-key",
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that the implementation of `BaseConnectorSettings` (from `connectors-sdk`) can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from `BaseConnectorSettings`)
+        - the method `to_helper_config` MUST return a dict (as in base class)
+    """
+    # Given: A valid settings dict (stubbed via `StubConnectorSettings`)
+    # When: We instantiate the settings
+    settings = StubConnectorSettings()
+
+    # Then: The settings instance is valid and can be converted to the helper config dict
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that `OpenCTIConnectorHelper` (from `pycti`) can be instantiated successfully:
+        - the value of `settings.to_helper_config` MUST be the expected dict for `OpenCTIConnectorHelper`
+        - the helper MUST be able to get its instance's attributes from the config dict
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    # Given: Valid settings
+    settings = StubConnectorSettings()
+
+    # When: We instantiate the helper from the settings' helper config
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    # Then: The helper's attributes match the settings
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "Palo Alto Cortex XDR Intel"
+    assert helper.connect_scope == "pan-cortex-xdr-intel"
+    assert helper.log_level == "ERROR"
+    assert helper.connect_live_stream_id == "test-stream-id"
+    assert helper.connect_live_stream_listen_delete == True
+    assert helper.connect_live_stream_no_dependencies == True
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST be able to access env/config vars through `self.settings`
+        - the connector's main class MUST be able to access `pycti` API through `self.helper`
+        - the connector's main class MUST be able to access the Cortex XDR client through `self.client`
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    # Given: Valid settings, a helper and a client
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+    client = CortexXdrClient(
+        api_base_url=settings.pan_cortex_xdr_intel.api_base_url,
+        api_key_id=settings.pan_cortex_xdr_intel.api_key_id,
+        api_key=settings.pan_cortex_xdr_intel.api_key.get_secret_value(),
+    )
+
+    # When: We instantiate the connector, injecting the helper, settings and client
+    connector = Connector(helper=helper, settings=settings, client=client)
+
+    # Then: The connector exposes the injected dependencies as-is
+    assert connector.helper == helper
+    assert connector.settings == settings
+    assert connector.client == client

--- a/stream/pan-cortex-xdr-intel/tests/tests_connector/test_settings.py
+++ b/stream/pan-cortex-xdr-intel/tests/tests_connector/test_settings.py
@@ -1,0 +1,180 @@
+from typing import Any
+
+import pytest
+from connector import ConnectorSettings
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Palo Alto Cortex XDR Intel",
+                    "scope": "pan-cortex-xdr-intel",
+                    "log_level": "error",
+                    "live_stream_id": "test-stream-id",
+                    "live_stream_listen_delete": True,
+                    "live_stream_no_dependencies": True,
+                },
+                "pan_cortex_xdr_intel": {
+                    "api_base_url": "https://api-test.com",
+                    "api_key_id": "test-key-id",
+                    "api_key": "test-api-key",
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "live_stream_id": "test-stream-id",
+                },
+                "pan_cortex_xdr_intel": {
+                    "api_base_url": "https://api-test.com",
+                    "api_key_id": "test-key-id",
+                    "api_key": "test-api-key",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) accepts valid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake but valid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    """
+
+    # Given: Valid input
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but valid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    # When: We create a ConnectorSettings instance with valid input data
+    settings = FakeConnectorSettings()
+
+    # Then: The ConnectorSettings instance should be created successfully
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.pan_cortex_xdr_intel, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param(
+            {},
+            "url",
+            id="empty_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:PORT",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Palo Alto Cortex XDR Intel",
+                    "scope": "pan-cortex-xdr-intel",
+                    "live_stream_id": "test-stream-id",
+                },
+                "pan_cortex_xdr_intel": {
+                    "api_base_url": "https://api-test.com",
+                    "api_key_id": "test-key-id",
+                    "api_key": "test-api-key",
+                },
+            },
+            "opencti.url",
+            id="invalid_opencti_url",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Palo Alto Cortex XDR Intel",
+                    "scope": "pan-cortex-xdr-intel",
+                    "live_stream_id": "test-stream-id",
+                },
+                "pan_cortex_xdr_intel": {
+                    "api_base_url": "https://api-test.com",
+                    "api_key": "test-api-key",
+                },
+            },
+            "pan_cortex_xdr_intel.api_key_id",
+            id="missing_api_key_id",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "Palo Alto Cortex XDR Intel",
+                    "scope": "pan-cortex-xdr-intel",
+                    "live_stream_id": "test-stream-id",
+                },
+                "pan_cortex_xdr_intel": {
+                    "api_key_id": "test-key-id",
+                    "api_key": "test-api-key",
+                },
+            },
+            "pan_cortex_xdr_intel.api_base_url",
+            id="missing_pan_cortex_xdr_intel_api_base_url",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that `ConnectorSettings` (implementation of `BaseConnectorSettings` from `connectors-sdk`) raises on invalid input.
+    For the test purpose, `BaseConnectorSettings._load_config_dict` is overridden to return
+    a fake and invalid dict (instead of the env/config vars parsed from `config.yml`, `.env` or env vars).
+
+    :param settings_dict: The dict to use as `ConnectorSettings` input
+    :param field_name: The pydantic field path expected to be reported as invalid/missing
+    """
+
+    # Given: Invalid input
+    class FakeConnectorSettings(ConnectorSettings):
+        """
+        Subclass of `ConnectorSettings` (implementation of `BaseConnectorSettings`) for testing purpose.
+        It overrides `BaseConnectorSettings._load_config_dict` to return a fake but invalid config dict.
+        """
+
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    # When: We instantiate the settings with invalid input data
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+
+    # Then: A ConfigValidationError is raised, caused by a pydantic validation error on the expected field
+    assert "Error validating configuration" in str(err.value)
+    assert field_name in str(err.value.__cause__)


### PR DESCRIPTION
### Proposed changes

* Implement `ConnectorSettings` (`connectors_sdk.BaseConnectorSettings`) exposing OpenCTI/stream base settings plus the Cortex XDR credentials (`api_base_url`, `api_key_id`, `api_key` typed as `SecretStr`)
* Wire real dependency injection in `main.py`: `ConnectorSettings()` → `OpenCTIConnectorHelper` → `CortexXdrClient` → `Connector`
* Implement `Connector.start()` with a minimal `_process_message` callback registered on `helper.listen_stream` (IOC upsert/delete mapping left for #7184/#7185)
* Add settings/main wiring tests adapted from `templates/stream`
* Add `config.yml.sample`, update `docker-compose.yml` for the `pan_cortex_xdr_intel` namespace, commenting out optional variables
* Flip `manager_supported` to `true` and generate `connector_config_schema.json` / `CONNECTOR_CONFIG_DOC.md` via the official pipeline — confirmed deployable through XTM Composer
* Document configuration, Cortex XDR API base URL and authentication setup in the README

### Related issues

Close #7183

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This PR is stacked on top of #7292 ("bootstrap bare skeleton and freeze concrete class contracts") and targets `feat/7182-pan-cortex-xdr-intel-connector-skeleton` as its base branch, not `master`. `CortexXdrClient`'s 3-parameter constructor is frozen by that parent branch and is left untouched here.
