### PR TITLE
feat(export-file-csv): migrate connector to manager-supported mode (#7224)

### DIFF
--- a/internal-export-file/export-file-csv/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-export-file/export-file-csv/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,15 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
+| CONNECTOR_NAME | `string` |  | string | `"ExportFileCsv"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["text/csv"]` | The scope of the connector, i.e. the MIME type of the exported files. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `INTERNAL_EXPORT_FILE` | `"INTERNAL_EXPORT_FILE"` |  |
+| EXPORT_FILE_CSV_DELIMITER | `string` |  | string | `";"` | The delimiter character used to separate the values in the exported CSV files. |

--- a/internal-export-file/export-file-csv/__metadata__/connector_config_schema.json
+++ b/internal-export-file/export-file-csv/__metadata__/connector_config_schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/export-file-csv_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_NAME": {
+      "default": "ExportFileCsv",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "text/csv"
+      ],
+      "description": "The scope of the connector, i.e. the MIME type of the exported files.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "INTERNAL_EXPORT_FILE",
+      "default": "INTERNAL_EXPORT_FILE",
+      "type": "string"
+    },
+    "EXPORT_FILE_CSV_DELIMITER": {
+      "default": ";",
+      "description": "The delimiter character used to separate the values in the exported CSV files.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN"
+  ],
+  "additionalProperties": true
+}

--- a/internal-export-file/export-file-csv/__metadata__/connector_manifest.json
+++ b/internal-export-file/export-file-csv/__metadata__/connector_manifest.json
@@ -19,7 +19,7 @@
   "support_version": ">=5.6.1",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-export-file/export-file-csv",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-export-file-csv",
   "container_type": "INTERNAL_EXPORT_FILE"

--- a/internal-export-file/export-file-csv/docker-compose.yml
+++ b/internal-export-file/export-file-csv/docker-compose.yml
@@ -3,12 +3,15 @@ services:
   connector-export-file-csv:
     image: opencti/connector-export-file-csv:latest
     environment:
+      # --- OpenCTI ---
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe
+      # --- Connector ---
       - CONNECTOR_ID=ChangeMe
       - CONNECTOR_NAME=ExportFileCsv
       - CONNECTOR_SCOPE=text/csv
       - CONNECTOR_CONFIDENCE_LEVEL=100 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_LOG_LEVEL=error
-      - "EXPORT_FILE_CSV_DELIMITER=;"
+      # --- Export File CSV ---
+      # - "EXPORT_FILE_CSV_DELIMITER=;" # optional (default: ';')
     restart: always

--- a/internal-export-file/export-file-csv/src/__init__.py
+++ b/internal-export-file/export-file-csv/src/__init__.py
@@ -1,0 +1,3 @@
+from settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings"]

--- a/internal-export-file/export-file-csv/src/config.yml.sample
+++ b/internal-export-file/export-file-csv/src/config.yml.sample
@@ -3,12 +3,11 @@ opencti:
   token: 'ChangeMe'
 
 connector:
-  type: 'INTERNAL_EXPORT_FILE'
   id: 'ChangeMe'
-  name: 'ExportFileCsv'
-  scope: 'text/csv'
+  # name: 'ExportFileCsv' # optional (default: 'ExportFileCsv')
+  # scope: 'text/csv' # optional (default: 'text/csv')
+  # log_level: 'error' # optional (default: 'error')
   confidence_level: 100 # From 0 (Unknown) to 100 (Fully trusted)
-  log_level: 'info'
 
-export-file-csv:
-  delimiter: ';'
+# export_file_csv:
+#   delimiter: ';' # optional (default: ';')

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -15,9 +15,9 @@ class ExportFileCsv:
         # Instantiate the connector helper from config
         self.helper = OpenCTIConnectorHelper(config=self.config.to_helper_config())
         self.export_file_csv_delimiter = self.config.export_file_csv.delimiter
-        self.errors: list[
-            Exception
-        ] = []  # error holder to be reset before each new process
+        self.errors: list[Exception] = (
+            []
+        )  # error holder to be reset before each new process
 
     # The frontend (opencti #15593) sends the visible DataTable column ids as
     # the ``visible_columns`` list. A few presentation column ids do not map 1:1

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -1,34 +1,23 @@
 import csv
 import io
 import json
-import os
 import sys
 import time
 
