### PR TITLE
feat(export-file-txt): migrate connector to manager-supported mode (#7222)

### DIFF
--- a/internal-export-file/export-file-txt/Dockerfile
+++ b/internal-export-file/export-file-txt/Dockerfile
@@ -11,7 +11,5 @@ RUN apk --no-cache add git build-base libmagic libffi-dev && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+WORKDIR /opt/opencti-connector-export-file-txt
+CMD ["python3", "export-file-txt.py"]

--- a/internal-export-file/export-file-txt/Dockerfile_fips
+++ b/internal-export-file/export-file-txt/Dockerfile_fips
@@ -11,7 +11,5 @@ RUN apk --no-cache add git build-base libmagic libffi-dev && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+WORKDIR /opt/opencti-connector-export-file-txt
+CMD ["python3", "export-file-txt.py"]

--- a/internal-export-file/export-file-txt/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-export-file/export-file-txt/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -8,7 +8,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
 | OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
-| CONNECTOR_NAME | `string` | ✅ | string |  | The name of the connector. |
-| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'indicator, vulnerability'. |
+| CONNECTOR_NAME | `string` |  | string | `"ExportFileTxt"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["text/plain"]` | The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only). |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `INTERNAL_EXPORT_FILE` | `"INTERNAL_EXPORT_FILE"` |  |

--- a/internal-export-file/export-file-txt/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-export-file/export-file-txt/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,14 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
+| CONNECTOR_NAME | `string` | ✅ | string |  | The name of the connector. |
+| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'indicator, vulnerability'. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `INTERNAL_EXPORT_FILE` | `"INTERNAL_EXPORT_FILE"` |  |

--- a/internal-export-file/export-file-txt/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-file-txt/__metadata__/connector_config_schema.json
@@ -17,11 +17,15 @@
       "writeOnly": true
     },
     "CONNECTOR_NAME": {
+      "default": "ExportFileTxt",
       "description": "The name of the connector.",
       "type": "string"
     },
     "CONNECTOR_SCOPE": {
-      "description": "The scope of the connector, e.g. 'indicator, vulnerability'.",
+      "default": [
+        "text/plain"
+      ],
+      "description": "The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only).",
       "items": {
         "type": "string"
       },
@@ -47,9 +51,7 @@
   },
   "required": [
     "OPENCTI_URL",
-    "OPENCTI_TOKEN",
-    "CONNECTOR_NAME",
-    "CONNECTOR_SCOPE"
+    "OPENCTI_TOKEN"
   ],
   "additionalProperties": true
 }

--- a/internal-export-file/export-file-txt/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-file-txt/__metadata__/connector_config_schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/export-file-txt_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_NAME": {
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "description": "The scope of the connector, e.g. 'indicator, vulnerability'.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_EXPORT_FILE",
+      "default": "INTERNAL_EXPORT_FILE",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_NAME",
+    "CONNECTOR_SCOPE"
+  ],
+  "additionalProperties": true
+}

--- a/internal-export-file/export-file-txt/__metadata__/connector_manifest.json
+++ b/internal-export-file/export-file-txt/__metadata__/connector_manifest.json
@@ -19,7 +19,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-export-file/export-file-txt",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-export-file-txt",
   "container_type": "INTERNAL_EXPORT_FILE"

--- a/internal-export-file/export-file-txt/docker-compose.yml
+++ b/internal-export-file/export-file-txt/docker-compose.yml
@@ -3,11 +3,10 @@ services:
   connector-export-file-txt:
     image: opencti/connector-export-file-txt:latest
     environment:
-      - OPENCTI_URL=http://localhost
+      - OPENCTI_URL=ChangeMe
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
       - CONNECTOR_NAME=ExportFileTxt
       - CONNECTOR_SCOPE=text/plain
-      - CONNECTOR_CONFIDENCE_LEVEL=100 # From 0 (Unknown) to 100 (Fully trusted)
-      - CONNECTOR_LOG_LEVEL=error
+      # - CONNECTOR_LOG_LEVEL=error
     restart: always

--- a/internal-export-file/export-file-txt/entrypoint.sh
+++ b/internal-export-file/export-file-txt/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-export-file-txt
-
-# Launch the worker
-python3 export-file-txt.py

--- a/internal-export-file/export-file-txt/src/__init__.py
+++ b/internal-export-file/export-file-txt/src/__init__.py
@@ -1,0 +1,3 @@
+from settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings"]

--- a/internal-export-file/export-file-txt/src/config.yml.sample
+++ b/internal-export-file/export-file-txt/src/config.yml.sample
@@ -1,11 +1,9 @@
 opencti:
-  url: 'http://localhost'
+  url: 'ChangeMe'
   token: 'ChangeMe'
 
 connector:
-  type: 'INTERNAL_EXPORT_FILE'
   id: 'ChangeMe'
   name: 'ExportFileTxt'
   scope: 'text/plain'
-  confidence_level: 100 # From 0 (Unknown) to 100 (Fully trusted)
-  log_level: 'info'
+  # log_level: 'error'

--- a/internal-export-file/export-file-txt/src/export-file-txt.py
+++ b/internal-export-file/export-file-txt/src/export-file-txt.py
@@ -1,22 +1,16 @@
 import json
-import os
 import sys
 import time
 
-import yaml
 from pycti import OpenCTIConnectorHelper
