### PR TITLE
feat(import-document): migrate to manager-supported mode (#7219)

### DIFF
--- a/internal-import-file/import-document/Dockerfile
+++ b/internal-import-file/import-document/Dockerfile
@@ -11,9 +11,5 @@ RUN apk --no-cache add git libmagic libffi-dev libxml2-dev libxslt-dev libffi-de
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh && chmod -R 0777 /opt/opencti-connector-import-document
 WORKDIR /opt/opencti-connector-import-document
-ENV HOME=/opt/opencti-connector-import-document
-ENTRYPOINT ["/entrypoint.sh"]
+CMD ["python3", "main.py"]

--- a/internal-import-file/import-document/Dockerfile_fips
+++ b/internal-import-file/import-document/Dockerfile_fips
@@ -11,9 +11,5 @@ RUN apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-de
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh && chmod -R 0777 /opt/opencti-connector-import-document
 WORKDIR /opt/opencti-connector-import-document
-ENV HOME=/opt/opencti-connector-import-document
-ENTRYPOINT ["/entrypoint.sh"]
+CMD ["python3", "main.py"]

--- a/internal-import-file/import-document/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-import-file/import-document/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,17 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
+| CONNECTOR_NAME | `string` |  | string | `"ImportDocument"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["application/pdf", "text/plain", "text/csv", "text/html", "text/markdown", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"]` | The scope of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `INTERNAL_IMPORT_FILE` | `"INTERNAL_IMPORT_FILE"` |  |
+| CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |
+| CONNECTOR_VALIDATE_BEFORE_IMPORT | `boolean` |  | boolean | `true` | Validate any bundle before import. |
+| IMPORT_DOCUMENT_CREATE_INDICATOR | `boolean` |  | boolean | `false` | If true, creates an Indicator for each extracted observable. |

--- a/internal-import-file/import-document/__metadata__/connector_config_schema.json
+++ b/internal-import-file/import-document/__metadata__/connector_config_schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/import-document_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_NAME": {
+      "default": "ImportDocument",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "application/pdf",
+        "text/plain",
+        "text/csv",
+        "text/html",
+        "text/markdown",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_IMPORT_FILE",
+      "default": "INTERNAL_IMPORT_FILE",
+      "type": "string"
+    },
+    "CONNECTOR_AUTO": {
+      "default": false,
+      "description": "Whether the connector should run automatically when an entity is created or updated.",
+      "type": "boolean"
+    },
+    "CONNECTOR_VALIDATE_BEFORE_IMPORT": {
+      "default": true,
+      "description": "Validate any bundle before import.",
+      "type": "boolean"
+    },
+    "IMPORT_DOCUMENT_CREATE_INDICATOR": {
+      "default": false,
+      "description": "If true, creates an Indicator for each extracted observable.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-import-file/import-document/__metadata__/connector_manifest.json
+++ b/internal-import-file/import-document/__metadata__/connector_manifest.json
@@ -19,7 +19,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-import-file/import-document",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-import-document",
   "container_type": "INTERNAL_IMPORT_FILE"

--- a/internal-import-file/import-document/docker-compose.yml
+++ b/internal-import-file/import-document/docker-compose.yml
@@ -6,10 +6,10 @@ services:
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
-      - CONNECTOR_NAME=ImportDocument
-      - CONNECTOR_VALIDATE_BEFORE_IMPORT=true # Validate any bundle before import
-      - CONNECTOR_SCOPE=application/pdf,text/plain,text/csv,text/html,text/markdown,application/vnd.openxmlformats-officedocument.wordprocessingml.document
-      - CONNECTOR_AUTO=false # Enable/disable auto-import of file
-      - CONNECTOR_LOG_LEVEL=error
-      - IMPORT_DOCUMENT_CREATE_INDICATOR=false
+      # - CONNECTOR_NAME=ImportDocument
+      # - CONNECTOR_VALIDATE_BEFORE_IMPORT=true # Validate any bundle before import
+      # - CONNECTOR_SCOPE=application/pdf,text/plain,text/csv,text/html,text/markdown,application/vnd.openxmlformats-officedocument.wordprocessingml.document
+      # - CONNECTOR_AUTO=false # Enable/disable auto-import of file
+      # - CONNECTOR_LOG_LEVEL=error
+      # - IMPORT_DOCUMENT_CREATE_INDICATOR=false
     restart: always

--- a/internal-import-file/import-document/entrypoint.sh
+++ b/internal-import-file/import-document/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Correct working directory
-cd /opt/opencti-connector-import-document
-
-# Start the connector
-python3 main.py

--- a/internal-import-file/import-document/src/__init__.py
+++ b/internal-import-file/import-document/src/__init__.py
@@ -1,0 +1,3 @@
+from reportimporter.settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings"]

--- a/internal-import-file/import-document/src/config.yml.sample
+++ b/internal-import-file/import-document/src/config.yml.sample
@@ -3,7 +3,6 @@ opencti:
   token: 'ChangeMe'
 
 connector:
-  type: 'INTERNAL_IMPORT_FILE'
   id: 'ChangeMe'
   name: 'ImportDocument'
   validate_before_import: true # Validate any bundle before import

--- a/internal-import-file/import-document/src/config.yml.sample
+++ b/internal-import-file/import-document/src/config.yml.sample
@@ -4,11 +4,11 @@ opencti:
 
 connector:
   id: 'ChangeMe'
-  name: 'ImportDocument'
-  validate_before_import: true # Validate any bundle before import
-  scope: 'application/pdf,text/plain,text/csv,text/html,text/markdown,application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-  auto: false # Enable/disable auto-import of file
-  log_level: 'info'
+  # name: 'ImportDocument'
+  # validate_before_import: true # Validate any bundle before import
+  # scope: 'application/pdf,text/plain,text/csv,text/html,text/markdown,application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+  # auto: false # Enable/disable auto-import of file
+  # log_level: 'error'
 
-import_document:
-  create_indicator: false
+# import_document:
+#   create_indicator: false

--- a/internal-import-file/import-document/src/reportimporter/core.py
+++ b/internal-import-file/import-document/src/reportimporter/core.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from typing import Callable, Dict, List
 
 import stix2
-import yaml
 from pycti import (
     CustomObservableICCID,
     CustomObservableIMEI,
@@ -16,7 +15,6 @@ from pycti import (
     OpenCTIConnectorHelper,
     Report,
     StixCoreRelationship,
-    get_config_variable,
 )
 from pydantic.v1 import BaseModel
 from reportimporter.constants import (
@@ -29,6 +27,7 @@ from reportimporter.constants import (
 )
 from reportimporter.models import Entity, EntityConfig, Observable
 from reportimporter.report_parser import ReportParser
+from reportimporter.settings import ConnectorSettings
 from reportimporter.util import MyConfigParser
 
 
@@ -36,19 +35,10 @@ class ReportImporter:
     def __init__(self) -> None:
         # Instantiate the connector helper from config
         base_path = os.path.dirname(os.path.abspath(__file__))
-        config_file_path = base_path + "/../config.yml"
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
 
-        self.helper = OpenCTIConnectorHelper(config)
-        self.create_indicator = get_config_variable(
-            "IMPORT_DOCUMENT_CREATE_INDICATOR",
-            ["import_document", "create_indicator"],
-            config,
-        )
+        self.config = ConnectorSettings()
+        self.helper = OpenCTIConnectorHelper(config=self.config.to_helper_config())
+        self.create_indicator = self.config.import_document.create_indicator
         self.current_file = None
 
         # Load Entity and Observable configs

--- a/internal-import-file/import-document/src/reportimporter/settings.py
+++ b/internal-import-file/import-document/src/reportimporter/settings.py
@@ -1,0 +1,51 @@
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseInternalImportFileConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field
+
+
+class InternalImportFileConnectorConfig(BaseInternalImportFileConnectorConfig):
+    """Override BaseInternalImportFileConnectorConfig to add defaults for ImportDocument."""
+
+    name: str = Field(
+        description="The name of the connector.",
+        default="ImportDocument",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+        default=[
+            "application/pdf",
+            "text/plain",
+            "text/csv",
+            "text/html",
+            "text/markdown",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ],
+    )
+    validate_before_import: bool = Field(
+        description="Validate any bundle before import.",
+        default=True,
+    )
+
+
+class ImportDocumentConfig(BaseConfigModel):
+    """Config fields specific to the ImportDocument connector."""
+
+    create_indicator: bool = Field(
+        description="If true, creates an Indicator for each extracted observable.",
+        default=False,
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """Global settings for the ImportDocument connector."""
+
+    connector: InternalImportFileConnectorConfig = Field(
+        default_factory=InternalImportFileConnectorConfig
+    )
+    import_document: ImportDocumentConfig = Field(
+        default_factory=ImportDocumentConfig
+    )

--- a/internal-import-file/import-document/src/reportimporter/settings.py
+++ b/internal-import-file/import-document/src/reportimporter/settings.py
@@ -10,6 +10,10 @@ from pydantic import Field
 class InternalImportFileConnectorConfig(BaseInternalImportFileConnectorConfig):
     """Override BaseInternalImportFileConnectorConfig to add defaults for ImportDocument."""
 
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="b4cc8d6b-1e61-4dc9-8aa1-5e494e6f8d5a",
+    )
     name: str = Field(
         description="The name of the connector.",
         default="ImportDocument",

--- a/internal-import-file/import-document/src/reportimporter/settings.py
+++ b/internal-import-file/import-document/src/reportimporter/settings.py
@@ -46,6 +46,4 @@ class ConnectorSettings(BaseConnectorSettings):
     connector: InternalImportFileConnectorConfig = Field(
         default_factory=InternalImportFileConnectorConfig
     )
-    import_document: ImportDocumentConfig = Field(
-        default_factory=ImportDocumentConfig
-    )
+    import_document: ImportDocumentConfig = Field(default_factory=ImportDocumentConfig)

--- a/internal-import-file/import-document/src/requirements.txt
+++ b/internal-import-file/import-document/src/requirements.txt
@@ -9,3 +9,4 @@ dateparser==1.4.0
 pyhumps==3.8.0
 chardet==5.2.0
 python-docx==1.1.2
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk


### PR DESCRIPTION
### Proposed changes

* Migrate the `import-document` connector to manager-supported mode using
  `connectors-sdk` Pydantic settings: new `reportimporter/settings.py` defines
  `ConnectorSettings` with an `InternalImportFileConnectorConfig` override
  (connector defaults for `name`, `scope`, `validate_before_import`) and an
  `ImportDocumentConfig` (`create_indicator`).
* Replace the manual `config.yml` + `yaml.load` + `get_config_variable` bootstrap in
  `reportimporter/core.py` with `ConnectorSettings()` and
  `OpenCTIConnectorHelper(config=self.config.to_helper_config())`.
* Normalize `config.yml.sample` and `docker-compose.yml`: values that now have
  defaults in the settings model are commented out, so only `opencti.url`,
  `opencti.token` and `connector.id` remain required.
* Add `manager_supported: true` to `__metadata__/connector_manifest.json` and
  generate `__metadata__/connector_config_schema.json` and
  `__metadata__/CONNECTOR_CONFIG_DOC.md`.
* Drop `entrypoint.sh` and switch `Dockerfile` / `Dockerfile_fips` to
  `CMD ["python3", "main.py"]`, as required for manager-supported connectors.
* Add `connectors-sdk` to `src/requirements.txt`.

### Related issues

* Closes #7219

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The migration is deliberately structure-preserving: file layout, module names and
the existing `ReportImporter` class are unchanged, so the diff is limited to
configuration handling and packaging. The parsing/STIX-conversion logic is
untouched.

**Testing:** `isort --profile black` and `black` were run over the connector
(dedicated formatting commit). No functional/runtime test of the connector was
executed against a live OpenCTI platform — hence the unticked box above.

**Risk:** configuration-surface change. `CONNECTOR_TYPE` is no longer read from
`config.yml` and `entrypoint.sh` is removed, so any deployment overriding the
image entrypoint must be updated. Existing env vars keep the same names and
defaults, so current deployments should continue to work.

### Screenshots

Display on OpenCTI
<img width="421" height="425" alt="image" src="https://github.com/user-attachments/assets/23785e50-4b09-4fc8-895d-57e9c83ca5ce" />

Use running container
<img width="596" height="173" alt="image" src="https://github.com/user-attachments/assets/2b5986f5-4fbe-4665-89be-caec14ba047e" />
