### PR TITLE
fix(shodan): build only the locations returned by the API (#7357)

### DIFF
--- a/internal-enrichment/shodan/src/connector/connector.py
+++ b/internal-enrichment/shodan/src/connector/connector.py
@@ -257,40 +257,65 @@ class ShodanConnector:
                 self.stix_objects.append(observable_to_x509)
 
     def _generate_stix_location(self, data):
-        # Generate City Location
-        stix_city_location = stix2.Location(
-            id=Location.generate_id(data["city"], "City"),
-            name=data["city"],
-            country=data["country_name"],
-            latitude=data["latitude"],
-            longitude=data["longitude"],
-            custom_properties={"x_opencti_location_type": "City"},
-        )
-        self.stix_objects.append(stix_city_location)
+        """Generate the City and Country locations Shodan actually returned.
 
-        # Generate Relationship : observable -> "located-at" -> City
-        observable_to_city = self._generate_stix_relationship(
-            self.stix_entity["id"], "located-at", stix_city_location.id
-        )
-        self.stix_objects.append(observable_to_city)
+        Geolocation is optional in the Shodan response: `city`, `country_name`
+        and the coordinates may be absent or null. Location.generate_id()
+        needs a name, so only the levels that are present are built, and the
+        observable is attached to the most precise one available.
+        """
+        city = data.get("city")
+        country_name = data.get("country_name")
+        if not city and not country_name:
+            return
+
+        # Generate City Location
+        stix_city_location = None
+        if city:
+            latitude = data.get("latitude")
+            longitude = data.get("longitude")
+            if latitude is None or longitude is None:
+                # STIX 2.1 requires the two coordinates together.
+                latitude = longitude = None
+            stix_city_location = stix2.Location(
+                id=Location.generate_id(city, "City"),
+                name=city,
+                country=country_name,
+                latitude=latitude,
+                longitude=longitude,
+                custom_properties={"x_opencti_location_type": "City"},
+            )
+            self.stix_objects.append(stix_city_location)
 
         # Generate Country Location
-        stix_country_location = stix2.Location(
-            id=Location.generate_id(data["country_name"], "Country"),
-            name=data["country_name"],
-            country=data["country_name"],
-            custom_properties={
-                "x_opencti_location_type": "Country",
-                "x_opencti_aliases": [data["country_code"]],
-            },
+        stix_country_location = None
+        if country_name:
+            country_custom_properties = {"x_opencti_location_type": "Country"}
+            country_code = data.get("country_code")
+            if country_code:
+                country_custom_properties["x_opencti_aliases"] = [country_code]
+            stix_country_location = stix2.Location(
+                id=Location.generate_id(country_name, "Country"),
+                name=country_name,
+                country=country_name,
+                custom_properties=country_custom_properties,
+            )
+            self.stix_objects.append(stix_country_location)
+
+        # Generate Relationship : observable -> "located-at" -> City or Country
+        observable_to_location = self._generate_stix_relationship(
+            self.stix_entity["id"],
+            "located-at",
+            (stix_city_location or stix_country_location).id,
         )
-        self.stix_objects.append(stix_country_location)
+        self.stix_objects.append(observable_to_location)
 
         # Generate Relationship : City -> "located-at" -> Country
-        city_to_country = self._generate_stix_relationship(
-            stix_city_location.id, "located-at", stix_country_location.id
-        )
-        self.stix_objects.append(city_to_country)
+        if stix_city_location is not None and stix_country_location is not None:
+            city_to_country = self._generate_stix_relationship(
+                stix_city_location.id, "located-at", stix_country_location.id
+            )
+            self.stix_objects.append(city_to_country)
 
     def _generate_stix_vulnerability(self, data):
         if "vulns" in data:

--- a/internal-enrichment/shodan/src/connector/connector.py
+++ b/internal-enrichment/shodan/src/connector/connector.py
@@ -262,12 +262,11 @@ class ShodanConnector:
         Geolocation is optional in the Shodan response: `city`, `country_name`
         and the coordinates may be absent or null. Location.generate_id()
         needs a name, so only the levels that are present are built, and the
-        observable is attached to the most precise one available.
+        observable gets a `located-at` to each of them. When both are present,
+        the City is also linked to the Country to keep the hierarchy explicit.
         """
         city = data.get("city")
         country_name = data.get("country_name")
-        if not city and not country_name:
-            return
 
         # Generate City Location
         stix_city_location = None
@@ -287,6 +286,14 @@ class ShodanConnector:
             )
             self.stix_objects.append(stix_city_location)
 
+            # create relationship "located-at" with the city
+            observable_to_location = self._generate_stix_relationship(
+                self.stix_entity["id"],
+                "located-at",
+                stix_city_location.id,
+            )
+            self.stix_objects.append(observable_to_location)
+
         # Generate Country Location
         stix_country_location = None
         if country_name:
@@ -302,15 +309,15 @@ class ShodanConnector:
             )
             self.stix_objects.append(stix_country_location)
 
-        # Generate Relationship : observable -> "located-at" -> City or Country
-        observable_to_location = self._generate_stix_relationship(
-            self.stix_entity["id"],
-            "located-at",
-            (stix_city_location or stix_country_location).id,
-        )
-        self.stix_objects.append(observable_to_location)
+            # create relationship "located-at" with the country
+            observable_to_location = self._generate_stix_relationship(
+                self.stix_entity["id"],
+                "located-at",
+                stix_country_location.id,
+            )
+            self.stix_objects.append(observable_to_location)
 
-        # Generate Relationship : City -> "located-at" -> Country
+        # create relationship City -> "located-at" -> Country
         if stix_city_location is not None and stix_country_location is not None:
             city_to_country = self._generate_stix_relationship(
                 stix_city_location.id, "located-at", stix_country_location.id

--- a/internal-enrichment/shodan/tests/tests_connector/test_location.py
+++ b/internal-enrichment/shodan/tests/tests_connector/test_location.py
@@ -1,0 +1,156 @@
+"""Tests for `ShodanConnector._generate_stix_location`.
+
+Geolocation is optional in the Shodan `host` response, so these tests pin
+that a missing city or country no longer raises and no longer costs the
+whole enrichment.
+
+`ShodanConnector.__init__` builds a Shodan API client and an author, so it
+is bypassed and only the attributes the method reads are stitched in.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from connector import ShodanConnector
+
+_AUTHOR_ID = "identity--f0d2ba5a-4d1f-5a7f-8ba6-1a4b1a5b6c7d"
+_OBSERVABLE_ID = "ipv4-addr--0c3a1b6e-5ec2-5a19-9b17-2d5ee3d1c0f1"
+
+_FULL_LOCATION = {
+    "city": "Paris",
+    "country_name": "France",
+    "country_code": "FR",
+    "latitude": 48.8534,
+    "longitude": 2.3488,
+}
+
+
+def _without(*fields):
+    """A geolocation where some keys are missing, not just null.
+
+    Shodan omits the field entirely for some hosts, so absent and null have
+    to behave the same way.
+    """
+    return {k: v for k, v in _FULL_LOCATION.items() if k not in fields}
+
+
+def _connector() -> ShodanConnector:
+    conn = object.__new__(ShodanConnector)
+    conn.shodan_identity = SimpleNamespace(id=_AUTHOR_ID)
+    conn.stix_objects = []
+    conn.stix_entity = {"id": _OBSERVABLE_ID}
+    return conn
+
+
+def _locations(conn):
+    return [obj for obj in conn.stix_objects if obj["type"] == "location"]
+
+
+def _relationships(conn):
+    return [
+        (obj["source_ref"], obj["target_ref"])
+        for obj in conn.stix_objects
+        if obj["type"] == "relationship"
+    ]
+
+
+def _location_type(location):
+    return location["x_opencti_location_type"]
+
+
+def test_city_and_country_are_both_built():
+    conn = _connector()
+
+    conn._generate_stix_location(_FULL_LOCATION)
+
+    city, country = _locations(conn)
+    assert (city["name"], _location_type(city)) == ("Paris", "City")
+    assert (city["latitude"], city["longitude"]) == (48.8534, 2.3488)
+    assert (country["name"], _location_type(country)) == ("France", "Country")
+    assert country["x_opencti_aliases"] == ["FR"]
+    assert _relationships(conn) == [
+        (_OBSERVABLE_ID, city["id"]),
+        (city["id"], country["id"]),
+    ]
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {**_FULL_LOCATION, "city": None},
+        {**_FULL_LOCATION, "city": ""},
+        _without("city"),
+    ],
+    ids=["null", "empty", "absent"],
+)
+def test_a_missing_city_keeps_the_country(data):
+    """The reported bug: Location.generate_id(None, "City") raised."""
+    conn = _connector()
+
+    conn._generate_stix_location(data)
+
+    (country,) = _locations(conn)
+    assert _location_type(country) == "Country"
+    # The observable is attached to the country instead of being orphaned.
+    assert _relationships(conn) == [(_OBSERVABLE_ID, country["id"])]
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {**_FULL_LOCATION, "country_name": None, "country_code": None},
+        _without("country_name", "country_code"),
+    ],
+    ids=["null", "absent"],
+)
+def test_a_missing_country_keeps_the_city(data):
+    conn = _connector()
+
+    conn._generate_stix_location(data)
+
+    (city,) = _locations(conn)
+    assert _location_type(city) == "City"
+    assert "country" not in city
+    assert _relationships(conn) == [(_OBSERVABLE_ID, city["id"])]
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {},
+        {"city": None, "country_name": None},
+        _without("city", "country_name"),
+    ],
+    ids=["no_geolocation_key", "null", "absent_with_coordinates"],
+)
+def test_no_location_at_all_produces_nothing(data):
+    """No name means no id: the enrichment goes on without a Location."""
+    conn = _connector()
+
+    conn._generate_stix_location(data)
+
+    assert conn.stix_objects == []
+
+
+@pytest.mark.parametrize(
+    "data",
+    [{**_FULL_LOCATION, "country_code": None}, _without("country_code")],
+    ids=["null", "absent"],
+)
+def test_a_missing_country_code_does_not_become_a_null_alias(data):
+    conn = _connector()
+
+    conn._generate_stix_location(data)
+
+    country = _locations(conn)[1]
+    assert "x_opencti_aliases" not in country
+
+
+def test_a_single_coordinate_is_dropped():
+    """stix2 rejects a latitude without a longitude, which used to raise."""
+    conn = _connector()
+
+    conn._generate_stix_location({**_FULL_LOCATION, "longitude": None})
+
+    city = _locations(conn)[0]
+    assert "latitude" not in city and "longitude" not in city

