### PR TITLE
feat(export-ttps-file-navigator): migrate connector to manager-supported mode (#7220)

### DIFF
--- a/internal-export-file/export-ttps-file-navigator/Dockerfile
+++ b/internal-export-file/export-ttps-file-navigator/Dockerfile
@@ -11,7 +11,5 @@ RUN apk --no-cache add git build-base libmagic libffi-dev && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+WORKDIR /opt/opencti-connector-export-ttps-file-navigator
+CMD ["python3", "export-ttps-file-navigator.py"]

--- a/internal-export-file/export-ttps-file-navigator/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-export-file/export-ttps-file-navigator/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -8,7 +8,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
 | OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
-| CONNECTOR_NAME | `string` | ✅ | string |  | The name of the connector. |
-| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'indicator, vulnerability'. |
+| CONNECTOR_NAME | `string` |  | string | `"ExportTTPsFileNavigator"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["application/vnd.mitre.navigator+json"]` | The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only). |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `INTERNAL_EXPORT_FILE` | `"INTERNAL_EXPORT_FILE"` |  |

--- a/internal-export-file/export-ttps-file-navigator/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-export-file/export-ttps-file-navigator/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -9,6 +9,6 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
 | OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
 | CONNECTOR_NAME | `string` |  | string | `"ExportTTPsFileNavigator"` | The name of the connector. |
-| CONNECTOR_SCOPE | `array` |  | string | `["application/vnd.mitre.navigator+json"]` | The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only). |
+| CONNECTOR_SCOPE | `array` |  | string | `["application/vnd.mitre.navigator+json"]` | The scope or type of data the connector is exporting, either a MIME type or Stix Object (for information only). |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `INTERNAL_EXPORT_FILE` | `"INTERNAL_EXPORT_FILE"` |  |

--- a/internal-export-file/export-ttps-file-navigator/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-export-file/export-ttps-file-navigator/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,14 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
+| CONNECTOR_NAME | `string` | ✅ | string |  | The name of the connector. |
+| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'indicator, vulnerability'. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `INTERNAL_EXPORT_FILE` | `"INTERNAL_EXPORT_FILE"` |  |

--- a/internal-export-file/export-ttps-file-navigator/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-ttps-file-navigator/__metadata__/connector_config_schema.json
@@ -25,12 +25,12 @@
       "default": [
         "application/vnd.mitre.navigator+json"
       ],
-      "description": "The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only).",
+      "description": "The scope or type of data the connector is exporting, either a MIME type or Stix Object (for information only).",
       "items": {
         "type": "string"
       },
       "type": "array"
-    },
+    }
     "CONNECTOR_LOG_LEVEL": {
       "default": "error",
       "description": "The minimum level of logs to display.",

--- a/internal-export-file/export-ttps-file-navigator/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-ttps-file-navigator/__metadata__/connector_config_schema.json
@@ -30,7 +30,7 @@
         "type": "string"
       },
       "type": "array"
-    }
+    },
     "CONNECTOR_LOG_LEVEL": {
       "default": "error",
       "description": "The minimum level of logs to display.",

--- a/internal-export-file/export-ttps-file-navigator/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-ttps-file-navigator/__metadata__/connector_config_schema.json
@@ -17,11 +17,15 @@
       "writeOnly": true
     },
     "CONNECTOR_NAME": {
+      "default": "ExportTTPsFileNavigator",
       "description": "The name of the connector.",
       "type": "string"
     },
     "CONNECTOR_SCOPE": {
-      "description": "The scope of the connector, e.g. 'indicator, vulnerability'.",
+      "default": [
+        "application/vnd.mitre.navigator+json"
+      ],
+      "description": "The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only).",
       "items": {
         "type": "string"
       },
@@ -47,9 +51,7 @@
   },
   "required": [
     "OPENCTI_URL",
-    "OPENCTI_TOKEN",
-    "CONNECTOR_NAME",
-    "CONNECTOR_SCOPE"
+    "OPENCTI_TOKEN"
   ],
   "additionalProperties": true
 }

--- a/internal-export-file/export-ttps-file-navigator/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-ttps-file-navigator/__metadata__/connector_config_schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/export-ttps-file-navigator_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_NAME": {
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "description": "The scope of the connector, e.g. 'indicator, vulnerability'.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_EXPORT_FILE",
+      "default": "INTERNAL_EXPORT_FILE",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_NAME",
+    "CONNECTOR_SCOPE"
+  ],
+  "additionalProperties": true
+}

