### PR TITLE
feat(import-ttps-file-navigator): migrate connector to manager-supported mode (#7215)

### DIFF
--- a/internal-import-file/import-ttps-file-navigator/README.md
+++ b/internal-import-file/import-ttps-file-navigator/README.md
@@ -11,8 +11,6 @@
   - [Installation](#installation)
     - [Requirements](#requirements)
   - [Configuration variables](#configuration-variables)
-    - [OpenCTI environment variables](#opencti-environment-variables)
-    - [Base connector environment variables](#base-connector-environment-variables)
   - [Deployment](#deployment)
     - [Docker Deployment](#docker-deployment)
     - [Manual Deployment](#manual-deployment)
@@ -40,29 +38,10 @@ When importing a layer file from ATT&CK Navigator, you have the option to associ
 
 ## Configuration variables
 
-There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or in `config.yml` (for manual deployment).
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-### OpenCTI environment variables
-
-Below are the parameters you'll need to set for OpenCTI:
-
-| Parameter     | config.yml `opencti` | Docker environment variable | Default | Mandatory | Description                                          |
-|---------------|----------------------|-----------------------------|---------|-----------|------------------------------------------------------|
-| OpenCTI URL   | `url`                | `OPENCTI_URL`               | /       | Yes       | The URL of the OpenCTI platform.                     |
-| OpenCTI Token | `token`              | `OPENCTI_TOKEN`             | /       | Yes       | The default admin token set in the OpenCTI platform. |
-
-### Base connector environment variables
-
-Below are the parameters you'll need to set for running the connector properly:
-
-| Parameter                | config.yml `connector`  | Docker environment variable        | Default                 | Mandatory | Description                                                                                         |
-|--------------------------|-------------------------|------------------------------------|-------------------------|-----------|-----------------------------------------------------------------------------------------------------|
-| Connector ID             | `id`                    | `CONNECTOR_ID`                     | /                       | Yes       | A unique `UUIDv4` identifier for this connector instance.                                           |
-| Connector Name           | `name`                  | `CONNECTOR_NAME`                   | ImportTTPsFileNavigator | No        | Name of the connector.                                                                              |
-| Connector Scope          | `scope`                 | `CONNECTOR_SCOPE`                  | application/json        | Yes       | The MIME type of files this connector handles. Must be `application/json`.                          |
-| Connector Auto           | `auto`                  | `CONNECTOR_AUTO`                   | false                   | No        | Enable/disable automatic import of files matching the scope.                                        |
-| Validate Before Import   | `validate_before_import`| `CONNECTOR_VALIDATE_BEFORE_IMPORT` | false                   | No        | If enabled, bundles are sent for validation before import.                                          |
-| Log Level                | `log_level`             | `CONNECTOR_LOG_LEVEL`              | error                   | No        | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.              |
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
 ## Deployment
 

--- a/internal-import-file/import-ttps-file-navigator/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-import-file/import-ttps-file-navigator/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,15 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
+| CONNECTOR_NAME | `string` |  | string | `"ImportTTPsFileNavigator"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["application/json"]` | The scope of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `INTERNAL_IMPORT_FILE` | `"INTERNAL_IMPORT_FILE"` |  |
+| CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |

--- a/internal-import-file/import-ttps-file-navigator/__metadata__/connector_config_schema.json
+++ b/internal-import-file/import-ttps-file-navigator/__metadata__/connector_config_schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/import-ttps-file-navigator_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_NAME": {
+      "default": "ImportTTPsFileNavigator",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "application/json"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_IMPORT_FILE",
+      "default": "INTERNAL_IMPORT_FILE",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Whether the connector should run automatically when an entity is created or updated.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-import-file/import-ttps-file-navigator/__metadata__/connector_manifest.json
+++ b/internal-import-file/import-ttps-file-navigator/__metadata__/connector_manifest.json
@@ -19,7 +19,7 @@
   "support_version": ">=6.7.10",
   "subscription_link": "https://mitre-attack.github.io/attack-navigator/",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-import-file/import-ttps-file-navigator",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-import-ttps-file-navigator",
   "container_type": "INTERNAL_IMPORT_FILE"

--- a/internal-import-file/import-ttps-file-navigator/src/config.yml.sample
+++ b/internal-import-file/import-ttps-file-navigator/src/config.yml.sample
@@ -3,11 +3,10 @@ opencti:
   token: 'ChangeMe'
 
 connector:
-  type: 'INTERNAL_IMPORT_FILE'
   id: 'ChangeMe'
-  name: 'ImportTTPsFileNavigator'
-  validate_before_import: true # Validate any bundle before import
-  scope: 'application/json'
-  auto: false # Enable/disable auto-import of file
-  log_level: 'error'
+  # name: 'ImportTTPsFileNavigator'
+  # scope: 'application/json'
+  # validate_before_import: true # Validate any bundle before import
+  # auto: false # Enable/disable auto-import of file
+  # log_level: 'error'
 

--- a/internal-import-file/import-ttps-file-navigator/src/main.py
+++ b/internal-import-file/import-ttps-file-navigator/src/main.py
@@ -1,27 +1,19 @@
 import json
-import os
 import sys
 import traceback
-from typing import Dict, List
 
 import stix2
-import yaml
 from pycti import AttackPattern, OpenCTIConnectorHelper, StixCoreRelationship
+from settings import ConnectorSettings
 
 
 class ImportTTPsFileNavigator:
-
     def __init__(self):
         # Instantiate the connector helper from config
-        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
-        self.helper = OpenCTIConnectorHelper(config)
+        self.config = ConnectorSettings()
+        self.helper = OpenCTIConnectorHelper(config=self.config.to_helper_config())
 
-    def _parse_mitre_navigator_content(self, content: str) -> List:
+    def _parse_mitre_navigator_content(self, content: str) -> list:
         """
         :param content:
         :return:
@@ -69,7 +61,7 @@ class ImportTTPsFileNavigator:
 
         return techniques_objects
 
-    def _process_message(self, data: Dict) -> str:
+    def _process_message(self, data: dict) -> str:
         """
         :param data:
         :return:
@@ -115,7 +107,7 @@ class ImportTTPsFileNavigator:
         """
         self.helper.listen(self._process_message)
 
-    def _update_bundle(self, stix_techniques: List, entity_id: str) -> List:
+    def _update_bundle(self, stix_techniques: list, entity_id: str) -> list:
         """
         :param stix_techniques:
         :param entity_id:

--- a/internal-import-file/import-ttps-file-navigator/src/requirements.txt
+++ b/internal-import-file/import-ttps-file-navigator/src/requirements.txt
@@ -1,2 +1,4 @@
 pycti==7.260817.0
 typing-extensions==4.15.0
+pydantic >=2.8.2, <3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-import-file/import-ttps-file-navigator/src/settings.py
+++ b/internal-import-file/import-ttps-file-navigator/src/settings.py
@@ -1,5 +1,4 @@
 from connectors_sdk import (
-    BaseConfigModel,
     BaseConnectorSettings,
     BaseInternalImportFileConnectorConfig,
     ListFromString,
@@ -27,20 +26,9 @@ class InternalImportFileConnectorConfig(BaseInternalImportFileConnectorConfig):
     )
 
 
-class ImportTTPsFileNavigatorConfig(BaseConfigModel):
-    """Config fields specific to the ImportTTPsFileNavigator connector.
-
-    This connector has no custom configuration fields beyond the standard
-    connector settings.
-    """
-
-
 class ConnectorSettings(BaseConnectorSettings):
     """Global settings for the ImportTTPsFileNavigator connector."""
 
     connector: InternalImportFileConnectorConfig = Field(
         default_factory=InternalImportFileConnectorConfig
-    )
-    import_ttps_file_navigator: ImportTTPsFileNavigatorConfig = Field(
-        default_factory=ImportTTPsFileNavigatorConfig
     )

--- a/internal-import-file/import-ttps-file-navigator/src/settings.py
+++ b/internal-import-file/import-ttps-file-navigator/src/settings.py
@@ -1,0 +1,46 @@
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseInternalImportFileConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field
+
+
+class InternalImportFileConnectorConfig(BaseInternalImportFileConnectorConfig):
+    """Override BaseInternalImportFileConnectorConfig with ImportTTPsFileNavigator defaults.
+
+    Mirrors the connector's existing ``connector`` section variables one-to-one.
+    """
+
+    name: str = Field(
+        description="The name of the connector.",
+        default="ImportTTPsFileNavigator",
+    )
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="cd378276-d36c-4cfd-99ab-20241e4b6bb3",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+        default=["application/json"],
+    )
+
+
+class ImportTTPsFileNavigatorConfig(BaseConfigModel):
+    """Config fields specific to the ImportTTPsFileNavigator connector.
+
+    This connector has no custom configuration fields beyond the standard
+    connector settings.
+    """
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """Global settings for the ImportTTPsFileNavigator connector."""
+
+    connector: InternalImportFileConnectorConfig = Field(
+        default_factory=InternalImportFileConnectorConfig
+    )
+    import_ttps_file_navigator: ImportTTPsFileNavigatorConfig = Field(
+        default_factory=ImportTTPsFileNavigatorConfig
+    )

--- a/internal-import-file/import-ttps-file-navigator/tests/conftest.py
+++ b/internal-import-file/import-ttps-file-navigator/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/internal-import-file/import-ttps-file-navigator/tests/test-requirements.txt
+++ b/internal-import-file/import-ttps-file-navigator/tests/test-requirements.txt
@@ -1,0 +1,3 @@
+# Main dependencies needs to be installed
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/internal-import-file/import-ttps-file-navigator/tests/test_main.py
+++ b/internal-import-file/import-ttps-file-navigator/tests/test_main.py
@@ -1,0 +1,91 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from main import ImportTTPsFileNavigator
+from pycti import OpenCTIConnectorHelper
+from settings import ConnectorSettings
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """
+    Subclass of ConnectorSettings for testing purpose.
+    Overrides _load_config_dict to return a fake but valid config dict.
+    """
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "ImportTTPsFileNavigator",
+                    "scope": "application/json",
+                    "log_level": "error",
+                    "validate_before_import": True,
+                    "auto": False,
+                },
+                "import_ttps_file_navigator": {},
+            }
+        )
+
+
+def test_connector_settings_is_instantiated():
+    """
+    Test that ConnectorSettings can be instantiated successfully:
+        - the implemented class MUST have a method `to_helper_config` (inherited from BaseConnectorSettings)
+        - the method `to_helper_config` MUST return a dict
+    """
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    """
+    Test that OpenCTIConnectorHelper can be instantiated successfully:
+        - the value of settings.to_helper_config MUST be the expected dict for OpenCTIConnectorHelper
+        - the helper MUST be able to get its instance's attributes from the config dict
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "ImportTTPsFileNavigator"
+    assert helper.connect_scope == "application/json"
+    assert helper.log_level == "ERROR"
+
+
+def test_connector_is_instantiated(mock_opencti_connector_helper, monkeypatch):
+    """
+    Test that the connector's main class can be instantiated successfully:
+        - the connector's main class MUST build its config through `ConnectorSettings`
+        - the connector's main class MUST expose the pycti API through self.helper
+    """
+    monkeypatch.setattr("main.ConnectorSettings", StubConnectorSettings)
+
+    connector = ImportTTPsFileNavigator()
+
+    assert isinstance(connector.config, ConnectorSettings)
+    assert isinstance(connector.helper, OpenCTIConnectorHelper)

--- a/internal-import-file/import-ttps-file-navigator/tests/tests_connector/test_settings.py
+++ b/internal-import-file/import-ttps-file-navigator/tests/tests_connector/test_settings.py
@@ -1,0 +1,116 @@
+from typing import Any
+
+import pytest
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+from settings import ConnectorSettings
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "ImportTTPsFileNavigator",
+                    "scope": "application/json",
+                    "log_level": "error",
+                    "validate_before_import": True,
+                    "auto": False,
+                },
+                "import_ttps_file_navigator": {},
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                },
+                "import_ttps_file_navigator": {},
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that ConnectorSettings accepts valid input.
+    _load_config_dict is overridden to return a fake but valid dict.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.import_ttps_file_navigator, BaseConfigModel) is True
+
+
+@pytest.mark.parametrize(
+    "settings_dict, field_name",
+    [
+        pytest.param(
+            {},
+            "settings",
+            id="empty_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "ImportTTPsFileNavigator",
+                    "scope": "application/json",
+                    "log_level": "error",
+                },
+                "import_ttps_file_navigator": {},
+            },
+            "opencti.token",
+            id="missing_opencti_token",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": 12345,
+                    "scope": "application/json",
+                },
+                "import_ttps_file_navigator": {},
+            },
+            "connector.id",
+            id="invalid_connector_id",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
+    """
+    Test that ConnectorSettings raises on invalid input.
+    _load_config_dict is overridden to return a fake and invalid dict.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert "Error validating configuration" in str(err)

--- a/internal-import-file/import-ttps-file-navigator/tests/tests_connector/test_settings.py
+++ b/internal-import-file/import-ttps-file-navigator/tests/tests_connector/test_settings.py
@@ -22,7 +22,6 @@ from settings import ConnectorSettings
                     "validate_before_import": True,
                     "auto": False,
                 },
-                "import_ttps_file_navigator": {},
             },
             id="full_valid_settings_dict",
         ),
@@ -35,7 +34,6 @@ from settings import ConnectorSettings
                 "connector": {
                     "id": "connector-id",
                 },
-                "import_ttps_file_navigator": {},
             },
             id="minimal_valid_settings_dict",
         ),
