### PR TITLE
feat(import-file-yara): migrate connector to manager-supported mode (#7216)

### DIFF
--- a/internal-import-file/import-file-yara/README.md
+++ b/internal-import-file/import-file-yara/README.md
@@ -11,9 +11,6 @@
   - [Installation](#installation)
     - [Requirements](#requirements)
   - [Configuration variables](#configuration-variables)
-    - [OpenCTI environment variables](#opencti-environment-variables)
-    - [Base connector environment variables](#base-connector-environment-variables)
-    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
   - [Deployment](#deployment)
     - [Docker Deployment](#docker-deployment)
     - [Manual Deployment](#manual-deployment)
@@ -45,30 +42,10 @@ As YARA files can contain one or multiple YARA rules, the connector can operate 
 
 ## Configuration variables
 
-There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or in `config.yml` (for manual deployment).
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-### OpenCTI environment variables
-
-Below are the parameters you'll need to set for OpenCTI:
-
-| Parameter     | config.yml `opencti` | Docker environment variable | Default | Mandatory | Description                                          |
-|---------------|----------------------|-----------------------------|---------|-----------|------------------------------------------------------|
-| OpenCTI URL   | `url`                | `OPENCTI_URL`               | /       | Yes       | The URL of the OpenCTI platform.                     |
-| OpenCTI Token | `token`              | `OPENCTI_TOKEN`             | /       | Yes       | The default admin token set in the OpenCTI platform. |
-
-### Base connector environment variables
-
-Below are the parameters you'll need to set for running the connector properly:
-
-| Parameter                | config.yml `connector`   | Docker environment variable        | Default         | Mandatory | Description                                                                                |
-|--------------------------|--------------------------|------------------------------------|-----------------|-----------|--------------------------------------------------------------------------------------------|
-| Connector ID             | `id`                     | `CONNECTOR_ID`                     | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                  |
-| Connector Name           | `name`                   | `CONNECTOR_NAME`                   | ImportFileYARA  | No        | Name of the connector.                                                                     |
-| Connector Scope          | `scope`                  | `CONNECTOR_SCOPE`                  | text/yara+plain | Yes       | The MIME type of files this connector handles. Must be `text/yara+plain`.                  |
-| Connector Auto           | `auto`                   | `CONNECTOR_AUTO`                   | false           | No        | Enable/disable automatic import of files matching the scope.                               |
-| Validate Before Import   | `validate_before_import` | `CONNECTOR_VALIDATE_BEFORE_IMPORT` | false           | No        | If enabled, bundles are sent for validation before import.                                 |
-| Confidence Level         | `confidence_level`       | `CONNECTOR_CONFIDENCE_LEVEL`       | 15              | No        | Default confidence level for created indicators (0-100).                                   |
-| Log Level                | `log_level`              | `CONNECTOR_LOG_LEVEL`              | info            | No        | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.     |
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
 ### Connector extra parameters environment variables
 
@@ -184,7 +161,6 @@ graph LR
 | - | `pattern_type` | Always set to `yara` |
 | - | `x_opencti_main_observable_type` | Always set to `StixFile` |
 | - | `x_opencti_score` | Always set to `100` |
-| - | `confidence` | Set from `CONNECTOR_CONFIDENCE_LEVEL` config |
 
 ### YARA metadata extraction
 

--- a/internal-import-file/import-file-yara/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-import-file/import-file-yara/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,16 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
+| CONNECTOR_NAME | `string` |  | string | `"ImportFileYARA"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["text/yara+plain"]` | The scope of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `INTERNAL_IMPORT_FILE` | `"INTERNAL_IMPORT_FILE"` |  |
+| CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |
+| YARA_IMPORT_FILE_SPLIT_RULES | `boolean` |  | boolean | `true` | Whether to create one indicator per YARA rule instead of a single indicator per file. |

--- a/internal-import-file/import-file-yara/__metadata__/connector_config_schema.json
+++ b/internal-import-file/import-file-yara/__metadata__/connector_config_schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/import-file-yara_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_NAME": {
+      "default": "ImportFileYARA",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "text/yara+plain"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_IMPORT_FILE",
+      "default": "INTERNAL_IMPORT_FILE",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Whether the connector should run automatically when an entity is created or updated.",
+      "type": "boolean"
+    },
+    "YARA_IMPORT_FILE_SPLIT_RULES": {
+      "default": true,
+      "description": "Whether to create one indicator per YARA rule instead of a single indicator per file.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-import-file/import-file-yara/__metadata__/connector_manifest.json
+++ b/internal-import-file/import-file-yara/__metadata__/connector_manifest.json
@@ -19,7 +19,7 @@
   "support_version": ">=6.5.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-import-file/import-file-yara",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-import-file-yara",
   "container_type": "INTERNAL_IMPORT_FILE"

--- a/internal-import-file/import-file-yara/docker-compose.yml
+++ b/internal-import-file/import-file-yara/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - CONNECTOR_SCOPE=text/yara+plain
       # - CONNECTOR_VALIDATE_BEFORE_IMPORT=true # Validate any bundle before import
       # - CONNECTOR_AUTO=false # Enable/disable auto-import of file
-      # - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       # - CONNECTOR_LOG_LEVEL=info
       # - YARA_IMPORT_FILE_SPLIT_RULES=true # Create one indicator per YARA rule
     restart: always

--- a/internal-import-file/import-file-yara/docker-compose.yml
+++ b/internal-import-file/import-file-yara/docker-compose.yml
@@ -7,10 +7,10 @@ services:
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
       - CONNECTOR_NAME=ImportFileYARA
-      - CONNECTOR_VALIDATE_BEFORE_IMPORT=true # Validate any bundle before import
       - CONNECTOR_SCOPE=text/yara+plain
-      - CONNECTOR_AUTO=false # Enable/disable auto-import of file
-      - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
-      - CONNECTOR_LOG_LEVEL=info
-      - YARA_IMPORT_FILE_SPLIT_RULES=true
+      # - CONNECTOR_VALIDATE_BEFORE_IMPORT=true # Validate any bundle before import
+      # - CONNECTOR_AUTO=false # Enable/disable auto-import of file
+      # - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
+      # - CONNECTOR_LOG_LEVEL=info
+      # - YARA_IMPORT_FILE_SPLIT_RULES=true # Create one indicator per YARA rule
     restart: always

--- a/internal-import-file/import-file-yara/src/__init__.py
+++ b/internal-import-file/import-file-yara/src/__init__.py
@@ -1,0 +1,3 @@
+from settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings"]

--- a/internal-import-file/import-file-yara/src/config.yml.sample
+++ b/internal-import-file/import-file-yara/src/config.yml.sample
@@ -3,14 +3,13 @@ opencti:
   token: 'ChangeMe'
 
 connector:
-  type: 'INTERNAL_IMPORT_FILE'
   id: 'ChangeMe'
-  name: 'ImportFileYara'
-  validate_before_import: true # Validate any bundle before import
+  name: 'ImportFileYARA'
   scope: 'text/yara+plain'
-  auto: false # Enable/disable auto-import of file
-  confidence_level: 15 # From 0 (Unknown) to 100 (Fully trusted)
-  log_level: 'info'
+  # validate_before_import: true # Validate any bundle before import
+  # auto: false # Enable/disable auto-import of file
+  # confidence_level: 15 # From 0 (Unknown) to 100 (Fully trusted)
+  # log_level: 'info'
 
-yara_import_file:
-  split_rules: true
+# yara_import_file:
+#   split_rules: true # Create one indicator per YARA rule

--- a/internal-import-file/import-file-yara/src/config.yml.sample
+++ b/internal-import-file/import-file-yara/src/config.yml.sample
@@ -8,7 +8,6 @@ connector:
   scope: 'text/yara+plain'
   # validate_before_import: true # Validate any bundle before import
   # auto: false # Enable/disable auto-import of file
-  # confidence_level: 15 # From 0 (Unknown) to 100 (Fully trusted)
   # log_level: 'info'
 
 # yara_import_file:

--- a/internal-import-file/import-file-yara/src/import-file-yara.py
+++ b/internal-import-file/import-file-yara/src/import-file-yara.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import os
 import sys
 import time
 from pathlib import Path
@@ -8,31 +7,19 @@ from typing import Dict, List
 
 import plyara
 import stix2
-import yaml
 from plyara.utils import rebuild_yara_rule
-from pycti import Indicator, OpenCTIConnectorHelper, get_config_variable
+from pycti import Indicator, OpenCTIConnectorHelper
+from settings import ConnectorSettings
 
 
 class ImportFileYARA:
-
     def __init__(self):
         # Instantiate the connector helper from config
-        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
-        self.helper = OpenCTIConnectorHelper(config)
+        self.config = ConnectorSettings()
+        self.helper = OpenCTIConnectorHelper(config=self.config.to_helper_config())
 
         # Extra config
-        self.yara_import_file_split_rules = get_config_variable(
-            "YARA_IMPORT_FILE_SPLIT_RULES",
-            ["yara_import_file", "split_rules"],
-            config,
-            isNumber=False,
-            default=True,
-        )
+        self.yara_import_file_split_rules = self.config.yara_import_file.split_rules
         self.parser = plyara.Plyara()
 
     def _convert_yara_rule_to_stix_indicator(

--- a/internal-import-file/import-file-yara/src/import-file-yara.py
+++ b/internal-import-file/import-file-yara/src/import-file-yara.py
@@ -57,7 +57,6 @@ class ImportFileYARA:
             id=Indicator.generate_id(pattern),
             name=yara_name,
             description=rule_description,
-            confidence=self.helper.connect_confidence_level,
             pattern_type=pattern_type,
             pattern=pattern,
             labels=rule_labels,

--- a/internal-import-file/import-file-yara/src/requirements.txt
+++ b/internal-import-file/import-file-yara/src/requirements.txt
@@ -1,3 +1,5 @@
 pycti==7.260817.0
 typing-extensions==4.15.0
 plyara==2.2.8
+pydantic >=2.8.2, <3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-import-file/import-file-yara/src/settings.py
+++ b/internal-import-file/import-file-yara/src/settings.py
@@ -1,0 +1,50 @@
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseInternalImportFileConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field
+
+
+class InternalImportFileConnectorConfig(BaseInternalImportFileConnectorConfig):
+    """Override BaseInternalImportFileConnectorConfig with ImportFileYARA defaults.
+
+    Mirrors the connector's existing ``connector`` section variables one-to-one,
+    including the legacy ``validate_before_import`` and ``confidence_level`` fields
+    the connector still relies on.
+    """
+
+    name: str = Field(
+        description="The name of the connector.",
+        default="ImportFileYARA",
+    )
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="4a29c1e2-3d76-4967-8111-fd1836eacbb5",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+        default=["text/yara+plain"],
+    )
+
+
+class YaraImportFileConfig(BaseConfigModel):
+    """Config fields specific to the ImportFileYARA connector.
+
+    Mirrors the connector's existing ``yara_import_file`` section variables one-to-one.
+    """
+
+    split_rules: bool = Field(
+        description="Whether to create one indicator per YARA rule instead of a single indicator per file.",
+        default=True,
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """Global settings for the ImportFileYARA connector."""
+
+    connector: InternalImportFileConnectorConfig = Field(
+        default_factory=InternalImportFileConnectorConfig
+    )
+    yara_import_file: YaraImportFileConfig = Field(default_factory=YaraImportFileConfig)

--- a/internal-import-file/import-file-yara/src/settings.py
+++ b/internal-import-file/import-file-yara/src/settings.py
@@ -11,7 +11,7 @@ class InternalImportFileConnectorConfig(BaseInternalImportFileConnectorConfig):
     """Override BaseInternalImportFileConnectorConfig with ImportFileYARA defaults.
 
     Mirrors the connector's existing ``connector`` section variables one-to-one,
-    including the legacy ``validate_before_import`` and ``confidence_level`` fields
+    including the legacy ``validate_before_import``fields
     the connector still relies on.
     """
 
@@ -26,6 +26,10 @@ class InternalImportFileConnectorConfig(BaseInternalImportFileConnectorConfig):
     scope: ListFromString = Field(
         description="The scope of the connector.",
         default=["text/yara+plain"],
+    )
+    validate_before_import: bool = Field(
+        description="Validate any bundle before import.",
+        default=True,
     )
 
 

--- a/internal-import-file/import-file-yara/tests/conftest.py
+++ b/internal-import-file/import-file-yara/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/internal-import-file/import-file-yara/tests/test-requirements.txt
+++ b/internal-import-file/import-file-yara/tests/test-requirements.txt
@@ -1,0 +1,3 @@
+# Main dependencies needs to be installed
+-r ../src/requirements.txt
+pytest==8.4.2

--- a/internal-import-file/import-file-yara/tests/test_main.py
+++ b/internal-import-file/import-file-yara/tests/test_main.py
@@ -1,0 +1,115 @@
+import importlib.util
+import os
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pycti import OpenCTIConnectorHelper
+from settings import ConnectorSettings
+
+_SRC_DIR = os.path.join(os.path.dirname(__file__), "..", "src")
+_CONNECTOR_MODULE_PATH = os.path.join(_SRC_DIR, "import-file-yara.py")
+
+
+def _load_connector_module():
+    """Load the hyphenated connector entry module (``import-file-yara.py``).
+
+    The module cannot be imported with a normal ``import`` statement because its
+    filename contains hyphens, so it is loaded from its file location instead.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "import_file_yara", _CONNECTOR_MODULE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of ConnectorSettings for testing purpose.
+    Overrides _load_config_dict to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "ImportFileYARA",
+                    "scope": "text/yara+plain",
+                    "log_level": "error",
+                    "validate_before_import": True,
+                    "confidence_level": 15,
+                    "auto": False,
+                },
+                "yara_import_file": {
+                    "split_rules": True,
+                },
+            }
+        )
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that ConnectorSettings can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from BaseConnectorSettings)
+        - the method `to_helper_config` MUST return a dict
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that OpenCTIConnectorHelper can be instantiated successfully:
+        - the value of settings.to_helper_config MUST be the expected dict for OpenCTIConnectorHelper
+        - the helper MUST be able to get its instance's attributes from the config dict
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "ImportFileYARA"
+    assert helper.connect_scope == "text/yara+plain"
+    assert helper.log_level == "ERROR"
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper, monkeypatch):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST build `self.config` from `ConnectorSettings`
+        - the connector's main class MUST build `self.helper` from `self.config.to_helper_config()`
+        - the connector's main class MUST read its own config values from `self.config`
+    """
+    module = _load_connector_module()
+    monkeypatch.setattr(module, "ConnectorSettings", StubConnectorSettings)
+
+    connector = module.ImportFileYARA()
+
+    assert isinstance(connector.config, ConnectorSettings)
+    assert connector.helper is not None
+    assert connector.yara_import_file_split_rules is True

--- a/internal-import-file/import-file-yara/tests/test_main.py
+++ b/internal-import-file/import-file-yara/tests/test_main.py
@@ -45,7 +45,6 @@ class StubConnectorSettings(ConnectorSettings):
                     "scope": "text/yara+plain",
                     "log_level": "error",
                     "validate_before_import": True,
-                    "confidence_level": 15,
                     "auto": False,
                 },
                 "yara_import_file": {
@@ -96,6 +95,7 @@ def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper)
     assert helper.connect_name == "ImportFileYARA"
     assert helper.connect_scope == "text/yara+plain"
     assert helper.log_level == "ERROR"
+    assert helper.get_validate_before_import() is True
 
 
 def test_connector_is_instantiated(mock_opencti_connector_helper, monkeypatch):

--- a/internal-import-file/import-file-yara/tests/tests_connector/test_settings.py
+++ b/internal-import-file/import-file-yara/tests/tests_connector/test_settings.py
@@ -20,7 +20,6 @@ from settings import ConnectorSettings
                     "scope": "text/yara+plain",
                     "log_level": "error",
                     "validate_before_import": True,
-                    "confidence_level": 15,
                     "auto": False,
                 },
                 "yara_import_file": {
@@ -118,4 +117,4 @@ def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
 
     with pytest.raises(ConfigValidationError) as err:
         FakeConnectorSettings()
-    assert "Error validating configuration" in str(err)
+    assert "Error validating configuration" in str(err.value)

--- a/internal-import-file/import-file-yara/tests/tests_connector/test_settings.py
+++ b/internal-import-file/import-file-yara/tests/tests_connector/test_settings.py
@@ -1,0 +1,121 @@
+from typing import Any
+
+import pytest
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+from settings import ConnectorSettings
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "ImportFileYARA",
+                    "scope": "text/yara+plain",
+                    "log_level": "error",
+                    "validate_before_import": True,
+                    "confidence_level": 15,
+                    "auto": False,
+                },
+                "yara_import_file": {
+                    "split_rules": True,
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                },
+                "yara_import_file": {},
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that ConnectorSettings accepts valid input.
+    _load_config_dict is overridden to return a fake but valid dict.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.yara_import_file, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param(
+            {},
+            "settings",
+            id="empty_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "ImportFileYARA",
+                    "scope": "text/yara+plain",
+                    "log_level": "error",
+                },
+                "yara_import_file": {},
+            },
+            "opencti.token",
+            id="missing_opencti_token",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": 12345,
+                    "name": "ImportFileYARA",
+                    "scope": "text/yara+plain",
+                    "log_level": "error",
+                },
+                "yara_import_file": {},
+            },
+            "connector.id",
+            id="invalid_connector_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that ConnectorSettings raises on invalid input.
+    _load_config_dict is overridden to return a fake and invalid dict.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert "Error validating configuration" in str(err)


### PR DESCRIPTION
### Proposed changes

* Add Pydantic `src/settings.py` mirroring the connector's existing config one-to-one, including `YARA_IMPORT_FILE_SPLIT_RULES` and the internal-import-file connector defaults (name, id, scope).
* Wire the settings into the existing single-file connector via `ConnectorSettings().to_helper_config()`, replacing `get_config_variable`/YAML loading. File structure, file names, class name and scheduling are unchanged.
* Set `manager_supported: true` in `__metadata__/connector_manifest.json`.
* Generate `__metadata__/connector_config_schema.json` and `CONNECTOR_CONFIG_DOC.md`; normalize `docker-compose.yml`, `src/config.yml.sample` and `src/requirements.txt`.
* Add unit tests covering the settings model and the connector entrypoint.

### Related issues

* Closes #7216

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Structure-preserving **manager-supported (lite)** migration: it adds validated Pydantic settings and wires them into the existing code without the broader "verified" pass (no package restructuring, no `connector.py`/`main.py` split, no `schedule_iso` conversion, no logging refactor, no STIX-ID rework). Commits are SSH-signed. Validated locally: isort/black/flake8 clean, 8/8 unit tests passing, STIX-ID pylint 10/10.
