### PR TITLE
fix(shodan-internetdb): run() should register process_message, not _process_message (#6780)

### DIFF
--- a/internal-enrichment/shodan-internetdb/src/shodan_internetdb/connector.py
+++ b/internal-enrichment/shodan-internetdb/src/shodan_internetdb/connector.py
@@ -110,4 +110,4 @@ class ShodanInternetDBConnector:
         Start the connector
         :return: None
         """
-        self.helper.listen(message_callback=self._process_message)
+        self.helper.listen(message_callback=self.process_message)


### PR DESCRIPTION
### Proposed changes

* run() register process_message, not _process_message ()

### Related issues

* closes #6780

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
