### PR TITLE
feat(export-file-stix): migrate connector to manager-supported mode (#7223)

### DIFF
--- a/internal-export-file/export-file-stix/Dockerfile
+++ b/internal-export-file/export-file-stix/Dockerfile
@@ -11,7 +11,5 @@ RUN apk --no-cache add git build-base libmagic libffi-dev && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+WORKDIR /opt/opencti-connector-export-file-stix
+CMD ["python3", "export-file-stix.py"]

--- a/internal-export-file/export-file-stix/Dockerfile_fips
+++ b/internal-export-file/export-file-stix/Dockerfile_fips
@@ -11,7 +11,5 @@ RUN apk --no-cache add git build-base libmagic libffi-dev && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+WORKDIR /opt/opencti-connector-export-file-stix
+CMD ["python3", "export-file-stix.py"]

--- a/internal-export-file/export-file-stix/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-export-file/export-file-stix/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -8,7 +8,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
 | OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
-| CONNECTOR_NAME | `string` | ✅ | string |  | The name of the connector. |
-| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'indicator, vulnerability'. |
+| CONNECTOR_NAME | `string` |  | string | `"ExportFileStix2"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["application/vnd.oasis.stix+json"]` | The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only). |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `INTERNAL_EXPORT_FILE` | `"INTERNAL_EXPORT_FILE"` |  |

--- a/internal-export-file/export-file-stix/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-export-file/export-file-stix/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,14 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
+| CONNECTOR_NAME | `string` | ✅ | string |  | The name of the connector. |
+| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'indicator, vulnerability'. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `INTERNAL_EXPORT_FILE` | `"INTERNAL_EXPORT_FILE"` |  |

--- a/internal-export-file/export-file-stix/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-file-stix/__metadata__/connector_config_schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/export-file-stix_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_NAME": {
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "description": "The scope of the connector, e.g. 'indicator, vulnerability'.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_EXPORT_FILE",
+      "default": "INTERNAL_EXPORT_FILE",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_NAME",
+    "CONNECTOR_SCOPE"
+  ],
+  "additionalProperties": true
+}

--- a/internal-export-file/export-file-stix/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-file-stix/__metadata__/connector_config_schema.json
@@ -17,11 +17,15 @@
       "writeOnly": true
     },
     "CONNECTOR_NAME": {
+      "default": "ExportFileStix2",
       "description": "The name of the connector.",
       "type": "string"
     },
     "CONNECTOR_SCOPE": {
-      "description": "The scope of the connector, e.g. 'indicator, vulnerability'.",
+      "default": [
+        "application/vnd.oasis.stix+json"
+      ],
+      "description": "The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only).",
       "items": {
         "type": "string"
       },
@@ -47,9 +51,7 @@
   },
   "required": [
     "OPENCTI_URL",
-    "OPENCTI_TOKEN",
-    "CONNECTOR_NAME",
-    "CONNECTOR_SCOPE"
+    "OPENCTI_TOKEN"
   ],
   "additionalProperties": true
 }

--- a/internal-export-file/export-file-stix/__metadata__/connector_manifest.json
+++ b/internal-export-file/export-file-stix/__metadata__/connector_manifest.json
@@ -19,7 +19,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-export-file/export-file-stix",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-export-file-stix",
   "container_type": "INTERNAL_EXPORT_FILE"

--- a/internal-export-file/export-file-stix/docker-compose.yml
+++ b/internal-export-file/export-file-stix/docker-compose.yml
@@ -8,6 +8,5 @@ services:
       - CONNECTOR_ID=ChangeMe
       - CONNECTOR_NAME=ExportFileStix2
       - CONNECTOR_SCOPE=application/vnd.oasis.stix+json
-      - CONNECTOR_CONFIDENCE_LEVEL=100 # From 0 (Unknown) to 100 (Fully trusted)
-      - CONNECTOR_LOG_LEVEL=error
+      # - CONNECTOR_LOG_LEVEL=error
     restart: always

--- a/internal-export-file/export-file-stix/entrypoint.sh
+++ b/internal-export-file/export-file-stix/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-export-file-stix
-
-# Launch the worker
-python3 export-file-stix.py

--- a/internal-export-file/export-file-stix/src/__init__.py
+++ b/internal-export-file/export-file-stix/src/__init__.py
@@ -1,0 +1,3 @@
+from settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings"]

--- a/internal-export-file/export-file-stix/src/config.yml.sample
+++ b/internal-export-file/export-file-stix/src/config.yml.sample
@@ -3,9 +3,7 @@ opencti:
   token: 'ChangeMe'
 
 connector:
-  type: 'INTERNAL_EXPORT_FILE'
   id: 'ChangeMe'
   name: 'ExportFileStix'
   scope: 'application/vnd.oasis.stix+json'
-  confidence_level: 100 # From 0 (Unknown) to 100 (Fully trusted)
-  log_level: 'info'
+  # log_level: 'error'

--- a/internal-export-file/export-file-stix/src/export-file-stix.py
+++ b/internal-export-file/export-file-stix/src/export-file-stix.py
@@ -1,22 +1,16 @@
 import json
-import os
 import sys
 import time
 
-import yaml
 from pycti import OpenCTIConnectorHelper
+from settings import ConnectorSettings
 
 
 class ExportFileStix:
     def __init__(self):
         # Instantiate the connector helper from config
