### PR TITLE
fix(virustotal): handle empty last_serving_ip_address relationship (#7390)

### DIFF
--- a/internal-enrichment/virustotal/src/virustotal/processors/url.py
+++ b/internal-enrichment/virustotal/src/virustotal/processors/url.py
@@ -28,8 +28,11 @@ class URLProcessor(EntityProcessor):
         related = self.client.get_url_related_objects(
             url=url, relationship="last_serving_ip_address"
         )
+        # VirusTotal returns {"data": null, "meta": {"count": 0}} when the
+        # relationship holds no object, so the key is present and the `get`
+        # default never applies: normalise with `or` rather than a default.
         url_related_object_data = (
-            related.get("data", {}) if isinstance(related, dict) else {}
+            (related.get("data") or {}) if isinstance(related, dict) else {}
         )
         return super()._make_builder(
             json_data, url_related_object_data=url_related_object_data, **kwargs

--- a/internal-enrichment/virustotal/tests/tests_virustotal/test_builder.py
+++ b/internal-enrichment/virustotal/tests/tests_virustotal/test_builder.py
@@ -232,6 +232,57 @@ class VirusTotalBuilderTest(unittest.TestCase):
             "url--94a2e4e9-bb9a-544a-b379-44923d37ca82" in builder.bundle[3].object_refs
         )
 
+    def test_create_notes_with_attributes_and_empty_serving_ip(self):
+        """An empty last_serving_ip_address relationship must not break the note.
+
+        VirusTotal returns {"data": null} for an empty to-one relationship, so
+        the processor hands over an empty mapping — the note must still be
+        produced, with N/A for the missing value.
+        """
+        observable = {
+            "standard_id": "url--94a2e4e9-bb9a-544a-b379-44923d37ca82",
+            "id": "94a2e4e9-bb9a-544a-b379-44923d37ca82",
+            "entity_type": "Url",
+            "observable_value": "http://soclosebutyetqq.com/69.exe",
+        }
+        stix_entity = {"id": "url--94a2e4e9-bb9a-544a-b379-44923d37ca82"}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            stix_objects=[stix_entity],
+            stix_entity=stix_entity,
+            opencti_entity=observable,
+            data=self.load_file("vt_test_url.json")["data"],
+            include_attributes_in_note=True,
+            url_related_object_data={},
+        )
+        builder.create_notes()
+        self.assertIn("| Serving IP Address | N/A |", builder.bundle[2].content)
+
+    def test_create_notes_with_attributes_and_serving_ip(self):
+        """When the relationship is populated, the IP is rendered in the note."""
+        observable = {
+            "standard_id": "url--94a2e4e9-bb9a-544a-b379-44923d37ca82",
+            "id": "94a2e4e9-bb9a-544a-b379-44923d37ca82",
+            "entity_type": "Url",
+            "observable_value": "http://soclosebutyetqq.com/69.exe",
+        }
+        stix_entity = {"id": "url--94a2e4e9-bb9a-544a-b379-44923d37ca82"}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            stix_objects=[stix_entity],
+            stix_entity=stix_entity,
+            opencti_entity=observable,
+            data=self.load_file("vt_test_url.json")["data"],
+            include_attributes_in_note=True,
+            url_related_object_data={"id": "1.2.3.4", "type": "ip_address"},
+        )
+        builder.create_notes()
+        self.assertIn("| Serving IP Address | 1.2.3.4 |", builder.bundle[2].content)
+
     def test_create_yara(self):
         observable = {
             "standard_id": "file--3a30a5ed-003e-5ef9-9ede-10823a9fb17f",


### PR DESCRIPTION
### Proposed changes

* `processors/url.py`: normalise `related.get("data")` with `or {}` — VirusTotal
  returns the key `data` explicitly set to `null` for an empty to-one
  relationship, so the `{}` default of `dict.get()` never applied and `None`
  reached `builder.py:646`, aborting the whole enrichment.
* Regression tests: `tests_virustotal/test_processors_url.py` covers the four
  response shapes the client can return (empty relationship with the real
  payload, populated, API error, no response); two tests in `test_builder.py`
  check the note renders `N/A` when the relationship is empty and the IP when
  it is not.

### Related issues

* Closes #7390

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I have signed my commits using GPG key.
- [X] I tested the code for its functionality using different use cases
- [X] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
