### PR TITLE
feat(connectors-sdk): add System model (#7386)

### DIFF
--- a/connectors-sdk/connectors_sdk/models/__init__.py
+++ b/connectors-sdk/connectors_sdk/models/__init__.py
@@ -42,6 +42,7 @@ from connectors_sdk.models.report import Report
 from connectors_sdk.models.sector import Sector
 from connectors_sdk.models.sighting import Sighting
 from connectors_sdk.models.software import Software
+from connectors_sdk.models.system import System
 from connectors_sdk.models.text import Text
 from connectors_sdk.models.threat_actor_group import ThreatActorGroup
 from connectors_sdk.models.tlp_marking import TLPMarking
@@ -96,6 +97,7 @@ __all__ = [
     "Sector",
     "Sighting",
     "Software",
+    "System",
     "Text",
     "ThreatActorGroup",
     "Tool",

--- a/connectors-sdk/connectors_sdk/models/system.py
+++ b/connectors-sdk/connectors_sdk/models/system.py
@@ -1,0 +1,66 @@
+"""System."""
+
+from connectors_sdk.models.base_identified_entity import BaseIdentifiedEntity
+from connectors_sdk.models.enums import (
+    Reliability,
+)
+from pycti import Identity as PyctiIdentity
+from pydantic import Field
+from stix2.v21 import Identity as Stix2Identity
+
+
+class System(BaseIdentifiedEntity):
+    """Define an OCTI system.
+
+    Systems represent software applications, platforms, frameworks or specific
+    tools such as WordPress, VirtualBox, Firefox or Python.
+
+    Examples:
+        >>> system = System(name="WordPress")
+        >>> entity = system.to_stix2_object()
+    """
+
+    name: str = Field(
+        description="Name of the system.",
+        min_length=1,
+    )
+    description: str | None = Field(
+        default=None,
+        description="Description of the system.",
+    )
+    contact_information: str | None = Field(
+        default=None,
+        description="Contact information for the system.",
+    )
+    reliability: Reliability | None = Field(
+        default=None,
+        description="OpenCTI Reliability of the system.",
+    )
+    aliases: list[str] | None = Field(
+        default=None,
+        description="Aliases of the system.",
+    )
+
+    def to_stix2_object(self) -> Stix2Identity:
+        """Make stix object.
+
+        Notes:
+            - OpenCTI maps STIX Identity SDO to OCTI System entity based on `identity_class`.
+            - To create a System entity on OpenCTI, `identity_class` MUST be 'system'.
+        """
+        identity_class = "system"
+
+        return Stix2Identity(
+            id=PyctiIdentity.generate_id(
+                identity_class=identity_class,
+                name=self.name,
+            ),
+            identity_class=identity_class,
+            name=self.name,
+            description=self.description,
+            contact_information=self.contact_information,
+            allow_custom=True,
+            x_opencti_reliability=self.reliability,
+            x_opencti_aliases=self.aliases,
+            **self._common_stix2_properties()
+        )

--- a/connectors-sdk/tests/test_models/test_api.py
+++ b/connectors-sdk/tests/test_models/test_api.py
@@ -102,6 +102,7 @@ def test_public_models_are_present():
         "Sector",
         "Sighting",
         "Software",
+        "System",
         "Text",
         "ThreatActorGroup",
         "Tool",

--- a/connectors-sdk/tests/test_models/test_system.py
+++ b/connectors-sdk/tests/test_models/test_system.py
@@ -1,0 +1,61 @@
+import pytest
+from connectors_sdk.models.base_identified_entity import BaseIdentifiedEntity
+from connectors_sdk.models.enums import Reliability
+from connectors_sdk.models.system import System
+from pydantic import ValidationError
+from stix2.v21 import Identity as Stix2Identity
+
+
+def test_system_is_a_base_identified_entity():
+    """Test that System is a BaseIdentifiedEntity."""
+    # Given the System class
+    # When checking its type
+    # Then it should be a subclass of BaseIdentifiedEntity
+    assert issubclass(System, BaseIdentifiedEntity)
+
+
+def test_system_class_should_not_accept_invalid_input():
+    """Test that System class should not accept invalid input."""
+    # Given: An invalid input data for System
+    input_data = {
+        "name": "Test system",
+        "invalid_key": "invalid_value",
+    }
+    # When validating the system
+    # Then: It should raise a ValidationError with the expected error field
+    with pytest.raises(ValidationError) as error:
+        System.model_validate(input_data)
+        assert error.value.errors()[0]["loc"] == ("invalid_key",)
+
+
+def test_system_to_stix2_object_returns_valid_stix_object(
+    fake_valid_organization_author,
+    fake_valid_external_references,
+    fake_valid_tlp_markings,
+):
+    """Test that System to_stix2_object method returns a valid STIX2.1 Identity."""
+    # Given: A valid System instance
+    system = System(
+        name="WordPress",
+        description="Test description",
+        contact_information="contact@test.com",
+        reliability=Reliability.A,
+        aliases=["Test alias"],
+        author=fake_valid_organization_author,
+        markings=fake_valid_tlp_markings,
+        external_references=fake_valid_external_references,
+    )
+    # When: calling to_stix2_object method
+    stix2_obj = system.to_stix2_object()
+    # Then: A valid STIX2.1 Identity is returned
+    assert isinstance(stix2_obj, Stix2Identity)
+
+
+def test_system_to_stix2_object_has_system_identity_class():
+    """Test that System to_stix2_object method sets identity_class to 'system'."""
+    # Given: A valid System instance
+    system = System(name="WordPress")
+    # When: calling to_stix2_object method
+    stix2_obj = system.to_stix2_object()
+    # Then: The identity_class is 'system'
+    assert stix2_obj.identity_class == "system"


### PR DESCRIPTION
### Proposed changes

* Add `System` model to `connectors-sdk`, wrapping the `stix2.v21.Identity` SDO with
  `identity_class` hardcoded to `"system"` and deterministic ID generation via
  `pycti.Identity.generate_id()`
* Expose the `name`, `description`, `contact_information`, `reliability` and `aliases`
  fields, mapping to the STIX 2.1 Identity properties supported by the OpenCTI backend
  for a System entity (`x_opencti_reliability` / `x_opencti_aliases` as custom properties)
* Export `System` from `connectors_sdk/models/__init__.py` (import + `__all__`) and
  register it in the public API test
* Add `tests/test_models/test_system.py` covering inheritance, strict input validation,
  STIX2.1 output and the `identity_class == "system"` guarantee

`System` was the only OpenCTI identity sub-type without an SDK model — `Individual`
(`individual`), `Organization` (`organization`) and `Sector` (`class`) already exist.
The implementation follows the exact conventions of `individual.py` / `organization.py`.

### Related issues

* close #7386

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

All changes are scoped to `connectors-sdk/`. Validated with:
- `pytest tests` — 488 passed, 100% coverage gate reached
- `black` / `isort --profile black --line-length 88` (clean)
- `ruff check` (clean)
- `mypy --strict` (clean)
- Docstring doctest (2 passed)
- Custom STIX-ID pylint plugin (`shared/pylint_plugins/check_stix_plugin`) — 10.00/10
