### PR TITLE
feat(pan-cortex-xdr-intel): implement shared integration foundation and global error handling (#7185)

### DIFF
--- a/stream/pan-cortex-xdr-intel/README.md
+++ b/stream/pan-cortex-xdr-intel/README.md
@@ -5,11 +5,20 @@
 - [OpenCTI Palo Alto Cortex XDR Intel Connector](#opencti-palo-alto-cortex-xdr-intel-connector)
   - [Table of Contents](#table-of-contents)
   - [Introduction](#introduction)
+  - [Behavior](#behavior)
+    - [Supported actions](#supported-actions)
+    - [Data flow](#data-flow)
+    - [Supported observable types](#supported-observable-types)
   - [Installation](#installation)
     - [Requirements](#requirements)
     - [Getting the Cortex XDR API base URL](#getting-the-cortex-xdr-api-base-url)
     - [Getting the Cortex XDR API credentials](#getting-the-cortex-xdr-api-credentials)
   - [Configuration variables](#configuration-variables)
+  - [Operational guidance](#operational-guidance)
+    - [Log interpretation](#log-interpretation)
+    - [Idempotency](#idempotency)
+    - [Unsupported observable handling](#unsupported-observable-handling)
+  - [Troubleshooting](#troubleshooting)
 
 
 ## Introduction
@@ -19,6 +28,55 @@ network, and cloud data to detect, investigate, and respond to threats across th
 
 This connector listens to an OpenCTI live stream and synchronizes indicators as Indicators of
 Compromise (IOCs) in Palo Alto Cortex XDR.
+
+## Behavior
+
+### Supported actions
+
+Only STIX **Indicator** entities are processed; any other entity type (e.g. Malware, Identity)
+received on the stream is skipped with a `warning` log.
+
+The connector reacts to the following live stream events on Indicator entities:
+
+| OpenCTI event | Cortex XDR action |
+| ------------- | ------------------ |
+| `create` / `update` | Upsert: insert the indicator's IOC(s), or update them if they already exist |
+| `delete` | Delete the indicator's IOC(s) |
+
+Any other event type (e.g. a custom event) is skipped with a `warning` log.
+
+`delete` events require `CONNECTOR_LIVE_STREAM_LISTEN_DELETE` to be enabled (`true` by default,
+see [Configuration variables](#configuration-variables)); when disabled, OpenCTI never emits
+delete events on the stream and this connector never removes IOCs from Cortex XDR.
+
+### Data flow
+
+1. OpenCTI's live stream emits an event for an Indicator create/update/delete.
+2. The indicator's `observable_values` extension attribute is normalized into the connector's
+   internal representation, keeping only observables of a [supported type](#supported-observable-types).
+3. Each supported observable is mapped to a Cortex XDR IOC (`type` + `indicator` value).
+4. On upsert, the indicator's `score`, `valid_until` and `description` are additionally mapped to
+   the IOC's `severity`, `expiration_date` and `comment`, and `reputation` is hardcoded to `BAD`
+   (see [Idempotency](#idempotency) for how updates to an already-existing IOC are handled).
+5. The resulting IOC(s) are sent to Cortex XDR in a single batched API call
+   (`insert_iocs` for upsert, `delete_iocs` for delete).
+
+An indicator whose observables map to **no** supported Cortex XDR IOC at all is skipped (see
+[Unsupported observable handling](#unsupported-observable-handling)).
+
+### Supported observable types
+
+| STIX observable | Cortex XDR IOC type |
+| --------------- | -------------------- |
+| `Domain-Name` | `DOMAIN_NAME` |
+| `IPv4-Addr` / `IPv6-Addr` | `IP` |
+| `StixFile` (hashes only, e.g. `MD5`, `SHA-1`, `SHA-256`) | `HASH` |
+
+Any other observable type (e.g. `Hostname`, `Email-Addr`, `Url`) is out of scope for this
+connector's MVP and is silently filtered out when building the indicator's observables. A
+`StixFile` observable is a supported type, but only its hash(es) are mapped to a Cortex XDR IOC:
+a `StixFile` with only a `name` and no hash passes the type filter but still yields no IOC (see
+[Unsupported observable handling](#unsupported-observable-handling)).
 
 ## Installation
 
@@ -57,3 +115,51 @@ Find all the configuration variables available here: [Connector Configurations](
 _The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
 For more information regarding these variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
+## Operational guidance
+
+### Log interpretation
+
+| Level | When | Example message |
+| ----- | ---- | ---------------- |
+| `warning` | An unsupported stream event or entity type is received (event skipped), or none of an indicator's observables are of a supported type (indicator skipped) | `Unsupported event type, skipping it` / `Unsupported entity type, skipping it` / `No supported observable(s) found in indicator, skipping it` |
+| `debug` | Right before an upsert/delete API call is sent to Cortex XDR | `Upserting IOC(s) into Cortex XDR` / `Deleting IOC(s) from Cortex XDR` |
+| `info` | An indicator was successfully parsed, upserted, or deleted | `Parsed observable(s) from stream event` / `Successfully upserted IOC(s) into Cortex XDR` / `Successfully deleted IOC(s) from Cortex XDR` |
+| `error` (indicator-scoped, stream continues) | The indicator has supported-type observable(s) but none of them could still be mapped to a Cortex XDR IOC (e.g. a `StixFile` without any hash), or the Cortex XDR API rejects one specific event (e.g. an invalid IOC value) | `No Cortex XDR IOC could be extracted from any observable, skipping indicator` / `Error while hitting Cortex XDR API. Skipping event and continuing with the next one.` |
+| `error` (fatal, connector exits) | A stream payload could not be parsed/validated, or the Cortex XDR API returned an authentication, authorization, not-found, rate-limit, or server error (401/403/404/429/5xx) | `Failed to parse stream event's data payload as JSON` / `Failed to parse indicator and/or observables from stream event` / `Error while hitting Cortex XDR API` |
+
+A fatal error stops the connector process on purpose, to avoid exhausting or silently
+mis-processing the live stream while a systemic issue (e.g. a revoked API key, or an
+unexpected breaking change in the stream payload) remains unresolved; the connector must be
+restarted manually once the root cause is fixed.
+
+### Idempotency
+
+- **Upsert**: before inserting an IOC, the connector looks up any existing Cortex XDR IOC with
+  the same indicator value. If found, its `rule_id` is included in the following insert call so
+  Cortex XDR *updates* the existing IOC in place instead of failing with a 400 "IOC indicator
+  exists" error. Replaying the same `create`/`update` event is therefore safe.
+- **Delete**: Cortex XDR's delete API is inherently idempotent — deleting an IOC that no longer
+  exists (e.g. already deleted) does not raise. Replaying the same `delete` event is safe.
+
+### Unsupported observable handling
+
+Observables of an unsupported type (see [Supported observable types](#supported-observable-types))
+are filtered out silently, without any log, when the indicator is parsed. If this filtering
+leaves the indicator with **no** observable at all, the connector logs a `warning` and skips that
+specific indicator, without stopping the stream — this is expected behavior, not a runtime error.
+
+A supported-type observable can still fail to yield a Cortex XDR IOC (e.g. a `StixFile` with only
+a `name` and no hash). If **all** of an indicator's supported-type observables end up in this
+situation, the connector logs an `error` (instead of a `warning`) and skips the indicator, since
+this points to an unexpected data shape rather than the normal type-filtering behavior.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| Connector exits right after startup or after processing one event; logs show a 401/403 Cortex XDR error | Invalid, revoked, or **Standard** (non-Advanced) API key | Generate an **Advanced** API key/Key ID pair (see [Getting the Cortex XDR API credentials](#getting-the-cortex-xdr-api-credentials)) and update `PAN_CORTEX_XDR_INTEL_API_KEY`/`PAN_CORTEX_XDR_INTEL_API_KEY_ID` |
+| Same as above but with a 429 error | Cortex XDR API rate limit exceeded (not currently configurable from the connector side) | Restart the connector; if the issue persists, contact Filigran support |
+| Logs repeatedly show `No supported observable(s) found in indicator, skipping it` | The indicator's observables are all of an unsupported type (e.g. `Hostname`, `Email-Addr`, `Url`) | Expected behavior for unspported observable types; no action needed unless those indicators are expected to be pushed to Cortex XDR |
+| Logs repeatedly show `No Cortex XDR IOC could be extracted from any observable, skipping indicator` | The indicator only has `StixFile` observable(s) without any hash (e.g. only a `name`) | Expected behavior since only hashes are mapped for `StixFile`; no action needed unless those indicators are expected to be pushed to Cortex XDR |
+| `delete` events never reach Cortex XDR | `CONNECTOR_LIVE_STREAM_LISTEN_DELETE` is set to `false` | Set `CONNECTOR_LIVE_STREAM_LISTEN_DELETE=true` (the default) |
+| Connector exits with `Failed to parse stream event's data payload as JSON` or `Failed to parse indicator and/or observables from stream event` | Unexpected OpenCTI/`pycti` stream payload shape (e.g. a breaking upstream change) | This should not happen; please report the issue with the connector's logs |

--- a/stream/pan-cortex-xdr-intel/data_samples/octi_stream_message_example.json
+++ b/stream/pan-cortex-xdr-intel/data_samples/octi_stream_message_example.json
@@ -1,0 +1,60 @@
+{
+    "event": "create",
+    "id": "609198385",
+    "retry": null,
+    "data": {
+        "data": {
+            "id": "indicator--32c6886b-68e6-45e5-bb0f-0f5defa8b7ef",
+            "spec_version": "2.1",
+            "type": "indicator",
+            "extensions": {
+                "extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba": {
+                    "extension_type": "property-extension",
+                    "id": "15926f6f-44b9-446d-94e0-cf66c6aceec7",
+                    "type": "Indicator",
+                    "created_at": "2027-03-11T14:22:05.000Z",
+                    "updated_at": "2027-03-11T14:39:05.000Z",
+                    "is_inferred": false,
+                    "creator_ids": [
+                        "7d9118e3-5f2f-453d-a20a-b4acd9a50e7a"
+                    ],
+                    "detection": false,
+                    "score": 50,
+                    "main_observable_type": "StixFile",
+                    "observable_values": [
+                        {
+                            "type": "StixFile",
+                            "hashes": {
+                                "MD5": "c2f7c2f12563246ea8ce5a4ea425de8e"
+                            }
+                        },
+                        {
+                            "type": "StixFile",
+                            "hashes": {
+                                "SHA-256": "b59444a310faa5ab8a774161cd8961012e3c02daa70273bc75de8acfd8f504b7"
+                            }
+                        }
+                    ]
+                },
+                "extension-definition--322b8f77-262a-4cb8-a915-1e441e00329b": {
+                    "extension_type": "property-extension"
+                }
+            },
+            "created": "2027-03-11T14:22:05.000Z",
+            "modified": "2027-03-11T14:39:05.000Z",
+            "revoked": false,
+            "confidence": 100,
+            "lang": "en",
+            "name": "sample-indicator",
+            "pattern": "[file:hashes.MD5 = 'c2f7c2f12563246ea8ce5a4ea425de8e' AND file:hashes.'SHA-256' = 'b59444a310faa5ab8a774161cd8961012e3c02daa70273bc75de8acfd8f504b7']",
+            "pattern_type": "stix",
+            "valid_from": "2027-03-11T14:20:05.000Z",
+            "valid_until": "2027-12-26T14:22:05.000Z"
+        },
+        "message": "creates a Indicator `sample-indicator`",
+        "origin": {
+            "referer": "init-create"
+        },
+        "version": "4"
+    }
+}

--- a/stream/pan-cortex-xdr-intel/src/connector/connector.py
+++ b/stream/pan-cortex-xdr-intel/src/connector/connector.py
@@ -1,11 +1,45 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+from typing import TYPE_CHECKING, Any, Protocol
+
+from connector.models import OctiIndicator
+from connectors_sdk import (
+    ApiForbiddenError,
+    ApiNotFoundError,
+    ApiRateLimitError,
+    ApiServerError,
+    ApiUnauthorizedError,
+)
+from cortex_xdr_client import CortexXdrApiError
+from pydantic import ValidationError
 
 if TYPE_CHECKING:
     from connector.settings import ConnectorSettings
     from cortex_xdr_client import CortexXdrClient
     from pycti import OpenCTIConnectorHelper
+
+
+_SUPPORTED_EVENTS = {"create", "update", "delete"}
+_SUPPORTED_ENTITY_TYPES = {"indicator"}
+_SUPPORTED_OBSERVABLE_TYPES = {
+    "domain-name",
+    "ipv4-addr",
+    "ipv6-addr",
+    "stixfile",
+}
+
+
+class StreamMessage(Protocol):
+    """Type for the SSE message passed to `listen_stream` callbacks.
+
+    Only the attributes actually consumed by this connector are declared,
+    decoupling us from `filigran_sseclient.sseclient.Event`'s concrete shape
+    (and from adding it as an explicit dependency just for typing).
+    """
+
+    event: str
+    data: str
 
 
 class Connector:
@@ -38,11 +72,167 @@ class Connector:
         self.settings = settings
         self.client = client
 
-    def _process_message(self, message: dict) -> None:
-        # TODO: implement IOC upsert/delete mapping from the stream message (#7184/#7185)
-        self.helper.connector_logger.info(
-            "Received stream event (baseline wiring phase)"
+        # Reusable exit message for fatal errors logging
+        self._exit_message = (
+            "Connector will exit to avoid further errors and/or exhausting the stream.\n"
+            "Please check connector's logs and report/fix the issue before restarting."
         )
 
+    def _build_octi_indicator(self, data: dict[str, Any]) -> OctiIndicator:
+        """Build a minimal, internal representation of an Indicator's stream
+        `data` payload. Field casting/validation is delegated to `OctiIndicator`.
+        """
+        # Use `observable_values` extension provided by OpenCTI to extract the list of observables
+        observable_values = (
+            self.helper.get_attribute_in_extension("observable_values", data) or []
+        )
+        # Filter out observable types not supported by Cortex XDR Client
+        supported_observable_values = [
+            observable_value
+            for observable_value in observable_values
+            if observable_value.get("type", "").lower() in _SUPPORTED_OBSERVABLE_TYPES
+        ]
+
+        # Build and validate the indicator from stream `data` payload
+        return OctiIndicator(
+            id=self.helper.get_attribute_in_extension("id", data),
+            description=data.get("description"),
+            observables=supported_observable_values,
+            valid_until=data.get("valid_until"),
+            score=self.helper.get_attribute_in_extension("score", data),
+        )
+
+    def _process_message(self, msg: StreamMessage) -> None:
+        """Process a single stream event message.
+
+        Unsupported event or entity types are logged as a warning and
+        skipped. Any failure while decoding, parsing, or validating the
+        message (JSON decode error, `Indicator` validation error, or any
+        other unexpected exception) is logged with context and re-raised,
+        deliberately letting `pycti` kill the connector process rather than
+        risk silently missing or corrupting further events.
+        """
+        event = msg.event
+        if event not in _SUPPORTED_EVENTS:
+            self.helper.connector_logger.warning(
+                "Unsupported event type, skipping it",
+                {"event": event},
+            )
+            return
+
+        try:
+            message_data = json.loads(msg.data)
+        except json.JSONDecodeError as err:
+            # This should never happen and if it does, it indicates a breaking change in `pycti`.
+            # To avoid data loss, the connector must stop and the issue must be investigated and fixed before resuming.
+            self.helper.connector_logger.error(
+                f"Failed to parse stream event's `data` payload as JSON.\n{self._exit_message}",
+                {
+                    "event": event,
+                    "data": msg.data,
+                    "error": err,
+                },
+            )
+            raise  # let `pycti` kill the connector process
+
+        entity_data = message_data.get("data", {})
+        entity_type = entity_data.get("type")
+        if entity_type not in _SUPPORTED_ENTITY_TYPES:
+            self.helper.connector_logger.warning(
+                "Unsupported entity type, skipping it",
+                {
+                    "event": event,
+                    "entity_type": entity_type,
+                },
+            )
+            return
+
+        try:
+            octi_indicator = self._build_octi_indicator(entity_data)
+            if not octi_indicator.observables:
+                self.helper.connector_logger.warning(
+                    "No supported observable(s) found in indicator, skipping it",
+                    {
+                        "event": event,
+                        "indicator_id": octi_indicator.id,
+                        "observables_count": len(octi_indicator.observables),
+                    },
+                )
+                return
+
+            self.helper.connector_logger.info(
+                "Parsed observable(s) from stream event",
+                {
+                    "event": event,
+                    "indicator_id": octi_indicator.id,
+                    "observables_count": len(octi_indicator.observables),
+                },
+            )
+        except ValidationError as err:
+            # This should never happen and if it does, it indicates a breaking change in `pycti`.
+            # To avoid data loss, the connector must stop and the issue must be investigated and fixed before resuming.
+            self.helper.connector_logger.error(
+                f"Failed to parse indicator and/or observables from stream event.\n{self._exit_message}",
+                {
+                    "event": event,
+                    "entity_data": entity_data,
+                    "error": err,
+                },
+            )
+            raise  # let `pycti` kill the connector process
+
+        try:
+            if event in {"create", "update"}:
+                pass  # TODO: upsert in Cortex XDR
+            elif event == "delete":
+                pass  # TODO: delete from Cortex XDR
+
+        except CortexXdrApiError as err:
+            fatal_causes = (
+                ApiUnauthorizedError,  # 401
+                ApiForbiddenError,  # 403
+                ApiNotFoundError,  # 404
+                ApiRateLimitError,  # 429
+                ApiServerError,  # 5xx
+            )
+
+            if err.__cause__ and isinstance(err.__cause__, fatal_causes):
+                # The process must be **killed to avoid exhausting** the stream with repeated global failure e.g.,
+                # invalid/revoked API key, rate limit exceeded, API breaking changes, etc.
+                self.helper.connector_logger.error(
+                    f"Error while hitting Cortex XDR API.\n{self._exit_message}",
+                    {
+                        "event": event,
+                        "entity_data": entity_data,
+                        "error": err,
+                    },
+                )
+                raise  # let `pycti` kill the connector process
+            else:
+                # The process must **continue to avoid blocking** the stream with a failure scoped to one specific event
+                # (e.g., rejected IOC value) so the next event get a chance to be processed.
+                self.helper.connector_logger.error(
+                    "Error while hitting Cortex XDR API. Skipping event and continuing with the next one.",
+                    {
+                        "event": event,
+                        "entity_data": entity_data,
+                        "error": err,
+                    },
+                )
+                return  # skip the event and continue
+        except Exception as err:
+            # Repetitive unexpected errors could consume the stream in vain (no action performed).
+            # To avoid data loss, the connector must stop and the issue must be investigated and fixed before resuming.
+            self.helper.connector_logger.error(
+                f"Unexpected error while processing stream event.\n{self._exit_message}",
+                {
+                    "event": event,
+                    "entity_data": entity_data,
+                    "error": err,
+                },
+            )
+            raise  # let `pycti` kill the connector process
+
     def start(self) -> None:
+        """Start the connector's main loop: listen to the OpenCTI stream and process each message."""
         self.helper.listen_stream(self._process_message)

--- a/stream/pan-cortex-xdr-intel/src/connector/connector.py
+++ b/stream/pan-cortex-xdr-intel/src/connector/connector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any, Protocol
 
-from connector.models import OctiIndicator
+from connector.models import CortexXdrIoc, OctiIndicator
 from connectors_sdk import (
     ApiForbiddenError,
     ApiNotFoundError,
@@ -102,6 +102,189 @@ class Connector:
             score=self.helper.get_attribute_in_extension("score", data),
         )
 
+    def _extract_xdr_iocs(self, octi_indicator: OctiIndicator) -> list[CortexXdrIoc]:
+        """Build `CortexXdrIoc`s from `octi_indicator`'s observables.
+
+        Used by both `_handle_upsert` and `_handle_delete` to extract the
+        Cortex XDR IOC `type` and `indicator` fields from the OpenCTI indicator's observables.
+        """
+        if not octi_indicator.observables:
+            return []
+
+        xdr_iocs: list[CortexXdrIoc] = []
+        # TODO: improve the mapping so it correspond to the mapping defined in the MVP
+        for observable in octi_indicator.observables:
+            if observable.type.lower() == "stixfile":
+                # Only hashes are mapped for now; filename is intentionally out of scope (currently commented)
+                # if observable.name:
+                #     xdr_iocs.append(
+                #         CortexXdrIoc(type="FILENAME", indicator=observable.name)
+                #     )
+                if observable.hashes:
+                    for hash_value in observable.hashes.values():
+                        xdr_iocs.append(CortexXdrIoc(type="HASH", indicator=hash_value))
+            elif observable.type.lower() == "domain-name":
+                xdr_iocs.append(
+                    CortexXdrIoc(type="DOMAIN_NAME", indicator=observable.value)  # type: ignore[union-attr]  # `value` is always set for DomainName observables
+                )
+            elif observable.type.lower() in ("ipv4-addr", "ipv6-addr"):
+                xdr_iocs.append(CortexXdrIoc(type="IP", indicator=observable.value))  # type: ignore[union-attr]  # `value` is always set for IP observables
+
+        return xdr_iocs
+
+    def _map_indicator_fields_to_xdr_iocs(
+        self, octi_indicator: OctiIndicator, xdr_iocs: list[CortexXdrIoc]
+    ) -> list[CortexXdrIoc]:
+        """Map OpenCTI indicator's properties to each Cortex XDR IOC.
+
+        Used by `_handle_upsert` to set the Cortex XDR IOC optional fields.
+        """
+        if not xdr_iocs:
+            return []
+
+        # TODO: fix the mapping so it correspond to the mapping defined in the MVP
+        if octi_indicator.score is None:
+            xdr_severity = None
+        elif octi_indicator.score >= 80:
+            xdr_severity = "SEV_040_HIGH"
+        elif octi_indicator.score >= 60:
+            xdr_severity = "SEV_030_MEDIUM"
+        elif octi_indicator.score >= 40:
+            xdr_severity = "SEV_020_LOW"
+        elif octi_indicator.score >= 20:
+            xdr_severity = "SEV_010_INFO"
+        else:
+            xdr_severity = None
+
+        xdr_expiration_timestamp = (
+            int(octi_indicator.valid_until.timestamp()) * 1000
+            if octi_indicator.valid_until
+            else None
+        )
+
+        indicator_properties = {
+            "severity": xdr_severity,
+            "expiration_date": xdr_expiration_timestamp,
+            "comment": octi_indicator.description,
+            "reputation": "BAD",  # intentionally hardcoded for now
+            "reliability": None,  # intentionally non-set for now
+        }
+
+        # Apply the indicator properties to each Cortex XDR IOC
+        for xdr_ioc in xdr_iocs:
+            for key, value in indicator_properties.items():
+                setattr(xdr_ioc, key, value)
+
+        return xdr_iocs
+
+    def _resolve_xdr_iocs_rule_ids(
+        self, extracted_xdr_iocs: list[CortexXdrIoc]
+    ) -> list[CortexXdrIoc]:
+        """Resolve `rule_id` for each Cortex XDR IOC extracted from OpenCTI indicator's observables.
+
+        Used by `_handle_upsert` to attach the Cortex XDR-assigned `rule_id` to each IOC
+        that already exists on Cortex XDR, so that XDR API will update it instead of creating a duplicate.
+        """
+        if not extracted_xdr_iocs:
+            return []
+
+        # Look up existing IOCs on Cortex XDR
+        result = self.client.get_iocs(
+            [
+                {
+                    "field": "indicator",
+                    "operator": "IN",
+                    "value": [ioc.indicator for ioc in extracted_xdr_iocs],
+                }
+            ]
+        )
+        existing_xdr_iocs = result.get("objects", [])
+
+        # Attach `rule_id` to each extracted IOC that already exists on Cortex XDR
+        for ioc in extracted_xdr_iocs:
+            existing_ioc = next(
+                (
+                    existing_ioc
+                    for existing_ioc in existing_xdr_iocs
+                    if existing_ioc["indicator"] == ioc.indicator
+                    and existing_ioc["type"] == ioc.type
+                ),
+                None,
+            )
+            if existing_ioc:
+                ioc.rule_id = existing_ioc.get("rule_id")
+
+        return extracted_xdr_iocs  # type: ignore[return-value]  # `rule_id` (int) is added to each dict
+
+    def _handle_upsert(self, octi_indicator: OctiIndicator) -> None:
+        """Upsert `octi_indicator`'s supported observables into Cortex XDR as IOCs."""
+        # Extract Cortex XDR IOCs from the indicator's observables
+        # (`xdr_iocs` is re-assigned after each transformation to ease debugging)
+        xdr_iocs = self._extract_xdr_iocs(octi_indicator)
+        xdr_iocs = self._map_indicator_fields_to_xdr_iocs(octi_indicator, xdr_iocs)
+        xdr_iocs = self._resolve_xdr_iocs_rule_ids(xdr_iocs)
+        if not xdr_iocs:
+            self.helper.connector_logger.error(
+                "No Cortex XDR IOC could be extracted from any observable, "
+                "skipping indicator",
+                {
+                    "indicator_id": octi_indicator.id,
+                    "observables_count": len(octi_indicator.observables),
+                },
+            )
+            return
+
+        self.helper.connector_logger.debug(
+            "Upserting IOC(s) into Cortex XDR",
+            {"indicator_id": octi_indicator.id, "xdr_iocs": len(xdr_iocs)},
+        )
+
+        # Send the payloads to Cortex XDR as dicts, omitting any unset fields to let client default them.
+        self.client.insert_iocs(
+            [ioc.model_dump(exclude_none=True) for ioc in xdr_iocs]  # type: ignore[arg-type]
+        )
+
+        self.helper.connector_logger.info(
+            "Successfully upserted IOC(s) into Cortex XDR",
+            {"indicator_id": octi_indicator.id, "xdr_iocs": len(xdr_iocs)},
+        )
+
+    def _handle_delete(self, octi_indicator: OctiIndicator) -> None:
+        """Delete `octi_indicator`'s supported observables from Cortex XDR."""
+        # Extract Cortex XDR IOCs from the indicator's observables
+        xdr_iocs = self._extract_xdr_iocs(octi_indicator)
+        if not xdr_iocs:
+            self.helper.connector_logger.error(
+                "No Cortex XDR IOC could be extracted from any observable, "
+                "skipping indicator",
+                {
+                    "indicator_id": octi_indicator.id,
+                    "observables_count": len(octi_indicator.observables),
+                },
+            )
+            return
+
+        self.helper.connector_logger.debug(
+            "Deleting IOC(s) from Cortex XDR",
+            {"indicator_id": octi_indicator.id, "xdr_iocs": len(xdr_iocs)},
+        )
+
+        # Delete all the IOCs corresponding to the filters on Cortex XDR
+        self.client.delete_iocs(
+            [
+                {
+                    "field": "indicator",
+                    "operator": "IN",
+                    "value": [ioc.indicator for ioc in xdr_iocs],
+                }
+            ]
+        )
+
+        self.helper.connector_logger.info(
+            "Successfully deleted IOC(s) from Cortex XDR",
+            {"indicator_id": octi_indicator.id, "xdr_iocs": len(xdr_iocs)},
+        )
+
     def _process_message(self, msg: StreamMessage) -> None:
         """Process a single stream event message.
 
@@ -183,9 +366,9 @@ class Connector:
 
         try:
             if event in {"create", "update"}:
-                pass  # TODO: upsert in Cortex XDR
+                self._handle_upsert(octi_indicator)
             elif event == "delete":
-                pass  # TODO: delete from Cortex XDR
+                self._handle_delete(octi_indicator)
 
         except CortexXdrApiError as err:
             fatal_causes = (

--- a/stream/pan-cortex-xdr-intel/src/connector/models.py
+++ b/stream/pan-cortex-xdr-intel/src/connector/models.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class OctiIndicatorObservable(BaseModel):
+    """A single observable extracted from an Indicator's `observable_values`."""
+
+    type: str
+    # For all observable types but `StixFile`
+    value: str | None = Field(default=None)
+    # For `StixFile` observables only
+    name: str | None = Field(default=None)
+    hashes: dict[str, str] | None = Field(default=None)
+
+
+class OctiIndicator(BaseModel):
+    """Minimal, internal representation of an Indicator's stream `data` payload."""
+
+    id: str
+    description: str | None = Field(default=None)
+    observables: list[OctiIndicatorObservable] = Field(default_factory=list)
+    valid_until: datetime | None = Field(default=None)
+    score: int | None = Field(default=None)
+
+    @field_validator("observables", mode="before")
+    def _validate_observables(
+        cls, value: list[dict[str, Any]] | None
+    ) -> list[dict[str, Any]]:
+        """Extract `observables` from the raw `observable_values` list returned by
+        `pycti.OpenCTIConnectorHelper.get_attribute_in_extension("observable_values", indicator)`.
+        """
+        if not value:
+            return []
+
+        observables = []
+        for observable_data in value:
+            observable_type = str(observable_data.get("type", ""))
+            if observable_type.lower() == "stixfile":
+                name = observable_data.get("name") or None
+                hashes = observable_data.get("hashes") or None
+                if name or hashes:
+                    observables.append(
+                        {
+                            "type": observable_type,
+                            "name": name,
+                            "hashes": hashes,
+                        }
+                    )
+            elif observable_value := observable_data.get("value"):
+                observables.append(
+                    {
+                        "type": observable_type,
+                        "value": observable_value,
+                    }
+                )
+
+        return observables
+
+    @field_validator("valid_until", mode="after")
+    def _validate_valid_until(cls, value: datetime | None) -> datetime | None:
+        """Convert naive or aware datetime to UTC."""
+        if not value:
+            return None
+
+        if value.tzinfo:
+            return value.astimezone(tz=timezone.utc)
+        else:
+            return value.replace(tzinfo=timezone.utc)

--- a/stream/pan-cortex-xdr-intel/src/connector/models.py
+++ b/stream/pan-cortex-xdr-intel/src/connector/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -70,3 +70,26 @@ class OctiIndicator(BaseModel):
             return value.astimezone(tz=timezone.utc)
         else:
             return value.replace(tzinfo=timezone.utc)
+
+
+class CortexXdrIoc(BaseModel):
+    """Cortex XDR Indicator of Compromise (IOC) model.
+
+    Field constraints intentionally mirror `cortex_xdr_client.types.IndicatorPayload`
+    that represent Cortex XDR API expected data.
+    """
+
+    # Existing IOC's Cortex XDR ID if known (update of an existing IOC), otherwise `None` (new IOC).
+    rule_id: int | None = Field(default=None)
+
+    indicator: str
+    type: Literal["HASH", "IP", "PATH", "DOMAIN_NAME", "FILENAME", "MIXED"]
+    severity: (
+        Literal["SEV_010_INFO", "SEV_020_LOW", "SEV_030_MEDIUM", "SEV_040_HIGH"] | None
+    ) = Field(default=None)
+    expiration_date: int | None = Field(default=None)
+    comment: str | None = Field(default=None)
+    reputation: (
+        Literal["GOOD", "BAD", "SUSPICIOUS", "UNKNOWN", "NO_REPUTATION"] | None
+    ) = Field(default=None)
+    reliability: Literal["A", "B", "C", "D"] | None = Field(default=None)

--- a/stream/pan-cortex-xdr-intel/tests/tests_connector/test_connector.py
+++ b/stream/pan-cortex-xdr-intel/tests/tests_connector/test_connector.py
@@ -4,7 +4,15 @@ from unittest.mock import MagicMock
 
 import pytest
 from connector.connector import Connector
-from connector.models import OctiIndicatorObservable
+from connector.models import CortexXdrIoc, OctiIndicator, OctiIndicatorObservable
+from connectors_sdk import (
+    ApiForbiddenError,
+    ApiNotFoundError,
+    ApiRateLimitError,
+    ApiServerError,
+    ApiUnauthorizedError,
+)
+from cortex_xdr_client import CortexXdrApiError
 from pydantic import ValidationError
 
 
@@ -15,7 +23,10 @@ def _make_msg(event: str, data: dict) -> SimpleNamespace:
 
 @pytest.fixture
 def connector():
-    return Connector(helper=MagicMock(), settings=MagicMock(), client=MagicMock())
+    client = MagicMock()
+    # By default, no existing IOC is found on Cortex XDR (fresh insert case).
+    client.get_iocs.return_value = {"objects": []}
+    return Connector(helper=MagicMock(), settings=MagicMock(), client=client)
 
 
 class TestProcessMessageEventGuardrail:
@@ -147,11 +158,11 @@ class TestProcessMessageUnsupportedObservableGuardrail:
         connector._process_message(msg)
         # Then: the indicator is parsed and logged, no warning is logged
         connector.helper.connector_logger.warning.assert_not_called()
-        connector.helper.connector_logger.info.assert_called_once()
+        assert connector.helper.connector_logger.info.called
 
 
 class TestProcessMessageErrorHandling:
-    # Fatal errors
+    # Fatal errors: always kill the connector
 
     def test_connector_logs_error_and_reraises_on_invalid_json(self, connector):
         # Given: a stream event whose `data` is not valid JSON
@@ -181,25 +192,539 @@ class TestProcessMessageErrorHandling:
             connector._process_message(msg)
         connector.helper.connector_logger.error.assert_called_once()
 
-    @pytest.mark.xfail(
-        reason=(
-            "Upsert/delete client calls are not implemented yet (see #7186/#7187); "
-            "the try/except around them currently only wraps `pass` placeholders, "
-            "so this expected error-handling behavior cannot be exercised yet. "
-            "Remove this xfail marker once real client calls land in that block."
-        ),
-        strict=True,
-    )
-    def test_connector_logs_error_and_reraises_on_unexpected_processing_error(
+    def test_connector_logs_error_and_reraises_on_unexpected_upsert_error(
         self, connector
     ):
-        # Given: the Cortex XDR client unexpectedly raises while upserting/deleting
-        connector.client.upsert_iocs.side_effect = RuntimeError("boom")
-        connector.client.delete_iocs.side_effect = RuntimeError("boom")
+        # Given: the Cortex XDR client unexpectedly raises a non-`CortexXdrApiError`
+        # while upserting
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        connector.client.insert_iocs.side_effect = RuntimeError("boom")
         msg = _make_msg("create", {"type": "indicator"})
         # When: processing the message
         # Then: the error is logged with context, and the exception is deliberately
         # re-raised to let `pycti` kill the connector process
         with pytest.raises(RuntimeError, match="boom"):
             connector._process_message(msg)
+        connector.helper.connector_logger.error.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "cause_cls",
+        [
+            ApiUnauthorizedError,
+            ApiForbiddenError,
+            ApiNotFoundError,
+            ApiRateLimitError,
+            ApiServerError,
+        ],
+    )
+    def test_connector_logs_error_and_reraises_on_fatal_api_error_cause(
+        self, connector, cause_cls
+    ):
+        # Given: the Cortex XDR client raises a `CortexXdrApiError` wrapping a
+        # fatal cause (auth/permission/rate-limit/server errors)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        try:
+            raise cause_cls("boom")
+        except cause_cls as cause:
+            api_error = CortexXdrApiError("Error while fetching Cortex XDR API")
+            api_error.__cause__ = cause
+        connector.client.insert_iocs.side_effect = api_error
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        # Then: the error is logged with context, and the exception is deliberately
+        # re-raised to let `pycti` kill the connector process, avoiding exhausting
+        # the stream with repeated global failures
+        with pytest.raises(CortexXdrApiError):
+            connector._process_message(msg)
+        connector.helper.connector_logger.error.assert_called_once()
+
+    # Non-fatal errors: skip the event, keep the stream alive
+
+    def test_connector_logs_error_and_continues_on_non_fatal_api_error_cause(
+        self, connector
+    ):
+        # Given: the Cortex XDR client raises a `CortexXdrApiError` whose cause
+        # is not one of the fatal causes (e.g. a rejected IOC value, 400)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        api_error = CortexXdrApiError("Error while fetching Cortex XDR API")
+        api_error.__cause__ = ValueError("rejected IOC value")
+        connector.client.insert_iocs.side_effect = api_error
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        # Then: the error is logged, the event is skipped, and no exception
+        # propagates so the stream keeps processing the next event
+        connector._process_message(msg)
+        connector.helper.connector_logger.error.assert_called_once()
+
+    def test_connector_logs_error_and_continues_when_api_error_has_no_cause(
+        self, connector
+    ):
+        # Given: the Cortex XDR client raises a `CortexXdrApiError` without any
+        # chained cause at all (defensive edge case)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        connector.client.insert_iocs.side_effect = CortexXdrApiError("boom")
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        # Then: it is treated as non-fatal: logged, event skipped, no re-raise
+        connector._process_message(msg)
+        connector.helper.connector_logger.error.assert_called_once()
+
+    def test_connector_logs_error_and_reraises_on_unexpected_delete_error(
+        self, connector
+    ):
+        # Given: the Cortex XDR client unexpectedly raises while deleting
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        connector.client.delete_iocs.side_effect = RuntimeError("boom")
+        msg = _make_msg("delete", {"type": "indicator"})
+        # When: processing the message
+        # Then: the error is logged with context, and the exception is deliberately
+        # re-raised to let `pycti` kill the connector process
+        with pytest.raises(RuntimeError, match="boom"):
+            connector._process_message(msg)
+        connector.helper.connector_logger.error.assert_called_once()
+
+
+class TestProcessMessageUpsertRouting:
+    def test_connector_calls_handle_upsert_on_create_event(
+        self, connector, monkeypatch
+    ):
+        # Given: a "create" stream event for an Indicator with a supported observable
+        handle_upsert = MagicMock()
+        monkeypatch.setattr(connector, "_handle_upsert", handle_upsert)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the upsert lifecycle is triggered
+        handle_upsert.assert_called_once()
+
+    def test_connector_calls_handle_upsert_on_update_event(
+        self, connector, monkeypatch
+    ):
+        # Given: an "update" stream event for an Indicator with a supported observable
+        handle_upsert = MagicMock()
+        monkeypatch.setattr(connector, "_handle_upsert", handle_upsert)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        msg = _make_msg("update", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the upsert lifecycle is triggered
+        handle_upsert.assert_called_once()
+
+    def test_connector_does_not_call_handle_upsert_on_delete_event(
+        self, connector, monkeypatch
+    ):
+        # Given: a "delete" stream event for an Indicator with a supported observable
+        handle_upsert = MagicMock()
+        monkeypatch.setattr(connector, "_handle_upsert", handle_upsert)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        msg = _make_msg("delete", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the upsert lifecycle is not triggered (delete events trigger
+        # the delete lifecycle instead, see `TestProcessMessageDeleteRouting`)
+        handle_upsert.assert_not_called()
+
+
+class TestProcessMessageDeleteRouting:
+    def test_connector_calls_handle_delete_on_delete_event(
+        self, connector, monkeypatch
+    ):
+        # Given: a "delete" stream event for an Indicator with a supported observable
+        handle_delete = MagicMock()
+        monkeypatch.setattr(connector, "_handle_delete", handle_delete)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        msg = _make_msg("delete", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the delete lifecycle is triggered
+        handle_delete.assert_called_once()
+
+    def test_connector_does_not_call_handle_delete_on_create_event(
+        self, connector, monkeypatch
+    ):
+        # Given: a "create" stream event for an Indicator with a supported observable
+        handle_delete = MagicMock()
+        monkeypatch.setattr(connector, "_handle_delete", handle_delete)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the delete lifecycle is not triggered
+        handle_delete.assert_not_called()
+
+    def test_connector_does_not_call_handle_delete_on_update_event(
+        self, connector, monkeypatch
+    ):
+        # Given: an "update" stream event for an Indicator with a supported observable
+        handle_delete = MagicMock()
+        monkeypatch.setattr(connector, "_handle_delete", handle_delete)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        msg = _make_msg("update", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the delete lifecycle is not triggered
+        handle_delete.assert_not_called()
+
+
+class TestExtractXdrIocs:
+    def test_maps_domain_observable_to_domain_name_type(self, connector):
+        # Given: an indicator with a supported Domain-Name observable
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+        )
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: the observable is mapped to a bare DOMAIN_NAME IOC (optional
+        # fields are only set later by `_map_indicator_fields_to_xdr_iocs`)
+        assert xdr_iocs == [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+
+    def test_maps_ip_observable_to_ip_type(self, connector):
+        # Given: an indicator with a supported IPv4-Addr observable
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "IPv4-Addr", "value": "1.2.3.4"}],
+        )
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: the observable is mapped to a bare IP IOC
+        assert xdr_iocs == [CortexXdrIoc(indicator="1.2.3.4", type="IP")]
+
+    def test_maps_stixfile_hash_observable_to_hash_type(self, connector):
+        # Given: an indicator with a StixFile hash observable
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "StixFile", "hashes": {"SHA-256": "deadbeef"}}],
+        )
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: the hash is mapped to a bare HASH IOC
+        assert xdr_iocs == [CortexXdrIoc(indicator="deadbeef", type="HASH")]
+
+    def test_skips_unsupported_observable_type(self, connector):
+        # Given: an indicator with only a StixFile filename observable
+        # (Cortex XDR's FILENAME IOC type is out of scope for now, see #7186)
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "StixFile", "name": "evil.exe"}],
+        )
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: no IOC is built (silently skipped; only `_handle_upsert`/
+        # `_handle_delete` log when the final list ends up empty)
+        assert xdr_iocs == []
+
+    def test_skips_hostname_observable_type(self, connector):
+        # Given: an indicator with a Hostname observable (support
+        # intentionally dropped, see #7187)
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Hostname", "value": "evil.com"}],
+        )
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: no IOC is built
+        assert xdr_iocs == []
+
+    def test_handles_indicator_without_any_observable(self, connector):
+        # Given: an indicator with no observables at all
+        indicator = OctiIndicator(id="indicator--id", observables=[])
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: no IOC is built, no crash
+        assert xdr_iocs == []
+
+
+class TestMapIndicatorFieldsToXdrIocs:
+    def test_hardcodes_reputation_to_bad(self, connector):
+        # Given: a bare Cortex XDR IOC and any indicator
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+        )
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        # When: mapping the indicator's fields onto the IOC(s)
+        result = connector._map_indicator_fields_to_xdr_iocs(indicator, xdr_iocs)
+        # Then: the IOC's reputation is hardcoded to "BAD"
+        assert result[0].reputation == "BAD"
+
+    def test_includes_expiration_date_when_valid_until_present(self, connector):
+        # Given: an indicator with a `valid_until` value
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+            valid_until="2030-01-01T00:00:00Z",
+        )
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        # When: mapping the indicator's fields onto the IOC(s)
+        result = connector._map_indicator_fields_to_xdr_iocs(indicator, xdr_iocs)
+        # Then: the IOC's expiration date is set as epoch milliseconds
+        assert result[0].expiration_date == 1893456000000
+
+    def test_omits_expiration_date_when_valid_until_absent(self, connector):
+        # Given: an indicator without a `valid_until` value
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+        )
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        # When: mapping the indicator's fields onto the IOC(s)
+        result = connector._map_indicator_fields_to_xdr_iocs(indicator, xdr_iocs)
+        # Then: no expiration date is set on the IOC
+        assert result[0].expiration_date is None
+
+    @pytest.mark.parametrize(
+        "score,expected_severity",
+        [
+            (None, None),
+            (10, None),
+            (20, "SEV_010_INFO"),
+            (40, "SEV_020_LOW"),
+            (60, "SEV_030_MEDIUM"),
+            (80, "SEV_040_HIGH"),
+            (100, "SEV_040_HIGH"),
+        ],
+    )
+    def test_maps_score_to_severity(self, connector, score, expected_severity):
+        # Given: an indicator with a given `score`
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+            score=score,
+        )
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        # When: mapping the indicator's fields onto the IOC(s)
+        result = connector._map_indicator_fields_to_xdr_iocs(indicator, xdr_iocs)
+        # Then: the score is mapped to the expected Cortex XDR severity
+        assert result[0].severity == expected_severity
+
+    def test_handles_empty_xdr_iocs_list(self, connector):
+        # Given: an indicator and an empty list of Cortex XDR IOCs
+        indicator = OctiIndicator(id="indicator--id", observables=[])
+        # When: mapping the indicator's fields onto the (empty) IOC list
+        result = connector._map_indicator_fields_to_xdr_iocs(indicator, [])
+        # Then: no IOC is built, no crash
+        assert result == []
+
+
+class TestResolveXdrIocsRuleIds:
+    def test_calls_get_iocs_with_indicator_values_filter(self, connector):
+        # Given: two extracted Cortex XDR IOCs
+        xdr_iocs = [
+            CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME"),
+            CortexXdrIoc(indicator="1.2.3.4", type="IP"),
+        ]
+        # When: resolving their `rule_id`
+        connector._resolve_xdr_iocs_rule_ids(xdr_iocs)
+        # Then: the client is asked to look up both indicator values via an
+        # "IN" filter on the "indicator" field
+        connector.client.get_iocs.assert_called_once_with(
+            [
+                {
+                    "field": "indicator",
+                    "operator": "IN",
+                    "value": ["evil.com", "1.2.3.4"],
+                }
+            ]
+        )
+
+    def test_attaches_rule_id_when_ioc_already_exists(self, connector):
+        # Given: an IOC that already exists on Cortex XDR
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        connector.client.get_iocs.return_value = {
+            "objects": [{"rule_id": 42, "indicator": "evil.com", "type": "DOMAIN_NAME"}]
+        }
+        # When: resolving `rule_id`
+        resolved = connector._resolve_xdr_iocs_rule_ids(xdr_iocs)
+        # Then: the existing `rule_id` is attached, so a subsequent insert
+        # overwrites the existing IOC instead of failing
+        assert resolved[0].rule_id == 42
+
+    def test_does_not_attach_rule_id_when_ioc_does_not_exist(self, connector):
+        # Given: an IOC that does not exist on Cortex XDR yet
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        connector.client.get_iocs.return_value = {"objects": []}
+        # When: resolving `rule_id`
+        resolved = connector._resolve_xdr_iocs_rule_ids(xdr_iocs)
+        # Then: no `rule_id` is attached, so a subsequent insert creates a new IOC
+        assert resolved[0].rule_id is None
+
+    def test_does_not_attach_rule_id_when_type_differs(self, connector):
+        # Given: a lookup match on the same indicator value but a different
+        # type (e.g. a same-looking value registered as a different IOC type)
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        connector.client.get_iocs.return_value = {
+            "objects": [{"rule_id": 42, "indicator": "evil.com", "type": "IP"}]
+        }
+        # When: resolving `rule_id`
+        resolved = connector._resolve_xdr_iocs_rule_ids(xdr_iocs)
+        # Then: no `rule_id` is attached, since the existing IOC is of a different type
+        assert resolved[0].rule_id is None
+
+    def test_returns_empty_list_without_calling_client_when_no_iocs(self, connector):
+        # Given: no extracted Cortex XDR IOCs at all
+        # When: resolving `rule_id`
+        resolved = connector._resolve_xdr_iocs_rule_ids([])
+        # Then: the client is never called, and an empty list is returned
+        connector.client.get_iocs.assert_not_called()
+        assert resolved == []
+
+
+class TestHandleUpsert:
+    def test_calls_client_insert_iocs_with_extracted_iocs(self, connector):
+        # Given: an indicator with a supported observable
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+        )
+        # When: handling the upsert
+        connector._handle_upsert(indicator)
+        # Then: the client is called once with the extracted IOC(s)
+        connector.client.insert_iocs.assert_called_once_with(
+            [{"indicator": "evil.com", "type": "DOMAIN_NAME", "reputation": "BAD"}]
+        )
+
+    def test_includes_rule_id_when_ioc_already_exists(self, connector):
+        # Given: an indicator whose IOC already exists on Cortex XDR
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+        )
+        connector.client.get_iocs.return_value = {
+            "objects": [{"rule_id": 42, "indicator": "evil.com", "type": "DOMAIN_NAME"}]
+        }
+        # When: handling the upsert
+        connector._handle_upsert(indicator)
+        # Then: the existing `rule_id` is included in the payload sent to
+        # Cortex XDR, so the request overwrites the existing IOC instead of
+        # failing with a 400 "IOC indicator exists"
+        connector.client.insert_iocs.assert_called_once_with(
+            [
+                {
+                    "indicator": "evil.com",
+                    "type": "DOMAIN_NAME",
+                    "reputation": "BAD",
+                    "rule_id": 42,
+                }
+            ]
+        )
+
+    def test_skips_client_call_when_no_supported_observable(self, connector):
+        # Given: an indicator with only unsupported observable(s)
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "StixFile", "name": "evil.exe"}],
+        )
+        # When: handling the upsert
+        connector._handle_upsert(indicator)
+        # Then: the client is never called
+        connector.client.insert_iocs.assert_not_called()
+
+    def test_logs_error_when_no_supported_observable(self, connector):
+        # Given: an indicator with only unsupported observable(s)
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "StixFile", "name": "evil.exe"}],
+        )
+        # When: handling the upsert
+        connector._handle_upsert(indicator)
+        # Then: the skip is logged as an error, not a mere info
+        connector.helper.connector_logger.error.assert_called_once()
+
+
+class TestHandleDelete:
+    def test_calls_client_delete_iocs_with_built_filter(self, connector):
+        # Given: an indicator with a supported observable
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+        )
+        # When: handling the delete
+        connector._handle_delete(indicator)
+        # Then: the client is called once with a single batched "IN" filter
+        connector.client.delete_iocs.assert_called_once_with(
+            [{"field": "indicator", "operator": "IN", "value": ["evil.com"]}]
+        )
+
+    def test_batches_multiple_iocs_into_a_single_filter(self, connector):
+        # Given: an indicator with several supported observables, one of
+        # which (StixFile) yields more than one Cortex XDR IOC
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[
+                {"type": "Domain-Name", "value": "evil.com"},
+                {
+                    "type": "StixFile",
+                    "hashes": {"SHA-256": "deadbeef", "MD5": "beefdead"},
+                },
+            ],
+        )
+        # When: handling the delete
+        connector._handle_delete(indicator)
+        # Then: all the extracted IOCs' indicator values are batched into a
+        # single "IN" filter
+        connector.client.delete_iocs.assert_called_once_with(
+            [
+                {
+                    "field": "indicator",
+                    "operator": "IN",
+                    "value": ["evil.com", "deadbeef", "beefdead"],
+                }
+            ]
+        )
+
+    def test_skips_client_call_when_no_supported_observable(self, connector):
+        # Given: an indicator with only unsupported observable(s)
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "StixFile", "name": "evil.exe"}],
+        )
+        # When: handling the delete
+        connector._handle_delete(indicator)
+        # Then: the client is never called
+        connector.client.delete_iocs.assert_not_called()
+
+    def test_logs_error_when_no_supported_observable(self, connector):
+        # Given: an indicator with only unsupported observable(s)
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "StixFile", "name": "evil.exe"}],
+        )
+        # When: handling the delete
+        connector._handle_delete(indicator)
+        # Then: the skip is logged as an error, not a mere info
         connector.helper.connector_logger.error.assert_called_once()

--- a/stream/pan-cortex-xdr-intel/tests/tests_connector/test_connector.py
+++ b/stream/pan-cortex-xdr-intel/tests/tests_connector/test_connector.py
@@ -1,0 +1,205 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from connector.connector import Connector
+from connector.models import OctiIndicatorObservable
+from pydantic import ValidationError
+
+
+def _make_msg(event: str, data: dict) -> SimpleNamespace:
+    """Build a fake SSE stream event (attributes: `data`, `event`, `id`)."""
+    return SimpleNamespace(event=event, data=json.dumps({"data": data}), id="1-0")
+
+
+@pytest.fixture
+def connector():
+    return Connector(helper=MagicMock(), settings=MagicMock(), client=MagicMock())
+
+
+class TestProcessMessageEventGuardrail:
+    def test_connector_skips_unsupported_event_without_parsing(
+        self, connector, monkeypatch
+    ):
+        # Given: a stream event whose action is not one of create/update/delete
+        build_indicator = MagicMock()
+        monkeypatch.setattr(connector, "_build_octi_indicator", build_indicator)
+        msg = _make_msg("invalid-event", {"type": "identity", "name": "Test Identity"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: no indicator parsing is attempted (the invalid JSON body is
+        # never even parsed)
+        build_indicator.assert_not_called()
+
+
+class TestProcessMessageEntityGuardrail:
+    def test_connector_skips_non_indicator_entity_without_parsing(
+        self, connector, monkeypatch
+    ):
+        # Given: a stream event for a non-Indicator entity (e.g. an Identity)
+        build_indicator = MagicMock()
+        monkeypatch.setattr(connector, "_build_octi_indicator", build_indicator)
+        msg = _make_msg("create", {"type": "identity", "name": "Test Identity"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: no indicator parsing is attempted
+        build_indicator.assert_not_called()
+
+    def test_connector_skips_event_missing_data_without_parsing(
+        self, connector, monkeypatch
+    ):
+        # Given: a stream event payload without a top-level "data" key
+        build_indicator = MagicMock()
+        monkeypatch.setattr(connector, "_build_octi_indicator", build_indicator)
+        msg = SimpleNamespace(event="create", data=json.dumps({}), id="1-0")
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: it is treated as a non-Indicator event, no indicator parsing
+        # is attempted
+        build_indicator.assert_not_called()
+
+
+class TestBuildIndicator:
+    def test_connector_extracts_supported_observable(self, connector):
+        # Given: an Indicator whose `observable_values` extension attribute
+        # contains a single MVP-supported (domain) observable
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        # When: building the indicator
+        indicator = connector._build_octi_indicator({"type": "indicator"})
+        # Then: the observable is extracted
+        assert indicator.observables == [
+            OctiIndicatorObservable(type="Domain-Name", value="evil.com")
+        ]
+
+    def test_connector_filters_out_unsupported_observable_type(self, connector):
+        # Given: an Indicator whose `observable_values` only contains an
+        # unsupported observable type (e.g. Mutex)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Mutex", "value": "some-mutex"}],
+        }.get(key)
+        # When: building the indicator
+        indicator = connector._build_octi_indicator({"type": "indicator"})
+        # Then: no observable is extracted
+        assert indicator.observables == []
+
+    def test_connector_filters_out_hostname_observable_type(self, connector):
+        # Given: an Indicator whose `observable_values` only contains a
+        # Hostname observable (support intentionally dropped, see #7187)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Hostname", "value": "evil.com"}],
+        }.get(key)
+        # When: building the indicator
+        indicator = connector._build_octi_indicator({"type": "indicator"})
+        # Then: no observable is extracted
+        assert indicator.observables == []
+
+    def test_connector_defaults_to_no_observables_when_extension_attribute_missing(
+        self, connector
+    ):
+        # Given: an Indicator without an `observable_values` extension attribute
+        # (e.g. older OpenCTI version, or non-STIX pattern indicator)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": None,
+        }.get(key)
+        # When: building the indicator
+        indicator = connector._build_octi_indicator({"type": "indicator"})
+        # Then: no observable is extracted, no crash
+        assert indicator.observables == []
+
+
+class TestProcessMessageUnsupportedObservableGuardrail:
+    def test_connector_skips_indicator_without_any_supported_observable(
+        self, connector
+    ):
+        # Given: an Indicator whose observables are all of an unsupported type
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Hostname", "value": "evil.com"}],
+        }.get(key)
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the indicator is skipped with a warning, before it is even
+        # logged as successfully parsed
+        connector.helper.connector_logger.warning.assert_called_once()
+        connector.helper.connector_logger.info.assert_not_called()
+
+    def test_connector_processes_indicator_with_at_least_one_supported_observable(
+        self, connector
+    ):
+        # Given: an Indicator mixing an unsupported and a supported observable
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [
+                {"type": "Hostname", "value": "evil.com"},
+                {"type": "Domain-Name", "value": "evil.com"},
+            ],
+        }.get(key)
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the indicator is parsed and logged, no warning is logged
+        connector.helper.connector_logger.warning.assert_not_called()
+        connector.helper.connector_logger.info.assert_called_once()
+
+
+class TestProcessMessageErrorHandling:
+    # Fatal errors
+
+    def test_connector_logs_error_and_reraises_on_invalid_json(self, connector):
+        # Given: a stream event whose `data` is not valid JSON
+        msg = SimpleNamespace(event="create", data="not-json", id="1-0")
+        # When: processing the message
+        # Then: the error is logged with context, and the exception is deliberately
+        # re-raised to let `pycti` kill the connector process
+        with pytest.raises(json.JSONDecodeError):
+            connector._process_message(msg)
+        connector.helper.connector_logger.error.assert_called_once()
+
+    def test_connector_logs_error_and_reraises_when_indicator_id_missing(
+        self, connector
+    ):
+        # Given: an Indicator stream event missing its "id" extension attribute
+        # (required by `OctiIndicator`), causing `_build_octi_indicator` to raise
+        # a `ValidationError`
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": None,
+            "observable_values": None,
+        }.get(key)
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        # Then: the error is logged with context, and the exception is deliberately
+        # re-raised to let `pycti` kill the connector process
+        with pytest.raises(ValidationError):
+            connector._process_message(msg)
+        connector.helper.connector_logger.error.assert_called_once()
+
+    @pytest.mark.xfail(
+        reason=(
+            "Upsert/delete client calls are not implemented yet (see #7186/#7187); "
+            "the try/except around them currently only wraps `pass` placeholders, "
+            "so this expected error-handling behavior cannot be exercised yet. "
+            "Remove this xfail marker once real client calls land in that block."
+        ),
+        strict=True,
+    )
+    def test_connector_logs_error_and_reraises_on_unexpected_processing_error(
+        self, connector
+    ):
+        # Given: the Cortex XDR client unexpectedly raises while upserting/deleting
+        connector.client.upsert_iocs.side_effect = RuntimeError("boom")
+        connector.client.delete_iocs.side_effect = RuntimeError("boom")
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        # Then: the error is logged with context, and the exception is deliberately
+        # re-raised to let `pycti` kill the connector process
+        with pytest.raises(RuntimeError, match="boom"):
+            connector._process_message(msg)
+        connector.helper.connector_logger.error.assert_called_once()

--- a/stream/pan-cortex-xdr-intel/tests/tests_connector/test_models.py
+++ b/stream/pan-cortex-xdr-intel/tests/tests_connector/test_models.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 import pytest
-from connector.models import OctiIndicator, OctiIndicatorObservable
+from connector.models import CortexXdrIoc, OctiIndicator, OctiIndicatorObservable
 from pydantic import ValidationError
 
 
@@ -106,3 +106,53 @@ class TestOctiIndicator:
         )
         # Then: `valid_until` is assumed to already be UTC, and tagged as such
         assert indicator.valid_until == datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+
+class TestCortexXdrIoc:
+    """Happy/unhappy path coverage for `CortexXdrIoc` construction."""
+
+    def test_accepts_minimal_valid_input(self):
+        # Given: only the required fields
+        # When: constructing a CortexXdrIoc
+        ioc = CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")
+        # Then: the IOC is constructed successfully, optional fields default to None
+        assert ioc.indicator == "evil.com"
+        assert ioc.type == "DOMAIN_NAME"
+        assert ioc.severity is None
+        assert ioc.expiration_date is None
+        assert ioc.comment is None
+        assert ioc.reputation is None
+        assert ioc.reliability is None
+        assert ioc.rule_id is None
+
+    def test_rejects_invalid_type(self):
+        # Given: an unsupported `type` value
+        # When: constructing a CortexXdrIoc
+        # Then: a ValidationError is raised
+        with pytest.raises(ValidationError):
+            CortexXdrIoc(indicator="evil.com", type="INVALID")
+
+    def test_accepts_int_expiration_date(self):
+        # Given: an `expiration_date` passed as an epoch-millisecond `int`
+        # When: constructing a CortexXdrIoc
+        ioc = CortexXdrIoc(
+            indicator="evil.com", type="DOMAIN_NAME", expiration_date=1893456000000
+        )
+        # Then: `expiration_date` is left unchanged
+        assert ioc.expiration_date == 1893456000000
+
+    def test_accepts_rule_id(self):
+        # Given: an existing IOC's `rule_id`
+        # When: constructing a CortexXdrIoc
+        ioc = CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME", rule_id=42)
+        # Then: `rule_id` is set as given
+        assert ioc.rule_id == 42
+
+    def test_is_mutable_so_rule_id_can_be_resolved_after_construction(self):
+        # Given: a constructed CortexXdrIoc without a `rule_id`
+        ioc = CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")
+        # When: mutating `rule_id` in place, as done by
+        # `Connector._resolve_xdr_iocs_rule_ids` once the existing IOC is looked up
+        ioc.rule_id = 42
+        # Then: no error is raised, and the new value is set
+        assert ioc.rule_id == 42

--- a/stream/pan-cortex-xdr-intel/tests/tests_connector/test_models.py
+++ b/stream/pan-cortex-xdr-intel/tests/tests_connector/test_models.py
@@ -1,0 +1,108 @@
+from datetime import datetime, timezone
+
+import pytest
+from connector.models import OctiIndicator, OctiIndicatorObservable
+from pydantic import ValidationError
+
+
+class TestOctiIndicator:
+    """Happy/unhappy path coverage for `OctiIndicator` construction, including
+    its `observables` field_validator - the only custom logic in `models.py`,
+    which normalizes OpenCTI's raw `observable_values` extension attribute.
+    """
+
+    def test_event_indicator_model_accepts_valid_input(self):
+        # Given: a valid, complete set of fields for an OctiIndicator
+        # When: constructing an OctiIndicator
+        indicator = OctiIndicator(
+            id="indicator--id",
+            description="Malicious domain",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+            valid_until="2030-01-01T00:00:00Z",
+            score=75,
+        )
+        # Then: the indicator is constructed successfully, fields cast to
+        # their expected Python type
+        assert indicator.id == "indicator--id"
+        assert indicator.description == "Malicious domain"
+        assert indicator.valid_until == datetime(2030, 1, 1, 0, 0, tzinfo=timezone.utc)
+        assert indicator.score == 75
+        assert indicator.observables == [
+            OctiIndicatorObservable(type="Domain-Name", value="evil.com")
+        ]
+
+    def test_event_indicator_model_rejects_missing_id(self):
+        # Given: no `id` value (e.g. missing extension attribute)
+        # When: constructing an OctiIndicator
+        # Then: a ValidationError is raised, reporting `id` as required
+        with pytest.raises(ValidationError, match=r"id\s+Field required"):
+            OctiIndicator()
+
+    def test_event_indicator_model_keeps_stixfile_name_and_hashes_on_one_observable(
+        self,
+    ):
+        # Given: a raw StixFile observable with a name and multiple hash algorithms
+        # When: constructing an OctiIndicator
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[
+                {
+                    "type": "StixFile",
+                    "name": "evil.exe",
+                    "hashes": {"MD5": "aaa", "SHA-256": "bbb"},
+                }
+            ],
+        )
+        # Then: a single observable is extracted, with `name` and `hashes` intact
+        assert indicator.observables == [
+            OctiIndicatorObservable(
+                type="StixFile",
+                name="evil.exe",
+                hashes={"MD5": "aaa", "SHA-256": "bbb"},
+            )
+        ]
+
+    def test_event_indicator_model_skips_stixfile_observable_without_name_or_hashes(
+        self,
+    ):
+        # Given: a raw StixFile observable without a "name" or "hashes" key
+        # When: constructing an OctiIndicator
+        indicator = OctiIndicator(
+            id="indicator--id", observables=[{"type": "StixFile"}]
+        )
+        # Then: no observable is extracted
+        assert indicator.observables == []
+
+    def test_event_indicator_model_skips_observable_without_value(self):
+        # Given: a raw observable missing its "value" key
+        # When: constructing an OctiIndicator
+        indicator = OctiIndicator(
+            id="indicator--id", observables=[{"type": "Domain-Name"}]
+        )
+        # Then: no observable is extracted
+        assert indicator.observables == []
+
+    def test_event_indicator_model_defaults_observables_to_empty_list_when_none(self):
+        # Given: observables explicitly set to None (e.g. missing extension attribute)
+        # When: constructing an OctiIndicator
+        indicator = OctiIndicator(id="indicator--id", observables=None)
+        # Then: observables default to an empty list, no error
+        assert indicator.observables == []
+
+    def test_event_indicator_model_converts_non_utc_aware_valid_until_to_utc(self):
+        # Given: a `valid_until` with a non-UTC UTC offset
+        # When: constructing an OctiIndicator
+        indicator = OctiIndicator(
+            id="indicator--id", valid_until="2030-01-01T12:00:00+02:00"
+        )
+        # Then: `valid_until` is converted to UTC
+        assert indicator.valid_until == datetime(2030, 1, 1, 10, 0, tzinfo=timezone.utc)
+
+    def test_event_indicator_model_treats_naive_valid_until_as_utc(self):
+        # Given: a naive (timezone-less) `valid_until`
+        # When: constructing an OctiIndicator
+        indicator = OctiIndicator(
+            id="indicator--id", valid_until=datetime(2030, 1, 1, 12, 0, 0)
+        )
+        # Then: `valid_until` is assumed to already be UTC, and tagged as such
+        assert indicator.valid_until == datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
### Proposed changes

* Add `EventIndicator`/`IndicatorObservable` pydantic models decoupling downstream upsert/delete handlers from OpenCTI's raw STIX stream payload shape (field casting/validation delegated to pydantic to fail fast).
* Implement `Connector._process_message`: entity/event guardrails (non-Indicator and unsupported-event stream messages are logged as a warning and skipped), indicator parsing via `_parse_indicator`, and observable extraction restricted to Cortex XDR's currently-supported types.
* Add global processing error handling: JSON decode errors, `Indicator` validation errors, and any other unexpected exception are logged with context and re-raised, letting `pycti` kill the connector process rather than risk silently missing/corrupting further stream events.
* Replace the `filigran_sseclient.Event` typing dependency with a local `StreamMessage` `Protocol` declaring only the attributes actually consumed.
* Add unit tests covering the model's field_validator and the connector's guardrails/parsing/error-handling behavior.
* Add an anonymized sample stream message fixture under `data_samples/` for local/manual reference.

### Related issues

* Close #7185

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This PR stacks on top of #7309 (#7184 - Cortex XDR API client). Upsert/delete lifecycle logic (#7186/#7187) is intentionally out of scope here; the corresponding `try/except` block in `_process_message` currently wraps `pass` placeholders, documented by a `strict=True` `xfail` test that must be removed once real client calls land there.

While investigating the observable → Cortex XDR IOC type mapping (comments left on #7186/#7187), found that the XDR IOC API's `type` enum has no dedicated `URL`/`EMAIL_ADDRESS` value; `url`/`email-addr` were dropped from `_SUPPORTED_OBSERVABLE_TYPES` for this reason, to be revisited when #7186/#7187 land.