@@ -56,7 +54,6 @@ def test_settings_should_accept_valid_input(settings_dict):
 
     assert isinstance(settings.opencti, BaseConfigModel) is True
     assert isinstance(settings.connector, BaseConfigModel) is True
-    assert isinstance(settings.import_ttps_file_navigator, BaseConfigModel) is True
 
 
 @pytest.mark.parametrize(
@@ -78,7 +75,6 @@ def test_settings_should_accept_valid_input(settings_dict):
                     "scope": "application/json",
                     "log_level": "error",
                 },
-                "import_ttps_file_navigator": {},
             },
             "opencti.token",
             id="missing_opencti_token",
@@ -93,7 +89,6 @@ def test_settings_should_accept_valid_input(settings_dict):
                     "id": 12345,
                     "scope": "application/json",
                 },
-                "import_ttps_file_navigator": {},
             },
             "connector.id",
             id="invalid_connector_id",


### PR DESCRIPTION
### Proposed changes

* Add Pydantic `src/settings.py` (connectors-sdk base settings) mirroring the existing `connector` config section one-to-one (name, id, scope); this connector has no custom config fields.
* Wire the settings into `src/main.py` via `ConnectorSettings().to_helper_config()`, replacing manual YAML/`get_config_variable` loading. File names, class name (`ImportTTPsFileNavigator`) and the `helper.listen()` scheduling are unchanged.
* Set `manager_supported: true` in `__metadata__/connector_manifest.json`.
* Generate `__metadata__/connector_config_schema.json` and `CONNECTOR_CONFIG_DOC.md`; normalize `src/config.yml.sample`, `src/requirements.txt` and the README.
* Add unit tests for the settings and entrypoint wiring.

### Related issues

* Closes #7215

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Structure-preserving **manager-supported (lite)** migration: it adds validated Pydantic settings and wires them into the existing code without the broader "verified" pass (no package restructuring, no `connector.py`/`main.py` split, no `schedule_iso` conversion, no logging refactor, no STIX-ID rework). Commits are SSH-signed. Validated locally: isort/black/flake8 clean, unit tests passing, STIX-ID pylint 10/10.