-import yaml
-from pycti import OpenCTIConnectorHelper, get_config_variable
+from pycti import OpenCTIConnectorHelper
+from settings import ConnectorSettings
 
 
 class ExportFileCsv:
     def __init__(self):
+        # Load and validate the configuration through the Pydantic settings
+        self.config = ConnectorSettings()
         # Instantiate the connector helper from config
-        config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/config.yml"
-        config = (
-            yaml.load(open(config_file_path), Loader=yaml.FullLoader)
-            if os.path.isfile(config_file_path)
-            else {}
-        )
-        self.helper = OpenCTIConnectorHelper(config)
-        self.export_file_csv_delimiter = get_config_variable(
-            "EXPORT_FILE_CSV_DELIMITER",
-            ["export-file-csv", "delimiter"],
-            config,
-            False,
-            ";",
-        )
-        self.errors: list[Exception] = (
-            []
-        )  # error holder to be reset before each new process
+        self.helper = OpenCTIConnectorHelper(config=self.config.to_helper_config())
+        self.export_file_csv_delimiter = self.config.export_file_csv.delimiter
+        self.errors: list[
+            Exception
+        ] = []  # error holder to be reset before each new process
 
     # The frontend (opencti #15593) sends the visible DataTable column ids as
     # the ``visible_columns`` list. A few presentation column ids do not map 1:1

--- a/internal-export-file/export-file-csv/src/requirements.txt
+++ b/internal-export-file/export-file-csv/src/requirements.txt
@@ -1,1 +1,3 @@
 pycti==7.260824.0