-        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
-        self.helper = OpenCTIConnectorHelper(config)
+        self.config = ConnectorSettings()
+        self.helper = OpenCTIConnectorHelper(config=self.config.to_helper_config())
 
     def _export_list(self, data, bundle, list_filters):
         entity_id = data.get("entity_id")

--- a/internal-export-file/export-file-stix/src/requirements.txt
+++ b/internal-export-file/export-file-stix/src/requirements.txt
@@ -1,1 +1,3 @@
 pycti==7.260901.0
+pydantic >=2.8.2, <3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-export-file/export-file-stix/src/settings.py
+++ b/internal-export-file/export-file-stix/src/settings.py
@@ -1,11 +1,23 @@
 from connectors_sdk import (
     BaseConnectorSettings,
     BaseInternalExportFileConnectorConfig,
+    ListFromString,
 )
 from pydantic import Field
 
 
+class InternalExportFileConnectorConfig(BaseInternalExportFileConnectorConfig):
+    """
+    Override the `BaseConnectorConfig` to add connector specific configuration parameters and/or defaults.
+    """
+
+    scope: ListFromString = Field(
+        default=["application/vnd.oasis.stix+json"],
+        description="The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only).",
+    )
+
+
 class ConnectorSettings(BaseConnectorSettings):
-    connector: BaseInternalExportFileConnectorConfig = Field(
-        default_factory=BaseInternalExportFileConnectorConfig
+    connector: InternalExportFileConnectorConfig = Field(
+        default_factory=InternalExportFileConnectorConfig
     )

--- a/internal-export-file/export-file-stix/src/settings.py
+++ b/internal-export-file/export-file-stix/src/settings.py
@@ -11,6 +11,14 @@ class InternalExportFileConnectorConfig(BaseInternalExportFileConnectorConfig):
     Override the `BaseConnectorConfig` to add connector specific configuration parameters and/or defaults.
     """
 
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="9c06c7a0-96e3-4ca5-924c-5437587660f1",
+    )
+    name: str = Field(
+        description="The name of the connector.",
+        default="ExportFileStix2",
+    )
     scope: ListFromString = Field(
         default=["application/vnd.oasis.stix+json"],
         description="The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only).",

--- a/internal-export-file/export-file-stix/src/settings.py
+++ b/internal-export-file/export-file-stix/src/settings.py
@@ -1,0 +1,11 @@
+from connectors_sdk import (
+    BaseConnectorSettings,
+    BaseInternalExportFileConnectorConfig,
+)
+from pydantic import Field
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    connector: BaseInternalExportFileConnectorConfig = Field(
+        default_factory=BaseInternalExportFileConnectorConfig
+    )


### PR DESCRIPTION
### Proposed changes

* Migrate `internal-export-file/export-file-stix` to manager-supported mode: configuration now goes through a Pydantic `ConnectorSettings` (`src/settings.py`) built on `connectors-sdk`'s `BaseConnectorSettings` / `BaseInternalExportFileConnectorConfig`, replacing the manual `config.yml` + `yaml.load` bootstrap in `export-file-stix.py`.
* Give `connector.id`, `connector.name` and `connector.scope` defaults in the settings model, so `CONNECTOR_NAME` and `CONNECTOR_SCOPE` are no longer required from the operator. Regenerated `connector_config_schema.json` and `CONNECTOR_CONFIG_DOC.md` accordingly.
* Set `manager_supported: true` in `__metadata__/connector_manifest.json`.
* Drop `entrypoint.sh` in favour of a direct `CMD ["python3", "export-file-stix.py"]` in both `Dockerfile` and `Dockerfile_fips`, since the config templating the entrypoint performed is now handled by the settings model.
* Remove the obsolete `CONNECTOR_CONFIDENCE_LEVEL` and the mandatory `CONNECTOR_TYPE` from `docker-compose.yml` / `config.yml.sample`.

### Related issues

* Closes #7223

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This is a structure-preserving migration: file names, the `ExportFileStix` class and the existing `listen()` scheduling are unchanged, so the diff stays reviewable and the runtime behaviour of the export itself is untouched.

**Risk / operator impact:**
- `entrypoint.sh` is removed. Any deployment overriding the image `ENTRYPOINT` or mounting its own entrypoint will need updating.
- `CONNECTOR_CONFIDENCE_LEVEL` is no longer read; it can be dropped from existing deployments.
- `CONNECTOR_TYPE` no longer needs to be set explicitly (defaults to `INTERNAL_EXPORT_FILE`).
- `CONNECTOR_NAME` / `CONNECTOR_SCOPE` become optional with defaults; existing explicit values keep working.
- New dependency on `connectors-sdk` (installed from the repo `master` subdirectory) and `pydantic >=2.8.2, <3`.

**Testing:** no automated tests were run — this connector has no `tests/` directory, and the connector has not yet been run end-to-end against a live OpenCTI instance. The functionality checkbox is left unticked for that reason.

## Screenshots

Display onOpenCTI
<img width="351" height="280" alt="image" src="https://github.com/user-attachments/assets/d767421f-52a8-4b76-b6a3-4c1c7031734a" />

Connector's running usage
<img width="973" height="322" alt="image" src="https://github.com/user-attachments/assets/8821ec42-3110-4587-827a-3515e9669329" />

