### PR TITLE
fix(cpe): report API failures instead of swallowing them (#7392)

### DIFF
--- a/external-import/cpe/README.md
+++ b/external-import/cpe/README.md
@@ -2,7 +2,7 @@
 
 | Status | Date | Comment |
 |--------|------|---------|
-| Community | -    | -       |
+| Filigran Verified | -    | -       |
 
 The CPE (Common Platform Enumeration) connector imports software and product information from the NIST National Vulnerability Database (NVD) into OpenCTI as Software entities.
 

--- a/external-import/cpe/src/cpe/connector.py
+++ b/external-import/cpe/src/cpe/connector.py
@@ -15,6 +15,10 @@ from .settings import ConnectorSettings
 APP_VERSION = "1.0.0"
 
 
+class NistApiError(Exception):
+    """Raised when the NIST API answers with anything other than a success."""
+
+
 class CPEConnector:
     def __init__(self, config: ConnectorSettings, helper: OpenCTIConnectorHelper):
         """
@@ -25,17 +29,20 @@ class CPEConnector:
         self.base_url = self.config.cpe.base_url
         self.api_key = self.config.cpe.api_key.get_secret_value()
 
-    def _get_request_params(self, api_url) -> dict:
+    def _get(self, api_url, context: str) -> dict:
         """
-        Collects the request parameters from the NIST API
+        Performs a GET request against the NIST API and returns the decoded payload.
 
         Args:
-            api_url (str): The URL to use to collect the request parameters
+            api_url (str): The URL to call
+            context (str): What is being retrieved, used in the error message
 
         Returns:
-            dict: The request parameters
+            dict: The decoded JSON payload
+
+        Raises:
+            NistApiError: If the API does not answer with a 200
         """
-        self.helper.log_info("Retrieving the API request parameters...")
         session = requests.Session()
         headers = {
             "apiKey": self.api_key,
@@ -47,23 +54,38 @@ class CPEConnector:
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session.mount("https://", adapter)
         response = session.get(str(api_url), headers=headers)
-        parameters = {}
-        if response.status_code == 200:
-            resultsPerPage = response.json().get("resultsPerPage")
-            startIndex = response.json().get("startIndex")
-            totalResults = response.json().get("totalResults")
-            parameters = dict(
-                resultsPerPage=resultsPerPage,
-                startIndex=startIndex,
-                totalResults=totalResults,
+        if response.status_code != 200:
+            # On client errors the NIST API answers with an empty body and puts the
+            # reason in a response header named "message" (e.g. "Invalid apiKey.").
+            # See https://nvd.nist.gov/developers/start-here
+            raise NistApiError(
+                f"Error retrieving {context} from the NIST API: "
+                f"{response.status_code} - {response.headers.get('message', 'no message header')}"
             )
-            self.helper.log_info("API request parameters retrieved!")
-            return parameters
-        else:
-            self.helper.log_error(
-                f"Error retrieving the API request parameters from the NIST API: {response.status_code}"
-            )
-            return parameters
+        return response.json()
+
+    def _get_request_params(self, api_url) -> dict:
+        """
+        Collects the request parameters from the NIST API
+
+        Args:
+            api_url (str): The URL to use to collect the request parameters
+
+        Returns:
+            dict: The request parameters
+
+        Raises:
+            NistApiError: If the API does not answer with a 200
+        """
+        self.helper.log_debug("Retrieving the API request parameters...")
+        payload = self._get(api_url, "the API request parameters")
+        parameters = dict(
+            resultsPerPage=payload.get("resultsPerPage"),
+            startIndex=payload.get("startIndex"),
+            totalResults=payload.get("totalResults"),
+        )
+        self.helper.log_debug("API request parameters retrieved!")
+        return parameters
 
     def _get_cpe_list(self, api_url) -> list:
         """
@@ -74,29 +96,14 @@ class CPEConnector:
 
         Returns:
             list: The CPE list
+
+        Raises:
+            NistApiError: If the API does not answer with a 200
         """
         self.helper.log_debug(api_url)
-        session = requests.Session()
-        headers = {
-            "apiKey": self.api_key,
-            "User-Agent": f"OpenCTI-cpe-connector/{APP_VERSION}",
-        }
-        retry_strategy = Retry(
-            total=4, backoff_factor=6, status_forcelist=[429, 500, 502, 503, 504]
-        )
-        adapter = HTTPAdapter(max_retries=retry_strategy)
-        session.mount("https://", adapter)
-        response = session.get(api_url, headers=headers)
-        if response.status_code == 200:
-            self.helper.log_info(
-                str(response.json().get("resultsPerPage")) + " CPEs retrieved!"
-            )
-            return response.json()
-        else:
-            self.helper.log_error(
-                f"Error retrieving the CPE list from the NIST API: {response.status_code}"
-            )
-            return []
+        payload = self._get(api_url, "the CPE list")
+        self.helper.log_info(str(payload.get("resultsPerPage")) + " CPEs retrieved!")
+        return payload
 
     def _get_date_iso(self, timestamp: int) -> str:
         """
@@ -287,6 +294,53 @@ class CPEConnector:
             self.helper.send_stix2_bundle(bundle, update=False, work_id=work_id)
             time.sleep(6)
 
+    def _execute_import(self, import_method, interval: float) -> None:
+        """
+        Runs an import, then reports the work and advances the state only on success.
+
+        On failure the work is reported in error and `last_run` is left untouched, so
+        the next run retries the same period instead of silently skipping it.
+
+        Args:
+            import_method (Callable[[str], None]): The import to run, taking a work ID
+            interval (float): The connector interval in seconds, used for logging
+        """
+        now = datetime.fromtimestamp(self.current_run, tz=timezone.utc)
+        friendly_name = f"{self.helper.connect_name} run @ " + now.strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        work_id = self.helper.api.work.initiate_work(
+            self.helper.connect_id, friendly_name
+        )
+        try:
+            import_method(work_id)
+        except Exception as err:
+            message = f"{self.helper.connect_name} connector run failed: {err}"
+            self.helper.log_error(message, {"error": str(err)})
+            self.helper.api.work.to_processed(work_id, message, in_error=True)
+            return
+
+        message = (
+            f"{self.helper.connect_name} connector successfully run, storing last_run as "
+            + str(self.current_run)
+        )
+        self.helper.log_info(message)
+        self.helper.log_debug(
+            f"Grabbing current state and update it with last_run: {self.current_run}"
+        )
+        current_state = self.helper.get_state()
+        if current_state:
+            current_state["last_run"] = self.current_run
+        else:
+            current_state = {"last_run": self.current_run}
+        self.helper.set_state(current_state)
+        self.helper.api.work.to_processed(work_id, message)
+        self.helper.log_info(
+            "Last_run stored, next run in: "
+            + str(round(interval / 60 / 60, 2))
+            + " hours"
+        )
+
     def run(self) -> None:
         """
         Runs the CPE connector
@@ -322,72 +376,12 @@ class CPEConnector:
                     self.helper.log_info(
                         f"{self.helper.connect_name} will run and collect all the CPEs!"
                     )
-                    now = datetime.fromtimestamp(self.current_run, tz=timezone.utc)
-                    friendly_name = f"{self.helper.connect_name} run @ " + now.strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    )
-                    work_id = self.helper.api.work.initiate_work(
-                        self.helper.connect_id, friendly_name
-                    )
-                    try:
-                        self._import_all(work_id)
-                    except Exception as e:
-                        self.helper.log_debug(str(e))
-                    message = (
-                        f"{self.helper.connect_name} connector successfully run, storing last_run as "
-                        + str(self.current_run)
-                    )
-                    self.helper.log_info(message)
-                    self.helper.log_debug(
-                        f"Grabbing current state and update it with last_run: {self.current_run}"
-                    )
-                    current_state = self.helper.get_state()
-                    if current_state:
-                        current_state["last_run"] = self.current_run
-                    else:
-                        current_state = {"last_run": self.current_run}
-                    self.helper.set_state(current_state)
-                    self.helper.api.work.to_processed(work_id, message)
-                    self.helper.log_info(
-                        "Last_run stored, next run in: "
-                        + str(round(interval / 60 / 60, 2))
-                        + " hours"
-                    )
+                    self._execute_import(self._import_all, interval)
                 elif self.current_run - last_run >= interval:
                     self.helper.log_info(
                         f"{self.helper.connect_name} will run and collect the CPEs based on a time difference!"
                     )
-                    now = datetime.fromtimestamp(self.current_run, tz=timezone.utc)
-                    friendly_name = f"{self.helper.connect_name} run @ " + now.strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    )
-                    work_id = self.helper.api.work.initiate_work(
-                        self.helper.connect_id, friendly_name
-                    )
-                    try:
-                        self._import_date(work_id)
-                    except Exception as e:
-                        self.helper.log_debug(str(e))
-                    message = (
-                        f"{self.helper.connect_name} connector successfully run, storing last_run as "
-                        + str(self.current_run)
-                    )
-                    self.helper.log_info(message)
-                    self.helper.log_debug(
-                        f"Grabbing current state and update it with last_run: {self.current_run}"
-                    )
-                    current_state = self.helper.get_state()
-                    if current_state:
-                        current_state["last_run"] = self.current_run
-                    else:
-                        current_state = {"last_run": self.current_run}
-                    self.helper.set_state(current_state)
-                    self.helper.api.work.to_processed(work_id, message)
-                    self.helper.log_info(
-                        "Last_run stored, next run in: "
-                        + str(round(interval / 60 / 60, 2))
-                        + " hours"
-                    )
+                    self._execute_import(self._import_date, interval)
                 else:
                     new_interval = interval - (self.current_run - last_run)
                     self.helper.log_info(

--- a/external-import/cpe/tests/tests_connector/test_error_handling.py
+++ b/external-import/cpe/tests/tests_connector/test_error_handling.py
@@ -1,0 +1,131 @@
+"""Error handling of the CPE connector: NIST API failures must not be silenced."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from cpe.connector import CPEConnector, NistApiError
+
+
+def _connector() -> CPEConnector:
+    """Build a CPEConnector with every external dependency mocked."""
+    config = MagicMock()
+    config.cpe.base_url = "https://services.nvd.nist.gov/rest/json/cpes/2.0"
+    config.cpe.api_key.get_secret_value.return_value = "invalid-key"
+    config.connector.duration_period.total_seconds.return_value = 3600
+
+    helper = MagicMock()
+    helper.connect_name = "Common Platform Enumeration"
+    helper.connect_id = "connector-id"
+
+    connector = CPEConnector(config=config, helper=helper)
+    connector.current_run = 1787638904
+    return connector
+
+
+def _response(status_code: int, headers: dict | None = None, payload=None) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = headers or {}
+    response.json.return_value = payload
+    return response
+
+
+@pytest.fixture
+def mock_session(monkeypatch):
+    """Patch requests.Session so no HTTP call is made."""
+    session = MagicMock()
+    monkeypatch.setattr("cpe.connector.requests.Session", lambda: session)
+    return session
+
+
+class TestNistApiErrors:
+    """A non-200 answer must raise, carrying the NIST `message` header."""
+
+    def test_request_params_raises_with_message_header(self, mock_session):
+        """NIST answers 404 with an empty body and the reason in a header."""
+        mock_session.get.return_value = _response(
+            404, headers={"message": "Invalid apiKey."}
+        )
+        connector = _connector()
+
+        with pytest.raises(NistApiError) as err:
+            connector._get_request_params(connector.base_url)
+
+        assert "404" in str(err.value)
+        assert "Invalid apiKey." in str(err.value)
+
+    def test_cpe_list_raises_with_message_header(self, mock_session):
+        mock_session.get.return_value = _response(
+            403, headers={"message": "Rate limit exceeded."}
+        )
+        connector = _connector()
+
+        with pytest.raises(NistApiError) as err:
+            connector._get_cpe_list(connector.base_url)
+
+        assert "403" in str(err.value)
+        assert "Rate limit exceeded." in str(err.value)
+
+    def test_error_is_explicit_when_no_message_header(self, mock_session):
+        """The header is not guaranteed: the status code must still be reported."""
+        mock_session.get.return_value = _response(500)
+        connector = _connector()
+
+        with pytest.raises(NistApiError) as err:
+            connector._get_request_params(connector.base_url)
+
+        assert "500" in str(err.value)
+
+    def test_request_params_returned_on_success(self, mock_session):
+        mock_session.get.return_value = _response(
+            200,
+            payload={"resultsPerPage": 10, "startIndex": 0, "totalResults": 1234},
+        )
+        connector = _connector()
+
+        assert connector._get_request_params(connector.base_url) == {
+            "resultsPerPage": 10,
+            "startIndex": 0,
+            "totalResults": 1234,
+        }
+
+
+class TestExecuteImport:
+    """A failed import must be reported as such, and must not advance the state."""
+
+    def test_failure_reports_work_in_error_and_keeps_state(self):
+        connector = _connector()
+        failing_import = MagicMock(side_effect=NistApiError("boom"))
+
+        connector._execute_import(failing_import, interval=3600)
+
+        # The work is reported in error...
+        connector.helper.api.work.to_processed.assert_called_once()
+        assert connector.helper.api.work.to_processed.call_args.kwargs.get(
+            "in_error"
+        ) or connector.helper.api.work.to_processed.call_args.args[2:] == (True,)
+        # ...the failure is logged at ERROR level...
+        connector.helper.log_error.assert_called_once()
+        # ...and last_run is left untouched so the next run retries.
+        connector.helper.set_state.assert_not_called()
+
+    def test_failure_is_not_reported_as_success(self):
+        connector = _connector()
+        connector._execute_import(MagicMock(side_effect=NistApiError("boom")), 3600)
+
+        logged = [str(call) for call in connector.helper.log_info.call_args_list]
+        assert not any("successfully run" in line for line in logged)
+
+    def test_success_advances_state_and_reports_work(self):
+        connector = _connector()
+        connector.helper.get_state.return_value = {"last_run": 1}
+
+        connector._execute_import(MagicMock(), 3600)
+
+        connector.helper.set_state.assert_called_once_with(
+            {"last_run": connector.current_run}
+        )
+        assert connector.helper.api.work.to_processed.call_args.kwargs.get(
+            "in_error", False
+        ) in (False, None)
+        connector.helper.log_error.assert_not_called()


### PR DESCRIPTION
### Proposed changes
 
* `_get()`: new shared helper for the NIST calls. Raises `NistApiError` on any
  non-200, including `response.headers["message"]` — NVD answers client errors
  with an empty body and puts the reason there (`Invalid apiKey.`), so the
  connector could only report a bare status code.
* `_get_request_params()` / `_get_cpe_list()`: raise instead of returning `{}` / `[]`,
  which made the caller hit `KeyError: 'totalResults'`.
* `_execute_import()`: extracts the post-import bookkeeping duplicated in both
  branches of `run()`. On failure it logs at ERROR with the traceback, marks the
  work `in_error=True` and returns before the success block — so `last_run` is not
  advanced and the next run retries instead of silently skipping the period.
* 7 regression tests on the API error paths and the state handling.
```
before:  ERROR  Error retrieving the API request parameters from the NIST API: 404
         DEBUG  'totalResults'
         INFO   ... connector successfully run, storing last_run as 1787638904
 
after:   ERROR  ... connector run failed: Error retrieving the API request parameters
                from the NIST API: 404 - Invalid apiKey.
```
 
### Related issues
 
* Closes #7392

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
