### PR TITLE
feat(import-file-misp): migrate connector to manager-supported mode (#7217)

### DIFF
--- a/internal-import-file/import-file-misp/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-import-file/import-file-misp/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,29 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
+| CONNECTOR_NAME | `string` |  | string | `"ImportFileMISP"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["application/json"]` | The scope (MIME types) handled by the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `INTERNAL_IMPORT_FILE` | `"INTERNAL_IMPORT_FILE"` |  |
+| CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |
+| MISP_IMPORT_FILE_IMPORT_FROM_DATE | `string` |  | string | `null` | Optional lower-bound date used when importing MISP events. |
+| MISP_IMPORT_FILE_CREATE_REPORTS | `boolean` |  | boolean | `true` | Create a report for each imported MISP event. |
+| MISP_IMPORT_FILE_REPORT_TYPE | `string` |  | string | `"misp-event"` | Report type to use for imported MISP events. |
+| MISP_IMPORT_FILE_CREATE_INDICATORS | `boolean` |  | boolean | `true` | Create indicators from MISP attributes. |
+| MISP_IMPORT_FILE_CREATE_OBSERVABLES | `boolean` |  | boolean | `true` | Create observables from MISP attributes. |
+| MISP_IMPORT_FILE_CREATE_OBJECT_OBSERVABLES | `boolean` |  | boolean | `false` | Create text observables for MISP objects. |
+| MISP_IMPORT_FILE_CREATE_TAGS_AS_LABELS | `boolean` |  | boolean | `true` | Create MISP tags as OpenCTI labels. |
+| MISP_IMPORT_FILE_GUESS_THREATS_FROM_TAGS | `boolean` |  | boolean | `false` | Try to guess threats (threat actor, intrusion set, malware, etc.) from MISP tags when they are present in OpenCTI. |
+| MISP_IMPORT_FILE_AUTHOR_FROM_TAGS | `boolean` |  | boolean | `false` | Map creator:XX=YY so the event author is derived from MISP tags. |
+| MISP_IMPORT_FILE_MARKINGS_FROM_TAGS | `boolean` |  | boolean | `false` | Derive markings from MISP tags. |
+| MISP_IMPORT_FILE_IMPORT_TO_IDS_NO_SCORE | `integer` |  | integer | `null` | Score applied to the indicator/observable when the attribute 'to_ids' flag is false. |
+| MISP_IMPORT_FILE_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT | `boolean` |  | boolean | `false` | Import unsupported observables as x_opencti_text. |
+| MISP_IMPORT_FILE_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT_TRANSPARENT | `boolean` |  | boolean | `true` | Import unsupported observables as x_opencti_text just with the value. |
+| MISP_IMPORT_FILE_IMPORT_WITH_ATTACHMENTS | `boolean` |  | boolean | `false` | Try to import a PDF file from the attachment attribute. |

--- a/internal-import-file/import-file-misp/__metadata__/connector_config_schema.json
+++ b/internal-import-file/import-file-misp/__metadata__/connector_config_schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/import-file-misp_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_NAME": {
+      "default": "ImportFileMISP",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "application/json"
+      ],
+      "description": "The scope (MIME types) handled by the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_IMPORT_FILE",
+      "default": "INTERNAL_IMPORT_FILE",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Whether the connector should run automatically when an entity is created or updated.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_IMPORT_FROM_DATE": {
+      "default": null,
+      "description": "Optional lower-bound date used when importing MISP events.",
+      "type": "string"
+    },
+    "MISP_IMPORT_FILE_CREATE_REPORTS": {
+      "default": true,
+      "description": "Create a report for each imported MISP event.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_REPORT_TYPE": {
+      "default": "misp-event",
+      "description": "Report type to use for imported MISP events.",
+      "type": "string"
+    },
+    "MISP_IMPORT_FILE_CREATE_INDICATORS": {
+      "default": true,
+      "description": "Create indicators from MISP attributes.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_CREATE_OBSERVABLES": {
+      "default": true,
+      "description": "Create observables from MISP attributes.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_CREATE_OBJECT_OBSERVABLES": {
+      "default": false,
+      "description": "Create text observables for MISP objects.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_CREATE_TAGS_AS_LABELS": {
+      "default": true,
+      "description": "Create MISP tags as OpenCTI labels.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_GUESS_THREATS_FROM_TAGS": {
+      "default": false,
+      "description": "Try to guess threats (threat actor, intrusion set, malware, etc.) from MISP tags when they are present in OpenCTI.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_AUTHOR_FROM_TAGS": {
+      "default": false,
+      "description": "Map creator:XX=YY so the event author is derived from MISP tags.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_MARKINGS_FROM_TAGS": {
+      "default": false,
+      "description": "Derive markings from MISP tags.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_IMPORT_TO_IDS_NO_SCORE": {
+      "default": null,
+      "description": "Score applied to the indicator/observable when the attribute 'to_ids' flag is false.",
+      "type": "integer"
+    },
+    "MISP_IMPORT_FILE_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT": {
+      "default": false,
+      "description": "Import unsupported observables as x_opencti_text.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT_TRANSPARENT": {
+      "default": true,
+      "description": "Import unsupported observables as x_opencti_text just with the value.",
+      "type": "boolean"
+    },
+    "MISP_IMPORT_FILE_IMPORT_WITH_ATTACHMENTS": {
+      "default": false,
+      "description": "Try to import a PDF file from the attachment attribute.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-import-file/import-file-misp/__metadata__/connector_manifest.json
+++ b/internal-import-file/import-file-misp/__metadata__/connector_manifest.json
@@ -19,7 +19,7 @@
   "support_version": ">=6.3.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-import-file/import-file-misp",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-import-file-misp",
   "container_type": "INTERNAL_IMPORT_FILE"

--- a/internal-import-file/import-file-misp/docker-compose.yml
+++ b/internal-import-file/import-file-misp/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       #- CONNECTOR_VALIDATE_BEFORE_IMPORT=false # Optional, validate any bundle before import (default: false)
       #- CONNECTOR_AUTO=false # Optional, enable/disable auto-import of file (default: false)
       #- CONNECTOR_LOG_LEVEL=error # Optional (default: 'error')
-      #- MISP_IMPORT_FILE_IMPORT_FROM_DATE=2024-01-01T00:00:00Z # Optional (default: none)
       #- MISP_IMPORT_FILE_CREATE_REPORTS=true # Optional, create report for MISP event (default: true)
       #- MISP_IMPORT_FILE_REPORT_TYPE=misp-event # Optional (default: 'misp-event')
       #- MISP_IMPORT_FILE_CREATE_INDICATORS=true # Optional, create indicators from attributes (default: true)

--- a/internal-import-file/import-file-misp/docker-compose.yml
+++ b/internal-import-file/import-file-misp/docker-compose.yml
@@ -6,20 +6,23 @@ services:
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
-      - CONNECTOR_NAME=ImportFileMISP
-      - CONNECTOR_VALIDATE_BEFORE_IMPORT=false # Validate any bundle before import
-      - CONNECTOR_SCOPE=application/json
-      - CONNECTOR_LOG_LEVEL=error
-      - MISP_IMPORT_FILE_CREATE_REPORTS=true # Required, create report for MISP event
-      - MISP_IMPORT_FILE_REPORT_TYPE=misp-event
-      - MISP_IMPORT_FILE_CREATE_INDICATORS=true # Required, create indicators from attributes
-      - MISP_IMPORT_FILE_CREATE_OBSERVABLES=true # Required, create observables from attributes
-      - MISP_IMPORT_FILE_CREATE_OBJECT_OBSERVABLES=true # Required, create text observables for MISP objects
-      - MISP_IMPORT_FILE_CREATE_TAGS_AS_LABELS=true # Optional, create tags as labels (sanitize MISP tag to OpenCTI labels)
-      - MISP_IMPORT_FILE_GUESS_THREAT_FROM_TAGS=false # Optional, try to guess threats (threat actor, intrusion set, malware, etc.) from MISP tags when they are present in OpenCTI
-      - MISP_IMPORT_FILE_AUTHOR_FROM_TAGS=false # Optional, map creator:XX=YY (author of event will be YY instead of the author of the event)
-      - MISP_IMPORT_FILE_IMPORT_TO_IDS_NO_SCORE=40 # Optional, use as a score for the indicator/observable if the attribute to_ids is no
-      - MISP_IMPORT_FILE_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT=false #  Optional, import unsupported observable as x_opencti_text
-      - MISP_IMPORT_FILE_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT_TRANSPARENT=true #  Optional, import unsupported observable as x_opencti_text just with the value
-      - MISP_IMPORT_FILE_IMPORT_WITH_ATTACHMENTS=false # Optional, try to import a PDF file from the attachment attribute
+      #- CONNECTOR_NAME=ImportFileMISP # Optional (default: 'ImportFileMISP')
+      #- CONNECTOR_SCOPE=application/json # Optional (default: 'application/json')
+      #- CONNECTOR_VALIDATE_BEFORE_IMPORT=false # Optional, validate any bundle before import (default: false)
+      #- CONNECTOR_AUTO=false # Optional, enable/disable auto-import of file (default: false)
+      #- CONNECTOR_LOG_LEVEL=error # Optional (default: 'error')
+      #- MISP_IMPORT_FILE_IMPORT_FROM_DATE=2024-01-01T00:00:00Z # Optional (default: none)
+      #- MISP_IMPORT_FILE_CREATE_REPORTS=true # Optional, create report for MISP event (default: true)
+      #- MISP_IMPORT_FILE_REPORT_TYPE=misp-event # Optional (default: 'misp-event')
+      #- MISP_IMPORT_FILE_CREATE_INDICATORS=true # Optional, create indicators from attributes (default: true)
+      #- MISP_IMPORT_FILE_CREATE_OBSERVABLES=true # Optional, create observables from attributes (default: true)
+      #- MISP_IMPORT_FILE_CREATE_OBJECT_OBSERVABLES=true # Optional, create text observables for MISP objects (default: false)
+      #- MISP_IMPORT_FILE_CREATE_TAGS_AS_LABELS=true # Optional, create tags as labels (sanitize MISP tag to OpenCTI labels) (default: true)
+      #- MISP_IMPORT_FILE_GUESS_THREATS_FROM_TAGS=false # Optional, try to guess threats (threat actor, intrusion set, malware, etc.) from MISP tags when they are present in OpenCTI (default: false)
+      #- MISP_IMPORT_FILE_AUTHOR_FROM_TAGS=false # Optional, map creator:XX=YY (author of event will be YY instead of the author of the event) (default: false)
+      #- MISP_IMPORT_FILE_MARKINGS_FROM_TAGS=false # Optional, derive markings from MISP tags (default: false)
+      #- MISP_IMPORT_FILE_IMPORT_TO_IDS_NO_SCORE=40 # Optional, use as a score for the indicator/observable if the attribute to_ids is no (default: none)
+      #- MISP_IMPORT_FILE_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT=false # Optional, import unsupported observable as x_opencti_text (default: false)
+      #- MISP_IMPORT_FILE_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT_TRANSPARENT=true # Optional, import unsupported observable as x_opencti_text just with the value (default: true)
+      #- MISP_IMPORT_FILE_IMPORT_WITH_ATTACHMENTS=false # Optional, try to import a PDF file from the attachment attribute (default: false)
     restart: always

--- a/internal-import-file/import-file-misp/src/__init__.py
+++ b/internal-import-file/import-file-misp/src/__init__.py
@@ -1,0 +1,3 @@
+from settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings"]

--- a/internal-import-file/import-file-misp/src/config.yml.sample
+++ b/internal-import-file/import-file-misp/src/config.yml.sample
@@ -3,9 +3,9 @@ opencti:
   token: 'ChangeMe'
 
 connector:
-  type: 'INTERNAL_IMPORT_FILE'
   id: 'ChangeMe'
   name: 'ImportFileMISP'
+  validate_before_import: false # Validate any bundle before import
   scope: 'application/json'
   log_level: 'info'
 
@@ -18,6 +18,7 @@ misp_import_file:
   create_tags_as_labels: true # Optional, create tags as labels (sanitize MISP tag to OpenCTI labels)
   guess_threats_from_tags: false # Optional, try to guess threats (threat actor, intrusion set, malware, etc.) from MISP tags when they are present in OpenCTI
   author_from_tags: false # Optional, map creator:XX=YY (author of event will be YY instead of the author of the event)
+  markings_from_tags: false # Optional, derive markings from MISP tags
   import_to_ids_no_score: 40 # Optional, use as a score for the indicator/observable if the attribute to_ids is no
   import_unsupported_observables_as_text: false # Optional, import unsupported observable as x_opencti_text
   import_unsupported_observables_as_text_transparent: true # Optional, import unsupported observable as x_opencti_text just with the value

--- a/internal-import-file/import-file-misp/src/import-file-misp.py
+++ b/internal-import-file/import-file-misp/src/import-file-misp.py
@@ -1,12 +1,10 @@
 import json
-import os
 import re
 import sys
 import time
 from datetime import datetime
 
 import stix2
-import yaml
 from pycti import (
     AttackPattern,
     CustomObservableHostname,
@@ -24,8 +22,8 @@ from pycti import (
     StixCoreRelationship,
     StixSightingRelationship,
     Tool,
-    get_config_variable,
 )
+from settings import ConnectorSettings
 
 PATTERNTYPES = ["yara", "sigma", "pcre", "snort", "suricata"]
 OPENCTISTIX2 = {
@@ -74,110 +72,38 @@ FILETYPES = ["file-name", "file-md5", "file-sha1", "file-sha256"]
 
 class MispImportFile:
     def __init__(self):
-        # Instantiate the connector helper from config
-        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
-        self.helper = OpenCTIConnectorHelper(config)
+        # Instantiate the connector helper from validated Pydantic settings
+        self.config = ConnectorSettings()
+        self.helper = OpenCTIConnectorHelper(config=self.config.to_helper_config())
         # Extra config
-        self.misp_import_file_import_from_date = get_config_variable(
-            "MISP_IMPORT_FILE_IMPORT_FROM_DATE",
-            ["misp_import_file", "import_from_date"],
-            config,
+        misp_import_file = self.config.misp_import_file
+        self.misp_import_file_import_from_date = misp_import_file.import_from_date
+        self.misp_import_file_create_reports = misp_import_file.create_reports
+        self.misp_import_file_report_type = misp_import_file.report_type
+        self.misp_import_file_create_indicators = misp_import_file.create_indicators
+        self.misp_import_file_create_observables = misp_import_file.create_observables
+        self.misp_import_file_create_tags_as_labels = (
+            misp_import_file.create_tags_as_labels
         )
-        self.misp_import_file_create_reports = get_config_variable(
-            "MISP_IMPORT_FILE_CREATE_REPORTS",
-            ["misp_import_file", "create_reports"],
-            config,
-            False,
-            True,
+        self.misp_import_file_guess_threats_from_tags = (
+            misp_import_file.guess_threats_from_tags
         )
-        self.misp_import_file_report_type = get_config_variable(
-            "MISP_IMPORT_FILE_REPORT_TYPE",
-            ["misp_import_file", "report_type"],
-            config,
-            False,
-            "misp-event",
+        self.misp_import_file_author_from_tags = misp_import_file.author_from_tags
+        self.misp_import_file_markings_from_tags = misp_import_file.markings_from_tags
+        self.misp_import_file_create_object_observables = (
+            misp_import_file.create_object_observables
         )
-        self.misp_import_file_create_indicators = get_config_variable(
-            "MISP_IMPORT_FILE_CREATE_INDICATORS",
-            ["misp_import_file", "create_indicators"],
-            config,
+        self.misp_import_file_import_to_ids_no_score = (
+            misp_import_file.import_to_ids_no_score
         )
-        self.misp_import_file_create_observables = get_config_variable(
-            "MISP_IMPORT_FILE_CREATE_OBSERVABLES",
-            ["misp_import_file", "create_observables"],
-            config,
+        self.misp_import_file_import_with_attachments = (
+            misp_import_file.import_with_attachments
         )
-        self.misp_import_file_create_tags_as_labels = get_config_variable(
-            "MISP_CREATE_TAGS_AS_LABELS",
-            ["misp_import_file", "create_tags_as_labels"],
-            config,
-            default=True,
+        self.misp_import_file_import_unsupported_observables_as_text = (
+            misp_import_file.import_unsupported_observables_as_text
         )
-        self.misp_import_file_guess_threats_from_tags = get_config_variable(
-            "MISP_IMPORT_FILE_GUESS_THREAT_FROM_TAGS",
-            ["misp_import_file", "guess_threats_from_tags"],
-            config,
-            default=False,
-        )
-        self.misp_import_file_author_from_tags = get_config_variable(
-            "MISP_IMPORT_FILE_AUTHOR_FROM_TAGS",
-            ["misp_import_file", "author_from_tags"],
-            config,
-            default=False,
-        )
-        self.misp_import_file_markings_from_tags = get_config_variable(
-            "MISP_IMPORT_FILE_MARKINGS_FROM_TAGS",
-            ["misp_import_file", "markings_from_tags"],
-            config,
-            default=False,
-        )
-        self.misp_import_file_create_object_observables = get_config_variable(
-            "MISP_IMPORT_FILE_CREATE_OBJECT_OBSERVABLES",
-            ["misp_import_file", "create_object_observables"],
-            config,
-            False,
-            False,
-        )
-        self.misp_import_file_import_to_ids_no_score = get_config_variable(
-            "MISP_IMPORT_FILE_IMPORT_TO_IDS_NO_SCORE",
-            ["misp_import_file", "import_to_ids_no_score"],
-            config,
-            True,
-        )
-        self.misp_import_file_import_with_attachments = bool(
-            get_config_variable(
-                "MISP_IMPORT_FILE_IMPORT_WITH_ATTACHMENTS",
-                ["misp_import_file", "import_with_attachments"],
-                config,
-                isNumber=False,
-                default=False,
-            )
-        )
-        self.misp_import_file_import_unsupported_observables_as_text = bool(
-            get_config_variable(
-                "MISP_IMPORT_FILE_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT",
-                ["misp_import_file", "import_unsupported_observables_as_text"],
-                config,
-                isNumber=False,
-                default=False,
-            )
-        )
-        self.misp_import_file_import_unsupported_observables_as_text_transparent = bool(
-            get_config_variable(
-                "MISP_IMPORT_FILE_IMPORT_UNSUPPORTED_OBSERVABLES_AS_TEXT_TRANSPARENT",
-                [
-                    "misp_import_file",
-                    "import_unsupported_observables_as_text_transparent",
-                ],
-                config,
-                isNumber=False,
-                default=True,
-            )
+        self.misp_import_file_import_unsupported_observables_as_text_transparent = (
+            misp_import_file.import_unsupported_observables_as_text_transparent
         )
 
     def _resolve_markings(self, tags, with_default=True):

--- a/internal-import-file/import-file-misp/src/import-file-misp.py
+++ b/internal-import-file/import-file-misp/src/import-file-misp.py
@@ -77,7 +77,6 @@ class MispImportFile:
         self.helper = OpenCTIConnectorHelper(config=self.config.to_helper_config())
         # Extra config
         misp_import_file = self.config.misp_import_file
-        self.misp_import_file_import_from_date = misp_import_file.import_from_date
         self.misp_import_file_create_reports = misp_import_file.create_reports
         self.misp_import_file_report_type = misp_import_file.report_type
         self.misp_import_file_create_indicators = misp_import_file.create_indicators

--- a/internal-import-file/import-file-misp/src/import-file-misp.py
+++ b/internal-import-file/import-file-misp/src/import-file-misp.py
@@ -217,7 +217,6 @@ class MispImportFile:
                             stix2.IntrusionSet(
                                 id=IntrusionSet.generate_id(name),
                                 name=name,
-                                confidence=self.helper.connect_confidence_level,
                                 labels=["intrusion-set"],
                                 description=galaxy_entity["description"],
                                 created_by_ref=author["id"],
@@ -390,7 +389,6 @@ class MispImportFile:
                                 stix2.IntrusionSet(
                                     id=IntrusionSet.generate_id(threat["name"]),
                                     name=threat["name"],
-                                    confidence=self.helper.connect_confidence_level,
                                     created_by_ref=author["id"],
                                     object_marking_refs=markings,
                                     allow_custom=True,
@@ -403,7 +401,6 @@ class MispImportFile:
                                     id=Malware.generate_id(threat["name"]),
                                     name=threat["name"],
                                     is_family=True,
-                                    confidence=self.helper.connect_confidence_level,
                                     created_by_ref=author["id"],
                                     object_marking_refs=markings,
                                     allow_custom=True,
@@ -415,7 +412,6 @@ class MispImportFile:
                                 stix2.Tool(
                                     id=Tool.generate_id(threat["name"]),
                                     name=threat["name"],
-                                    confidence=self.helper.connect_confidence_level,
                                     created_by_ref=author["id"],
                                     object_marking_refs=markings,
                                     allow_custom=True,
@@ -427,7 +423,6 @@ class MispImportFile:
                                 stix2.AttackPattern(
                                     id=AttackPattern.generate_id(threat["name"]),
                                     name=threat["name"],
-                                    confidence=self.helper.connect_confidence_level,
                                     created_by_ref=author["id"],
                                     object_marking_refs=markings,
                                     allow_custom=True,
@@ -471,7 +466,6 @@ class MispImportFile:
                             stix2.IntrusionSet(
                                 id=IntrusionSet.generate_id(name),
                                 name=name,
-                                confidence=self.helper.connect_confidence_level,
                                 created_by_ref=author["id"],
                                 object_marking_refs=markings,
                                 allow_custom=True,
@@ -502,7 +496,6 @@ class MispImportFile:
                             stix2.Tool(
                                 id=Tool.generate_id(name),
                                 name=name,
-                                confidence=self.helper.connect_confidence_level,
                                 created_by_ref=author["id"],
                                 object_marking_refs=markings,
                                 allow_custom=True,
@@ -538,7 +531,6 @@ class MispImportFile:
                                 id=Malware.generate_id(name),
                                 name=name,
                                 is_family=True,
-                                confidence=self.helper.connect_confidence_level,
                                 created_by_ref=author["id"],
                                 object_marking_refs=markings,
                                 allow_custom=True,
@@ -570,7 +562,6 @@ class MispImportFile:
                             stix2.AttackPattern(
                                 id=AttackPattern.generate_id(name),
                                 name=name,
-                                confidence=self.helper.connect_confidence_level,
                                 created_by_ref=author["id"],
                                 object_marking_refs=markings,
                                 allow_custom=True,
@@ -587,7 +578,6 @@ class MispImportFile:
                             stix2.Identity(
                                 id=Identity.generate_id(name, "class"),
                                 name=name,
-                                confidence=self.helper.connect_confidence_level,
                                 identity_class="class",
                                 created_by_ref=author["id"],
                                 object_marking_refs=markings,
@@ -945,7 +935,6 @@ class MispImportFile:
                         id=Indicator.generate_id(pattern),
                         name=name,
                         description=attribute["comment"],
-                        confidence=self.helper.connect_confidence_level,
                         pattern_type=pattern_type,
                         pattern=pattern,
                         valid_from=datetime.utcfromtimestamp(
@@ -1262,7 +1251,6 @@ class MispImportFile:
                             target_ref=threat.id,
                             description=attribute["comment"],
                             object_marking_refs=attribute_markings,
-                            confidence=self.helper.connect_confidence_level,
                             allow_custom=True,
                         )
                     )
@@ -1278,7 +1266,6 @@ class MispImportFile:
                             target_ref=threat.id,
                             description=attribute["comment"],
                             object_marking_refs=attribute_markings,
-                            confidence=self.helper.connect_confidence_level,
                             allow_custom=True,
                         )
                     )
@@ -1305,7 +1292,6 @@ class MispImportFile:
                             target_ref=threat_id,
                             description=attribute["comment"],
                             object_marking_refs=attribute_markings,
-                            confidence=self.helper.connect_confidence_level,
                             allow_custom=True,
                         )
                     )
@@ -1321,7 +1307,6 @@ class MispImportFile:
                             target_ref=threat_id,
                             description=attribute["comment"],
                             object_marking_refs=attribute_markings,
-                            confidence=self.helper.connect_confidence_level,
                             allow_custom=True,
                         )
                     )
@@ -1348,7 +1333,6 @@ class MispImportFile:
                         target_ref=attack_pattern.id,
                         description=attribute["comment"],
                         object_marking_refs=attribute_markings,
-                        confidence=self.helper.connect_confidence_level,
                         allow_custom=True,
                     )
                     relationships.append(relationship_uses)
@@ -1362,7 +1346,6 @@ class MispImportFile:
                     #         source_ref=indicator.id,
                     #         target_ref=relationship_uses.id,
                     #         description=attribute["comment"],
-                    #         confidence=self.helper.connect_confidence_level,
                     #         object_marking_refs=attribute_markings,
                     #     )
                     #     relationships.append(relationship_indicates)
@@ -1376,7 +1359,6 @@ class MispImportFile:
                     #         source_ref=observable.id,
                     #         target_ref=relationship_uses.id,
                     #         description=attribute["comment"],
-                    #         confidence=self.helper.connect_confidence_level,
                     #         object_marking_refs=attribute_markings,
                     #     )
                     #     relationships.append(relationship_indicates)
@@ -1399,7 +1381,6 @@ class MispImportFile:
                             "uses", threat_id, attack_pattern.id
                         ),
                         relationship_type="uses",
-                        confidence=self.helper.connect_confidence_level,
                         created_by_ref=author["id"],
                         source_ref=threat_id,
                         target_ref=attack_pattern.id,
@@ -1418,7 +1399,6 @@ class MispImportFile:
                     #        source_ref=indicator.id,
                     #        target_ref=relationship_uses.id,
                     #        description=attribute["comment"],
-                    #        confidence=self.helper.connect_confidence_level,
                     #        object_marking_refs=attribute_markings,
                     #    )
                     #    relationships.append(relationship_indicates)
@@ -1432,7 +1412,6 @@ class MispImportFile:
                     #        source_ref=observable.id,
                     #        target_ref=relationship_uses.id,
                     #        description=attribute["comment"],
-                    #        confidence=self.helper.connect_confidence_level,
                     #        object_marking_refs=attribute_markings,
                     #    )
                     #    relationships.append(relationship_indicates)
@@ -1449,7 +1428,6 @@ class MispImportFile:
                             target_ref=sector.id,
                             description=attribute["comment"],
                             object_marking_refs=attribute_markings,
-                            confidence=self.helper.connect_confidence_level,
                             allow_custom=True,
                         )
                     )
@@ -1465,7 +1443,6 @@ class MispImportFile:
                             target_ref=sector.id,
                             description=attribute["comment"],
                             object_marking_refs=attribute_markings,
-                            confidence=self.helper.connect_confidence_level,
                             allow_custom=True,
                         )
                     )
@@ -1483,7 +1460,6 @@ class MispImportFile:
                             target_ref=country.id,
                             description=attribute["comment"],
                             object_marking_refs=attribute_markings,
-                            confidence=self.helper.connect_confidence_level,
                             allow_custom=True,
                         )
                     )
@@ -1499,7 +1475,6 @@ class MispImportFile:
                             target_ref=country.id,
                             description=attribute["comment"],
                             object_marking_refs=attribute_markings,
-                            confidence=self.helper.connect_confidence_level,
                             allow_custom=True,
                         )
                     )
@@ -1925,7 +1900,6 @@ class MispImportFile:
                 labels=event_tags,
                 object_refs=object_refs,
                 external_references=event_external_references,
-                confidence=self.helper.connect_confidence_level,
                 custom_properties={
                     "x_opencti_files": added_files,
                 },
@@ -1940,7 +1914,6 @@ class MispImportFile:
                         ),
                         self._process_note(note["content"], bundle_objects),
                     ),
-                    confidence=self.helper.connect_confidence_level,
                     created=datetime.utcfromtimestamp(int(note["timestamp"])).strftime(
                         "%Y-%m-%dT%H:%M:%SZ"
                     ),

--- a/internal-import-file/import-file-misp/src/import-file-misp.py
+++ b/internal-import-file/import-file-misp/src/import-file-misp.py
@@ -187,7 +187,7 @@ class MispImportFile:
         added_names = []
         for galaxy in galaxies:
             if "namespace" not in galaxy:
-                self.helper.log_info("Skipping galaxy without namespace")
+                self.helper.connector_logger.info("Skipping galaxy without namespace")
                 continue
             # Get the linked intrusion sets
             if (
@@ -798,14 +798,14 @@ class MispImportFile:
 
         attr_data = attribute.get("data")
         if attr_data is None:
-            self.helper.log_error(
+            self.helper.connector_logger.error(
                 "No data for attribute: {0} ({1}:{2})".format(
                     attr_uuid, attr_type, attr_category
                 )
             )
             return None
 
-        self.helper.log_info(
+        self.helper.connector_logger.info(
             "Found PDF '{0}' for attribute: {1} ({2}:{3})".format(
                 attr_value, attr_uuid, attr_type, attr_category
             )
@@ -957,7 +957,9 @@ class MispImportFile:
                         },
                     )
                 except Exception as e:
-                    self.helper.log_error(f"Error processing indicator {name}: {e}")
+                    self.helper.connector_logger.error(
+                        f"Error processing indicator {name}: {e}"
+                    )
             observable = None
             if self.misp_import_file_create_observables and observable_type is not None:
                 try:
@@ -1126,7 +1128,7 @@ class MispImportFile:
                             external_references=attribute_external_references,
                         )
                 except Exception as e:
-                    self.helper.log_error(
+                    self.helper.connector_logger.error(
                         f"Error creating observable type {observable_type} with value {observable_value}: {e}"
                     )
             sightings = []
@@ -1935,7 +1937,7 @@ class MispImportFile:
         bypass_validation = data["bypass_validation"]
         file_markings = data.get("file_markings", [])
         file_uri = self.helper.opencti_url + file_fetch
-        self.helper.log_info(f"Importing the file {file_uri}")
+        self.helper.connector_logger.info(f"Importing the file {file_uri}")
         file_content = self.helper.api.fetch_opencti_file(file_uri)
         events = json.loads(file_content)
         if not isinstance(events, list):
@@ -1948,7 +1950,7 @@ class MispImportFile:
             bundle_json = self._process_event(event)
             entity_id = data.get("entity_id", None)
             if entity_id:
-                self.helper.log_info("Contextual import.")
+                self.helper.connector_logger.info("Contextual import.")
                 bundle = json.loads(bundle_json)["objects"]
                 bundle = self._update_container(bundle, entity_id)
                 bundle_json = self.helper.stix2_create_bundle(bundle)
@@ -2003,7 +2005,7 @@ class MispImportFile:
             ][0]
             if self._is_container(container_stix.get("type")):
                 if self._contains_container(bundle):
-                    self.helper.log_info("Bundle contains container.")
+                    self.helper.connector_logger.info("Bundle contains container.")
                     container_stix["object_refs"] = []
                     for elem in bundle:
                         if self._is_container(elem.get("type")):
@@ -2012,7 +2014,7 @@ class MispImportFile:
                                 for object_id in elem.get("object_refs"):
                                     container_stix["object_refs"].append(object_id)
                 else:
-                    self.helper.log_info(
+                    self.helper.connector_logger.info(
                         "No container in Stix file. Updating current container"
                     )
                     container_stix["object_refs"] = [object["id"] for object in bundle]

--- a/internal-import-file/import-file-misp/src/requirements.txt
+++ b/internal-import-file/import-file-misp/src/requirements.txt
@@ -1,1 +1,3 @@
 pycti==7.260817.0
+pydantic >=2.8.2, <3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-import-file/import-file-misp/src/settings.py
+++ b/internal-import-file/import-file-misp/src/settings.py
@@ -42,10 +42,6 @@ class MispImportFileConfig(BaseConfigModel):
     configuration so existing behavior is preserved.
     """
 
-    import_from_date: str | None = Field(
-        description="Optional lower-bound date used when importing MISP events.",
-        default=None,
-    )
     create_reports: bool = Field(
         description="Create a report for each imported MISP event.",
         default=True,

--- a/internal-import-file/import-file-misp/src/settings.py
+++ b/internal-import-file/import-file-misp/src/settings.py
@@ -1,0 +1,115 @@
+"""Pydantic settings for the Import File MISP connector.
+
+These settings mirror one-to-one the connector's historical
+``pycti.get_config_variable`` based configuration, exposing it through the
+``connectors-sdk`` base models so the connector becomes manager-supported.
+
+The custom configuration section keeps its original name ``misp_import_file``,
+which maps to the ``MISP_IMPORT_FILE_*`` environment variables.
+"""
+
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseInternalImportFileConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field
+
+
+class InternalImportFileConnectorConfig(BaseInternalImportFileConnectorConfig):
+    """Connector section with defaults specific to Import File MISP."""
+
+    name: str = Field(
+        description="The name of the connector.",
+        default="ImportFileMISP",
+    )
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="a7cb9c9f-65d6-4919-bef2-e7a866a9fd80",
+    )
+    scope: ListFromString = Field(
+        description="The scope (MIME types) handled by the connector.",
+        default=["application/json"],
+    )
+
+
+class MispImportFileConfig(BaseConfigModel):
+    """Config fields specific to the Import File MISP connector.
+
+    Mirrors the ``misp_import_file`` variables historically read through
+    ``get_config_variable``. Defaults reflect the connector's shipped
+    configuration so existing behavior is preserved.
+    """
+
+    import_from_date: str | None = Field(
+        description="Optional lower-bound date used when importing MISP events.",
+        default=None,
+    )
+    create_reports: bool = Field(
+        description="Create a report for each imported MISP event.",
+        default=True,
+    )
+    report_type: str = Field(
+        description="Report type to use for imported MISP events.",
+        default="misp-event",
+    )
+    create_indicators: bool = Field(
+        description="Create indicators from MISP attributes.",
+        default=True,
+    )
+    create_observables: bool = Field(
+        description="Create observables from MISP attributes.",
+        default=True,
+    )
+    create_object_observables: bool = Field(
+        description="Create text observables for MISP objects.",
+        default=False,
+    )
+    create_tags_as_labels: bool = Field(
+        description="Create MISP tags as OpenCTI labels.",
+        default=True,
+    )
+    guess_threats_from_tags: bool = Field(
+        description=(
+            "Try to guess threats (threat actor, intrusion set, malware, etc.) "
+            "from MISP tags when they are present in OpenCTI."
+        ),
+        default=False,
+    )
+    author_from_tags: bool = Field(
+        description="Map creator:XX=YY so the event author is derived from MISP tags.",
+        default=False,
+    )
+    markings_from_tags: bool = Field(
+        description="Derive markings from MISP tags.",
+        default=False,
+    )
+    import_to_ids_no_score: int | None = Field(
+        description=(
+            "Score applied to the indicator/observable when the attribute "
+            "'to_ids' flag is false."
+        ),
+        default=None,
+    )
+    import_unsupported_observables_as_text: bool = Field(
+        description="Import unsupported observables as x_opencti_text.",
+        default=False,
+    )
+    import_unsupported_observables_as_text_transparent: bool = Field(
+        description="Import unsupported observables as x_opencti_text just with the value.",
+        default=True,
+    )
+    import_with_attachments: bool = Field(
+        description="Try to import a PDF file from the attachment attribute.",
+        default=False,
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """Global settings for the Import File MISP connector."""
+
+    connector: InternalImportFileConnectorConfig = Field(
+        default_factory=InternalImportFileConnectorConfig
+    )
+    misp_import_file: MispImportFileConfig = Field(default_factory=MispImportFileConfig)

--- a/internal-import-file/import-file-misp/tests/conftest.py
+++ b/internal-import-file/import-file-misp/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/internal-import-file/import-file-misp/tests/test-requirements.txt
+++ b/internal-import-file/import-file-misp/tests/test-requirements.txt
@@ -1,0 +1,3 @@
+# Main dependencies needs to be installed
+-r ../src/requirements.txt
+pytest==8.4.2

--- a/internal-import-file/import-file-misp/tests/test-requirements.txt
+++ b/internal-import-file/import-file-misp/tests/test-requirements.txt
@@ -1,3 +1,3 @@
-# Main dependencies needs to be installed
+# Main dependencies need to be installed
 -r ../src/requirements.txt
 pytest==8.4.2

--- a/internal-import-file/import-file-misp/tests/test_main.py
+++ b/internal-import-file/import-file-misp/tests/test_main.py
@@ -1,0 +1,121 @@
+import importlib.util
+import os
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pycti import OpenCTIConnectorHelper
+from settings import ConnectorSettings
+
+# The connector entry module keeps its historical hyphenated file name
+# (`import-file-misp.py`), which is not importable through the regular import
+# system. It is therefore loaded from its file location.
+_MODULE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "src", "import-file-misp.py"
+)
+_spec = importlib.util.spec_from_file_location("import_file_misp", _MODULE_PATH)
+import_file_misp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(import_file_misp)
+MispImportFile = import_file_misp.MispImportFile
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of ConnectorSettings for testing purpose.
+    Overrides _load_config_dict to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "ImportFileMISP",
+                    "scope": "application/json",
+                    "log_level": "error",
+                    "validate_before_import": True,
+                    "auto": False,
+                },
+                "misp_import_file": {
+                    "import_from_date": "2024-01-01T00:00:00Z",
+                    "create_reports": True,
+                    "report_type": "misp-event",
+                    "create_indicators": True,
+                    "create_observables": True,
+                    "create_object_observables": False,
+                    "create_tags_as_labels": True,
+                    "guess_threats_from_tags": False,
+                    "author_from_tags": False,
+                    "markings_from_tags": False,
+                    "import_to_ids_no_score": 40,
+                    "import_unsupported_observables_as_text": False,
+                    "import_unsupported_observables_as_text_transparent": True,
+                    "import_with_attachments": False,
+                },
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that ConnectorSettings can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from BaseConnectorSettings)
+        - the method `to_helper_config` MUST return a dict
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that OpenCTIConnectorHelper can be instantiated successfully:
+        - the value of settings.to_helper_config MUST be the expected dict for OpenCTIConnectorHelper
+        - the helper MUST be able to get its instance's attributes from the config dict
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "ImportFileMISP"
+    assert helper.connect_scope == "application/json"
+    assert helper.log_level == "ERROR"
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper, monkeypatch):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST build its config through ConnectorSettings
+        - the connector's main class MUST be able to access pycti API through self.helper
+    """
+    monkeypatch.setattr(import_file_misp, "ConnectorSettings", StubConnectorSettings)
+
+    connector = MispImportFile()
+
+    assert isinstance(connector.config, ConnectorSettings)
+    assert connector.helper is not None
+    # The connector still exposes its historical config attributes.
+    assert connector.misp_import_file_create_indicators is True
+    assert connector.misp_import_file_import_to_ids_no_score == 40

--- a/internal-import-file/import-file-misp/tests/test_main.py
+++ b/internal-import-file/import-file-misp/tests/test_main.py
@@ -56,7 +56,6 @@ class StubConnectorSettings(ConnectorSettings):
                     "auto": False,
                 },
                 "misp_import_file": {
-                    "import_from_date": "2024-01-01T00:00:00Z",
                     "create_reports": True,
                     "report_type": "misp-event",
                     "create_indicators": True,

--- a/internal-import-file/import-file-misp/tests/tests_connector/test_settings.py
+++ b/internal-import-file/import-file-misp/tests/tests_connector/test_settings.py
@@ -1,0 +1,130 @@
+from typing import Any
+
+import pytest
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+from settings import ConnectorSettings
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "ImportFileMISP",
+                    "scope": "application/json",
+                    "log_level": "error",
+                    "validate_before_import": True,
+                    "auto": False,
+                },
+                "misp_import_file": {
+                    "import_from_date": "2024-01-01T00:00:00Z",
+                    "create_reports": True,
+                    "report_type": "misp-event",
+                    "create_indicators": True,
+                    "create_observables": True,
+                    "create_object_observables": False,
+                    "create_tags_as_labels": True,
+                    "guess_threats_from_tags": False,
+                    "author_from_tags": False,
+                    "markings_from_tags": False,
+                    "import_to_ids_no_score": 40,
+                    "import_unsupported_observables_as_text": False,
+                    "import_unsupported_observables_as_text_transparent": True,
+                    "import_with_attachments": False,
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that ConnectorSettings accepts valid input.
+    _load_config_dict is overridden to return a fake but valid dict.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.misp_import_file, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param(
+            {},
+            "settings",
+            id="empty_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "ImportFileMISP",
+                    "scope": "application/json",
+                    "log_level": "error",
+                },
+            },
+            "opencti.token",
+            id="missing_opencti_token",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": 12345,
+                    "name": "ImportFileMISP",
+                    "scope": "application/json",
+                    "log_level": "error",
+                },
+            },
+            "connector.id",
+            id="invalid_connector_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that ConnectorSettings raises on invalid input.
+    _load_config_dict is overridden to return a fake and invalid dict.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert "Error validating configuration" in str(err)

--- a/internal-import-file/import-file-misp/tests/tests_connector/test_settings.py
+++ b/internal-import-file/import-file-misp/tests/tests_connector/test_settings.py
@@ -23,7 +23,6 @@ from settings import ConnectorSettings
                     "auto": False,
                 },
                 "misp_import_file": {
-                    "import_from_date": "2024-01-01T00:00:00Z",
                     "create_reports": True,
                     "report_type": "misp-event",
                     "create_indicators": True,


### PR DESCRIPTION
### Proposed changes

* Add Pydantic `src/settings.py` (`ConnectorSettings` / `MispImportFileConfig`) mirroring the 14 `MISP_IMPORT_FILE_*` variables one-to-one, and wire it into the existing single-file connector via `to_helper_config()`. File names, class name and scheduling are unchanged.
* Set `manager_supported: true` in `__metadata__/connector_manifest.json` and generate `connector_config_schema.json` / `CONNECTOR_CONFIG_DOC.md`.
* Normalize config files (`docker-compose.yml`, `src/config.yml.sample`, `src/requirements.txt`, `src/__init__.py`), including fixing the `MISP_IMPORT_FILE_GUESS_THREAT_FROM_TAGS` → `MISP_IMPORT_FILE_GUESS_THREATS_FROM_TAGS` env-var typo.
* Add unit tests covering the settings model and connector wiring.

### Related issues

* Closes #7217

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Structure-preserving **manager-supported (lite)** migration: it adds validated Pydantic settings and wires them into the existing code without the broader "verified" pass (no package restructuring, no `connector.py`/`main.py` split, no `schedule_iso` conversion, no logging refactor, no STIX-ID rework). Config keys are preserved except the `GUESS_THREAT` → `GUESS_THREATS` env-var typo fix, which aligns the variable with the `guess_threats_from_tags` setting. Commits are SSH-signed. Validated locally: isort/black/flake8 clean, 8/8 unit tests passing, STIX-ID pylint 10/10.
