### PR TITLE
fix(composer): allow null license_type and subscription_link in manifest schema (#7119)

### DIFF
--- a/external-import/spur/__metadata__/connector_manifest.json
+++ b/external-import/spur/__metadata__/connector_manifest.json
@@ -1,6 +1,5 @@
 {
   "title": "Spur",
-  "name": "Spur",
   "slug": "spur",
   "description": "Import Spur anonymous and residential proxy feed data into OpenCTI as STIX observables. Each IP is enriched with ASN, location, infrastructure type, risk labels, tunnel operators, and a computed threat score.",
   "short_description": "Bulk import of Spur anonymous and residential proxy feeds as IPv4/IPv6 STIX observables.",

--- a/shared/tools/composer/generate_manifest_fragment/connector_manifest_schema.json
+++ b/shared/tools/composer/generate_manifest_fragment/connector_manifest_schema.json
@@ -128,9 +128,9 @@
       ]
     },
     "license_type": {
-      "type": ["string"],
+      "type": ["string", "null"],
       "description": "Licensing model of the connector.",
-      "enum": ["Free", "Commercial", ""]
+      "enum": ["Free", "Commercial", null]
     },
     "contact": {
       "type": ["string"],
@@ -147,7 +147,7 @@
       "examples": ["2025-01-01"]
     },
     "subscription_link": {
-      "type": "string",
+      "type": ["string", "null"],
       "description": "URL to the external service or subscription page for the data source. Empty string if none.",
       "examples": ["https://www.misp-project.org", ""]
     },

--- a/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
+++ b/shared/tools/composer/generate_manifest_fragment/generate_manifest_fragment.py
@@ -346,11 +346,11 @@ def build_fragment(
         "logo": logo,
         "use_cases": manifest["use_cases"],
         "solution_categories": manifest["solution_categories"],
-        "license_type": manifest.get("license_type") or "",
+        "license_type": manifest.get("license_type") or None,
         "contact": manifest.get("contact") or "",
         "verified": manifest.get("verified", False),
         "last_verified_date": manifest.get("last_verified_date") or None,
-        "subscription_link": manifest.get("subscription_link") or "",
+        "subscription_link": manifest.get("subscription_link") or None,
         "source_code": manifest["source_code"],
         "manager_supported": manifest["manager_supported"],
         "min_version": parse_pycti_version(


### PR DESCRIPTION
### Proposed changes

* Allow `license_type` and `subscription_link` to be `null` in the manifest fragment JSON schema, replacing the previous empty-string convention for "no value".
* Update `generate_manifest_fragment.py` to emit `null` (instead of `""`) for `license_type` and `subscription_link` when the source manifest omits them.
* Anchor the `PYCTI_PIN_PATTERN` regex (`^...$` with `re.MULTILINE`) so it only matches a full pinned `pycti==X.Y.Z` line, preventing accidental partial/substring matches on lines with multiple dependency entries.
* Regenerate the Spur connector manifest fragment to drop the redundant `name` field, reflecting the updated generator output.

### Related issues

* Closes #7119

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

`license_type` and `subscription_link` previously used an empty string (`""`) as the "no value" sentinel, which is ambiguous with an actual empty value and doesn't map cleanly to JSON Schema's `null` type. Switching to `null` makes the "not set" case explicit and consistent with how other optional fields (e.g. `last_verified_date`) are already handled in the schema and generator.

The `PYCTI_PIN_PATTERN` regex was previously unanchored, so it could match a `pycti==X.Y.Z` pin anywhere within a line — including inside a `pyproject.toml` dependencies array with multiple quoted entries on one line, or as a partial substring of a longer token. Anchoring the pattern with `^`/`$` and `re.MULTILINE` ensures it only matches when the entire line is a pinned `pycti` requirement, avoiding false positives from adjacent entries on the same line.