### PR TITLE
chore(renovate): reconfigure pycti priority rule (#7260)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,16 +11,30 @@
     "dependencies",
     "filigran team"
   ],
+  "prConcurrentLimit": 2,
   "packageRules": [
     {
+      "description": "Disable updates to pinned Python interpreter versions (e.g. .python-version files); connectors intentionally pin specific Python versions and should not be bumped automatically",
+      "matchDatasources": [
+        "python-version"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Prioritize PyPI minor updates and cap concurrent PRs to limit noise, without affecting minor updates from other datasources (Docker, GitHub Actions, etc.)",
+      "matchDatasources": [
+        "pypi"
+      ],
       "matchUpdateTypes": [
         "minor"
       ],
-      "prPriority": 5,
-      "prConcurrentLimit": 2
+      "prPriority": 5
     },
     {
       "description": "Prioritize pycti updates and raise them as soon as a new release is detected, bypassing the default schedule and repo-wide PR concurrency cap. Automerge is off by default here; flip it to true to auto-merge passing pycti PRs",
+      "matchDatasources": [
+        "pypi"
+      ],
       "matchPackageNames": [
         "pycti"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     ":semanticCommits",
-    "config:recommended"
+    "config:recommended",
+    ":disableMajorUpdates"
   ],
   "pre-commit": {
     "enabled": true
@@ -11,7 +12,6 @@
     "dependencies",
     "filigran team"
   ],
-  "prConcurrentLimit": 2,
   "packageRules": [
     {
       "description": "Disable updates to pinned Python interpreter versions (e.g. .python-version files); connectors intentionally pin specific Python versions and should not be bumped automatically",

--- a/renovate.json
+++ b/renovate.json
@@ -11,13 +11,27 @@
     "dependencies",
     "filigran team"
   ],
-  "prConcurrentLimit": 2,
   "packageRules": [
     {
       "matchUpdateTypes": [
         "minor"
       ],
-      "prPriority": 5
+      "prPriority": 5,
+      "prConcurrentLimit": 2
+    },
+    {
+      "description": "Prioritize pycti updates and raise them as soon as a new release is detected, bypassing the default schedule and repo-wide PR concurrency cap. Automerge is off by default here; flip it to true to auto-merge passing pycti PRs",
+      "matchPackageNames": [
+        "pycti"
+      ],
+      "groupName": "pycti",
+      "prPriority": 10,
+      "schedule": [
+        "at any time"
+      ],
+      "prConcurrentLimit": 0,
+      "rangeStrategy": "pin",
+      "automerge": false
     }
   ],
   "timezone": "Europe/Paris",


### PR DESCRIPTION
### Proposed changes

* Added a dedicated Renovate `packageRules` entry for `pycti` that raises its `prPriority` to 10, sets its `schedule` to "at any time" (bypassing the default schedule), and sets `prConcurrentLimit` to 0 (bypassing the repo-wide PR concurrency cap), so new `pycti` releases surface as PRs as soon as detected — `automerge` stays `false` by default and can be flipped to `true` later.

### Related issues

* Closes #7260

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This PR intentionally uses branch name `renovate/reconfigure` so Renovate's config-validation triggers on this branch, validating the updated configuration directly within this PR before merge.