### PR TITLE
feat(dual-signal-triage): add Gate/Prove dual-signal enrichment (#7297)

### DIFF
--- a/internal-enrichment/dual-signal-triage/.dockerignore
+++ b/internal-enrichment/dual-signal-triage/.dockerignore
@@ -1,0 +1,9 @@
+__metadata__
+**/__pycache__
+**/__docs__
+**/.venv
+**/venv
+**/logs
+**/config.yml
+**/*.egg-info
+**/*.gql

--- a/internal-enrichment/dual-signal-triage/.gitignore
+++ b/internal-enrichment/dual-signal-triage/.gitignore
@@ -3,5 +3,3 @@ __pycache__/
 *.pyc
 .env
 .venv/
-.venv/
-**/dual-signal-triage/.venv/

--- a/internal-enrichment/dual-signal-triage/.gitignore
+++ b/internal-enrichment/dual-signal-triage/.gitignore
@@ -1,0 +1,7 @@
+config.yml
+__pycache__/
+*.pyc
+.env
+.venv/
+.venv/
+**/dual-signal-triage/.venv/

--- a/internal-enrichment/dual-signal-triage/Dockerfile
+++ b/internal-enrichment/dual-signal-triage/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-alpine
+ENV CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+
+COPY src /opt/opencti-connector-dual-signal-triage
+
+# hadolint ignore=DL3003
+RUN apk update && apk upgrade && \
+    apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
+
+RUN cd /opt/opencti-connector-dual-signal-triage && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    apk del git build-base
+
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/internal-enrichment/dual-signal-triage/README.md
+++ b/internal-enrichment/dual-signal-triage/README.md
@@ -4,14 +4,14 @@ Playbook-compatible enrichment that applies **Gate→Prove** dual-signal triage 
 
 ## Hard rule
 
-**Machine-learning confidence ≠ signature true positive.**
+**Machine-learning confidence is not a signature true positive.**
 
 | Signal basis | Disposition | Labels (examples) |
 |---|---|---|
 | `ml_only` | escalate | `dual-signal:ml-only`, `gate:escalate`, `remediation:deny-auto-contain` |
 | `signature` | gated_fix_now | `dual-signal:signature`, `gate:fix-now`, `remediation:hitl-required` |
 | `corroborated` | gated_fix_now | `dual-signal:corroborated`, `gate:fix-now`, `remediation:hitl-required` |
-| `unknown` | accept | `dual-signal:unknown`, `gate:accept` |
+| `unknown` | accept | `dual-signal:unknown`, `gate:accept`, `remediation:deny-auto-contain` |
 
 ## What it looks for
 

--- a/internal-enrichment/dual-signal-triage/README.md
+++ b/internal-enrichment/dual-signal-triage/README.md
@@ -1,0 +1,51 @@
+# Dual Signal Triage (OpenCTI Internal Enrichment)
+
+Playbook-compatible enrichment that applies **Gate→Prove** dual-signal triage labels to OpenCTI cases and detections.
+
+## Hard rule
+
+**Machine-learning confidence ≠ signature true positive.**
+
+| Signal basis | Disposition | Labels (examples) |
+|---|---|---|
+| `ml_only` | escalate | `dual-signal:ml-only`, `gate:escalate`, `remediation:deny-auto-contain` |
+| `signature` | gated_fix_now | `dual-signal:signature`, `gate:fix-now`, `remediation:hitl-required` |
+| `corroborated` | gated_fix_now | `dual-signal:corroborated`, `gate:fix-now`, `remediation:hitl-required` |
+| `unknown` | accept | `dual-signal:unknown`, `gate:accept` |
+
+## What it looks for
+
+Entity name/description/labels/custom fields containing markers such as:
+
+- OCSF-aligned: `is_ml_only`, `is_corroborated`
+- Snort-family: `gid:411`, `SnortML`
+- Signature classifications / dual-signal corroboration phrases
+
+## Scope
+
+Default: `Case-Incident,Incident,Report,Indicator`
+
+## Configuration
+
+See `src/config.yml.sample` and `docker-compose.yml`.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `DUAL_SIGNAL_TRIAGE_MAX_TLP_LEVEL` | `amber+strict` | Max TLP allowed for enrichment |
+| `DUAL_SIGNAL_TRIAGE_CREATE_NOTE` | `true` | Attach a Note with triage summary |
+
+## Playbooks
+
+Wire this connector after alert/case creation. Automations that call containment tools should **deny** when `remediation:deny-auto-contain` is present, and require Gate→Prove HITL when `remediation:hitl-required` is present.
+
+## Portable sisters
+
+- OCSF: https://github.com/ocsf/ocsf-schema/pull/1732
+- Sigma: https://github.com/SigmaHQ/sigma/pull/6237
+- Elastic: https://github.com/elastic/detection-rules/pull/6662
+- Splunk: https://github.com/splunk/security_content/issues/4220
+
+## Production consumer
+
+Aegis Decision Fabric (gated remediation): https://github.com/AAH20/aegis-decision-fabric  
+Paid Continuous Trust / consultation: https://a2zsoc.com/consultation

--- a/internal-enrichment/dual-signal-triage/__metadata__/connector_manifest.json
+++ b/internal-enrichment/dual-signal-triage/__metadata__/connector_manifest.json
@@ -5,11 +5,11 @@
   "short_description": "Gate/Prove dual-signal triage: ML-only escalate and deny auto-contain; signature/corroborated get HITL-gated fix-now labels.",
   "logo": null,
   "use_cases": [
-    "Detection & Response Enablement",
-    "Incident Response & Case Management"
+    "Detection & Response Enablement"
   ],
   "solution_categories": [
-    "Enrichment & Reputation"
+    "Enrichment & Reputation",
+    "Incident Response & Case Management"
   ],
   "license_type": "Free",
   "contact": null,

--- a/internal-enrichment/dual-signal-triage/__metadata__/connector_manifest.json
+++ b/internal-enrichment/dual-signal-triage/__metadata__/connector_manifest.json
@@ -1,0 +1,27 @@
+{
+  "title": "Dual Signal Triage",
+  "slug": "dual-signal-triage",
+  "description": "Encodes dual-signal triage for OpenCTI case and detection entities so machine-learning-only confidence is never treated as equivalent to a classic rule or signature true positive. The connector classifies entities as ml_only, signature, or corroborated, applies Gate/Prove labels (escalate, fix-now, accept, deny-auto-contain), and optionally attaches a Note summarizing the remediation disposition for playbooks and analysts.",
+  "short_description": "Gate/Prove dual-signal triage: ML-only escalate and deny auto-contain; signature/corroborated get HITL-gated fix-now labels.",
+  "logo": null,
+  "use_cases": [
+    "Detection & Response Enablement",
+    "Incident Response & Case Management"
+  ],
+  "solution_categories": [
+    "Enrichment & Reputation"
+  ],
+  "license_type": "Free",
+  "contact": null,
+  "verified": false,
+  "last_verified_date": null,
+  "playbook_supported": true,
+  "max_confidence_level": 80,
+  "support_version": ">=6.8.12",
+  "subscription_link": null,
+  "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/dual-signal-triage",
+  "manager_supported": false,
+  "container_version": "rolling",
+  "container_image": "opencti/connector-dual-signal-triage",
+  "container_type": "INTERNAL_ENRICHMENT"
+}

--- a/internal-enrichment/dual-signal-triage/docker-compose.yml
+++ b/internal-enrichment/dual-signal-triage/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  connector-dual-signal-triage:
+    image: opencti/connector-dual-signal-triage:latest
+    environment:
+      - OPENCTI_URL=http://localhost
+      - OPENCTI_TOKEN=CHANGEME
+      - CONNECTOR_ID=CHANGEME
+      - CONNECTOR_NAME=Dual Signal Triage
+      - CONNECTOR_SCOPE=Case-Incident,Incident,Report,Indicator
+      - CONNECTOR_LOG_LEVEL=error
+      - CONNECTOR_AUTO=false
+      - DUAL_SIGNAL_TRIAGE_MAX_TLP_LEVEL=amber+strict
+      - DUAL_SIGNAL_TRIAGE_CREATE_NOTE=true
+    restart: always

--- a/internal-enrichment/dual-signal-triage/entrypoint.sh
+++ b/internal-enrichment/dual-signal-triage/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Go to the right directory
+cd /opt/opencti-connector-dual-signal-triage
+
+# Launch the worker
+python3 main.py

--- a/internal-enrichment/dual-signal-triage/src/config.yml.sample
+++ b/internal-enrichment/dual-signal-triage/src/config.yml.sample
@@ -1,0 +1,15 @@
+opencti:
+  url: 'http://localhost'
+  token: 'ChangeMe'
+
+connector:
+  id: 'ChangeMe'
+  type: 'INTERNAL_ENRICHMENT'
+  name: 'Dual Signal Triage'
+  scope: 'Case-Incident,Incident,Report,Indicator'
+  auto: false
+  log_level: 'info'
+
+dual_signal_triage:
+  max_tlp_level: 'amber+strict'
+  create_note: true

--- a/internal-enrichment/dual-signal-triage/src/connector/__init__.py
+++ b/internal-enrichment/dual-signal-triage/src/connector/__init__.py
@@ -1,0 +1,4 @@
+from connector.connector import DualSignalTriageConnector
+from connector.settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings", "DualSignalTriageConnector"]

--- a/internal-enrichment/dual-signal-triage/src/connector/connector.py
+++ b/internal-enrichment/dual-signal-triage/src/connector/connector.py
@@ -1,0 +1,145 @@
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from connector.settings import ConnectorSettings
+from connector.triage import TriageResult, triage_entity
+from pycti import OpenCTIConnectorHelper
+
+
+class DualSignalTriageConnector:
+    """Internal enrichment that encodes Gate→Prove dual-signal triage labels.
+
+    Hard rule: ML-only confidence must never be equated to a signature true positive
+    for automated containment.
+    """
+
+    def __init__(self, config: ConnectorSettings, helper: OpenCTIConnectorHelper):
+        self.config = config
+        self.helper = helper
+        self.tlp = None
+
+    def entity_in_scope(self, data: dict) -> bool:
+        scopes = self.helper.connect_scope.lower().replace(" ", "").split(",")
+        entity_type = data["entity_id"].split("--")[0].lower()
+        return entity_type in scopes
+
+    def extract_and_check_markings(self, opencti_entity: dict) -> None:
+        markings = opencti_entity.get("objectMarking") or []
+        for marking_definition in markings:
+            if marking_definition.get("definition_type") == "TLP":
+                self.tlp = marking_definition.get("definition")
+        valid_max_tlp = self.helper.check_max_tlp(
+            self.tlp, self.config.dual_signal_triage.max_tlp_level
+        )
+        if not valid_max_tlp:
+            raise ValueError(
+                "[CONNECTOR] TLP of the entity is greater than MAX TLP; skipping enrichment"
+            )
+
+    def _ensure_labels(self, result: TriageResult) -> list[str]:
+        label_ids: list[str] = []
+        for value in result.labels:
+            color = "#d32f2f" if result.deny_auto_contain else "#2e7d32"
+            if "escalate" in value or "ml-only" in value:
+                color = "#ed6c02"
+            if "fix-now" in value:
+                color = "#1565c0"
+            label = self.helper.api.label.read_or_create_unchecked(
+                value=value, color=color
+            )
+            if label and label.get("id"):
+                label_ids.append(label["id"])
+                self.helper.api.stix_domain_object.add_label(
+                    id=self._current_entity_id, label_id=label["id"]
+                )
+        return label_ids
+
+    def _append_labels_to_stix(self, stix_entity: dict, result: TriageResult) -> None:
+        existing = stix_entity.get("labels") or []
+        merged = list(dict.fromkeys([*existing, *result.labels]))
+        stix_entity["labels"] = merged
+        extensions = stix_entity.setdefault("extensions", {})
+        octi = extensions.setdefault(
+            "extension-definition--ea279b57-12d3-40be-9208-279dbcbc3d70", {}
+        )
+        octi["dual_signal_basis"] = result.signal_basis
+        octi["dual_signal_disposition"] = result.disposition
+        octi["deny_auto_contain"] = result.deny_auto_contain
+
+    def _create_note_stix(self, stix_entity: dict, result: TriageResult) -> dict[str, Any]:
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        return {
+            "type": "note",
+            "spec_version": "2.1",
+            "id": f"note--{uuid4()}",
+            "created": now,
+            "modified": now,
+            "abstract": f"Dual-signal triage: {result.disposition}",
+            "content": (
+                f"**Signal basis:** `{result.signal_basis}`\n\n"
+                f"**Disposition:** `{result.disposition}`\n\n"
+                f"**Deny auto-contain:** `{result.deny_auto_contain}`\n\n"
+                f"{result.summary}\n\n"
+                "Doctrine: machine-learning confidence ≠ signature true positive."
+            ),
+            "object_refs": [stix_entity["id"]],
+            "labels": list(result.labels),
+        }
+
+    def process_message(self, data: dict) -> str:
+        try:
+            opencti_entity = data["enrichment_entity"]
+            self._current_entity_id = opencti_entity.get("id") or data.get("entity_id")
+            self.extract_and_check_markings(opencti_entity)
+
+            stix_objects = list(data.get("stix_objects") or [])
+            stix_entity = data["stix_entity"]
+
+            if not self.entity_in_scope(data):
+                if not data.get("event_type"):
+                    return self._send_bundle(stix_objects)
+                raise ValueError(
+                    f"Unsupported entity type for dual-signal triage: "
+                    f"{opencti_entity.get('entity_type')}"
+                )
+
+            result = triage_entity({**opencti_entity, **stix_entity})
+            self.helper.connector_logger.info(
+                "[CONNECTOR] Dual-signal triage result",
+                {
+                    "signal_basis": result.signal_basis,
+                    "disposition": result.disposition,
+                    "deny_auto_contain": result.deny_auto_contain,
+                },
+            )
+
+            self._ensure_labels(result)
+            self._append_labels_to_stix(stix_entity, result)
+
+            # Keep a single updated copy of the enriched entity in the bundle
+            replaced = False
+            for idx, obj in enumerate(stix_objects):
+                if obj.get("id") == stix_entity.get("id"):
+                    stix_objects[idx] = stix_entity
+                    replaced = True
+                    break
+            if not replaced:
+                stix_objects.append(stix_entity)
+
+            if self.config.dual_signal_triage.create_note:
+                stix_objects.append(self._create_note_stix(stix_entity, result))
+
+            return self._send_bundle(stix_objects)
+        except Exception as err:
+            return self.helper.connector_logger.error(
+                "[CONNECTOR] Unexpected Error occurred", {"error_message": str(err)}
+            )
+
+    def _send_bundle(self, stix_objects: list) -> str:
+        stix_objects_bundle = self.helper.stix2_create_bundle(stix_objects)
+        bundles_sent = self.helper.send_stix2_bundle(stix_objects_bundle)
+        return f"Sending {len(bundles_sent)} stix bundle(s) for worker import"
+
+    def run(self) -> None:
+        self.helper.listen(message_callback=self.process_message)

--- a/internal-enrichment/dual-signal-triage/src/connector/connector.py
+++ b/internal-enrichment/dual-signal-triage/src/connector/connector.py
@@ -67,7 +67,9 @@ class DualSignalTriageConnector:
         octi["dual_signal_disposition"] = result.disposition
         octi["deny_auto_contain"] = result.deny_auto_contain
 
-    def _create_note_stix(self, stix_entity: dict, result: TriageResult) -> dict[str, Any]:
+    def _create_note_stix(
+        self, stix_entity: dict, result: TriageResult
+    ) -> dict[str, Any]:
         now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         abstract = f"Dual-signal triage: {result.disposition}"
         content = (

--- a/internal-enrichment/dual-signal-triage/src/connector/connector.py
+++ b/internal-enrichment/dual-signal-triage/src/connector/connector.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Any
-from uuid import uuid4
 
+import pycti
 from connector.settings import ConnectorSettings
 from connector.triage import TriageResult, triage_entity
 from pycti import OpenCTIConnectorHelper
@@ -69,20 +69,22 @@ class DualSignalTriageConnector:
 
     def _create_note_stix(self, stix_entity: dict, result: TriageResult) -> dict[str, Any]:
         now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        abstract = f"Dual-signal triage: {result.disposition}"
+        content = (
+            f"**Signal basis:** `{result.signal_basis}`\n\n"
+            f"**Disposition:** `{result.disposition}`\n\n"
+            f"**Deny auto-contain:** `{result.deny_auto_contain}`\n\n"
+            f"{result.summary}\n\n"
+            "Doctrine: machine-learning confidence is not a signature true positive."
+        )
         return {
             "type": "note",
             "spec_version": "2.1",
-            "id": f"note--{uuid4()}",
+            "id": pycti.Note.generate_id(None, content, abstract),
             "created": now,
             "modified": now,
-            "abstract": f"Dual-signal triage: {result.disposition}",
-            "content": (
-                f"**Signal basis:** `{result.signal_basis}`\n\n"
-                f"**Disposition:** `{result.disposition}`\n\n"
-                f"**Deny auto-contain:** `{result.deny_auto_contain}`\n\n"
-                f"{result.summary}\n\n"
-                "Doctrine: machine-learning confidence ≠ signature true positive."
-            ),
+            "abstract": abstract,
+            "content": content,
             "object_refs": [stix_entity["id"]],
             "labels": list(result.labels),
         }

--- a/internal-enrichment/dual-signal-triage/src/connector/settings.py
+++ b/internal-enrichment/dual-signal-triage/src/connector/settings.py
@@ -1,0 +1,40 @@
+from typing import Literal
+
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseInternalEnrichmentConnectorConfig,
+)
+from pydantic import Field
+
+
+class InternalEnrichmentConnectorConfig(BaseInternalEnrichmentConnectorConfig):
+    name: str = Field(
+        description="The name of the connector.",
+        default="Dual Signal Triage",
+    )
+
+
+class DualSignalConfig(BaseConfigModel):
+    max_tlp_level: Literal[
+        "clear",
+        "white",
+        "green",
+        "amber",
+        "amber+strict",
+        "red",
+    ] = Field(
+        description="Max TLP level of the entities to enrich.",
+        default="amber+strict",
+    )
+    create_note: bool = Field(
+        description="Create a Note with the Gate/Prove triage summary.",
+        default=True,
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    connector: InternalEnrichmentConnectorConfig = Field(
+        default_factory=InternalEnrichmentConnectorConfig
+    )
+    dual_signal_triage: DualSignalConfig = Field(default_factory=DualSignalConfig)

--- a/internal-enrichment/dual-signal-triage/src/connector/triage.py
+++ b/internal-enrichment/dual-signal-triage/src/connector/triage.py
@@ -1,0 +1,154 @@
+"""Pure dual-signal triage — ML confidence ≠ signature true positive."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, Mapping, NamedTuple
+
+
+ML_ONLY_PATTERNS = (
+    r"\bis_ml_only\b",
+    r"\bml[_ -]?only\b",
+    r"\bgid[\s:_=]*411\b",
+    r"\bgenerator[\s_-]?id[\s:_=]*411\b",
+    r"\bsnortml\b",
+    r"\blearning\s*\(ml/dl\)\b",
+    r"\bnever_equate_ml\b",
+    r"\bnever[_ -]?equate[_ -]?ml[_ -]?to[_ -]?signature\b",
+)
+
+SIGNATURE_PATTERNS = (
+    r"\bis_ml_only\s*[:=]\s*false\b",
+    r"\bsignature[_ -]?high\b",
+    r"\bsignature[_ -]?tp\b",
+    r"\banalytic\.type_id\s*[:=]\s*1\b",
+    r"\ba network trojan was detected\b",
+    r"\bprivilege gain\b",
+    r"\bmalware command and control\b",
+    r"\bknown malware command and control\b",
+)
+
+CORROBORATED_PATTERNS = (
+    r"\bis_corroborated\b",
+    r"\bcorroborat(?:ed|ion)\b",
+    r"\bsignature[_ -]?and[_ -]?(?:eve|ml|high)\b",
+    r"\bdual[_ -]?signal[_ -]?corroborat",
+    r"\bsignature\s*\+\s*(?:ml|eve)\b",
+)
+
+
+class TriageResult(NamedTuple):
+    signal_basis: str
+    disposition: str
+    labels: tuple[str, ...]
+    deny_auto_contain: bool
+    summary: str
+
+
+def _flatten_entity(entity: Mapping[str, Any] | None) -> str:
+    if not entity:
+        return ""
+    parts: list[str] = []
+    for key in ("name", "value", "description", "content", "pattern", "abstract"):
+        val = entity.get(key)
+        if isinstance(val, str) and val.strip():
+            parts.append(val)
+    labels = entity.get("labels") or entity.get("x_opencti_labels") or []
+    if isinstance(labels, list):
+        for label in labels:
+            if isinstance(label, str):
+                parts.append(label)
+            elif isinstance(label, Mapping):
+                value = label.get("value") or label.get("name")
+                if isinstance(value, str):
+                    parts.append(value)
+    custom = entity.get("customFieldValues") or entity.get("x_opencti_custom_fields")
+    if isinstance(custom, list):
+        for item in custom:
+            if isinstance(item, Mapping):
+                parts.extend(str(v) for v in item.values() if v is not None)
+    elif isinstance(custom, Mapping):
+        parts.extend(str(v) for v in custom.values() if v is not None)
+    for key, val in entity.items():
+        if key.startswith("x_") and isinstance(val, (str, bool, int, float)):
+            parts.append(f"{key}={val}")
+    return "\n".join(parts).lower()
+
+
+def _any_match(text: str, patterns: Iterable[str]) -> bool:
+    return any(re.search(pat, text, flags=re.IGNORECASE) for pat in patterns)
+
+
+def triage_text(text: str) -> TriageResult:
+    blob = (text or "").lower()
+    has_ml = _any_match(blob, ML_ONLY_PATTERNS)
+    has_signature = _any_match(blob, SIGNATURE_PATTERNS)
+    is_corroborated = _any_match(blob, CORROBORATED_PATTERNS) or (
+        has_ml and has_signature
+    )
+    is_ml_only = has_ml and not is_corroborated
+    is_signature = has_signature and not is_corroborated
+
+    if is_corroborated:
+        return TriageResult(
+            signal_basis="corroborated",
+            disposition="gated_fix_now",
+            labels=(
+                "dual-signal:corroborated",
+                "gate:fix-now",
+                "remediation:hitl-required",
+            ),
+            deny_auto_contain=False,
+            summary=(
+                "Corroborated dual-signal finding (rule/signature + second signal). "
+                "Eligible for Gate→Prove remediation after human/policy confirmation. "
+                "Do not auto-contain without Gate."
+            ),
+        )
+
+    if is_ml_only:
+        return TriageResult(
+            signal_basis="ml_only",
+            disposition="escalate",
+            labels=(
+                "dual-signal:ml-only",
+                "gate:escalate",
+                "remediation:deny-auto-contain",
+            ),
+            deny_auto_contain=True,
+            summary=(
+                "ML-only signal path. Machine-learning confidence must not be treated as "
+                "equivalent to a classic signature true positive. Escalate for corroboration; "
+                "deny auto-containment."
+            ),
+        )
+
+    if is_signature:
+        return TriageResult(
+            signal_basis="signature",
+            disposition="gated_fix_now",
+            labels=(
+                "dual-signal:signature",
+                "gate:fix-now",
+                "remediation:hitl-required",
+            ),
+            deny_auto_contain=False,
+            summary=(
+                "Classic rule/signature true-positive candidate. Prefer gated remediation "
+                "(HITL/policy Gate→Prove) over ungated automation."
+            ),
+        )
+
+    return TriageResult(
+        signal_basis="unknown",
+        disposition="accept",
+        labels=("dual-signal:unknown", "gate:accept"),
+        deny_auto_contain=True,
+        summary=(
+            "Insufficient dual-signal markers. Default to accept/monitor; do not auto-contain."
+        ),
+    )
+
+
+def triage_entity(entity: Mapping[str, Any] | None) -> TriageResult:
+    return triage_text(_flatten_entity(entity))

--- a/internal-enrichment/dual-signal-triage/src/connector/triage.py
+++ b/internal-enrichment/dual-signal-triage/src/connector/triage.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 from typing import Any, Iterable, Mapping, NamedTuple
 
-
 ML_ONLY_PATTERNS = (
     r"\bis_ml_only\b",
     r"\bml[_ -]?only\b",

--- a/internal-enrichment/dual-signal-triage/src/connector/triage.py
+++ b/internal-enrichment/dual-signal-triage/src/connector/triage.py
@@ -53,7 +53,12 @@ def _flatten_entity(entity: Mapping[str, Any] | None) -> str:
         val = entity.get(key)
         if isinstance(val, str) and val.strip():
             parts.append(val)
-    labels = entity.get("labels") or entity.get("x_opencti_labels") or []
+    labels = (
+        entity.get("labels")
+        or entity.get("x_opencti_labels")
+        or entity.get("objectLabel")
+        or []
+    )
     if isinstance(labels, list):
         for label in labels:
             if isinstance(label, str):
@@ -142,7 +147,7 @@ def triage_text(text: str) -> TriageResult:
     return TriageResult(
         signal_basis="unknown",
         disposition="accept",
-        labels=("dual-signal:unknown", "gate:accept"),
+        labels=("dual-signal:unknown", "gate:accept", "remediation:deny-auto-contain"),
         deny_auto_contain=True,
         summary=(
             "Insufficient dual-signal markers. Default to accept/monitor; do not auto-contain."

--- a/internal-enrichment/dual-signal-triage/src/main.py
+++ b/internal-enrichment/dual-signal-triage/src/main.py
@@ -1,0 +1,17 @@
+import traceback
+
+from connector import ConnectorSettings, DualSignalTriageConnector
+from pycti import OpenCTIConnectorHelper
+
+if __name__ == "__main__":
+    try:
+        settings = ConnectorSettings()
+        helper = OpenCTIConnectorHelper(
+            config=settings.to_helper_config(),
+            playbook_compatible=True,
+        )
+        connector = DualSignalTriageConnector(config=settings, helper=helper)
+        connector.run()
+    except Exception:
+        traceback.print_exc()
+        exit(1)

--- a/internal-enrichment/dual-signal-triage/src/requirements.txt
+++ b/internal-enrichment/dual-signal-triage/src/requirements.txt
@@ -1,3 +1,3 @@
-pycti==7.260811.0
+pycti==7.260817.0
 pydantic~=2.11.3
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/dual-signal-triage/src/requirements.txt
+++ b/internal-enrichment/dual-signal-triage/src/requirements.txt
@@ -1,0 +1,3 @@
+pycti==7.260811.0
+pydantic~=2.11.3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-enrichment/dual-signal-triage/tests/test-requirements.txt
+++ b/internal-enrichment/dual-signal-triage/tests/test-requirements.txt
@@ -1,0 +1,2 @@
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/internal-enrichment/dual-signal-triage/tests/test_triage.py
+++ b/internal-enrichment/dual-signal-triage/tests/test_triage.py
@@ -1,12 +1,12 @@
 import importlib.util
+import sys
 from pathlib import Path
 
 _TRIAGE = Path(__file__).resolve().parents[1] / "src" / "connector" / "triage.py"
 _spec = importlib.util.spec_from_file_location("dual_signal_triage_logic", _TRIAGE)
+if _spec is None or _spec.loader is None:
+    raise ImportError(f"cannot load triage module from {_TRIAGE}")
 triage = importlib.util.module_from_spec(_spec)
-assert _spec.loader is not None
-import sys
-
 sys.modules[_spec.name] = triage
 _spec.loader.exec_module(triage)
 
@@ -39,6 +39,17 @@ def test_corroborated_ocsf_flags():
     assert "dual-signal:corroborated" in result.labels
 
 
+def test_object_label_payload():
+    result = triage.triage_entity(
+        {
+            "name": "incident",
+            "objectLabel": [{"value": "is_ml_only"}, {"name": "snortml"}],
+        }
+    )
+    assert result.signal_basis == "ml_only"
+    assert result.deny_auto_contain is True
+
+
 def test_ml_plus_signature_is_corroborated():
     result = triage.triage_text("gid 411 and A Network Trojan was Detected")
     assert result.signal_basis == "corroborated"
@@ -49,3 +60,4 @@ def test_unknown_defaults_to_accept():
     assert result.signal_basis == "unknown"
     assert result.disposition == "accept"
     assert result.deny_auto_contain is True
+    assert "remediation:deny-auto-contain" in result.labels

--- a/internal-enrichment/dual-signal-triage/tests/test_triage.py
+++ b/internal-enrichment/dual-signal-triage/tests/test_triage.py
@@ -1,0 +1,51 @@
+import importlib.util
+from pathlib import Path
+
+_TRIAGE = Path(__file__).resolve().parents[1] / "src" / "connector" / "triage.py"
+_spec = importlib.util.spec_from_file_location("dual_signal_triage_logic", _TRIAGE)
+triage = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+import sys
+
+sys.modules[_spec.name] = triage
+_spec.loader.exec_module(triage)
+
+
+def test_ml_only_gid_411():
+    result = triage.triage_text("SnortML alert GeneratorID=411 high impact")
+    assert result.signal_basis == "ml_only"
+    assert result.disposition == "escalate"
+    assert result.deny_auto_contain is True
+    assert "remediation:deny-auto-contain" in result.labels
+
+
+def test_signature_high():
+    result = triage.triage_text("Classification: A Network Trojan was Detected")
+    assert result.signal_basis == "signature"
+    assert result.disposition == "gated_fix_now"
+    assert result.deny_auto_contain is False
+
+
+def test_corroborated_ocsf_flags():
+    result = triage.triage_entity(
+        {
+            "name": "C2 candidate",
+            "description": "signature and eve high",
+            "labels": ["is_corroborated"],
+        }
+    )
+    assert result.signal_basis == "corroborated"
+    assert result.disposition == "gated_fix_now"
+    assert "dual-signal:corroborated" in result.labels
+
+
+def test_ml_plus_signature_is_corroborated():
+    result = triage.triage_text("gid 411 and A Network Trojan was Detected")
+    assert result.signal_basis == "corroborated"
+
+
+def test_unknown_defaults_to_accept():
+    result = triage.triage_text("routine host inventory note")
+    assert result.signal_basis == "unknown"
+    assert result.disposition == "accept"
+    assert result.deny_auto_contain is True


### PR DESCRIPTION
## Summary

Closes https://github.com/OpenCTI-Platform/connectors/issues/7297

Adds playbook-compatible internal enrichment connector `dual-signal-triage` so OpenCTI cases/detections encode **Gate→Prove** dual-signal dispositions:

| Basis | Disposition | Labels |
|---|---|---|
| `ml_only` | escalate | `dual-signal:ml-only`, `gate:escalate`, `remediation:deny-auto-contain` |
| `signature` | gated_fix_now | `dual-signal:signature`, `gate:fix-now`, `remediation:hitl-required` |
| `corroborated` | gated_fix_now | `dual-signal:corroborated`, `gate:fix-now`, `remediation:hitl-required` |
| `unknown` | accept | `dual-signal:unknown`, `gate:accept` |

**Hard rule:** ML confidence ≠ signature true positive. Containment automations should deny when `remediation:deny-auto-contain` is present.

## Contents

- `internal-enrichment/dual-signal-triage/` (connector, README, docker, metadata)
- Unit-tested pure triage module (`tests/test_triage.py` — 5 passed)
- Default scope: `Case-Incident,Incident,Report,Indicator`

## Portable sisters

- OCSF https://github.com/ocsf/ocsf-schema/pull/1732
- Sigma https://github.com/SigmaHQ/sigma/pull/6237
- Elastic https://github.com/elastic/detection-rules/pull/6662

Optional production consumer (paid Continuous Trust, not unpaid R&D): https://github.com/AAH20/aegis-decision-fabric · https://a2zsoc.com/consultation

## Test plan

- [ ] Review triage unit tests / run `pytest tests/test_triage.py`
- [ ] Deploy connector against OpenCTI; enrich a Case-Incident with `gid:411` → expect deny-auto-contain
- [ ] Enrich with signature classification → expect gate:fix-now
- [ ] Enrich with `is_corroborated` → expect dual-signal:corroborated
- [ ] Confirm playbook path returns STIX bundle

Made with [Cursor](https://cursor.com)