### PR TITLE
fix(import-document): reinstate CONNECTOR_ONLY_CONTEXTUAL setting (#7219)

### DIFF
--- a/internal-import-file/import-document/README.md
+++ b/internal-import-file/import-document/README.md
@@ -113,6 +113,8 @@ The connector will parse the document, extract entities and observables, and imp
 
 The connector supports two processing modes:
 
+> **Note**: Setting `CONNECTOR_ONLY_CONTEXTUAL` to `true` is what triggers the **Internal Analysis** mode for this connector. While this option is generic at the pycti level (it only tells the platform whether the connector processes contextual data), for this connector it is specifically used to switch it into the "Internal Analysis" use case rather than the standard "File Import" mode.
+
 ```mermaid
 flowchart TD
     A[Incoming Request] --> B{Event Type?}

--- a/internal-import-file/import-document/README.md
+++ b/internal-import-file/import-document/README.md
@@ -11,9 +11,6 @@
   - [Installation](#installation)
     - [Requirements](#requirements)
   - [Configuration variables](#configuration-variables)
-    - [OpenCTI environment variables](#opencti-environment-variables)
-    - [Base connector environment variables](#base-connector-environment-variables)
-    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
   - [Deployment](#deployment)
     - [Docker Deployment](#docker-deployment)
     - [Manual Deployment](#manual-deployment)
@@ -52,38 +49,10 @@ The connector can operate in two modes:
 
 ## Configuration variables
 
-There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or in `config.yml` (for manual deployment).
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-### OpenCTI environment variables
-
-Below are the parameters you'll need to set for OpenCTI:
-
-| Parameter     | config.yml `opencti` | Docker environment variable | Default | Mandatory | Description                                          |
-|---------------|----------------------|-----------------------------|---------|-----------|------------------------------------------------------|
-| OpenCTI URL   | `url`                | `OPENCTI_URL`               | /       | Yes       | The URL of the OpenCTI platform.                     |
-| OpenCTI Token | `token`              | `OPENCTI_TOKEN`             | /       | Yes       | The default admin token set in the OpenCTI platform. |
-
-### Base connector environment variables
-
-Below are the parameters you'll need to set for running the connector properly:
-
-| Parameter                | config.yml `connector`   | Docker environment variable        | Default                                             | Mandatory | Description                                                                              |
-|--------------------------|--------------------------|------------------------------------|-----------------------------------------------------|-----------|------------------------------------------------------------------------------------------|
-| Connector ID             | `id`                     | `CONNECTOR_ID`                     | /                                                   | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
-| Connector Name           | `name`                   | `CONNECTOR_NAME`                   | ImportDocument                                      | No        | Name of the connector.                                                                   |
-| Connector Scope          | `scope`                  | `CONNECTOR_SCOPE`                  | application/pdf,text/plain,text/csv,text/html,text/markdown,application/vnd.openxmlformats-officedocument.wordprocessingml.document  | Yes       | Comma-separated list of supported MIME types.                                            |
-| Connector Auto           | `auto`                   | `CONNECTOR_AUTO`                   | false                                               | No        | Enable/disable automatic import of files matching the scope.                             |
-| Connector Only Contextual| `only_contextual`        | `CONNECTOR_ONLY_CONTEXTUAL`        | false                                               | No        | If `true`, only extract data when an entity context is provided.                         |
-| Validate Before Import   | `validate_before_import` | `CONNECTOR_VALIDATE_BEFORE_IMPORT` | false                                               | No        | If enabled, bundles are sent for validation before import.                               |
-| Log Level                | `log_level`              | `CONNECTOR_LOG_LEVEL`              | info                                                | No        | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
-
-### Connector extra parameters environment variables
-
-Below are the parameters you'll need to set for the Import Document connector:
-
-| Parameter        | config.yml `import_document` | Docker environment variable       | Default | Mandatory | Description                                                    |
-|------------------|------------------------------|-----------------------------------|---------|-----------|----------------------------------------------------------------|
-| Create Indicator | `create_indicator`           | `IMPORT_DOCUMENT_CREATE_INDICATOR`| false   | No        | If `true`, creates an Indicator for each extracted observable. |
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
 ## Deployment
 

--- a/internal-import-file/import-document/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-import-file/import-document/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -14,4 +14,5 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | CONNECTOR_TYPE | `const` |  | `INTERNAL_IMPORT_FILE` | `"INTERNAL_IMPORT_FILE"` |  |
 | CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |
 | CONNECTOR_VALIDATE_BEFORE_IMPORT | `boolean` |  | boolean | `true` | Validate any bundle before import. |
+| CONNECTOR_ONLY_CONTEXTUAL | `boolean` |  | boolean | `false` | If `true`, only extract data when an entity context is provided. |
 | IMPORT_DOCUMENT_CREATE_INDICATOR | `boolean` |  | boolean | `false` | If true, creates an Indicator for each extracted observable. |

--- a/internal-import-file/import-document/__metadata__/connector_config_schema.json
+++ b/internal-import-file/import-document/__metadata__/connector_config_schema.json
@@ -63,6 +63,11 @@
       "description": "Validate any bundle before import.",
       "type": "boolean"
     },
+    "CONNECTOR_ONLY_CONTEXTUAL": {
+      "default": false,
+      "description": "If `true`, only extract data when an entity context is provided.",
+      "type": "boolean"
+    },
     "IMPORT_DOCUMENT_CREATE_INDICATOR": {
       "default": false,
       "description": "If true, creates an Indicator for each extracted observable.",

--- a/internal-import-file/import-document/src/reportimporter/settings.py
+++ b/internal-import-file/import-document/src/reportimporter/settings.py
@@ -33,6 +33,10 @@ class InternalImportFileConnectorConfig(BaseInternalImportFileConnectorConfig):
         description="Validate any bundle before import.",
         default=True,
     )
+    only_contextual: bool = Field(
+        description="If `true`, only extract data when an entity context is provided.",
+        default=False,
+    )
 
 
 class ImportDocumentConfig(BaseConfigModel):


### PR DESCRIPTION
### Proposed changes

* Reinstate the `only_contextual` field in the `import-document` Pydantic settings model (`settings.py`), which was accidentally dropped during a prior manager-supported migration.
* Regenerate `connector_config_schema.json` to include the `CONNECTOR_ONLY_CONTEXTUAL` option.
* Regenerate `CONNECTOR_CONFIG_DOC.md` to document the `CONNECTOR_ONLY_CONTEXTUAL` option.
* Clean up `README.md` by removing the stale, duplicated configuration tables and replacing them with a link to the generated config doc, consistent with other already-migrated connectors.

### Related issues

* Closes #7219

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The `CONNECTOR_ONLY_CONTEXTUAL` option was still expected/documented elsewhere in the codebase even though it had been silently removed from the settings model, effectively making the setting non-functional. No behavior change is intended beyond restoring the previously existing option.