+pydantic >=2.8.2, <3
+connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/internal-export-file/export-file-csv/src/settings.py
+++ b/internal-export-file/export-file-csv/src/settings.py
@@ -10,8 +10,7 @@ from pydantic import Field
 class ExportFileCsvConnectorConfig(BaseInternalExportFileConnectorConfig):
     """Connector-section configuration for the Export File CSV connector.
 
-    Mirrors the standard connector variables previously loaded through
-    `pycti.get_config_variable`, with the connector's own defaults.
+    Overrides the SDK defaults with the connector's own identity and scope.
     """
 
     id: str = Field(

--- a/internal-export-file/export-file-csv/src/settings.py
+++ b/internal-export-file/export-file-csv/src/settings.py
@@ -14,6 +14,10 @@ class ExportFileCsvConnectorConfig(BaseInternalExportFileConnectorConfig):
     `pycti.get_config_variable`, with the connector's own defaults.
     """
 
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="177c0a43-9dfe-4350-9706-040e12414d11",
+    )
     name: str = Field(
         description="The name of the connector.",
         default="ExportFileCsv",

--- a/internal-export-file/export-file-csv/src/settings.py
+++ b/internal-export-file/export-file-csv/src/settings.py
@@ -1,0 +1,45 @@
+from connectors_sdk import (
+    BaseConfigModel,
+    BaseConnectorSettings,
+    BaseInternalExportFileConnectorConfig,
+    ListFromString,
+)
+from pydantic import Field
+
+
+class ExportFileCsvConnectorConfig(BaseInternalExportFileConnectorConfig):
+    """Connector-section configuration for the Export File CSV connector.
+
+    Mirrors the standard connector variables previously loaded through
+    `pycti.get_config_variable`, with the connector's own defaults.
+    """
+
+    name: str = Field(
+        description="The name of the connector.",
+        default="ExportFileCsv",
+    )
+    scope: ListFromString = Field(
+        description="The scope of the connector, i.e. the MIME type of the exported files.",
+        default=["text/csv"],
+    )
+
+
+class ExportFileCsvConfig(BaseConfigModel):
+    """Export File CSV specific configuration.
+
+    Mirror of the existing `export-file-csv` variables.
+    """
+
+    delimiter: str = Field(
+        description="The delimiter character used to separate the values in the exported CSV files.",
+        default=";",
+    )
+
+
+class ConnectorSettings(BaseConnectorSettings):
+    """Global settings for the Export File CSV connector."""
+
+    connector: ExportFileCsvConnectorConfig = Field(
+        default_factory=ExportFileCsvConnectorConfig
+    )
+    export_file_csv: ExportFileCsvConfig = Field(default_factory=ExportFileCsvConfig)

--- a/internal-export-file/export-file-csv/tests/conftest.py
+++ b/internal-export-file/export-file-csv/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)

--- a/internal-export-file/export-file-csv/tests/test-requirements.txt
+++ b/internal-export-file/export-file-csv/tests/test-requirements.txt
@@ -1,3 +1,5 @@
+-r ../src/requirements.txt
 pytest==9.0.3
 PyYAML==6.0.2
 pycti==7.260824.0
+PyYAML==6.0.2

--- a/internal-export-file/export-file-csv/tests/test_main.py
+++ b/internal-export-file/export-file-csv/tests/test_main.py
@@ -1,0 +1,119 @@
+"""Tests for the manager-supported wiring of the export-file-csv connector.
+
+The connector module file name is hyphenated (`export-file-csv.py`) and is not
+importable as a normal package, so it is loaded by path via importlib.
+"""
+
+import importlib.util
+import os
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pycti import OpenCTIConnectorHelper
+from settings import ConnectorSettings
+
+_SRC = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "src", "export-file-csv.py")
+)
+_spec = importlib.util.spec_from_file_location("export_file_csv", _SRC)
+if _spec is None or _spec.loader is None:
+    raise ImportError(f"Could not load export-file-csv module from {_SRC}")
+export_file_csv = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(export_file_csv)
+ExportFileCsv = export_file_csv.ExportFileCsv
+
+
+class StubConnectorSettings(ConnectorSettings):
+    """Subclass of ``ConnectorSettings`` returning a fake but valid config dict."""
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "name": "ExportFileCsv",
+                    "scope": "text/csv",
+                    "log_level": "error",
+                },
+                "export_file_csv": {
+                    "delimiter": ";",
+                },
+            }
+        )
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper (API calls to OpenCTI)."""
+
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())
+
+
+def test_connector_settings_is_instantiated():
+    settings = StubConnectorSettings()
+
+    assert isinstance(settings, ConnectorSettings)
+    assert isinstance(settings.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.connect_id == "connector-id"
+    assert helper.connect_name == "ExportFileCsv"
+    assert helper.connect_scope == "text/csv"
+    assert helper.connect_type == "INTERNAL_EXPORT_FILE"
+
+
+def test_connector_is_instantiated(monkeypatch, mock_opencti_connector_helper):
+    monkeypatch.setattr(export_file_csv, "ConnectorSettings", StubConnectorSettings)
+
+    connector = ExportFileCsv()
+
+    assert isinstance(connector.config, ConnectorSettings)
+    assert isinstance(connector.helper, OpenCTIConnectorHelper)
+    assert connector.export_file_csv_delimiter == ";"
+    assert connector.errors == []
+
+
+def test_connector_uses_configured_delimiter(
+    monkeypatch, mock_opencti_connector_helper
+):
+    """The CSV delimiter is read from the validated Pydantic settings."""
+
+    class CommaDelimiterSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(
+                {
+                    "opencti": {
+                        "url": "http://localhost:8080",
+                        "token": "test-token",
+                    },
+                    "connector": {"id": "connector-id"},
+                    "export_file_csv": {"delimiter": ","},
+                }
+            )
+
+    monkeypatch.setattr(export_file_csv, "ConnectorSettings", CommaDelimiterSettings)
+
+    connector = ExportFileCsv()
+
+    assert connector.export_file_csv_delimiter == ","
+    csv_output = connector.export_dict_list_to_csv([{"name": "foo", "value": "bar"}])
+    assert csv_output.splitlines()[0] == '"name","value"'

--- a/internal-export-file/export-file-csv/tests/tests_connector/test_settings.py
+++ b/internal-export-file/export-file-csv/tests/tests_connector/test_settings.py
@@ -1,0 +1,134 @@
+from typing import Any
+
+import pytest
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+from settings import ConnectorSettings
+
+
+def _full_valid_settings() -> dict[str, Any]:
+    """A configuration dict setting every field (required + optional)."""
+    return {
+        "opencti": {
+            "url": "http://localhost:8080",
+            "token": "test-token",
+        },
+        "connector": {
+            "id": "connector-id",
+            "name": "ExportFileCsv",
+            "scope": "text/csv",
+            "log_level": "info",
+        },
+        "export_file_csv": {
+            "delimiter": ",",
+        },
+    }
+
+
+def _minimal_valid_settings() -> dict[str, Any]:
+    """A configuration dict setting only the required fields."""
+    return {
+        "opencti": {
+            "url": "http://localhost:8080",
+            "token": "test-token",
+        },
+        "connector": {
+            "id": "connector-id",
+        },
+        "export_file_csv": {},
+    }
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(_full_valid_settings(), id="full_valid_settings_dict"),
+        pytest.param(_minimal_valid_settings(), id="minimal_valid_settings_dict"),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.export_file_csv, BaseConfigModel) is True
+    # Required values are exposed as validated Pydantic settings.
+    assert settings.connector.id == "connector-id"
+    assert settings.connector.type == "INTERNAL_EXPORT_FILE"
+    assert settings.opencti.token.get_secret_value() == "test-token"
+
+
+def test_settings_should_apply_defaults():
+    """Optional fields fall back to the defaults declared in settings.py."""
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(_minimal_valid_settings())
+
+    settings = FakeConnectorSettings()
+
+    assert settings.connector.name == "ExportFileCsv"
+    assert settings.connector.scope == ["text/csv"]
+    assert settings.connector.log_level == "error"
+    assert settings.export_file_csv.delimiter == ";"
+
+
+def test_settings_should_be_convertible_to_helper_config():
+    """`to_helper_config()` returns a `pycti.OpenCTIConnectorHelper` compatible dict."""
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(_full_valid_settings())
+
+    helper_config = FakeConnectorSettings().to_helper_config()
+
+    assert helper_config["opencti"]["token"] == "test-token"
+    assert helper_config["connector"]["scope"] == "text/csv"
+    assert helper_config["connector"]["type"] == "INTERNAL_EXPORT_FILE"
+    assert helper_config["export_file_csv"]["delimiter"] == ","
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param({}, id="empty_settings_dict"),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080"},
+                "connector": {"id": "connector-id"},
+                "export_file_csv": {},
+            },
+            id="missing_opencti_token",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {"id": 123},
+                "export_file_csv": {},
+            },
+            id="invalid_connector_id",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {"id": "connector-id", "log_level": "verbose"},
+                "export_file_csv": {},
+            },
+            id="invalid_connector_log_level",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict):
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError, match="Error validating configuration"):
+        FakeConnectorSettings()