+from settings import ConnectorSettings
 
 
 class ExportFileTxt:
     def __init__(self):
         # Instantiate the connector helper from config
-        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
-        self.helper = OpenCTIConnectorHelper(config)
+        self.config = ConnectorSettings()
+        self.helper = OpenCTIConnectorHelper(config=self.config.to_helper_config())
 
     def _process_message(self, data):
         file_name = data["file_name"]

--- a/internal-export-file/export-file-txt/src/requirements.txt
+++ b/internal-export-file/export-file-txt/src/requirements.txt
@@ -1,1 +1,3 @@
 pycti==7.260901.0
+pydantic >=2.8.2, <3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-export-file/export-file-txt/src/settings.py
+++ b/internal-export-file/export-file-txt/src/settings.py
@@ -3,14 +3,23 @@
 from connectors_sdk import (
     BaseConnectorSettings,
     BaseInternalExportFileConnectorConfig,
+    ListFromString,
 )
 from pydantic import Field
 
 
-class ConnectorSettings(BaseConnectorSettings):
-    """Configuration of the Export File TXT connector."""
+class InternalExportFileConnectorConfig(BaseInternalExportFileConnectorConfig):
+    """
+    Override the `BaseConnectorConfig` to add connector specific configuration parameters and/or defaults.
+    """
 
-    connector: BaseInternalExportFileConnectorConfig = Field(
-        default_factory=BaseInternalExportFileConnectorConfig,
-        description="Connector configurations.",
+    scope: ListFromString = Field(
+        default=["text/plain"],
+        description="The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only).",
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    connector: InternalExportFileConnectorConfig = Field(
+        default_factory=InternalExportFileConnectorConfig
     )

--- a/internal-export-file/export-file-txt/src/settings.py
+++ b/internal-export-file/export-file-txt/src/settings.py
@@ -1,0 +1,16 @@
+"""Pydantic settings for the Export File TXT connector."""
+
+from connectors_sdk import (
+    BaseConnectorSettings,
+    BaseInternalExportFileConnectorConfig,
+)
+from pydantic import Field
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """Configuration of the Export File TXT connector."""
+
+    connector: BaseInternalExportFileConnectorConfig = Field(
+        default_factory=BaseInternalExportFileConnectorConfig,
+        description="Connector configurations.",
+    )

--- a/internal-export-file/export-file-txt/src/settings.py
+++ b/internal-export-file/export-file-txt/src/settings.py
@@ -10,7 +10,8 @@ from pydantic import Field
 
 class InternalExportFileConnectorConfig(BaseInternalExportFileConnectorConfig):
     """
-    Override the `BaseConnectorConfig` to add connector specific configuration parameters and/or defaults.
+    Override `BaseInternalExportFileConnectorConfig` to add connector-specific configuration
+    parameters and/or defaults.
     """
 
     id: str = Field(

--- a/internal-export-file/export-file-txt/src/settings.py
+++ b/internal-export-file/export-file-txt/src/settings.py
@@ -13,6 +13,14 @@ class InternalExportFileConnectorConfig(BaseInternalExportFileConnectorConfig):
     Override the `BaseConnectorConfig` to add connector specific configuration parameters and/or defaults.
     """
 
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="4ba9523e-5283-48ce-86e5-23f9c8223ac2",
+    )
+    name: str = Field(
+        description="The name of the connector.",
+        default="ExportFileTxt",
+    )
     scope: ListFromString = Field(
         default=["text/plain"],
         description="The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only).",


### PR DESCRIPTION
### Proposed changes

* Migrate `internal-export-file/export-file-txt` to manager-supported mode: replace the `config.yml` / `os.environ` loading with a Pydantic `ConnectorSettings` built on `connectors-sdk` (`BaseConnectorSettings`, `BaseInternalExportFileConnectorConfig`), passed to `OpenCTIConnectorHelper` via `to_helper_config()`.
* Set connector-specific defaults (`id`, `name: ExportFileTxt`, `scope: ["text/plain"]`) so the connector is deployable from the manager without mandatory name/scope input.
* Set `manager_supported: true` in `__metadata__/connector_manifest.json` and regenerate `connector_config_schema.json` / `CONNECTOR_CONFIG_DOC.md`.
* Drop `entrypoint.sh` in favour of a direct `CMD` in `Dockerfile` and `Dockerfile_fips`; normalize `docker-compose.yml` and `config.yml.sample` (removed the obsolete `confidence_level` and the hardcoded `connector.type`).

The file structure, class names and processing logic are intentionally unchanged — this is a structure-preserving (lite) migration.

### Related issues

* Closes #7222

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

`CONNECTOR_NAME` and `CONNECTOR_SCOPE` move from required to defaulted in the config schema. This is not breaking for existing deployments — explicitly set values still override the defaults — but it does change the generated schema consumed by the platform.

Removing `entrypoint.sh` changes how the image starts. Any deployment overriding the entrypoint will need adjusting; the standard `docker-compose.yml` is unaffected.

## Screenshots

Display on OpenCTI catalog
<img width="372" height="289" alt="image" src="https://github.com/user-attachments/assets/12b42d49-4081-4e4a-ba67-683122de23a3" />

Usage when exporting
<img width="972" height="250" alt="image" src="https://github.com/user-attachments/assets/e66a251d-36d9-4749-a702-986281ff53f7" />
