### PR TITLE
fix(assetnote-import): remove unsupported course of action option (#7141)

### DIFF
--- a/external-import/assetnote-import/src/connector/converter_to_stix.py
+++ b/external-import/assetnote-import/src/connector/converter_to_stix.py
@@ -187,7 +187,6 @@ class ConverterToStix:
             created=datetime.fromisoformat(exposure["created"]),
             author=self.author,
             markings=[self.tlp_marking],
-            allow_custom=True,
         ).to_stix2_object()
 
     def _map_incident_response(


### PR DESCRIPTION
### Proposed changes

* Remove the unsupported `allow_custom` argument from Assetnote Course of Action conversion.
* Prevent SDK model validation errors when converting Assetnote exposures.

### Related issues

* Closes #7141

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

No documentation changes are needed because this fix only removes an unsupported SDK model argument.