--- a/internal-export-file/export-file-csv/tests/tests_connector/test_settings.py
+++ b/internal-export-file/export-file-csv/tests/tests_connector/test_settings.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import UUID
 
 import pytest
 from connectors_sdk import BaseConfigModel, ConfigValidationError
@@ -76,6 +77,22 @@ def test_settings_should_apply_defaults():
     assert settings.connector.scope == ["text/csv"]
     assert settings.connector.log_level == "error"
     assert settings.export_file_csv.delimiter == ";"
+
+
+def test_settings_should_default_connector_id():
+    """The connector id falls back on its unique default UUID v4."""
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            settings_dict = _minimal_valid_settings()
+            settings_dict["connector"] = {}
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+
+    assert settings.connector.id == "177c0a43-9dfe-4350-9706-040e12414d11"
+    assert UUID(settings.connector.id).version == 4
 
 
 def test_settings_should_be_convertible_to_helper_config():


### PR DESCRIPTION
### Proposed changes

* Normalize `docker-compose.yml`, `config.yml.sample` and `src/requirements.txt` (required vars uncommented as `ChangeMe`, defaulted vars commented out)
* Add Pydantic settings mirroring the connector's existing configuration 1:1
* Wire the settings into the existing code in place — the helper is now built from `to_helper_config()`
* Set `manager_supported: true` in the connector manifest
* Generate `__metadata__/connector_config_schema.json` and `CONNECTOR_CONFIG_DOC.md`
* Give `connector.id` a unique UUIDv4 default (the SDK declares it required with no default)
* Add unit tests covering settings validation, the manager-supported wiring and the CSV delimiter
* Drop a stale docstring reference to the removed `pycti.get_config_variable` loader

### Related issues

* Closes #7224

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Structure-preserving ("lite") migration: the file layout, class names, scheduling
mechanism and logging are unchanged. The connector is manager-supported but not yet
"verified"; that broader pass is tracked separately.

**Note for `config.yml` users:** the YAML section key changed from `export-file-csv`
to `export_file_csv`, which the SDK loader requires (it matches Pydantic field names).
Environment-variable deployments (`EXPORT_FILE_CSV_DELIMITER`) are unaffected.

Validation: isort, black, `flake8 --ignore=E,W` and the custom STIX-ID pylint checker
(10.00/10) all pass; 27 unit tests pass. Regenerating the config schema produces no
diff against the committed version.
