### PR TITLE
fix(cisa-kev):  store last_update only after a successful publication (#7354)

### DIFF
--- a/external-import/cisa-known-exploited-vulnerabilities/README.md
+++ b/external-import/cisa-known-exploited-vulnerabilities/README.md
@@ -1,8 +1,8 @@
 # OpenCTI CISA Known Exploited Vulnerabilities (KEV) Connector
 
-| Status | Date | Comment |
-|--------|------|---------|
-| Community | -    | -       |
+| Status   | Date | Comment |
+|----------|------|---------|
+| Verified | -    | -       |
 
 The CISA KEV connector imports the Known Exploited Vulnerabilities Catalog from CISA into OpenCTI as Vulnerability entities with related Software and vendor information.
 

--- a/external-import/cisa-known-exploited-vulnerabilities/README.md
+++ b/external-import/cisa-known-exploited-vulnerabilities/README.md
@@ -199,6 +199,21 @@ When `CISA_KEV_FLAG_ONLY` is set to `true`, the connector operates in a minimal 
 
 This is useful when you already have Vulnerability data from other sources (e.g., a CVE connector) and you only want to tag which ones appear in the CISA KEV catalog, without overwriting any existing attributes.
 
+> **Note — confidence level.** 
+> 
+> In this mode the connector updates Vulnerability objects
+> that another source owns. OpenCTI applies an update only when the incoming confidence is
+> greater than or equal to the confidence of the existing data, so the user running this
+> connector must have a **max confidence level at least equal** to that of the connector
+> which created the vulnerabilities (for example the CVE connector). With a lower confidence
+> the flag is silently not applied. 
+
+> **Note — vulnerabilities absent from your platform.** 
+> 
+> The connector still emits a Vulnerability for every catalog entry, so a KEV entry you do not already have is created
+> with nothing but its name and the flag. Pair this mode with a vulnerability source such as
+> the CVE connector if you want those entries enriched.
+> 
 **Example configuration:**
 
 ```yaml
@@ -219,16 +234,50 @@ This allows you to prioritize remediation efforts for actively exploited vulnera
 
 ## Debugging
 
-Enable verbose logging:
+The connector logs its whole run at `info`. Note that the **default log level is `error`**,
+so nothing but failures is visible until you raise it:
 
 ```env
-CONNECTOR_LOG_LEVEL=debug
+CONNECTOR_LOG_LEVEL=info
 ```
 
-Log output includes:
-- Catalog retrieval status
-- Bundle creation progress
-- State management (last update tracking)
+A complete run then reads as follows — the connector's own configuration, the two catalog
+versions being compared, one line per published entry naming the CVE and the progress, and
+the completion line stating how many entries were sent and which version was stored:
+
+```
+Starting the CISA Known Exploited Vulnerabilities connector  {catalog_url=..., create_infrastructures=false, kev_flag_only=false, tlp=TLP:CLEAR, schedule=duration_period=P2D}
+Last CISA KEV catalog version ingested by this connector (from connector state): 2026-08-20T09:00:00.0000Z
+CISA KEV catalog version served by CISA (dateReleased): 2026-08-21T17:46:43.6019Z, 1394 entries
+New CISA KEV catalog version 2026-08-21T17:46:43.6019Z (previously ingested: 2026-08-20T09:00:00.0000Z), starting ingestion
+Publishing CISA KEV entry CVE-2023-32315 (1/1394)
+...
+Connector successfully run, 1394 entries sent, storing last_update as 2026-08-21T17:46:43.6019Z
+```
+
+`CONNECTOR_LOG_LEVEL=debug` adds pycti's own internal logging (API calls, queue handling);
+the connector itself emits nothing extra at that level.
+
+### Reading a run
+
+Situations that look alike from the outside are told apart by these lines:
+
+| What you see | What it means |
+|---|---|
+| `CISA KEV catalog version ... has already been ingested, nothing to do` | CISA has not published a new catalog since the last successful run. Nothing is sent and the state is left as is. |
+| The two versions differ, followed by `Publishing CISA KEV entry ...` lines | A new catalog version is being ingested. |
+| `Publication interrupted after N of M entries, on CVE-...` | The platform or the queue refused a bundle. `last_update` is **not** stored and the work is reported in error, so the whole catalog is processed again on the next run. |
+| `Error retrieving the CISA KEV catalog` with an `attempt` counter, then `Could not retrieve the CISA KEV catalog from ...` | The catalog could not be downloaded after all attempts. The state is untouched and the work is closed in error. |
+
+Two lines are worth knowing about:
+
+- `CISA Known Exploited Vulnerabilities sending bundle to queue` comes from pycti, not from
+  this connector, and is emitted once per bundle — so once per catalog entry. The
+  connector's own `Publishing CISA KEV entry ...` line is logged just before it and tells
+  you which entry it refers to.
+- the version logged at the start of a run is the one held in **the connector state**, not
+  the one currently served by CISA. Both are logged side by side precisely so that they can
+  be compared.
 
 ## Additional information
 

--- a/external-import/cisa-known-exploited-vulnerabilities/src/main.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/src/main.py
@@ -19,6 +19,12 @@ from pycti import (
 
 
 class Cisa:
+    # Downloading the catalog: without a timeout, urlopen waits forever on a
+    # hung connection and the whole connector stops running silently.
+    HTTP_TIMEOUT = 60
+    HTTP_ATTEMPTS = 3
+    HTTP_RETRY_DELAY = 5
+
     def __init__(self):
         # Instantiate the connector helper from config
         self.config = ConfigLoader()
@@ -42,6 +48,9 @@ class Cisa:
         """
         Retrieve data from the given url.
 
+        Retried a few times: the connector runs at most once a day, so a
+        transient network failure would otherwise cost a full day of staleness.
+
         Parameters
         ----------
         url : str
@@ -52,21 +61,35 @@ class Cisa:
         str
             A string with the content or None in case of failure.
         """
-        try:
-            return (
-                urllib.request.urlopen(
-                    url,
-                    context=ssl.create_default_context(),
+        for attempt in range(1, self.HTTP_ATTEMPTS + 1):
+            try:
+                return (
+                    urllib.request.urlopen(
+                        url,
+                        context=ssl.create_default_context(),
+                        timeout=self.HTTP_TIMEOUT,
+                    )
+                    .read()
+                    .decode("utf-8")
                 )
-                .read()
-                .decode("utf-8")
-            )
-        except (
-            urllib.error.URLError,
-            urllib.error.HTTPError,
-            urllib.error.ContentTooShortError,
-        ) as urllib_error:
-            self.helper.log_error(f"Error retrieving url {url}: {urllib_error}")
+            except (
+                urllib.error.URLError,
+                urllib.error.HTTPError,
+                urllib.error.ContentTooShortError,
+                TimeoutError,
+            ) as retrieve_error:
+                # Logged as a error: the caller turns the missing catalog
+                # into the run error, these lines only carry the causes.
+                self.helper.log_error(
+                    "Error retrieving the CISA KEV catalog",
+                    {
+                        "url": url,
+                        "error": str(retrieve_error),
+                        "attempt": f"{attempt}/{self.HTTP_ATTEMPTS}",
+                    },
+                )
+                if attempt < self.HTTP_ATTEMPTS:
+                    time.sleep(self.HTTP_RETRY_DELAY * attempt)
         return None
 
     # Get Identity info
@@ -98,7 +121,6 @@ class Cisa:
     def set_tlp_marking(self, tlp_mark):
         if tlp_mark is None:
             tlp_mark = self.tlp
-        self.helper.log_info("Retrieving TLP Data from CTI Service")
         marking = self.helper.api.marking_definition.read(
             filters={
                 "mode": "and",
@@ -107,10 +129,12 @@ class Cisa:
             }
         )
         self.tlp_marking = marking["standard_id"]
-        self.helper.log_info(f"Marking Definition: {self.tlp_marking}")
+        self.helper.log_info(
+            "TLP marking resolved from the platform",
+            {"tlp": tlp_mark, "marking_definition": self.tlp_marking},
+        )
 
     def build_bundle(self, data):
-        self.helper.log_info("Building CISA Bundle")
         vuln = data
         vuln_cve = vuln["cveID"]
 
@@ -125,9 +149,7 @@ class Cisa:
                     "x_opencti_cisa_kev": True,
                 },
             )
-            bundle = self.helper.stix2_create_bundle([stix_vuln])
-            self.helper.log_info("CISA Bundle Complete (KEV flag only mode)")
-            return bundle
+            return self.helper.stix2_create_bundle([stix_vuln])
 
         stix_objects = [self.created_by_stix]
         vendor_name = vuln["vendorProject"]
@@ -237,21 +259,28 @@ class Cisa:
         )
         stix_objects.append(software_vuln_relationship)
 
-        bundle = self.helper.stix2_create_bundle(stix_objects)
-        self.helper.log_info("CISA Bundle Complete")
-        return bundle
+        return self.helper.stix2_create_bundle(stix_objects)
 
     def process_data(self):
+        work_id = None
         try:
             # Get the current timestamp and check
             timestamp = int(time.time())
-            current_state = self.helper.get_state()
-            last_update = None
-            if current_state is not None and "last_update" in current_state:
-                last_update = current_state["last_update"]
-                self.helper.log_info(f"CISA KEV last catalog update: {last_update}")
+            current_state = self.helper.get_state() or {}
+            # 'last_update' holds the 'dateReleased' of the last CISA KEV
+            # catalog version this connector successfully ingested. It is a
+            # connector state value, not the version currently served by CISA.
+            last_update = current_state.get("last_update")
+            if last_update is not None:
+                self.helper.log_info(
+                    "Last CISA KEV catalog version ingested by this connector "
+                    f"(from connector state): {last_update}"
+                )
             else:
-                self.helper.log_info("CISA KEV connector has never run")
+                self.helper.log_info(
+                    "No CISA KEV catalog version in the connector state, "
+                    "the connector has never ingested the catalog"
+                )
 
             now = datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
             friendly_name = "CISA run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
@@ -259,38 +288,109 @@ class Cisa:
                 work_id = self.helper.api.work.initiate_work(
                     self.helper.connect_id, friendly_name
                 )
-                cisa_data = self.retrieve_data(self.cisa_catalog_url)
-                cisa_data = json.loads(cisa_data)
-                if cisa_data.get("dateReleased") != last_update:
-                    self.set_created_by_stix(org=self.org)
-                    self.set_tlp_marking(tlp_mark=self.tlp)
-                    for vuln in cisa_data["vulnerabilities"]:
-                        bundle = self.build_bundle(vuln)
-                        self.send_bundle(work_id, bundle)
-                    # Store the current timestamp as a last run
-                    message = (
-                        "Connector successfully run, storing last_update as "
-                        + str(cisa_data.get("dateReleased"))
+                raw_catalog = self.retrieve_data(self.cisa_catalog_url)
+                if raw_catalog is None:
+                    raise ValueError(
+                        "Could not retrieve the CISA KEV catalog from "
+                        f"{self.cisa_catalog_url}"
                     )
-                    self.helper.log_info(message)
-                    self.helper.set_state(
-                        {"last_update": cisa_data.get("dateReleased")}
+                cisa_data = json.loads(raw_catalog)
+                date_released = cisa_data.get("dateReleased")
+                vulnerabilities = cisa_data["vulnerabilities"]
+                self.helper.log_info(
+                    "CISA KEV catalog version served by CISA "
+                    f"(dateReleased): {date_released}, "
+                    f"{len(vulnerabilities)} entries"
+                )
+
+                if date_released == last_update:
+                    self.helper.log_info(
+                        f"CISA KEV catalog version {date_released} has already "
+                        "been ingested, nothing to do"
                     )
-                    self.helper.api.work.to_processed(work_id, message)
-                else:
-                    # Store the current timestamp as a last run
                     message = "Connector successfully run, nothing to do"
-                    self.helper.log_info(message)
                     self.helper.api.work.to_processed(work_id, message)
+                    return
+
+                self.helper.log_info(
+                    f"New CISA KEV catalog version {date_released} "
+                    f"(previously ingested: {last_update}), starting ingestion"
+                )
+                self.set_created_by_stix(org=self.org)
+                self.set_tlp_marking(tlp_mark=self.tlp)
+
+                # 'last_update' is a catalog version: recording it means the
+                # whole catalog has been published. A failure to send stops
+                # the run right away, both because every following send would
+                # fail the same way (the platform or the queue is down) and
+                # because the state must not record a version that is only
+                # partially published.
+                total = len(vulnerabilities)
+                sent = 0
+                for vuln in vulnerabilities:
+                    cve_id = vuln.get("cveID", "unknown")
+                    bundle = self.build_bundle(vuln)
+                    # Logged before the send, and at info level, so that it
+                    # reads right above the "<connector> sending bundle to
+                    # queue" line pycti emits for every call — that line
+                    # carries no context, this one tells which entry it is.
+                    self.helper.log_info(
+                        f"Publishing CISA KEV entry {cve_id} ({sent + 1}/{total})"
+                    )
+                    if not self.send_bundle(work_id, bundle):
+                        message = (
+                            f"Publication interrupted after {sent} of {total} "
+                            f"entries, on {cve_id}: last_update is not stored, "
+                            "the catalog will be processed again on the next run"
+                        )
+                        self.helper.log_error(message)
+                        self.helper.api.work.to_processed(work_id, message, True)
+                        return
+                    sent += 1
+
+                # Store the catalog version only once it has been published
+                message = (
+                    f"Connector successfully run, {sent} entries sent, "
+                    f"storing last_update as {date_released}"
+                )
+                self.helper.log_info(message)
+                current_state["last_update"] = date_released
+                self.helper.set_state(current_state)
+                self.helper.force_ping()
+                self.helper.api.work.to_processed(work_id, message)
 
         except (KeyboardInterrupt, SystemExit):
             self.helper.log_info("Connector stop")
             sys.exit(0)
         except Exception as e:
             self.helper.log_error(str(e))
+            if work_id is not None:
+                self.helper.api.work.to_processed(work_id, str(e), True)
+
+    def log_configuration(self):
+        """Log the connector's own configuration once, at startup.
+
+        None of these values is a secret, and every support request on this
+        connector starts by asking for them.
+        """
+        schedule = (
+            f"duration_period={self.duration_period}"
+            if self.duration_period
+            else f"interval={self.cisa_interval} day(s) (deprecated)"
+        )
+        self.helper.log_info(
+            "Starting the CISA Known Exploited Vulnerabilities connector",
+            {
+                "catalog_url": self.cisa_catalog_url,
+                "create_infrastructures": self.cisa_create_infrastructures,
+                "kev_flag_only": self.cisa_kev_flag_only,
+                "tlp": self.tlp,
+                "schedule": schedule,
+            },
+        )
 
     def run(self):
-        self.helper.log_info("Fetching CISA Known Exploited Vulnerabilities...")
+        self.log_configuration()
         if self.duration_period:
             self.helper.schedule_iso(
                 message_callback=self.process_data, duration_period=self.duration_period
@@ -302,14 +402,21 @@ class Cisa:
                 time_unit=self.helper.TimeUnit.DAYS,
             )
 
-    def send_bundle(self, work_id: str, serialized_bundle: str) -> None:
+    def send_bundle(self, work_id: str, serialized_bundle: str) -> bool:
+        """Send a bundle to OpenCTI, returning whether it was accepted.
+
+        The caller relies on the returned value to decide whether the
+        connector state can be moved forward.
+        """
         try:
             self.helper.send_stix2_bundle(
                 serialized_bundle,
                 work_id=work_id,
             )
+            return True
         except Exception as e:
             self.helper.log_error(f"Error while sending bundle: {e}")
+            return False
 
 
 if __name__ == "__main__":

--- a/external-import/cisa-known-exploited-vulnerabilities/tests/test_process_data.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/tests/test_process_data.py
@@ -240,7 +240,12 @@ def test_retrieve_data_retries_then_gives_up():
     assert urlopen.call_count == Cisa.HTTP_ATTEMPTS
     # No sleep after the last attempt.
     assert sleep.call_count == Cisa.HTTP_ATTEMPTS - 1
-    assert conn.helper.log_warning.call_count == Cisa.HTTP_ATTEMPTS
+    # One line per attempt, each naming which attempt failed.
+    assert conn.helper.log_error.call_count == Cisa.HTTP_ATTEMPTS
+    attempts_logged = [
+        call.args[1]["attempt"] for call in conn.helper.log_error.call_args_list
+    ]
+    assert attempts_logged == ["1/3", "2/3", "3/3"]
 
 
 def test_retrieve_data_recovers_on_a_later_attempt():

--- a/external-import/cisa-known-exploited-vulnerabilities/tests/test_process_data.py
+++ b/external-import/cisa-known-exploited-vulnerabilities/tests/test_process_data.py
@@ -1,0 +1,267 @@
+"""Tests for `Cisa.process_data` — when the connector state may move forward.
+
+`last_update` holds the CISA catalog version (`dateReleased`), so it is an
+all-or-nothing cursor: recording it means "this catalog version has been
+published to OpenCTI". Entries are still published one bundle at a time,
+so these tests pin that a failed publication stops the run and leaves the
+state untouched, instead of being logged and forgotten.
+
+As in `test_bundle.py`, `Cisa.__init__` is bypassed (it connects to
+OpenCTI) and only the attributes `process_data` reads are stitched in.
+"""
+
+import json
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+from main import Cisa
+
+_MARKING = "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9"
+_WORK_ID = "work--cisa-test"
+_DATE_RELEASED = "2026-08-20"
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _make_connector(
+    catalog, state=None, send_ok=True, retrieve_none=False, fail_after=None
+) -> Cisa:
+    """Build a Cisa instance whose I/O is mocked.
+
+    ``send_ok=False`` makes every publication fail; ``fail_after=n`` lets the
+    first ``n`` publications succeed and fails the ones after that, the way an
+    outage happening mid-catalog would.
+    """
+    conn = object.__new__(Cisa)
+
+    conn.helper = MagicMock()
+    conn.helper.get_state.return_value = state
+    conn.helper.api.work.initiate_work.return_value = _WORK_ID
+    # The real helper returns a serialised bundle; keep the object list so
+    # tests can introspect what was actually sent.
+    conn.helper.stix2_create_bundle.side_effect = lambda objs: {"objects": objs}
+    if not send_ok:
+        conn.helper.send_stix2_bundle.side_effect = RuntimeError("RabbitMQ unreachable")
+    elif fail_after is not None:
+        sends = {"count": 0}
+
+        def _send(*args, **kwargs):
+            sends["count"] += 1
+            if sends["count"] > fail_after:
+                raise RuntimeError("RabbitMQ unreachable")
+
+        conn.helper.send_stix2_bundle.side_effect = _send
+
+    conn.cisa_catalog_url = (
+        "https://example.invalid/known_exploited_vulnerabilities.json"
+    )
+    conn.cisa_create_infrastructures = False
+    conn.cisa_kev_flag_only = False
+    conn.cisa_interval = 1
+    conn.tlp = "TLP:CLEAR"
+    conn.org = "Cybersecurity and Infrastructure Security Agency"
+    conn.created_by_stix = None
+
+    # set_tlp_marking would call the OpenCTI API; short-circuit it.
+    conn.tlp_marking = _MARKING
+    conn.set_tlp_marking = lambda tlp_mark=None: None
+
+    conn.retrieve_data = lambda url: None if retrieve_none else json.dumps(catalog)
+
+    return conn
+
+
+def _catalog(entries, date_released=_DATE_RELEASED):
+    return {"dateReleased": date_released, "vulnerabilities": entries}
+
+
+def _to_processed_call(conn):
+    conn.helper.api.work.to_processed.assert_called_once()
+    return conn.helper.api.work.to_processed.call_args.args
+
+
+# --------------------------------------------------------------------------
+# The state may only move forward after a successful publication
+# --------------------------------------------------------------------------
+
+
+def test_state_is_stored_after_a_successful_send(
+    sample_kev_entry, kev_entry_software_product
+):
+    conn = _make_connector(_catalog([sample_kev_entry, kev_entry_software_product]))
+
+    conn.process_data()
+
+    # One bundle per catalog entry, as before.
+    assert conn.helper.send_stix2_bundle.call_count == 2
+    conn.helper.set_state.assert_called_once_with({"last_update": _DATE_RELEASED})
+    conn.helper.force_ping.assert_called_once()
+    work_args = _to_processed_call(conn)
+    assert work_args[0] == _WORK_ID
+    # No in_error flag on the success path.
+    assert len(work_args) == 2
+
+
+def test_state_is_not_stored_when_a_send_fails(sample_kev_entry):
+    """The reported bug: the catalog version was recorded anyway."""
+    conn = _make_connector(_catalog([sample_kev_entry]), send_ok=False)
+
+    conn.process_data()
+
+    conn.helper.set_state.assert_not_called()
+    conn.helper.force_ping.assert_not_called()
+    work_args = _to_processed_call(conn)
+    assert work_args[0] == _WORK_ID
+    assert work_args[2] is True  # work reported in error
+
+
+def test_run_stops_on_the_first_failed_send(
+    sample_kev_entry, kev_entry_software_product
+):
+    """The remaining entries used to be converted and sent into the void."""
+    conn = _make_connector(
+        _catalog([sample_kev_entry, kev_entry_software_product]), send_ok=False
+    )
+
+    conn.process_data()
+
+    assert conn.helper.send_stix2_bundle.call_count == 1
+    conn.helper.set_state.assert_not_called()
+
+
+def test_failure_message_names_the_entry_and_the_progress(
+    sample_kev_entry, kev_entry_software_product
+):
+    conn = _make_connector(
+        _catalog([sample_kev_entry, kev_entry_software_product]), fail_after=1
+    )
+
+    conn.process_data()
+
+    assert conn.helper.send_stix2_bundle.call_count == 2
+    conn.helper.set_state.assert_not_called()
+    work_args = _to_processed_call(conn)
+    assert work_args[2] is True
+    assert "after 1 of 2 entries" in work_args[1]
+    assert kev_entry_software_product["cveID"] in work_args[1]
+
+
+def test_state_is_not_stored_when_the_catalog_cannot_be_retrieved(sample_kev_entry):
+    conn = _make_connector(_catalog([sample_kev_entry]), retrieve_none=True)
+
+    conn.process_data()
+
+    conn.helper.send_stix2_bundle.assert_not_called()
+    conn.helper.set_state.assert_not_called()
+    # The work is closed instead of being left dangling.
+    work_args = _to_processed_call(conn)
+    assert work_args[2] is True
+    assert "Could not retrieve the CISA KEV catalog" in work_args[1]
+
+
+def test_unchanged_catalog_version_sends_nothing(sample_kev_entry):
+    conn = _make_connector(
+        _catalog([sample_kev_entry]), state={"last_update": _DATE_RELEASED}
+    )
+
+    conn.process_data()
+
+    conn.helper.send_stix2_bundle.assert_not_called()
+    conn.helper.set_state.assert_not_called()
+    work_args = _to_processed_call(conn)
+    assert work_args[1] == "Connector successfully run, nothing to do"
+
+
+def test_other_state_keys_are_preserved(sample_kev_entry):
+    conn = _make_connector(_catalog([sample_kev_entry]), state={"unrelated": "keep-me"})
+
+    conn.process_data()
+
+    conn.helper.set_state.assert_called_once_with(
+        {"unrelated": "keep-me", "last_update": _DATE_RELEASED}
+    )
+
+
+# --------------------------------------------------------------------------
+# One bundle per entry, in both emission modes
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kev_flag_only", [False, True])
+def test_one_bundle_is_published_per_entry(
+    sample_kev_entry, kev_entry_software_product, kev_flag_only
+):
+    conn = _make_connector(_catalog([sample_kev_entry, kev_entry_software_product]))
+    conn.cisa_kev_flag_only = kev_flag_only
+
+    conn.process_data()
+
+    assert conn.helper.send_stix2_bundle.call_count == 2
+    conn.helper.set_state.assert_called_once_with({"last_update": _DATE_RELEASED})
+
+
+# --------------------------------------------------------------------------
+# Downloading the catalog
+# --------------------------------------------------------------------------
+
+
+def _retriever() -> Cisa:
+    conn = object.__new__(Cisa)
+    conn.helper = MagicMock()
+    return conn
+
+
+def test_retrieve_data_returns_the_payload():
+    conn = _retriever()
+    response = MagicMock()
+    response.read.return_value = b'{"dateReleased": "2026-08-20"}'
+
+    with patch("main.urllib.request.urlopen", return_value=response) as urlopen:
+        assert conn.retrieve_data("https://example.invalid/kev.json") == (
+            '{"dateReleased": "2026-08-20"}'
+        )
+
+    # A timeout is always passed: urlopen waits forever without one.
+    assert urlopen.call_args.kwargs["timeout"] == Cisa.HTTP_TIMEOUT
+
+
+def test_retrieve_data_retries_then_gives_up():
+    conn = _retriever()
+
+    with patch(
+        "main.urllib.request.urlopen", side_effect=urllib.error.URLError("boom")
+    ) as urlopen, patch("main.time.sleep") as sleep:
+        assert conn.retrieve_data("https://example.invalid/kev.json") is None
+
+    assert urlopen.call_count == Cisa.HTTP_ATTEMPTS
+    # No sleep after the last attempt.
+    assert sleep.call_count == Cisa.HTTP_ATTEMPTS - 1
+    assert conn.helper.log_warning.call_count == Cisa.HTTP_ATTEMPTS
+
+
+def test_retrieve_data_recovers_on_a_later_attempt():
+    conn = _retriever()
+    response = MagicMock()
+    response.read.return_value = b"{}"
+
+    with patch(
+        "main.urllib.request.urlopen",
+        side_effect=[urllib.error.URLError("boom"), response],
+    ) as urlopen, patch("main.time.sleep"):
+        assert conn.retrieve_data("https://example.invalid/kev.json") == "{}"
+
+    assert urlopen.call_count == 2
+
+
+def test_retrieve_data_handles_a_timeout():
+    """A socket timeout is not a URLError and used to escape the handler."""
+    conn = _retriever()
+
+    with patch(
+        "main.urllib.request.urlopen", side_effect=TimeoutError("timed out")
+    ), patch("main.time.sleep"):
+        assert conn.retrieve_data("https://example.invalid/kev.json") is None


### PR DESCRIPTION
### Proposed changes

* `send_bundle()` now returns whether the bundle was accepted, instead of logging the failure and swallowing it
* stop the run at the first failed publication, naming the entry and the progress reached, instead of carrying on and publishing into the void
* store `last_update` only after a fully successful publication — otherwise leave the state untouched and report the work in error, so the catalog is processed again on the next run
* call `force_ping()` after `set_state()`, so the checkpoint is persisted instead of waiting for the next 40 s ping
* bound and retry the catalog download: 60 s timeout, three attempts, `TimeoutError` handled — and raise an explicit error naming the URL instead of letting `json.loads(None)` fail with a `TypeError`
* close the work on every path, which removes the works left "in progress" whenever CISA was unreachable
* update the state document instead of replacing it; the `last_update` key itself is unchanged
* rework the logs: drop the two lines `build_bundle()` emitted per entry, name the CVE and the progress just before each send, log the connector's configuration at startup, and log the catalog version served by CISA next to the one held in the state (#5272)
* add `tests/test_process_data.py` — 13 tests, 10 of which fail on `master`; the connector's suite goes from 32 to 45

### Related issues

* closes #7354
* closes #5272

### Checklist

- [X] I consider the submitted work as finished
- [X] I have signed my commits using GPG key.
- [X] I tested the code for its functionality using different use cases
- [X] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality
