### PR TITLE
fix(tenable): pin restfly version to fix failing tests due to outdated package (#7320)

### DIFF
--- a/external-import/tenable-security-center/pyproject.toml
+++ b/external-import/tenable-security-center/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "validators~=0.35.0",
     "pydantic>=2.8.2,<3.0.0",
     "pytenable~=1.5.3", # for now we handle API from 5.13 to 6.4
+    "restfly==1.5.1",
     "cvss~=3.3",
     "semver>=3,<4",
 ]

--- a/external-import/tenable-vuln-management/requirements.txt
+++ b/external-import/tenable-vuln-management/requirements.txt
@@ -1,3 +1,4 @@
+restfly==1.5.1
 pyTenable==1.5.3
 python-dateutil==2.9.0.post0
 pycti==7.260817.0


### PR DESCRIPTION
### Proposed changes

* Pin `restfly==1.5.1` in `tenable-vuln-management/requirements.txt`, preventing an incompatible, transitively-resolved newer version of `restfly` from breaking the connector.
* Pin `restfly==1.5.1` in `tenable-security-center/pyproject.toml`, restoring compatibility with `pytenable~=1.5.3` and fixing the same transitive dependency issue for that connector.

### Related issues

* Fixes #7320

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

`pyTenable` depends on `restfly`, but does not pin a compatible version. A newer, incompatible `restfly` release was being resolved transitively, breaking tests for both `tenable-vuln-management` and `tenable-security-center`. Explicitly pinning `restfly==1.5.1` in both connectors' dependency manifests restores compatibility with `pytenable~=1.5.3` / `pyTenable==1.5.3`.