### PR TITLE
fix(infoblox-threat-defense): make CSP endpoint URL configurable (#7325)

### DIFF
--- a/stream/infoblox-threat-defense/README.md
+++ b/stream/infoblox-threat-defense/README.md
@@ -75,6 +75,7 @@ There are a number of configuration options, which are set either in `docker-com
 | Infoblox API Key         | infoblox.api_key        | `INFOBLOX_API_KEY`           |         | Yes       | API key generated in Infoblox Threat Defense console.      |
 | Infoblox Verify SSL      | infoblox.verify_ssl     | `INFOBLOX_VERIFY_SSL`        | true    | No        | Whether to verify SSL certificates.                        |
 | Infoblox Custom List ID  | infoblox.custom_list_id | `INFOBLOX_CUSTOM_LIST_ID`    |         | Yes       | The custom list ID where indicators will be added/removed. |
+| Infoblox URL             | infoblox.url            | `INFOBLOX_URL`               | `https://csp.infoblox.com` | No | The Infoblox CSP endpoint. Override for regional deployments (e.g. `https://csp.eu.infoblox.com`). |
 
 ## Deployment
 
@@ -104,6 +105,7 @@ Configure the connector in `docker-compose.yml`:
       - INFOBLOX_API_KEY=ChangeMe
       - INFOBLOX_VERIFY_SSL=true
       - INFOBLOX_CUSTOM_LIST_ID=ChangeMe
+      - INFOBLOX_URL=https://csp.infoblox.com
     restart: always
 ```
 

--- a/stream/infoblox-threat-defense/docker-compose.yml
+++ b/stream/infoblox-threat-defense/docker-compose.yml
@@ -16,4 +16,5 @@ services:
       - INFOBLOX_API_KEY=ChangeMe # Infoblox Threat Defense API Key
       - INFOBLOX_VERIFY_SSL=true # Determine if you want to verify the SSL on requests
       - INFOBLOX_CUSTOM_LIST_ID=ChangeMe # This is the specific custom list id you will be updating
+      - INFOBLOX_URL=https://csp.infoblox.com # Infoblox CSP endpoint, change for regional deployments (e.g. https://csp.eu.infoblox.com)
     restart: always

--- a/stream/infoblox-threat-defense/src/config.yml.sample
+++ b/stream/infoblox-threat-defense/src/config.yml.sample
@@ -17,3 +17,4 @@ infoblox:
   api_key: 'ChangeMe' 
   verify_ssl: true
   custom_list_id: 'ChangeMe' # Custom List ID in Infoblox
+  url: 'https://csp.infoblox.com' # Infoblox CSP endpoint, change for regional deployments (e.g. https://csp.eu.infoblox.com)

--- a/stream/infoblox-threat-defense/src/main.py
+++ b/stream/infoblox-threat-defense/src/main.py
@@ -31,6 +31,12 @@ class InfobloxThreatDefenseConnector:
         self.infoblox_custom_list_id = get_config_variable(
             "INFOBLOX_CUSTOM_LIST_ID", ["infoblox", "custom_list_id"], config
         )
+        self.infoblox_url = get_config_variable(
+            "INFOBLOX_URL",
+            ["infoblox", "url"],
+            config,
+            default="https://csp.infoblox.com",
+        ).rstrip("/")
 
     def check_stream_id(self):
         """
@@ -75,7 +81,7 @@ class InfobloxThreatDefenseConnector:
 
     def get_custom_lists(self):
         """Retrieve all custom lists from the Infoblox portal."""
-        url = "https://csp.infoblox.com/api/atcfw/v1/named_lists"
+        url = f"{self.infoblox_url}/api/atcfw/v1/named_lists"
         response = self.make_request_with_retries(
             "GET", url, headers=self.get_headers()
         )
@@ -90,7 +96,7 @@ class InfobloxThreatDefenseConnector:
 
     def update_custom_list(self, list_id, updated_items, operation):
         """Update a custom list with the given items by adding or removing them."""
-        url = f"https://csp.infoblox.com/api/atcfw/v1/named_lists/{list_id}"
+        url = f"{self.infoblox_url}/api/atcfw/v1/named_lists/{list_id}"
         response = self.make_request_with_retries(
             "GET", url, headers=self.get_headers()
         )


### PR DESCRIPTION
## Purpose

The `stream/infoblox-threat-defense` connector had the Infoblox CSP (Cloud Services Portal) endpoint hardcoded to `https://csp.infoblox.com` in `src/main.py`, with no way to override it. Infoblox operates regional CSP endpoints (e.g. `csp.eu.infoblox.com`), so customers on a non-US region could not use this connector without maintaining a custom fork.

This mirrors the pattern already used by `external-import/infoblox`, which exposes a configurable `INFOBLOX_URL`.

## Changes

- Added `INFOBLOX_URL` / `infoblox.url` config option (defaults to `https://csp.infoblox.com`, preserving current behavior)
- Replaced hardcoded CSP URLs in `get_custom_lists()` and `update_custom_list()` with the configurable base URL
- Updated `config.yml.sample` and `docker-compose.yml` with the new option
- Updated README parameter table and docker-compose example

## Related issue

Closes #7325