--- a/internal-export-file/export-ttps-file-navigator/__metadata__/connector_manifest.json
+++ b/internal-export-file/export-ttps-file-navigator/__metadata__/connector_manifest.json
@@ -19,7 +19,7 @@
   "support_version": ">=5.12.10",
   "subscription_link": "https://mitre-attack.github.io/attack-navigator",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-export-file/export-ttps-file-navigator",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-export-ttps-file-navigator",
   "container_type": "INTERNAL_EXPORT_FILE"

--- a/internal-export-file/export-ttps-file-navigator/docker-compose.yml
+++ b/internal-export-file/export-ttps-file-navigator/docker-compose.yml
@@ -3,11 +3,10 @@ services:
   connector-export-ttps-file-navigator:
     image: opencti/connector-export-ttps-file-navigator:latest
     environment:
-      - OPENCTI_URL=http://localhost
+      - OPENCTI_URL=ChangeMe
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
       - CONNECTOR_NAME=ExportTTPsFileNavigator
       - CONNECTOR_SCOPE=application/vnd.mitre.navigator+json
-      - CONNECTOR_CONFIDENCE_LEVEL=100 # From 0 (Unknown) to 100 (Fully trusted)
-      - CONNECTOR_LOG_LEVEL=error
+      # - CONNECTOR_LOG_LEVEL=error
     restart: always

--- a/internal-export-file/export-ttps-file-navigator/entrypoint.sh
+++ b/internal-export-file/export-ttps-file-navigator/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-export-ttps-file-navigator
-
-# Launch the connector
-python3 export-ttps-file-navigator.py

--- a/internal-export-file/export-ttps-file-navigator/src/__init__.py
+++ b/internal-export-file/export-ttps-file-navigator/src/__init__.py
@@ -1,0 +1,3 @@
+from settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings"]

--- a/internal-export-file/export-ttps-file-navigator/src/config.yml.sample
+++ b/internal-export-file/export-ttps-file-navigator/src/config.yml.sample
@@ -6,5 +6,4 @@ connector:
   id: 'ChangeMe'
   name: 'ExportTTPsFileNavigator'
   scope: 'application/vnd.mitre.navigator+json'
-  # type: 'INTERNAL_EXPORT_FILE'
   # log_level: 'error'

--- a/internal-export-file/export-ttps-file-navigator/src/config.yml.sample
+++ b/internal-export-file/export-ttps-file-navigator/src/config.yml.sample
@@ -1,11 +1,10 @@
 opencti:
-  url: 'http://localhost'
+  url: 'ChangeMe'
   token: 'ChangeMe'
 
 connector:
-  type: 'INTERNAL_EXPORT_FILE'
   id: 'ChangeMe'
   name: 'ExportTTPsFileNavigator'
   scope: 'application/vnd.mitre.navigator+json'
-  confidence_level: 100 # From 0 (Unknown) to 100 (Fully trusted)
-  log_level: 'info'
+  # type: 'INTERNAL_EXPORT_FILE'
+  # log_level: 'error'

--- a/internal-export-file/export-ttps-file-navigator/src/export-ttps-file-navigator.py
+++ b/internal-export-file/export-ttps-file-navigator/src/export-ttps-file-navigator.py
@@ -1,23 +1,16 @@
 import json
-import os
 import sys
 import time
 
-import yaml
 from pycti import OpenCTIConnectorHelper
+from settings import ConnectorSettings
 
 
 class ExportTTPsFileNavigator:
     def __init__(self):
         # Instantiate the connector helper from config
-        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
-        print(config_file_path)
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
-        self.helper = OpenCTIConnectorHelper(config)
+        self.config = ConnectorSettings()
+        self.helper = OpenCTIConnectorHelper(config=self.config.to_helper_config())
 
     def _process_message(self, data):
         export_scope = data["export_scope"]  # query or selection or single

--- a/internal-export-file/export-ttps-file-navigator/src/requirements.txt
+++ b/internal-export-file/export-ttps-file-navigator/src/requirements.txt
@@ -1,1 +1,3 @@
 pycti==7.260901.0
+pydantic >=2.8.2, <3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-export-file/export-ttps-file-navigator/src/settings.py
+++ b/internal-export-file/export-ttps-file-navigator/src/settings.py
@@ -3,18 +3,23 @@
 from connectors_sdk import (
     BaseConnectorSettings,
     BaseInternalExportFileConnectorConfig,
+    ListFromString,
 )
 from pydantic import Field
 
 
