### PR TITLE
fix(manifest-fragment): derive min_version from the pinned pycti version (#7119)

### DIFF
--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -556,6 +556,11 @@ jobs:
           VERSION="${{ needs.resolve.outputs.version }}"
           MANIFEST="${CONNECTOR_DIR}/__metadata__/connector_manifest.json"
 
+          # Same resolution as the `build` job's `sdk_ref` input, so the fragment's
+          # min_version is derived from the connectors-sdk ref actually pinned into
+          # the built image, not whatever happens to be checked out here.
+          SDK_REF="${{ inputs.sdk_ref != '' && inputs.sdk_ref || github.sha }}"
+
           if [ ! -f "$MANIFEST" ]; then
             echo "::error::Manifest not found for ${CONNECTOR_DIR}"
             exit 1
@@ -567,6 +572,7 @@ jobs:
           python shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py \
             --connector-dir "$CONNECTOR_DIR" \
             --version "$VERSION" \
+            --sdk-ref "$SDK_REF" \
             --output "$FRAGMENT_PATH"
 
           echo "fragment_path=$FRAGMENT_PATH" >> "$GITHUB_OUTPUT"

--- a/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
+++ b/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
@@ -21,12 +21,14 @@ Usage:
     python generate_manifest_fragment.py \
         --connector-dir external-import/mitre \
         --version 7.260630.0 \
+        --sdk-ref 7.260630.0 \
         --output /tmp/mitre_manifest_fragment.json
 
 Field mapping (existing manifest -> fragment):
     slug              -> id, slug
     logo (file path)  -> logo (base64 data URL)
-    support_version   -> min_version (">=" and whitespace stripped)
+    pinned pycti version (requirements.txt / pyproject.toml, connectors-sdk
+        pin, or support_version as an ultimate fallback) -> min_version
     <release version> -> version
     container_image   -> image_name
     container_type    -> image_type
@@ -46,6 +48,7 @@ import io
 import json
 import os
 import re
+import subprocess
 import sys
 import traceback
 from pathlib import Path
@@ -56,6 +59,29 @@ from PIL import Image
 CONNECTOR_METADATA_DIRECTORY = "__metadata__"
 CONNECTOR_MANIFEST_FILENAME = "connector_manifest.json"
 CONNECTOR_CONFIG_SCHEMA_FILENAME = "connector_config_schema.json"
+
+# Where a connector may declare its pycti pin, checked in order. Most
+# connectors use `src/requirements.txt`; some (uv/pyproject-based, or older
+# ones) pin it in a root `requirements.txt` or in `pyproject.toml` instead.
+CONNECTOR_REQUIREMENTS_CANDIDATES = (
+    Path("src") / "requirements.txt",
+    Path("requirements.txt"),
+    Path("pyproject.toml"),
+)
+
+# A handful of connectors only depend on connectors-sdk and don't pin pycti
+# directly; connectors-sdk's own pin is what actually gets installed then.
+CONNECTORS_SDK_PYPROJECT = (
+    Path(__file__).parents[4] / "connectors-sdk" / "pyproject.toml"
+)
+
+# Matches a pinned `pycti==X.Y.Z` requirement, whether as a plain
+# requirements.txt line or a quoted `pyproject.toml` dependencies-array entry
+# (e.g. `"pycti==X.Y.Z",`). Optional extras (`pycti[extra]==`) are handled.
+PYCTI_PIN_PATTERN = re.compile(
+    r"^\s*['\"]?pycti(?:\[[^\]]*\])?\s*==\s*['\"]?([^\s'\";,]+)['\"]?,?\s*$",
+    re.MULTILINE,
+)
 
 PLATFORM = "OpenCTI"
 INTEGRATION_TYPE = "connector"
@@ -81,6 +107,9 @@ MANIFEST_KEYS_HANDLED_EXPLICITLY = frozenset(
         "subscription_link",
         "source_code",
         "manager_supported",
+        # Only used as a last-resort fallback for min_version (see
+        # parse_pycti_version), so it's excluded from passthrough rather than
+        # published as its own field.
         "support_version",
         "container_image",
         "container_type",
@@ -169,12 +198,105 @@ def encode_logo_to_base64(logo_path: Path) -> str:
     return f"data:{mime_type};base64,{encoded_logo}"
 
 
-def parse_min_version(support_version: str | None) -> str:
-    """Convert a `support_version` constraint (e.g. ">= 6.8.0") to a bare version."""
+def parse_support_version_fallback(support_version: str | None) -> str | None:
+    """Extract a bare version (e.g. "6.8.0") from a `support_version` constraint
+    (e.g. ">= 6.8.0"), used only as a last resort when no pycti pin is found.
+    """
     if not support_version:
-        return ""
+        return None
     match = re.search(r"[0-9]+\.[0-9]+(?:\.[0-9]+)?", support_version)
-    return match.group() if match else ""
+    return match.group() if match else None
+
+
+def read_connectors_sdk_pyproject(sdk_ref: str | None) -> str | None:
+    """Return the contents of connectors-sdk/pyproject.toml as pinned into the
+    built image.
+
+    A release can pin connectors-sdk to a git ref other than the one currently
+    checked out (release-connector.yml's `sdk_ref` input, applied by
+    build-connector-image's "Pin connectors-sdk for release" step), so the
+    pycti version actually shipped in the image can differ from the local,
+    checked-out connectors-sdk/pyproject.toml. When `sdk_ref` is given, fetch
+    that ref and read the file from it instead of from disk.
+    """
+    if not sdk_ref:
+        if CONNECTORS_SDK_PYPROJECT.is_file():
+            return CONNECTORS_SDK_PYPROJECT.read_text(encoding="utf-8")
+        return None
+
+    repo_root = CONNECTORS_SDK_PYPROJECT.parents[1]
+    try:
+        subprocess.run(
+            ["git", "fetch", "--quiet", "--depth", "1", "origin", sdk_ref],
+            cwd=repo_root,
+            check=True,
+        )
+        result = subprocess.run(
+            ["git", "show", "FETCH_HEAD:connectors-sdk/pyproject.toml"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout
+    except (subprocess.CalledProcessError, OSError) as error:
+        print(
+            f"⚠️  Could not read connectors-sdk/pyproject.toml at sdk_ref "
+            f"{sdk_ref!r}: {error}"
+        )
+        return None
+
+
+def parse_pycti_version(
+    connector_dir: Path, support_version: str | None, sdk_ref: str | None = None
+) -> str:
+    """Return the exact pycti version this connector release was built against.
+
+    This is the minimum OpenCTI platform version we know the connector works
+    with, since it's the pycti version the release was actually built and
+    tested against.
+
+    Checked in order: each of CONNECTOR_REQUIREMENTS_CANDIDATES at the
+    connector root; then the connectors-sdk pin (read from `sdk_ref` when
+    given, otherwise the local checkout), for connectors that only depend on
+    connectors-sdk (no direct pycti pin of their own) — that's what actually
+    gets installed then. As an ultimate fallback, the manually maintained
+    `support_version` manifest field is used, since it's better than failing
+    the release outright even though it can drift out of sync.
+    """
+    checked_paths = []
+    for relative_path in CONNECTOR_REQUIREMENTS_CANDIDATES:
+        candidate = connector_dir / relative_path
+        checked_paths.append(candidate)
+        if candidate.is_file():
+            match = PYCTI_PIN_PATTERN.search(candidate.read_text(encoding="utf-8"))
+            if match:
+                return match.group(1)
+
+    sdk_pyproject_content = read_connectors_sdk_pyproject(sdk_ref)
+    if sdk_pyproject_content:
+        match = PYCTI_PIN_PATTERN.search(sdk_pyproject_content)
+        if match:
+            return match.group(1)
+    checked_paths.append(
+        f"connectors-sdk/pyproject.toml@{sdk_ref}"
+        if sdk_ref
+        else CONNECTORS_SDK_PYPROJECT
+    )
+
+    fallback = parse_support_version_fallback(support_version)
+    if fallback:
+        print(
+            "⚠️  No pinned 'pycti==<version>' requirement found — falling back "
+            f"to manifest 'support_version' ({support_version!r}) for min_version."
+        )
+        return fallback
+
+    raise ValueError(
+        "No pinned 'pycti==<version>' requirement found, and no usable "
+        f"'support_version' fallback in the manifest. Checked: "
+        f"{', '.join(str(path) for path in checked_paths)}"
+    )
 
 
 def normalize_slug(slug: str) -> str:
@@ -191,8 +313,15 @@ def load_json(path: Path) -> dict:
         return json.load(file)
 
 
-def build_fragment(connector_dir: Path, version: str) -> dict:
-    """Build the manifest fragment for a single connector."""
+def build_fragment(
+    connector_dir: Path, version: str, sdk_ref: str | None = None
+) -> dict:
+    """Build the manifest fragment for a single connector.
+
+    `sdk_ref` is the git ref connectors-sdk was actually pinned to for this
+    release build (see `read_connectors_sdk_pyproject`); when omitted, the
+    locally checked-out connectors-sdk/pyproject.toml is used instead.
+    """
     metadata_dir = connector_dir / CONNECTOR_METADATA_DIRECTORY
     manifest_path = metadata_dir / CONNECTOR_MANIFEST_FILENAME
     if not manifest_path.is_file():
@@ -224,7 +353,9 @@ def build_fragment(connector_dir: Path, version: str) -> dict:
         "subscription_link": manifest.get("subscription_link") or "",
         "source_code": manifest["source_code"],
         "manager_supported": manifest["manager_supported"],
-        "min_version": parse_min_version(manifest.get("support_version")),
+        "min_version": parse_pycti_version(
+            connector_dir, manifest.get("support_version"), sdk_ref
+        ),
         "version": version,
         "image_name": manifest["container_image"],
         "image_type": manifest["container_type"],
@@ -296,6 +427,15 @@ def main() -> None:
         help="Path where the generated fragment JSON will be written.",
     )
     parser.add_argument(
+        "--sdk-ref",
+        default=None,
+        help="Git ref connectors-sdk was pinned to for this release build "
+        "(e.g. the release-connector 'sdk_ref' input, or the release commit "
+        "SHA). Used to derive 'min_version' from that ref's "
+        "connectors-sdk/pyproject.toml instead of the local checkout. "
+        "Defaults to the local checkout when omitted.",
+    )
+    parser.add_argument(
         "--schema",
         default=None,
         help="Path to connector_manifest_schema.json for optional validation. "
@@ -304,7 +444,7 @@ def main() -> None:
     args = parser.parse_args()
 
     connector_dir = Path(args.connector_dir)
-    fragment = build_fragment(connector_dir, args.version)
+    fragment = build_fragment(connector_dir, args.version, args.sdk_ref)
 
     schema_path = (
         Path(args.schema)


### PR DESCRIPTION
### Proposed changes

* Derive the manifest fragment's `min_version` from the connector's pinned pycti version (checked in `src/requirements.txt`, root `requirements.txt`, `pyproject.toml`, then the connectors-sdk pin) instead of the manually maintained `support_version` manifest field, since it's the version the release was actually built and tested against
* Keep `support_version` as an ultimate fallback when no pycti pin can be found anywhere

### Related issues

* Closes #7119

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Stacked on top of #7119 (feat/7119-release-connector-force-option) — base branch will need updating to master once that PR merges.