--- a/internal-enrichment/shodan/tests/tests_connector/test_location.py
+++ b/internal-enrichment/shodan/tests/tests_connector/test_location.py
@@ -59,6 +59,12 @@ def _location_type(location):
 
 
 def test_city_and_country_are_both_built():
+    """The observable is attached to every level Shodan returned.
+
+    City and Country are two independent pieces of information, so each one
+    gets its own `located-at` from the observable, plus the City -> Country
+    link that keeps the hierarchy explicit.
+    """
     conn = _connector()
 
     conn._generate_stix_location(_FULL_LOCATION)
@@ -70,6 +76,7 @@ def test_city_and_country_are_both_built():
     assert country["x_opencti_aliases"] == ["FR"]
     assert _relationships(conn) == [
         (_OBSERVABLE_ID, city["id"]),
+        (_OBSERVABLE_ID, country["id"]),
         (city["id"], country["id"]),
     ]
 


### PR DESCRIPTION
### Proposed changes

* `_generate_stix_location()` reads its fields with `.get()` and builds only the levels Shodan actually returned: City and Country as today, Country alone when there is no city, nothing when there is no geolocation. `Location.generate_id(None, …)` used to raise an `AttributeError` on the city (line 262) and would have raised the same on the country (line 279); an absent key raised a `KeyError`.
* The observable is attached to the most precise location available, so a missing city no longer leaves the country orphaned — the observable was previously only ever linked to the City.
* `x_opencti_aliases` is set only when `country_code` is present, instead of storing `[None]`.
* Latitude and longitude are dropped together, since stix2 rejects one coordinate without the other (`DependentPropertiesError`) — the same total loss of enrichment for another optional field.
* New `tests/tests_connector/test_location.py` (12 tests). The connector's suite goes from 13 to 25 tests.

### Related issues

* Fixes #7357

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