-class ConnectorSettings(BaseConnectorSettings):
-    """Settings for the Export TTPs File Navigator connector.
-
-    This connector has no connector-specific configuration variables: it only
-    relies on the standard `opencti` and `connector` configuration sections.
+class InternalExportFileConnectorConfig(BaseInternalExportFileConnectorConfig):
+    """
+    Override the `BaseConnectorConfig` to add connector specific configuration parameters and/or defaults.
     """
 
-    connector: BaseInternalExportFileConnectorConfig = Field(
-        default_factory=BaseInternalExportFileConnectorConfig,  # type: ignore[arg-type]
-        description="Connector configurations.",
+    scope: ListFromString = Field(
+        default=["application/vnd.mitre.navigator+json"],
+        description="The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only).",
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    connector: InternalExportFileConnectorConfig = Field(
+        default_factory=InternalExportFileConnectorConfig
     )

--- a/internal-export-file/export-ttps-file-navigator/src/settings.py
+++ b/internal-export-file/export-ttps-file-navigator/src/settings.py
@@ -1,0 +1,20 @@
+"""Pydantic settings for the Export TTPs File Navigator connector."""
+
+from connectors_sdk import (
+    BaseConnectorSettings,
+    BaseInternalExportFileConnectorConfig,
+)
+from pydantic import Field
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """Settings for the Export TTPs File Navigator connector.
+
+    This connector has no connector-specific configuration variables: it only
+    relies on the standard `opencti` and `connector` configuration sections.
+    """
+
+    connector: BaseInternalExportFileConnectorConfig = Field(
+        default_factory=BaseInternalExportFileConnectorConfig,  # type: ignore[arg-type]
+        description="Connector configurations.",
+    )

--- a/internal-export-file/export-ttps-file-navigator/src/settings.py
+++ b/internal-export-file/export-ttps-file-navigator/src/settings.py
@@ -13,6 +13,14 @@ class InternalExportFileConnectorConfig(BaseInternalExportFileConnectorConfig):
     Override the `BaseConnectorConfig` to add connector specific configuration parameters and/or defaults.
     """
 
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="0bc22724-1cd0-416c-b400-6d4e9fbf9829",
+    )
+    name: str = Field(
+        description="The name of the connector.",
+        default="ExportTTPsFileNavigator",
+    )
     scope: ListFromString = Field(
         default=["application/vnd.mitre.navigator+json"],
         description="The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only).",


### PR DESCRIPTION
### Proposed changes

* Replace the manual `config.yml` / `os.environ` loading with Pydantic settings (`src/settings.py`) built on `connectors-sdk`'s `BaseConnectorSettings` and `BaseInternalExportFileConnectorConfig`, and feed `OpenCTIConnectorHelper` via `to_helper_config()`.
* Flag the connector as `manager_supported` in `__metadata__/connector_manifest.json` and generate `__metadata__/connector_config_schema.json` + `CONNECTOR_CONFIG_DOC.md` from the settings model.
* Normalise `config.yml.sample` and `docker-compose.yml`: drop the removed `confidence_level`, comment out optional keys (`type`, `log_level`) and use `ChangeMe` placeholders.
* Drop `entrypoint.sh` and run the connector directly through `CMD` in the Dockerfile, as required for manager-supported connectors.
* Declare the `scope` default as `application/vnd.mitre.navigator+json` in the settings model instead of relying on the environment.

### Related issues

* Closes #7220

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The file structure, module names and class names are unchanged on purpose: this is a structure-preserving migration limited to configuration handling, so the diff stays reviewable against the previous behaviour.

**Risk — breaking config change.** `CONNECTOR_CONFIDENCE_LEVEL` is no longer read, and `entrypoint.sh` is gone, so existing deployments that override the entrypoint must be updated. No data migration.

**Testing.** No automated tests: this connector has no test suite. `black`, `isort` and `flake8` pass on the changed sources (run via pre-commit). Runtime behaviour has not been exercised against a live OpenCTI instance yet.

**Point for reviewers.** `InternalExportFileConnectorConfig.id` now carries a hardcoded default UUID. That means any deployment omitting `CONNECTOR_ID` will share the same connector identity in OpenCTI — please confirm this is the intended convention for manager-supported connectors.

## Screenshots

Display on OpenCTI
<img width="380" height="291" alt="image" src="https://github.com/user-attachments/assets/6eed549a-48ea-4a32-8677-4c6c11d3e8b6" />

Connector running
<img width="946" height="460" alt="image" src="https://github.com/user-attachments/assets/762987dc-062f-4f34-986f-d2c5627fac09" />
