### PR TITLE
feat(release): add force option to delete/recreate dangling tags and releases (#7119)

### DIFF
--- a/.github/scripts/bulk_release.py
+++ b/.github/scripts/bulk_release.py
@@ -122,9 +122,10 @@ def discover_all_connectors(repo_root: Path) -> list[Connector]:
     """Discover every buildable connector across all type directories.
 
     A directory is a connector when it lives directly under a type directory,
-    does not start with '.' or '_', and contains a ``Dockerfile``. This mirrors
-    the CI build matrix (.github/scripts/build_alpine_matrix.py) so that every
-    connector the pipeline can build is releasable in bulk.
+    does not start with '.' or '_', and contains both a ``Dockerfile`` and a
+    ``__metadata__/connector_manifest.json``. This mirrors the CI build matrix
+    (.github/scripts/build_alpine_matrix.py) so that every connector the
+    pipeline can build is releasable in bulk.
     """
     connectors: list[Connector] = []
     for type_dir in common.CONNECTOR_TYPE_DIRS:
@@ -137,6 +138,10 @@ def discover_all_connectors(repo_root: Path) -> list[Connector]:
             if connector_path.name.startswith((".", "_")):
                 continue
             if not (connector_path / "Dockerfile").exists():
+                continue
+            if not (
+                connector_path / "__metadata__" / "connector_manifest.json"
+            ).exists():
                 continue
             connectors.append(
                 Connector(

--- a/.github/workflows/release-bulk-connectors.yml
+++ b/.github/workflows/release-bulk-connectors.yml
@@ -8,11 +8,12 @@ run-name: >-
   ${{
     github.event_name == 'push'
       && format('🚀 bulk (platform tag {0})', github.ref_name)
-      || format('🚀 bulk: {0}{1}{2}{3}',
+      || format('🚀 bulk: {0}{1}{2}{3}{4}',
            inputs.connectors,
            inputs.version != '' && format('@{0}', inputs.version) || '',
            inputs.dry_run && ' · dry-run' || '',
-           inputs.manifest_only && ' · manifest-only' || '')
+           inputs.manifest_only && ' · manifest-only' || '',
+           inputs.force && ' · force' || '')
   }}
 
 # Bulk release orchestrator.
@@ -85,6 +86,14 @@ on:
         required: false
         type: boolean
         default: true
+      force:
+        description: >
+          Force — for every dispatched connector, delete any existing GitHub
+          Release for this version before recreating it. If the tag already
+          exists, it is reused as-is (it is not deleted/recreated).
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: release-bulk-connectors
@@ -122,6 +131,7 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
           INPUT_MANIFEST_ONLY: ${{ inputs.manifest_only }}
+          INPUT_FORCE: ${{ inputs.force }}
         run: |
           set -euo pipefail
 
@@ -133,12 +143,14 @@ jobs:
             echo "version=${TAG_NAME}" >> "$GITHUB_OUTPUT"
             echo "dry_run=false" >> "$GITHUB_OUTPUT"
             echo "manifest_only=true" >> "$GITHUB_OUTPUT"
+            echo "force=false" >> "$GITHUB_OUTPUT"
             echo "🏷️ Platform release tag: ${TAG_NAME} → bulk manifest-only run for all connectors"
           else
             echo "connectors=${INPUT_CONNECTORS}" >> "$GITHUB_OUTPUT"
             echo "version=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
             echo "dry_run=${INPUT_DRY_RUN}" >> "$GITHUB_OUTPUT"
             echo "manifest_only=${INPUT_MANIFEST_ONLY}" >> "$GITHUB_OUTPUT"
+            echo "force=${INPUT_FORCE}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Resolve connectors and version
@@ -188,6 +200,7 @@ jobs:
           CONNECTORS_JSON: ${{ steps.resolve.outputs.connectors }}
           VERSION: ${{ steps.resolve.outputs.version }}
           MANIFEST_ONLY: ${{ steps.trigger.outputs.manifest_only }}
+          FORCE: ${{ steps.trigger.outputs.force }}
           REF: ${{ github.ref_name }}
           REPO: ${{ github.repository }}
           DRY_RUN: ${{ steps.trigger.outputs.dry_run }}
@@ -205,6 +218,10 @@ jobs:
             echo ""
             if [ "$MANIFEST_ONLY" = "true" ]; then
               echo "🧩 **Manifest-only mode** — Docker build/push is skipped for every connector (still handled by CircleCI during the transition). Tag, GitHub Release, manifest fragment, and container_version commit-back are still fully produced for each connector."
+              echo ""
+            fi
+            if [ "$FORCE" = "true" ]; then
+              echo "⚠️ **Force mode** — any existing tag/GitHub Release at this version will be deleted and recreated for every connector."
               echo ""
             fi
             echo "Dispatching connector release(s) on ref \`$REF\`."
@@ -228,7 +245,8 @@ jobs:
                  -f connector_name="$name" \
                  -f version="$VERSION" \
                  -f dry_run="$DRY_RUN" \
-                 -f manifest_only="$MANIFEST_ONLY"; then
+                 -f manifest_only="$MANIFEST_ONLY" \
+                 -f force="$FORCE"; then
               echo "| $name | $target_label | ✅ dispatched | [view run]($track_url) |" >> "$GITHUB_STEP_SUMMARY"
               ok=$((ok + 1))
             else
@@ -265,6 +283,7 @@ jobs:
           CONNECTORS_JSON: ${{ steps.resolve.outputs.connectors }}
           VERSION: ${{ steps.resolve.outputs.version }}
           MANIFEST_ONLY: ${{ steps.trigger.outputs.manifest_only }}
+          FORCE: ${{ steps.trigger.outputs.force }}
           DRY_RUN: ${{ steps.trigger.outputs.dry_run }}
           START_TIME: ${{ steps.dispatch.outputs.start_time }}
         run: |
@@ -288,12 +307,13 @@ jobs:
           mapfile -t NAMES < <(printf '%s' "$CONNECTORS_JSON" | jq -r '.[]')
 
           # Must match release-connector.yml's run-name template exactly:
-          # "🚀 {connector_name}@{version}[ · dry-run][ · manifest-only]"
+          # "🚀 {connector_name}@{version}[ · dry-run][ · manifest-only][ · force]"
           declare -A TITLE_OF
           for name in "${NAMES[@]}"; do
             title="🚀 ${name}@${VERSION}"
             [ "$DRY_RUN" = "true" ] && title="${title} · dry-run"
             [ "$MANIFEST_ONLY" = "true" ] && title="${title} · manifest-only"
+            [ "$FORCE" = "true" ] && title="${title} · force"
             TITLE_OF["$name"]="$title"
           done
 

--- a/.github/workflows/release-bulk-connectors.yml
+++ b/.github/workflows/release-bulk-connectors.yml
@@ -160,6 +160,7 @@ jobs:
           VERSION: ${{ steps.trigger.outputs.version }}
           DRY_RUN: ${{ steps.trigger.outputs.dry_run }}
           MANIFEST_ONLY: ${{ steps.trigger.outputs.manifest_only }}
+          FORCE: ${{ steps.trigger.outputs.force }}
         run: |
           set -euo pipefail
 
@@ -177,8 +178,11 @@ jobs:
           # A dry run previews the full intended set, including connectors already
           # released at this version. A real run (manifest-only or not) skips them,
           # since it creates a real tag/GitHub Release per connector and re-running
-          # for an already-released version would collide with the existing tag.
-          if [ "${DRY_RUN}" = "true" ]; then
+          # for an already-released version would collide with the existing tag —
+          # unless force is set, in which case those connectors must still be
+          # dispatched so release-connector.yml's own force logic can delete and
+          # recreate their tag/release.
+          if [ "${DRY_RUN}" = "true" ] || [ "${FORCE}" = "true" ]; then
             ARGS+=("--include-released")
           fi
 

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -78,10 +78,12 @@ on:
         default: false
       force:
         description: >
-          Force — delete any existing tag and/or GitHub Release for this
-          version before recreating them from scratch. Use this to recover
-          from a partially failed release (e.g. manifest fragment generation
-          or XTM Hub publish failure) that left a dangling tag/release behind.
+          Force — delete any existing GitHub Release for this version before
+          recreating it. If a tag already exists for this version, it is
+          reused as-is rather than being deleted/recreated. Use this to
+          recover from a partially failed release (e.g. manifest fragment
+          generation or XTM Hub publish failure) that left a dangling
+          tag/release behind.
         required: false
         type: boolean
         default: false
@@ -504,21 +506,22 @@ jobs:
           FORCE: ${{ needs.resolve.outputs.force }}
         run: |
           TAG="${{ needs.resolve.outputs.tag }}"
-          echo "🏷️  Creating tag: $TAG"
 
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+          # `git rev-parse refs/tags/...` can't be used here: this job's checkout
+          # doesn't fetch tags, so a remote-only tag would look absent locally.
+          # `ls-remote` checks the remote directly regardless of local state.
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
             if [ "$FORCE" = "true" ]; then
-              echo "⚠️ Force enabled — deleting existing tag '${TAG}'"
-              git push origin --delete "$TAG" || true
-              git tag -d "$TAG" || true
+              echo "⚠️ Force enabled — tag '${TAG}' already exists, reusing it as-is"
             else
-              echo "::error::Tag '$TAG' already exists. Use a different version, push the existing tag to trigger a release, or re-run with 'force' enabled to delete and recreate it."
+              echo "::error::Tag '$TAG' already exists. Use a different version, push the existing tag to trigger a release, or re-run with 'force' enabled to reuse it."
               exit 1
             fi
+          else
+            echo "🏷️  Creating tag: $TAG"
+            git tag "$TAG"
+            git push origin "$TAG"
           fi
-
-          git tag "$TAG"
-          git push origin "$TAG"
 
       - name: Patch manifest container_version
         id: patch-manifest

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -10,11 +10,12 @@ run-name: >-
   ${{
     github.event_name == 'push'
       && format('🚀 {0}', github.ref_name)
-      || format('🚀 {0}{1}{2}{3}',
+      || format('🚀 {0}{1}{2}{3}{4}',
            inputs.connector_name,
            inputs.version != '' && format('@{0}', inputs.version) || '',
            inputs.dry_run && ' · dry-run' || '',
-           inputs.manifest_only && ' · manifest-only' || '')
+           inputs.manifest_only && ' · manifest-only' || '',
+           inputs.force && ' · force' || '')
   }}
 
 # Production release pipeline for individual connectors.
@@ -75,6 +76,15 @@ on:
         required: false
         type: boolean
         default: false
+      force:
+        description: >
+          Force — delete any existing tag and/or GitHub Release for this
+          version before recreating them from scratch. Use this to recover
+          from a partially failed release (e.g. manifest fragment generation
+          or XTM Hub publish failure) that left a dangling tag/release behind.
+        required: false
+        type: boolean
+        default: false
       sdk_ref:
         description: >
           Optional git ref to pin connectors-sdk to in the built image.
@@ -112,6 +122,7 @@ jobs:
       is_tag_push: ${{ steps.parse.outputs.is_tag_push }}
       dry_run: ${{ steps.parse.outputs.dry_run }}
       manifest_only: ${{ steps.parse.outputs.manifest_only }}
+      force: ${{ steps.parse.outputs.force }}
       tag: ${{ steps.version.outputs.tag }}
       matrix_json: ${{ steps.matrix.outputs.matrix_json }}
     steps:
@@ -133,6 +144,7 @@ jobs:
             echo "is_tag_push=true" >> "$GITHUB_OUTPUT"
             echo "dry_run=false" >> "$GITHUB_OUTPUT"
             echo "manifest_only=false" >> "$GITHUB_OUTPUT"
+            echo "force=false" >> "$GITHUB_OUTPUT"
             echo "🏷️ Tag push: $TAG → connector=$CONNECTOR_NAME version=$VERSION"
           else
             # workflow_dispatch: use inputs directly
@@ -140,6 +152,7 @@ jobs:
             echo "is_tag_push=false" >> "$GITHUB_OUTPUT"
             echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
             echo "manifest_only=${{ inputs.manifest_only }}" >> "$GITHUB_OUTPUT"
+            echo "force=${{ inputs.force }}" >> "$GITHUB_OUTPUT"
             echo "📋 Manual dispatch: connector=${{ inputs.connector_name }}"
           fi
 
@@ -469,24 +482,39 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Overwrite guard
+        id: overwrite-guard
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORCE: ${{ needs.resolve.outputs.force }}
         run: |
           TAG="${{ needs.resolve.outputs.tag }}"
           if gh release view "$TAG" --json tagName >/dev/null 2>&1; then
-            echo "::error::A GitHub Release already exists for tag '${TAG}'. Aborting to prevent overwrite."
-            exit 1
+            if [ "$FORCE" = "true" ]; then
+              echo "⚠️ Force enabled — deleting existing release for '${TAG}'"
+              gh release delete "$TAG" --yes
+            else
+              echo "::error::A GitHub Release already exists for tag '${TAG}'. Aborting to prevent overwrite. Re-run with 'force' enabled to delete and recreate it."
+              exit 1
+            fi
           fi
 
       - name: Create tag (manual dispatch only)
         if: needs.resolve.outputs.is_tag_push != 'true'
+        env:
+          FORCE: ${{ needs.resolve.outputs.force }}
         run: |
           TAG="${{ needs.resolve.outputs.tag }}"
           echo "🏷️  Creating tag: $TAG"
 
           if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "::error::Tag '$TAG' already exists. Use a different version or push the existing tag to trigger a release."
-            exit 1
+            if [ "$FORCE" = "true" ]; then
+              echo "⚠️ Force enabled — deleting existing tag '${TAG}'"
+              git push origin --delete "$TAG" || true
+              git tag -d "$TAG" || true
+            else
+              echo "::error::Tag '$TAG' already exists. Use a different version, push the existing tag to trigger a release, or re-run with 'force' enabled to delete and recreate it."
+              exit 1
+            fi
           fi
 
           git tag "$TAG"
@@ -500,9 +528,8 @@ jobs:
           MANIFEST="${CONNECTOR_DIR}/__metadata__/connector_manifest.json"
 
           if [ ! -f "$MANIFEST" ]; then
-            echo "patched=false" >> "$GITHUB_OUTPUT"
-            echo "⚠️ Manifest not found: $MANIFEST — skipping version patch"
-            exit 0
+            echo "::error::Manifest not found: $MANIFEST — cannot patch version"
+            exit 1
           fi
 
           jq --arg v "$VERSION" '.container_version = $v' "$MANIFEST" > "$RUNNER_TEMP/manifest.json" \
@@ -527,8 +554,8 @@ jobs:
           MANIFEST="${CONNECTOR_DIR}/__metadata__/connector_manifest.json"
 
           if [ ! -f "$MANIFEST" ]; then
-            echo "::warning::Manifest not found for ${CONNECTOR_DIR} — skipping fragment generation"
-            exit 0
+            echo "::error::Manifest not found for ${CONNECTOR_DIR}"
+            exit 1
           fi
 
           pip install --quiet -r shared/tools/composer/generate_manifest_fragment/requirements.txt
@@ -554,8 +581,8 @@ jobs:
           FRAGMENT_PATH="${{ steps.fragment.outputs.fragment_path }}"
 
           if [ -z "$XTM_HUB_TOKEN" ]; then
-            echo "::warning::XTM_HUB_TOKEN secret not set -- skipping XTM Hub publish"
-            exit 0
+            echo "::error::XTM_HUB_TOKEN secret not set — cannot publish to XTM Hub"
+            exit 1
           fi
 
           QUERY='mutation IngestManifestFragments($manifestFragments: [ManifestFragmentInput!]!) {
@@ -586,20 +613,20 @@ jobs:
           echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
 
           if [ "$HTTP_STATUS" -ge 400 ]; then
-            echo "::warning::XTM Hub publish failed with HTTP $HTTP_STATUS"
-            exit 0
+            echo "::error::XTM Hub publish failed with HTTP $HTTP_STATUS"
+            exit 1
           fi
 
           if echo "$RESPONSE" | jq -e '.errors' >/dev/null 2>&1; then
-            echo "::warning::XTM Hub returned errors: $(echo "$RESPONSE" | jq -c '.errors')"
-            exit 0
+            echo "::error::XTM Hub returned errors: $(echo "$RESPONSE" | jq -c '.errors')"
+            exit 1
           fi
 
           SUCCESS=$(echo "$RESPONSE" | jq -r '.data.ingestManifestFragments.success // false')
           if [ "$SUCCESS" = "true" ]; then
             echo "✅ Manifest fragment published to XTM Hub"
           else
-            echo "::warning::XTM Hub did not report success for manifest fragment publish"
+            echo "::error::XTM Hub did not report success for manifest fragment publish"
           fi
 
       - name: Download pinned dependency files
@@ -701,6 +728,23 @@ jobs:
 
           echo "✅ Release created: $TITLE"
 
+      # Runs on any failure in this job that happens after the overwrite guard
+      # passed (guard failing itself means a real prior release exists and
+      # must be left untouched). Without this, a mid-job failure (e.g.
+      # manifest fragment generation or XTM Hub publish) leaves a dangling
+      # tag/release that blocks every future retry, since "Create tag" and
+      # "Overwrite guard" would then refuse to proceed on the next run.
+      - name: Cleanup tag on failure
+        if: failure() && steps.overwrite-guard.conclusion == 'success'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ needs.resolve.outputs.tag }}"
+          echo "::warning::Release job failed — deleting tag '${TAG}' and any partial release so a retry can recreate it cleanly."
+          gh release delete "$TAG" --yes 2>/dev/null || true
+          git push origin --delete "$TAG" 2>/dev/null || true
+
   # ──────────────────────────────────────────────────────────
   # 5. Commit manifest version back to default branch
   # ──────────────────────────────────────────────────────────
@@ -729,8 +773,8 @@ jobs:
           MANIFEST="${CONNECTOR_DIR}/__metadata__/connector_manifest.json"
 
           if [ ! -f "$MANIFEST" ]; then
-            echo "⚠️ Manifest not found: $MANIFEST — skipping"
-            exit 0
+            echo "::error::Manifest not found: $MANIFEST — cannot patch version"
+            exit 1
           fi
 
           # Patch container_version
@@ -779,6 +823,7 @@ jobs:
         run: |
           DRY_RUN="${{ needs.resolve.outputs.dry_run }}"
           MANIFEST_ONLY="${{ needs.resolve.outputs.manifest_only }}"
+          FORCE="${{ needs.resolve.outputs.force }}"
           CONNECTOR="${{ needs.resolve.outputs.connector_name }}"
           VERSION="${{ needs.resolve.outputs.version }}"
           DIR="${{ needs.resolve.outputs.connector_dir }}"
@@ -808,6 +853,7 @@ jobs:
             echo "| Trigger | $([ \"$IS_TAG_PUSH\" = \"true\" ] && echo \"tag push\" || echo \"manual dispatch\") |"
             echo "| Dry Run | ${DRY_RUN} |"
             echo "| Manifest Only | ${MANIFEST_ONLY} |"
+            echo "| Force | ${FORCE} |"
             echo ""
 
             echo "### Job Results"


### PR DESCRIPTION
### Proposed changes

* Add a `force` option to the release-connector workflow that deletes and recreates an existing GitHub Release/tag for a version, to recover from a partially failed release (e.g. manifest fragment generation or XTM Hub publish failure) that left a dangling tag/release behind
* Skip connectors without a manifest file in the bulk-release workflow instead of failing the whole run

### Related issues

* Closes #7119

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

A follow-up stacked PR (manifest-fragment min_version fix) branches off this one; merge this PR first.