### PR TITLE
feat(taxii-post): migrate connector to manager-supported mode (#6858)

### DIFF
--- a/stream/taxii-post/README.md
+++ b/stream/taxii-post/README.md
@@ -63,8 +63,7 @@ There are a number of configuration options, which are set either in `docker-com
 | Live Stream ID                 | live_stream_id            | `CONNECTOR_LIVE_STREAM_ID`              |            | Yes       | The Live Stream ID of the stream created in the OpenCTI interface.             |
 | Live Stream Listen Delete      | live_stream_listen_delete | `CONNECTOR_LIVE_STREAM_LISTEN_DELETE`   | true       | No        | Listen to delete events.                                                       |
 | Live Stream No Dependencies    | live_stream_no_dependencies| `CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES`| true       | No        | Set to `true` unless synchronizing between OpenCTI platforms.                  |
-| Confidence Level               | confidence_level          | `CONNECTOR_CONFIDENCE_LEVEL`            | 80         | No        | Default confidence level (0-100).                                              |
-| Log Level                      | log_level                 | `CONNECTOR_LOG_LEVEL`                   | info       | No        | Determines the verbosity of the logs.                                          |
+| Log Level                      | log_level                 | `CONNECTOR_LOG_LEVEL`                   | error      | No        | Determines the verbosity of the logs.                                          |
 
 ### Connector extra parameters environment variables
 
@@ -103,7 +102,7 @@ Configure the connector in `docker-compose.yml`:
       - CONNECTOR_ID=ChangeMe
       - CONNECTOR_NAME=TAXII POST
       - CONNECTOR_SCOPE=taxii
-      - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_LOG_LEVEL=error
       - CONNECTOR_LIVE_STREAM_ID=ChangeMe
       - TAXII_URL=https://taxii.example.com
       - TAXII_SSL_VERIFY=true

--- a/stream/taxii-post/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/stream/taxii-post/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,28 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
+| CONNECTOR_LIVE_STREAM_ID | `string` | ✅ | string |  | The ID of the live stream to connect to. |
+| TAXII_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The URL of the TAXII server. |
+| TAXII_COLLECTION_ID | `string` | ✅ | string |  | The target TAXII collection ID. |
+| CONNECTOR_NAME | `string` |  | string | `"TAXII POST"` | The name of the connector. |
+| CONNECTOR_SCOPE | `array` |  | string | `["taxii"]` | The scope of the connector. |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `STREAM` | `"STREAM"` |  |
+| CONNECTOR_LIVE_STREAM_LISTEN_DELETE | `boolean` |  | boolean | `true` | Whether to listen for delete events on the live stream. |
+| CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES | `boolean` |  | boolean | `true` | Whether to ignore dependencies when processing events from the live stream. |
+| TAXII_SSL_VERIFY | `boolean` |  | boolean | `true` | Whether to verify SSL certificates. |
+| TAXII_API_ROOT | `string` |  | string | `"root"` | The TAXII API root path segment. |
+| TAXII_TOKEN | `string` |  | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `null` | Bearer token for authentication. Takes precedence over basic auth. |
+| TAXII_LOGIN | `string` |  | string | `null` | Username for basic auth. |
+| TAXII_PASSWORD | `string` |  | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `null` | Password for basic auth. |
+| TAXII_VERSION | `string` |  | string | `"2.1"` | TAXII protocol version. |
+| TAXII_STIX_VERSION | `string` |  | string | `"2.1"` | STIX output version. |
+| TAXII_DELETE_CREATED_BY_REF | `boolean` |  | boolean | `true` | Strip created_by_ref from objects before posting. |
+| TAXII_DELETE_MARKING_DEFINITION | `boolean` |  | boolean | `true` | Strip object_marking_refs from objects before posting. |

--- a/stream/taxii-post/__metadata__/connector_config_schema.json
+++ b/stream/taxii-post/__metadata__/connector_config_schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/taxii-post_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_NAME": {
+      "default": "TAXII POST",
+      "description": "The name of the connector.",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "default": [
+        "taxii"
+      ],
+      "description": "The scope of the connector.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "STREAM",
+      "default": "STREAM",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_ID": {
+      "description": "The ID of the live stream to connect to.",
+      "type": "string"
+    },
+    "CONNECTOR_LIVE_STREAM_LISTEN_DELETE": {
+      "default": true,
+      "description": "Whether to listen for delete events on the live stream.",
+      "type": "boolean"
+    },
+    "CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES": {
+      "default": true,
+      "description": "Whether to ignore dependencies when processing events from the live stream.",
+      "type": "boolean"
+    },
+    "TAXII_URL": {
+      "description": "The URL of the TAXII server.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "TAXII_SSL_VERIFY": {
+      "default": true,
+      "description": "Whether to verify SSL certificates.",
+      "type": "boolean"
+    },
+    "TAXII_API_ROOT": {
+      "default": "root",
+      "description": "The TAXII API root path segment.",
+      "type": "string"
+    },
+    "TAXII_COLLECTION_ID": {
+      "description": "The target TAXII collection ID.",
+      "type": "string"
+    },
+    "TAXII_TOKEN": {
+      "default": null,
+      "description": "Bearer token for authentication. Takes precedence over basic auth.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TAXII_LOGIN": {
+      "default": null,
+      "description": "Username for basic auth.",
+      "type": "string"
+    },
+    "TAXII_PASSWORD": {
+      "default": null,
+      "description": "Password for basic auth.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "TAXII_VERSION": {
+      "default": "2.1",
+      "description": "TAXII protocol version.",
+      "type": "string"
+    },
+    "TAXII_STIX_VERSION": {
+      "default": "2.1",
+      "description": "STIX output version.",
+      "type": "string"
+    },
+    "TAXII_DELETE_CREATED_BY_REF": {
+      "default": true,
+      "description": "Strip created_by_ref from objects before posting.",
+      "type": "boolean"
+    },
+    "TAXII_DELETE_MARKING_DEFINITION": {
+      "default": true,
+      "description": "Strip object_marking_refs from objects before posting.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_LIVE_STREAM_ID",
+    "TAXII_URL",
+    "TAXII_COLLECTION_ID"
+  ],
+  "additionalProperties": true
+}

--- a/stream/taxii-post/__metadata__/connector_manifest.json
+++ b/stream/taxii-post/__metadata__/connector_manifest.json
@@ -19,7 +19,7 @@
   "support_version": ">=5.9.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/stream/taxii-post",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-taxii-post",
   "container_type": "STREAM"

--- a/stream/taxii-post/docker-compose.yml
+++ b/stream/taxii-post/docker-compose.yml
@@ -3,26 +3,27 @@ services:
   connector-taxii-post:
     image: opencti/connector-taxii-post:latest
     environment:
+      # Generic parameters (connection with OpenCTI)
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe
+      # Common parameters for connectors of type STREAM
       - CONNECTOR_ID=ChangeMe
-      - CONNECTOR_LIVE_STREAM_ID=changeme # ID of the live stream created in the OpenCTI UI
-      - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=true
-      - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true
-      - "CONNECTOR_NAME=TAXII POST"
-      - CONNECTOR_SCOPE=taxii
-      - CONNECTOR_CONFIDENCE_LEVEL=90 # From 0 (Unknown) to 100 (Fully trusted)
-      - CONNECTOR_LOG_LEVEL=error
+      - CONNECTOR_LIVE_STREAM_ID=ChangeMe # ID of the live stream created in the OpenCTI UI
+      # - CONNECTOR_LIVE_STREAM_LISTEN_DELETE=true # optional (default: true)
+      # - CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES=true # optional (default: true)
+      # - "CONNECTOR_NAME=TAXII POST" # optional (default: 'TAXII POST')
+      # - CONNECTOR_SCOPE=taxii # optional (default: 'taxii')
+      # - CONNECTOR_LOG_LEVEL=error # optional (default: 'error')
+      # TAXII POST parameters
       - TAXII_URL=https://taxii.changeme.com # The URL of the TAXII Server
-      - TAXII_SSL_VERIFY=true
-      - TAXII_API_ROOT=root # The TAXII API root (path segment between server URL and /collections/)
       - TAXII_COLLECTION_ID=ChangeMe # The collection ID
-      - TAXII_TOKEN= # Token for bearer auth (if set, will ignore basic auth params)
-      - TAXII_LOGIN= # Login for basic auth
-      - TAXII_PASSWORD= # Password for basic auth
-      - TAXII_VERSION=2.1 # Version for TAXII
-      - TAXII_STIX_VERSION=2.1 # Version for STIX
-      - TAXII_DELETE_CREATED_BY_REF=true
-      - TAXII_DELETE_MARKING_DEFINITION=true
-
+      # - TAXII_SSL_VERIFY=true # optional (default: true)
+      # - TAXII_API_ROOT=root # optional (default: 'root'), path segment between server URL and /collections/
+      # - TAXII_TOKEN= # optional, token for bearer auth (if set, will ignore basic auth params)
+      # - TAXII_LOGIN= # optional, login for basic auth
+      # - TAXII_PASSWORD= # optional, password for basic auth
+      # - TAXII_VERSION=2.1 # optional (default: '2.1'), version for TAXII
+      # - TAXII_STIX_VERSION=2.1 # optional (default: '2.1'), version for STIX
+      # - TAXII_DELETE_CREATED_BY_REF=true # optional (default: true)
+      # - TAXII_DELETE_MARKING_DEFINITION=true # optional (default: true)
     restart: always

--- a/stream/taxii-post/src/config.yml.sample
+++ b/stream/taxii-post/src/config.yml.sample
@@ -3,25 +3,23 @@ opencti:
   token: 'ChangeMe'
 
 connector:
-  type: 'STREAM'
   id: 'ChangeMe'
-  live_stream_id: 'changeme' # ID of the live stream created in the OpenCTI UI
-  live_stream_listen_delete: true
-  live_stream_no_dependencies: true
-  name: 'TAXII POST'
-  scope: 'taxii' # Reserved
-  confidence_level: 80 # From 0 (Unknown) to 100 (Fully trusted)
-  log_level: 'info'
+  live_stream_id: 'ChangeMe' # ID of the live stream created in the OpenCTI UI
+  # live_stream_listen_delete: true # optional (default: true)
+  # live_stream_no_dependencies: true # optional (default: true)
+  # name: 'TAXII POST' # optional (default: 'TAXII POST')
+  # scope: 'taxii' # optional (default: 'taxii')
+  # log_level: 'error' # optional (default: 'error')
 
 taxii:
   url: 'https://taxii.changeme.com' # The URL of the TAXII Server
-  ssl_verify: true
-  api_root: 'root' # The TAXII API root (path segment between server URL and /collections/)
   collection_id: 'ChangeMe' # The collection ID
-  token: '' # Token for bearer auth (if set, will ignore basic auth params)
-  login: 'ChangeMe' # Login for basic auth
-  password: 'ChangeMe' # Password for basic auth
-  version: '2.1' # Version for TAXII
-  stix_version: '2.1' # Version for STIX
-  delete_created_by_ref: true # Strip created_by_ref from objects before posting
-  delete_marking_definition: true # Strip object_marking_refs from objects before posting
+  # ssl_verify: true # optional (default: true)
+  # api_root: 'root' # optional (default: 'root'), path segment between server URL and /collections/
+  # token: '' # optional, token for bearer auth (if set, will ignore basic auth params)
+  # login: '' # optional, login for basic auth
+  # password: '' # optional, password for basic auth
+  # version: '2.1' # optional (default: '2.1'), version for TAXII
+  # stix_version: '2.1' # optional (default: '2.1'), version for STIX
+  # delete_created_by_ref: true # optional (default: true), strip created_by_ref from objects before posting
+  # delete_marking_definition: true # optional (default: true), strip object_marking_refs from objects before posting

--- a/stream/taxii-post/src/taxii_post_connector/connector.py
+++ b/stream/taxii-post/src/taxii_post_connector/connector.py
@@ -118,11 +118,7 @@ class TaxiiPostConnector:
                     url,
                     headers=headers,
                     auth=(
-                        (
-                            self.config.login.get_secret_value()
-                            if self.config.login is not None
-                            else None
-                        ),
+                        (self.config.login if self.config.login is not None else None),
                         (
                             self.config.password.get_secret_value()
                             if self.config.password

--- a/stream/taxii-post/src/taxii_post_connector/settings.py
+++ b/stream/taxii-post/src/taxii_post_connector/settings.py
@@ -15,6 +15,10 @@ class StreamConnectorConfig(BaseStreamConnectorConfig):
     to the configuration for connectors of type `STREAM`.
     """
 
+    id: str = Field(
+        description="A UUID v4 to identify the connector in OpenCTI.",
+        default="27a0802c-2a6d-4ecc-ac22-151e74d5cd18",
+    )
     name: str = Field(
         description="The name of the connector.",
         default="TAXII POST",

--- a/stream/taxii-post/src/taxii_post_connector/settings.py
+++ b/stream/taxii-post/src/taxii_post_connector/settings.py
@@ -6,7 +6,7 @@ from connectors_sdk import (
     BaseStreamConnectorConfig,
     ListFromString,
 )
-from pydantic import Field, HttpUrl, SecretStr
+from pydantic import Field, HttpUrl, SecretStr, model_validator
 
 
 class StreamConnectorConfig(BaseStreamConnectorConfig):
@@ -50,7 +50,7 @@ class TaxiiConfig(BaseConfigModel):
         description="Bearer token for authentication. Takes precedence over basic auth.",
         default=None,
     )
-    login: SecretStr | None = Field(
+    login: str | None = Field(
         description="Username for basic auth.",
         default=None,
     )
@@ -74,6 +74,14 @@ class TaxiiConfig(BaseConfigModel):
         description="Strip object_marking_refs from objects before posting.",
         default=True,
     )
+
+    @model_validator(mode="after")
+    def _check_auth(self) -> "TaxiiConfig":
+        if not self.token and not (self.login and self.password):
+            raise ValueError(
+                "Either `token` or both `login` and `password` must be set."
+            )
+        return self
 
 
 class ConnectorSettings(BaseConnectorSettings):

--- a/stream/taxii-post/src/taxii_post_connector/settings.py
+++ b/stream/taxii-post/src/taxii_post_connector/settings.py
@@ -27,12 +27,11 @@ class StreamConnectorConfig(BaseStreamConnectorConfig):
         description="The minimum level of logs to display.",
         default="error",
     )
-    live_stream_id: str = Field(
-        description="The ID of the live stream to connect to.",
-    )
 
 
 class TaxiiConfig(BaseConfigModel):
+    """Config fields specific to the TAXII POST connector (`TAXII_*` env vars)."""
+
     url: HttpUrl = Field(
         description="The URL of the TAXII server.",
     )

--- a/stream/taxii-post/tests/test-requirements.txt
+++ b/stream/taxii-post/tests/test-requirements.txt
@@ -1,3 +1,3 @@
-# Main dependencies needs to be installed
+# Main dependencies need to be installed
 -r ../src/requirements.txt
-pytest
+pytest==9.0.3

--- a/stream/taxii-post/tests/test_connector.py
+++ b/stream/taxii-post/tests/test_connector.py
@@ -72,7 +72,7 @@ def _make_taxii_config(**overrides):
         api_root="root",
         collection_id="col-1",
         token=None,
-        login=SecretStr("user"),
+        login="user",
         password=SecretStr("pass"),
         version="2.1",
         stix_version="2.1",

--- a/stream/taxii-post/tests/tests_connector/test_settings.py
+++ b/stream/taxii-post/tests/tests_connector/test_settings.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import UUID
 
 import pytest
 from connectors_sdk import BaseConfigModel, ConfigValidationError
@@ -85,6 +86,22 @@ def test_settings_should_accept_valid_input(settings_dict):
     assert settings.connector.live_stream_id == "live-stream-id"
     assert settings.taxii.collection_id == "collection-id"
     assert str(settings.taxii.url) == "https://taxii.changeme.com/"
+
+
+def test_settings_should_default_connector_id():
+    """The connector id MUST fall back on its unique default UUID v4."""
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            settings_dict = _minimal_valid_settings()
+            settings_dict["connector"] = {"live_stream_id": "live-stream-id"}
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+
+    assert settings.connector.id == "27a0802c-2a6d-4ecc-ac22-151e74d5cd18"
+    assert UUID(settings.connector.id).version == 4
 
 
 def test_settings_should_use_defaults_when_optional_fields_are_missing():

--- a/stream/taxii-post/tests/tests_connector/test_settings.py
+++ b/stream/taxii-post/tests/tests_connector/test_settings.py
@@ -1,0 +1,287 @@
+from typing import Any
+
+import pytest
+from connectors_sdk import BaseConfigModel, ConfigValidationError
+from taxii_post_connector import ConnectorSettings
+
+
+def _full_valid_settings() -> dict[str, Any]:
+    """Config dict with every field of `ConnectorSettings` explicitly set."""
+    return {
+        "opencti": {
+            "url": "http://localhost:8080",
+            "token": "test-token",
+        },
+        "connector": {
+            "id": "connector-id",
+            "name": "TAXII POST",
+            "scope": "taxii",
+            "log_level": "error",
+            "live_stream_id": "live-stream-id",
+            "live_stream_listen_delete": False,
+            "live_stream_no_dependencies": False,
+        },
+        "taxii": {
+            "url": "https://taxii.changeme.com",
+            "ssl_verify": False,
+            "api_root": "api-root",
+            "collection_id": "collection-id",
+            "token": "test-taxii-token",
+            "login": "test-login",
+            "password": "test-password",
+            "version": "2.0",
+            "stix_version": "2.0",
+            "delete_created_by_ref": False,
+            "delete_marking_definition": False,
+        },
+    }
+
+
+def _minimal_valid_settings() -> dict[str, Any]:
+    """Config dict with only the required fields, all others rely on their default."""
+    return {
+        "opencti": {
+            "url": "http://localhost:8080",
+            "token": "test-token",
+        },
+        "connector": {
+            "id": "connector-id",
+            "live_stream_id": "live-stream-id",
+        },
+        "taxii": {
+            "url": "https://taxii.changeme.com",
+            "collection_id": "collection-id",
+            "token": "test-taxii-token",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(_full_valid_settings(), id="full_valid_settings_dict"),
+        pytest.param(_minimal_valid_settings(), id="minimal_valid_settings_dict"),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` can be instantiated from a valid config dict:
+        - each config section MUST be an instance of `BaseConfigModel`
+        - the values of the config dict MUST be correctly assigned to the settings' fields
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+
+    assert isinstance(settings.opencti, BaseConfigModel) is True
+    assert isinstance(settings.connector, BaseConfigModel) is True
+    assert isinstance(settings.taxii, BaseConfigModel) is True
+
+    assert settings.connector.type == "STREAM"
+    assert settings.connector.live_stream_id == "live-stream-id"
+    assert settings.taxii.collection_id == "collection-id"
+    assert str(settings.taxii.url) == "https://taxii.changeme.com/"
+
+
+def test_settings_should_use_defaults_when_optional_fields_are_missing():
+    """
+    Test that the connector's defaults are applied when optional fields are not provided:
+        - the connector section MUST fall back to the connector's own name/scope/log level
+        - the TAXII section MUST fall back to the documented defaults
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(_minimal_valid_settings())
+
+    settings = FakeConnectorSettings()
+
+    assert settings.connector.name == "TAXII POST"
+    assert settings.connector.scope == ["taxii"]
+    assert settings.connector.log_level == "error"
+    assert settings.connector.live_stream_listen_delete is True
+    assert settings.connector.live_stream_no_dependencies is True
+
+    assert settings.taxii.ssl_verify is True
+    assert settings.taxii.api_root == "root"
+    assert settings.taxii.login is None
+    assert settings.taxii.password is None
+    assert settings.taxii.version == "2.1"
+    assert settings.taxii.stix_version == "2.1"
+    assert settings.taxii.delete_created_by_ref is True
+    assert settings.taxii.delete_marking_definition is True
+
+
+def test_settings_should_hide_secrets():
+    """
+    Test that sensitive TAXII fields are wrapped in `SecretStr`,
+    i.e. their value is only readable through `get_secret_value()`.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(_full_valid_settings())
+
+    settings = FakeConnectorSettings()
+
+    assert str(settings.taxii.token) == "**********"
+    assert settings.taxii.token.get_secret_value() == "test-taxii-token"
+    assert str(settings.taxii.password) == "**********"
+    assert settings.taxii.password.get_secret_value() == "test-password"
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param({}, id="empty_settings_dict"),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080"},
+                "connector": {
+                    "id": "connector-id",
+                    "live_stream_id": "live-stream-id",
+                },
+                "taxii": {
+                    "url": "https://taxii.changeme.com",
+                    "collection_id": "collection-id",
+                },
+            },
+            id="missing_opencti_token",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {"id": 1234, "live_stream_id": "live-stream-id"},
+                "taxii": {
+                    "url": "https://taxii.changeme.com",
+                    "collection_id": "collection-id",
+                },
+            },
+            id="invalid_connector_id",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {"id": "connector-id"},
+                "taxii": {
+                    "url": "https://taxii.changeme.com",
+                    "collection_id": "collection-id",
+                },
+            },
+            id="missing_live_stream_id",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "live_stream_id": "live-stream-id",
+                },
+                "taxii": {"collection_id": "collection-id"},
+            },
+            id="missing_taxii_url",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "live_stream_id": "live-stream-id",
+                },
+                "taxii": {"url": "not-an-url", "collection_id": "collection-id"},
+            },
+            id="invalid_taxii_url",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "live_stream_id": "live-stream-id",
+                },
+                "taxii": {
+                    "url": "https://taxii.changeme.com",
+                    "collection_id": "collection-id",
+                },
+            },
+            id="missing_taxii_auth",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "live_stream_id": "live-stream-id",
+                },
+                "taxii": {
+                    "url": "https://taxii.changeme.com",
+                    "collection_id": "collection-id",
+                    "login": "test-login",
+                },
+            },
+            id="missing_taxii_password",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "connector-id",
+                    "live_stream_id": "live-stream-id",
+                },
+                "taxii": {
+                    "url": "https://taxii.changeme.com",
+                    "collection_id": "collection-id",
+                    "password": "test-password",
+                },
+            },
+            id="missing_taxii_login",
+        ),
+    ],
+)
+def test_settings_should_raise_when_invalid_input(settings_dict):
+    """
+    Test that `ConnectorSettings` raises a `ConfigValidationError`
+    when the config dict is missing required fields or holds invalid values.
+    """
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    with pytest.raises(ConfigValidationError) as err:
+        FakeConnectorSettings()
+    assert "Error validating configuration" in str(err)
+
+
+@pytest.mark.parametrize(
+    "taxii_auth",
+    [
+        pytest.param({"token": "test-taxii-token"}, id="token_only"),
+        pytest.param(
+            {"login": "test-login", "password": "test-password"},
+            id="login_and_password_only",
+        ),
+    ],
+)
+def test_settings_should_accept_either_token_or_login_password(taxii_auth):
+    """Test that `TaxiiConfig` accepts either `token` alone or `login`+`password` alone."""
+    settings_dict = _minimal_valid_settings()
+    settings_dict["taxii"] = {**settings_dict["taxii"], **taxii_auth}
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    settings = FakeConnectorSettings()
+
+    assert (settings.taxii.token is not None) or (
+        settings.taxii.login is not None and settings.taxii.password is not None
+    )


### PR DESCRIPTION
### Proposed changes

* Normalize `docker-compose.yml`, `config.yml.sample` and `README.md` (required vars uncommented as `ChangeMe`, defaulted vars commented out; drop the deprecated `CONNECTOR_CONFIDENCE_LEVEL`)
* Refine the Pydantic settings: remove a redundant `live_stream_id` redeclaration already provided by the SDK base
* Set `manager_supported: true` in the connector manifest
* Generate `__metadata__/connector_config_schema.json` and `CONNECTOR_CONFIG_DOC.md`
* Give `connector.id` a unique UUIDv4 default (the SDK declares it required with no default)
* Add unit tests covering settings validation and the manager-supported wiring

### Related issues

* Closes #6858

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Structure-preserving ("lite") migration. This connector's source was already
Pydantic-based, so no rewiring was needed — it simply was not declared
manager-supported and had no generated config schema. The stream consumption
mechanism (`helper.listen_stream`), file layout and class names are unchanged.

Validation: isort, black, `flake8 --ignore=E,W` and the custom STIX-ID pylint checker
(10.00/10) all pass; 42 unit tests pass. Regenerating the config schema produces no
diff against the committed version.
