### PR TITLE
feat(censys-enrichment): split enrichment connector and add NVD CVE enrichment (#7401)

### DIFF
--- a/internal-enrichment/censys-enrichment/Dockerfile
+++ b/internal-enrichment/censys-enrichment/Dockerfile
@@ -1,24 +1,17 @@
-FROM python:3.12-alpine AS base
+FROM python:3.12-alpine
+
 ENV CONNECTOR_TYPE=INTERNAL_ENRICHMENT
 
+# hadolint ignore=DL3003
 RUN apk update && apk upgrade && \
-    apk add --no-cache  \
-      build-base  \
-      git  \
-      libffi-dev  \
-      libmagic  \
-      libxml2-dev  \
-      libxslt-dev
+    apk --no-cache add git build-base libmagic libffi-dev
 
-FROM base AS dependencies
+COPY src/censys_enrichment /opt/opencti-connector-censys-enrichment/src/censys_enrichment
+COPY pyproject.toml /opt/opencti-connector-censys-enrichment/pyproject.toml
+WORKDIR /opt/opencti-connector-censys-enrichment
 
-COPY requirements.txt /tmp/requirements.txt
-RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && \
-    rm /tmp/requirements.txt
+# git is required to resolve the connectors-sdk VCS dependency declared in pyproject.toml
+RUN pip3 install --no-cache-dir . && \
+    apk del git build-base
 
-FROM dependencies AS connector
-# Copy the connector
-COPY src /opt/connector
-WORKDIR /opt/connector
-
-CMD ["python3", "main.py"]
+CMD ["censys-enrichment-connector"]

--- a/internal-enrichment/censys-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/censys-enrichment/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -7,11 +7,11 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | Property | Type | Required | Possible values | Default | Description |
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
-| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
+| OPENCTI_TOKEN | `string` | ✅ | string |  | The API token to connect to OpenCTI. |
 | CENSYS_ENRICHMENT_ORGANISATION_ID | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Censys organisation ID. |
 | CENSYS_ENRICHMENT_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Censys API token. |
 | CONNECTOR_NAME | `string` |  | string | `"Censys Enrichment"` | The name of the connector. |
-| CONNECTOR_SCOPE | `array` |  | string | `["IPv4-Addr", "IPv6-Addr", "X509-Certificate", "Domain-Name"]` | The scope of the connector. Must be a subset of: ['Domain-Name', 'IPv4-Addr', 'IPv6-Addr', 'X509-Certificate']. |
+| CONNECTOR_SCOPE | `array` |  | string | `["IPv4-Addr", "IPv6-Addr", "X509-Certificate", "Domain-Name"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `INTERNAL_ENRICHMENT` | `"INTERNAL_ENRICHMENT"` |  |
 | CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |

--- a/internal-enrichment/censys-enrichment/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/censys-enrichment/__metadata__/connector_config_schema.json
@@ -12,9 +12,7 @@
     },
     "OPENCTI_TOKEN": {
       "description": "The API token to connect to OpenCTI.",
-      "format": "password",
-      "type": "string",
-      "writeOnly": true
+      "type": "string"
     },
     "CONNECTOR_NAME": {
       "default": "Censys Enrichment",
@@ -28,7 +26,7 @@
         "X509-Certificate",
         "Domain-Name"
       ],
-      "description": "The scope of the connector. Must be a subset of: ['Domain-Name', 'IPv4-Addr', 'IPv6-Addr', 'X509-Certificate'].",
+      "description": "The scope of the connector.",
       "items": {
         "type": "string"
       },

--- a/internal-enrichment/censys-enrichment/__metadata__/connector_manifest.json
+++ b/internal-enrichment/censys-enrichment/__metadata__/connector_manifest.json
@@ -2,17 +2,11 @@
   "title": "Censys Enrichment",
   "slug": "censys-enrichment",
   "description": "The Censys Enrichment connector allows OpenCTI to enrich observables (such as domains, IP addresses, and certificates) using data from the Censys search and intelligence platform. It retrieves detailed information on hosts, certificates, services, and organizations to enhance context and visibility within investigations.",
-  "short_description": "Enriches domains, IP addresses, and certificates in OpenCTI with Censys data, including host services, open ports, and certificate details for infrastructure visibility.",
-  "logo": "internal-enrichment/censys-enrichment/__metadata__/logo.png",
+  "short_description": "The Censys Enrichment connector allows OpenCTI to enrich observables (such as domains, IP addresses, and certificates) using data from the Censys search and intelligence platform. It retrieves detailed information on hosts, certificates, services, and organizations to enhance context and visibility within investigations.",
+  "logo": "internal-enrichment/censys/__metadata__/logo.png",
   "use_cases": [
-    "Infrastructure & Attack Surface Visibility",
-    "Detection & Response Enablement"
+    "Enrichment & Analysis"
   ],
-  "solution_categories": [
-    "Enrichment & Reputation"
-  ],
-  "license_type": "Commercial",
-  "contact": null,
   "verified": true,
   "last_verified_date": "2025-11-04",
   "playbook_supported": true,

--- a/internal-enrichment/censys-enrichment/docker-compose.yml
+++ b/internal-enrichment/censys-enrichment/docker-compose.yml
@@ -7,13 +7,15 @@ services:
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe
       # Common connector configuration
-      - CONNECTOR_ID=ChangeMe
-      - CONNECTOR_NAME=Censys Enrichment
-      - CONNECTOR_SCOPE=IPv4-Addr,IPv6-Addr,X509-Certificate,Domain-Name
-      - CONNECTOR_LOG_LEVEL=error
-      - CONNECTOR_AUTO=false
+      - CONNECTOR_ID=ChangeMe                                              # Unique UUID v4 identifying this connector instance in OpenCTI
+      - CONNECTOR_NAME=Censys Enrichment                                   # Display name shown in the OpenCTI connectors list
+      - CONNECTOR_SCOPE=IPv4-Addr,IPv6-Addr,X509-Certificate,Domain-Name  # Observable types this connector will enrich
+      - CONNECTOR_LOG_LEVEL=error                                          # Minimum log level: debug | info | warn | error
+      - CONNECTOR_AUTO=false                                               # Set to true to enrich automatically on observable creation
       # Censys configuration
-      - CENSYS_ENRICHMENT_ORGANISATION_ID=ChangeMe
-      - CENSYS_ENRICHMENT_TOKEN=ChangeMe
-      # - CENSYS_ENRICHMENT_MAX_TLP=TLP:AMBER # Optional
+      - CENSYS_ENRICHMENT_ORGANISATION_ID=ChangeMe  # Censys organisation ID (required)
+      - CENSYS_ENRICHMENT_TOKEN=ChangeMe            # Censys API token (required)
+      # - CENSYS_ENRICHMENT_MAX_TLP=TLP:AMBER       # Optional – highest TLP level that will be enriched (default: TLP:AMBER)
+      # - CENSYS_ENRICHMENT_NVD_ENABLED=true        # Optional – set to false to disable NVD CVE enrichment (e.g. if another connector already handles it)
+      # - CENSYS_ENRICHMENT_NVD_API_KEY=            # Optional – NVD API key; raises rate limit from 5 to 50 requests/30s (https://nvd.nist.gov/developers/request-an-api-key)
     restart: always

--- a/internal-enrichment/censys-enrichment/pyproject.toml
+++ b/internal-enrichment/censys-enrichment/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "CensysEnrichmentConnector"
+description = "Internal Enrichment connector for Censys."
+dynamic = ["version"]
+requires-python = ">=3.11"
+
+dependencies = [
+    "pycti==7.260811.0",
+    "censys-platform~=0.14.0",
+    "pydantic~=2.12.0",
+    "pydantic-settings~=2.11.0",
+    "connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk",
+]
+
+[project.scripts]
+censys-enrichment-connector = "censys_enrichment.__main__:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.2",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["./tests"]
+pythonpath = ["src"]

--- a/internal-enrichment/censys-enrichment/src/censys_enrichment/__main__.py
+++ b/internal-enrichment/censys-enrichment/src/censys_enrichment/__main__.py
@@ -1,0 +1,39 @@
+"""Main entry point for the Censys Enrichment connector."""
+
+import sys
+import traceback
+
+
+def main() -> None:
+    try:
+        from censys_enrichment.client import Client
+        from censys_enrichment.connector import Connector
+        from censys_enrichment.converter import Converter
+        from censys_enrichment.settings import ConfigLoader
+        from pycti import OpenCTIConnectorHelper
+
+        config = ConfigLoader()
+        helper = OpenCTIConnectorHelper(
+            config=config.to_helper_config(),
+            playbook_compatible=True,
+        )
+        client = Client(
+            organisation_id=config.censys_enrichment.organisation_id.get_secret_value(),
+            token=config.censys_enrichment.token.get_secret_value(),
+            nvd_api_key=(
+                config.censys_enrichment.nvd_api_key.get_secret_value()
+                if config.censys_enrichment.nvd_api_key
+                else None
+            ),
+        )
+        converter = Converter()
+        connector = Connector(
+            config=config,
+            helper=helper,
+            client=client,
+            converter=converter,
+        )
+        connector.run()
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)

--- a/internal-enrichment/censys-enrichment/src/censys_enrichment/client.py
+++ b/internal-enrichment/censys-enrichment/src/censys_enrichment/client.py
@@ -1,6 +1,9 @@
-from typing import Dict, Generator
+import time
+from dataclasses import dataclass, field
+from typing import Generator
+from urllib.parse import urlparse
 
-from censys_enrichment.errors import EntityHasNoUsableHashError
+import requests
 from censys_platform import (
     SDK,
     Certificate,
@@ -9,11 +12,60 @@ from censys_platform import (
     V3GlobaldataSearchQueryResponse,
 )
 
+_NVD_CVE_API = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+
+
+@dataclass
+class NVDReference:
+    """A single reference entry from the NVD CVE API."""
+
+    url: str
+    source_name: str
+
+
+@dataclass
+class NVDAffectedSoftware:
+    """Affected software entry parsed from NVD CPE 2.3 configurations.
+
+    Populated for application-type (``cpe:2.3:a:``) CPE match entries where
+    ``vulnerable`` is ``True``.  At most 10 unique vendor+product pairs are
+    stored per CVE to avoid flooding OpenCTI with low-signal entries.
+    """
+
+    vendor: str
+    product: str
+    cpe: str
+    version_info: str | None = None  # exact version or human-readable range
+
+
+@dataclass
+class NVDData:
+    """Enrichment data for a single CVE fetched from the NVD CVE 2.0 API."""
+
+    description: str | None = None
+    # NVD-provided severity label (uppercase: CRITICAL / HIGH / MEDIUM / LOW)
+    cvss_v3_base_severity: str | None = None
+    cvss_v2_base_score: float | None = None
+    cvss_v2_vector_string: str | None = None
+    cvss_v2_access_vector: str | None = None
+    cvss_v2_access_complexity: str | None = None
+    cvss_v2_authentication: str | None = None
+    cvss_v2_confidentiality_impact: str | None = None
+    cvss_v2_integrity_impact: str | None = None
+    cvss_v2_availability_impact: str | None = None
+    references: list[NVDReference] = field(default_factory=list)
+    affected_software: list[NVDAffectedSoftware] = field(default_factory=list)
+
+
+class EntityHasNoUsableHashError(Exception):
+    """Custom exception for entity having no usable hash"""
+
 
 class Client:
-    def __init__(self, organisation_id: str, token: str):
+    def __init__(self, organisation_id: str, token: str, nvd_api_key: str | None = None):
         self.organisation_id = organisation_id
         self.token = token
+        self._nvd_api_key = nvd_api_key
 
     def fetch_ip(self, ip: str) -> Host:
         """Fetch host data for a given IP address from Censys.
@@ -33,11 +85,11 @@ class Client:
                 return host_asset.resource
             raise ValueError(f"No data found for IP {ip}")
 
-    def fetch_certs(self, hashes: Dict[str, str]) -> Generator[Certificate, None, None]:
+    def fetch_certs(self, hashes: dict[str, str]) -> Generator[Certificate, None, None]:
         """Fetch certificates by their hashes
 
         Args:
-            hashes (Dict[str, str]): A dictionary containing one or more of the following keys
+            hashes (dict[str, str]): A dictionary containing one or more of the following keys
                 with their corresponding hash values:
                     - "MD5"
                     - "SHA-1"
@@ -68,7 +120,7 @@ class Client:
                 search_query_input_body=search_query
             )
             if res.result.result:
-                for hit in res.result.result.hits:
+                for hit in res.result.result.hits if isinstance(res.result.result.hits, list) else []:
                     if hit.certificate_v1:
                         yield hit.certificate_v1.resource
 
@@ -89,7 +141,7 @@ class Client:
                 search_query_input_body=search_query
             )
             if res.result.result:
-                for hit in res.result.result.hits:
+                for hit in res.result.result.hits if isinstance(res.result.result.hits, list) else []:
                     if hit.host_v1:
                         yield hit.host_v1.resource
 
@@ -112,6 +164,151 @@ class Client:
                 search_query_input_body=search_query
             )
             if res.result.result:
-                for hit in res.result.result.hits:
+                for hit in res.result.result.hits if isinstance(res.result.result.hits, list) else []:
                     if hit.certificate_v1:
                         yield hit.certificate_v1.resource
+
+    def fetch_nvd_data(self, cve_id: str) -> NVDData | None:
+        """Fetch enrichment data for a single CVE from the NVD CVE 2.0 API.
+        Args:
+            cve_id (str): A CVE identifier such as ``"CVE-2021-44228"``.
+        Returns:
+            NVDData | None: An NVDData instance populated with description, CVSS
+            v2/v3 severity, and external references, or ``None`` if the CVE is
+            not found, the API is unavailable, or the response contains no
+            useful data.
+        """
+        try:
+            headers = {"apiKey": self._nvd_api_key} if self._nvd_api_key else {}
+            response = None
+            for attempt in range(2):
+                response = requests.get(
+                    _NVD_CVE_API,
+                    params={"cveId": cve_id},
+                    headers=headers,
+                    timeout=10,
+                )
+                if response.status_code == 403 and attempt == 0:
+                    # NVD returns 403 when the rate limit is exhausted.
+                    # Wait for the 30-second rolling window to reset and retry once.
+                    time.sleep(30)
+                    continue
+                response.raise_for_status()
+                break
+            if response is None:
+                return None
+            data = response.json()
+            vulns = data.get("vulnerabilities", [])
+            if not vulns:
+                return None
+            cve = vulns[0].get("cve", {})
+            result = NVDData()
+
+            # English description
+            for desc in cve.get("descriptions", []):
+                if desc.get("lang") == "en":
+                    result.description = desc.get("value") or None
+                    break
+
+            # CVSS severity — prefer v3.1 over v3.0
+            metrics = cve.get("metrics", {})
+            for metric_key in ("cvssMetricV31", "cvssMetricV30"):
+                for entry in metrics.get(metric_key, []):
+                    severity = entry.get("cvssData", {}).get("baseSeverity")
+                    if severity:
+                        result.cvss_v3_base_severity = severity.upper()
+                        break
+                if result.cvss_v3_base_severity:
+                    break
+
+            # CVSS v2 — take the first (primary) entry only
+            for entry in metrics.get("cvssMetricV2", []):
+                d = entry.get("cvssData", {})
+                result.cvss_v2_base_score = d.get("baseScore")
+                result.cvss_v2_vector_string = d.get("vectorString")
+                result.cvss_v2_access_vector = d.get("accessVector")
+                result.cvss_v2_access_complexity = d.get("accessComplexity")
+                result.cvss_v2_authentication = d.get("authentication")
+                result.cvss_v2_confidentiality_impact = d.get("confidentialityImpact")
+                result.cvss_v2_integrity_impact = d.get("integrityImpact")
+                result.cvss_v2_availability_impact = d.get("availabilityImpact")
+                break
+
+            # External references (capped at 20 to avoid flooding OpenCTI)
+            for ref in cve.get("references", [])[:20]:
+                url = ref.get("url", "")
+                if not url:
+                    continue
+                tags = ref.get("tags", [])
+                if tags:
+                    source_name = ", ".join(tags[:3])
+                else:
+                    parsed = urlparse(url)
+                    source_name = parsed.netloc or ref.get("source") or "NVD Reference"
+                result.references.append(NVDReference(url=url, source_name=source_name))
+
+            # Affected software from CPE 2.3 configurations.
+            # Only application-type entries (cpe:2.3:a:...) where vulnerable=True
+            # are included, deduplicated by vendor+product, capped at 10.
+            seen_sw: dict[tuple[str, str], NVDAffectedSoftware] = {}
+            for config in cve.get("configurations", []):
+                for node in config.get("nodes", []):
+                    for match in node.get("cpeMatch", []):
+                        if not match.get("vulnerable", False):
+                            continue
+                        criteria = match.get("criteria", "")
+                        parts = criteria.split(":")
+                        # cpe:2.3:<part>:<vendor>:<product>:<version>:...
+                        if len(parts) < 6 or parts[2] != "a":
+                            continue
+                        vendor = parts[3].replace("_", " ").title()
+                        product = parts[4].replace("_", " ").title()
+                        if vendor in ("*", "") or product in ("*", ""):
+                            continue
+                        key = (vendor.lower(), product.lower())
+                        if key in seen_sw or len(seen_sw) >= 10:
+                            continue
+                        # Build version info: prefer explicit range over exact CPE version
+                        cpe_ver = parts[5] if len(parts) > 5 else "*"
+                        vsi = match.get("versionStartIncluding")
+                        vse = match.get("versionStartExcluding")
+                        vei = match.get("versionEndIncluding")
+                        vee = match.get("versionEndExcluding")
+                        if vsi or vse or vei or vee:
+                            range_parts: list[str] = []
+                            if vsi:
+                                range_parts.append(f">= {vsi}")
+                            elif vse:
+                                range_parts.append(f"> {vse}")
+                            if vei:
+                                range_parts.append(f"<= {vei}")
+                            elif vee:
+                                range_parts.append(f"< {vee}")
+                            version_info: str | None = ", ".join(range_parts) or None
+                        elif cpe_ver and cpe_ver != "*":
+                            version_info = cpe_ver
+                        else:
+                            version_info = None
+                        seen_sw[key] = NVDAffectedSoftware(
+                            vendor=vendor,
+                            product=product,
+                            cpe=criteria,
+                            version_info=version_info,
+                        )
+            result.affected_software = list(seen_sw.values())
+
+            # Return None if the response contained nothing actionable
+            if not any(
+                [
+                    result.description,
+                    result.cvss_v3_base_severity,
+                    result.cvss_v2_base_score is not None,
+                    result.references,
+                ]
+            ):
+                return None
+
+            return result
+        except Exception:
+            pass
+        return None

--- a/internal-enrichment/censys-enrichment/src/censys_enrichment/connector.py
+++ b/internal-enrichment/censys-enrichment/src/censys_enrichment/connector.py
@@ -1,15 +1,23 @@
-from typing import Any, Iterator
+from typing import Any, Generator
 
-from censys_enrichment.client import Client
-from censys_enrichment.converters import get_converter
-from censys_enrichment.converters.base import CensysConverter
-from censys_enrichment.errors import (
-    EntityNotInScopeError,
-    MaxTlpError,
-)
+from censys_enrichment.client import Client, NVDData
+from censys_enrichment.converter import Converter
 from censys_enrichment.settings import ConfigLoader
+from censys_platform import Host, Service
 from connectors_sdk.models import BaseObject
 from pycti import OpenCTIConnectorHelper
+
+
+class EntityNotInScopeError(Exception):
+    """Custom exception for entity not in scope"""
+
+
+class MaxTlpError(Exception):
+    """Custom exception for exceeding maximum TLP level"""
+
+
+class EntityTypeNotSupportedError(Exception):
+    """Custom exception for unsupported entity type"""
 
 
 class Connector:
@@ -20,10 +28,12 @@ class Connector:
         config: ConfigLoader,
         helper: OpenCTIConnectorHelper,
         client: Client,
+        converter: Converter,
     ) -> None:
         self.config = config
         self.helper = helper
         self.client = client
+        self.converter = converter
 
     def _send_bundle(self, stix_objects: list[dict[str, Any]]) -> str:
         bundle = self.helper.stix2_create_bundle(items=stix_objects)
@@ -52,28 +62,92 @@ class Connector:
             max_tlp=self.config.censys_enrichment.max_tlp,
         )
 
+    def _build_nvd_data_map(self, data: Host) -> dict[str, NVDData]:
+        """Return a CVE-ID → NVDData mapping for use during enrichment.
+
+        For each CVE referenced by the host's services, we fetch full NVD data
+        (description, CVSS v2, v3 severity, external references).  If OpenCTI
+        already holds a non-empty description for a given CVE, we clear the
+        ``description`` field on the returned :class:`NVDData` to avoid
+        overwriting it — all other enrichment fields are still applied.
+        """
+        cve_ids: set[str] = set()
+        for service in data.services if isinstance(data.services, list) else []:
+            if not isinstance(service, Service):
+                continue
+            for vuln in service.vulns if isinstance(service.vulns, list) else []:
+                if vuln.id:
+                    cve_ids.add(vuln.id)
+
+        nvd_data_map: dict[str, NVDData] = {}
+        for cve_id in cve_ids:
+            nvd_data = self.client.fetch_nvd_data(cve_id)
+            if nvd_data is None:
+                continue
+            try:
+                existing = self.helper.api.vulnerability.read(
+                    filters={
+                        "mode": "and",
+                        "filters": [{"key": "name", "values": [cve_id]}],
+                        "filterGroups": [],
+                    }
+                )
+                if existing and existing.get("description"):
+                    # OpenCTI already has a description — leave it untouched.
+                    nvd_data.description = None
+            except Exception:
+                pass
+            nvd_data_map[cve_id] = nvd_data
+
+        return nvd_data_map
+
     def _generate_octi_objects(
         self, stix_entity: dict[str, Any]
-    ) -> Iterator[BaseObject]:
-        # Annotate ``Iterator`` (not ``Generator``) so the type
-        # matches the ``list_iterator`` returned by
-        # ``iter(converter.to_stix(...))``. Keeping ``return
-        # iter(...)`` instead of rewriting as a real ``yield from``
-        # generator is deliberate: the converter dispatch
-        # (``_get_converter`` → ``get_converter`` →
-        # ``EntityTypeNotSupportedError``) must run eagerly so
-        # misconfigured entity types surface at call time rather
-        # than only when something starts iterating the returned
-        # object — the test suite (and the ``_message_callback``
-        # error path that wraps this) both rely on the eager
-        # behaviour.
-        converter = self._get_converter(entity_type=stix_entity["type"])
-        return iter(converter.to_stix(observable=stix_entity))
+    ) -> Generator[BaseObject, None, None]:
+        match stix_entity["type"]:
+            case "ipv4-addr" | "ipv6-addr":
+                data = self.client.fetch_ip(stix_entity["value"])
+                nvd_data_map = (
+                    self._build_nvd_data_map(data)
+                    if self.config.censys_enrichment.nvd_enabled
+                    else None
+                )
+                return self.converter.generate_octi_objects(
+                    stix_entity=stix_entity,
+                    data=data,
+                    nvd_data_map=nvd_data_map,
+                )
+            case "x509-certificate":
+                return self.converter.generate_octi_objects_from_certs(
+                    certs=list(self.client.fetch_certs(hashes=stix_entity["hashes"])),
+                )
+            case "domain-name":
 
-    def _get_converter(self, entity_type: str) -> CensysConverter:
-        converter = get_converter(entity_type=entity_type)
-        converter.client = self.client
-        return converter
+                def _generate_domain_objects():
+                    # yield objects from associated hosts
+                    yield from self.converter.generate_octi_objects_from_hosts(
+                        stix_entity=stix_entity,
+                        hosts=list(self.client.fetch_hosts(stix_entity["value"])),
+                        nvd_data_provider=(
+                            self._build_nvd_data_map
+                            if self.config.censys_enrichment.nvd_enabled
+                            else None
+                        ),
+                    )
+                    # yield certificates associated with the domain
+                    yield from self.converter.generate_octi_objects_from_domain_certs(
+                        stix_entity=stix_entity,
+                        certs=list(
+                            self.client.fetch_certs_by_domain(stix_entity["value"])
+                        ),
+                    )
+
+                return _generate_domain_objects()
+
+            case _:
+                raise EntityTypeNotSupportedError(
+                    f"Observable type {stix_entity['type']} not supported"
+                )
 
     def _process(
         self,

--- a/internal-enrichment/censys-enrichment/src/censys_enrichment/converter.py
+++ b/internal-enrichment/censys-enrichment/src/censys_enrichment/converter.py
@@ -1,0 +1,1613 @@
+import datetime
+import ipaddress
+from typing import Any, Callable, Generator
+
+from censys_platform import (
+    Attribute,
+    Certificate,
+    CobaltStrike,
+    CobaltStrikeConfig,
+    Coordinates,
+    Darkcomet,
+    Darkgate,
+    Dcerpc,
+    Ftp,
+    Host,
+    HostDNS,
+    Label,
+    Ldap,
+    Mongodb,
+    Rdp,
+    Redis,
+    Redline,
+    Risk,
+    Smb,
+    SMTP,
+    Snmp,
+    SSH,
+    Service,
+    Telnet,
+    Threat,
+    Vnc,
+    Vuln,
+    Winrm,
+)
+from connectors_sdk.models import (
+    AdministrativeArea,
+    AutonomousSystem,
+    BaseObject,
+    City,
+    Country,
+    DomainName,
+    EmailAddress,
+    ExternalReference,
+    Hostname,
+    IPV4Address,
+    IPV6Address,
+    Malware,
+    Note,
+    Organization,
+    OrganizationAuthor,
+    Reference,
+    Region,
+    Relationship,
+    Software,
+    TLPMarking,
+    Vulnerability,
+    X509Certificate,
+)
+from connectors_sdk.models.enums import (
+    CvssSeverity,
+    HashAlgorithm,
+    RelationshipType,
+    TLPLevel,
+)
+
+from censys_enrichment.client import NVDData
+
+# Maps common lowercase severity strings (from Censys or NVD) to the SDK enum.
+_SEVERITY_MAP: dict[str, CvssSeverity] = {
+    "critical": CvssSeverity.CRITICAL,
+    "high": CvssSeverity.HIGH,
+    "medium": CvssSeverity.MEDIUM,
+    "low": CvssSeverity.LOW,
+}
+
+
+def _cvss_component(obj: Any, attr: str) -> str | None:
+    """Return a CVSS component enum value as an uppercase string, or None if absent."""
+    if obj is None:
+        return None
+    val = getattr(obj, attr, None)
+    if val is None:
+        return None
+    raw: str = getattr(val, "value", "")
+    return raw.upper() if raw else None
+
+
+class Converter:
+    def __init__(self) -> None:
+        self.author = OrganizationAuthor(name="Censys Enrichment Connector")  # type: ignore[call-arg]
+        self.marking = TLPMarking(level=TLPLevel.CLEAR)
+        self._common_props = {"author": self.author, "markings": [self.marking]}
+
+    def _generate_city(
+        self, observable: Reference, name: str | None
+    ) -> Generator[BaseObject, None, None]:
+        if not name:
+            return
+
+        city = City(
+            name=name,
+            **self._common_props,
+        )
+        yield from [
+            city,
+            Relationship(
+                source=observable,
+                target=city,
+                type=RelationshipType.LOCATED_AT,
+                **self._common_props,
+            ),
+        ]
+
+    def _generate_country(
+        self, observable: Reference, name: str | None
+    ) -> Generator[BaseObject, None, Country | None]:
+        if not name:
+            return None
+
+        country = Country(
+            name=name,
+            **self._common_props,
+        )
+        yield from [
+            country,
+            Relationship(
+                source=observable,
+                target=country,
+                type=RelationshipType.LOCATED_AT,
+                **self._common_props,
+            ),
+        ]
+        return country
+
+    def _generate_region(
+        self, observable: Reference, name: str | None
+    ) -> Generator[BaseObject, None, None]:
+        if not name:
+            return
+
+        region = Region(
+            name=name,
+            **self._common_props,
+        )
+        yield from [
+            region,
+            Relationship(
+                source=observable,
+                target=region,
+                type=RelationshipType.LOCATED_AT,
+                **self._common_props,
+            ),
+        ]
+
+    def _generate_administrative_area(
+        self,
+        observable: Reference,
+        name: str | None,
+        coordinates: Coordinates | None,
+    ) -> Generator[BaseObject, None, None]:
+        if not name:
+            return
+
+        administrative_area = (
+            AdministrativeArea(
+                name=name,
+                latitude=coordinates.latitude,
+                longitude=coordinates.longitude,
+                **self._common_props,
+            )
+            if coordinates
+            else AdministrativeArea(
+                name=name,
+                **self._common_props,
+            )
+        )
+
+        yield from [
+            administrative_area,
+            Relationship(
+                source=observable,
+                target=administrative_area,
+                type=RelationshipType.LOCATED_AT,
+                **self._common_props,
+            ),
+        ]
+
+    def _generate_hostnames(
+        self, observable: Reference, dns: HostDNS | None
+    ) -> Generator[BaseObject, None, None]:
+        if not dns:
+            return
+
+        # Combine forward DNS names with reverse DNS PTR records, deduplicating
+        # so a name that appears in both doesn't produce duplicate observables.
+        seen: set[str] = set()
+        all_names = list(dns.names if isinstance(dns.names, list) else [])
+        if dns.reverse_dns:
+            all_names.extend(
+                dns.reverse_dns.names
+                if isinstance(dns.reverse_dns.names, list)
+                else []
+            )
+
+        for name in all_names:
+            if name in seen:
+                continue
+            seen.add(name)
+            host_name = Hostname(
+                value=name,
+                **self._common_props,
+            )
+            yield from [
+                host_name,
+                Relationship(
+                    source=host_name,
+                    target=observable,
+                    type=RelationshipType.RESOLVES_TO,
+                    **self._common_props,
+                ),
+            ]
+
+    def _generate_organization(
+        self,
+        observable: Reference,
+        name: str | None,
+    ) -> Generator[BaseObject, None, Organization | None]:
+        if not name:
+            return None
+
+        organization = Organization(
+            name=name,
+            **self._common_props,
+        )
+        yield from [
+            organization,
+            Relationship(
+                source=observable,
+                target=organization,
+                type=RelationshipType.RELATED_TO,
+                **self._common_props,
+            ),
+        ]
+        return organization
+
+    def _generate_autonomous_system(
+        self,
+        observable: Reference,
+        number: int | None,
+        name: str | None,
+        description: str | None,
+    ) -> Generator[BaseObject, None, AutonomousSystem | None]:
+        if not number:
+            return None
+
+        autonomous_system = AutonomousSystem(
+            name=name,
+            description=description,
+            number=number,
+            **self._common_props,
+        )
+        yield from [
+            autonomous_system,
+            Relationship(
+                source=observable,
+                target=autonomous_system,
+                type=RelationshipType.BELONGS_TO,
+                **self._common_props,
+            ),
+        ]
+        return autonomous_system
+
+    def _generate_software(
+        self,
+        observable: Reference,
+        name: str | None,
+        vendor: str | None,
+        cpe: str | None,
+        version: str | None = None,
+    ) -> Generator[BaseObject, None, Software | None]:
+        if not name:
+            return None
+
+        software = Software(
+            name=name,
+            vendor=vendor,
+            cpe=cpe,
+            version=version,
+            **self._common_props,
+        )
+        yield from [
+            software,
+            Relationship(
+                source=observable,
+                target=software,
+                type=RelationshipType.RELATED_TO,
+                **self._common_props,
+            ),
+        ]
+        return software
+
+    def _generate_vulnerability(
+        self,
+        observable: Reference,
+        vuln: Vuln,
+        nvd_data: NVDData | None = None,
+    ) -> Generator[BaseObject, None, None]:
+        # Use the CVE/Censys ID as the name; fall back to the human-readable name
+        name = vuln.id or vuln.name
+        if not name:
+            return
+
+        # Prefer CVSSv3.1 > v3.0 for v3 scoring; also pick up v4 if available
+        cvss3 = None
+        cvss4 = None
+        if vuln.metrics:
+            cvss3 = vuln.metrics.cvss_v31 or vuln.metrics.cvss_v30
+            cvss4 = vuln.metrics.cvss_v40
+
+        epss_score = None
+        epss_percentile = None
+        if vuln.metrics and vuln.metrics.epss:
+            epss_score = vuln.metrics.epss.score
+            epss_percentile = vuln.metrics.epss.percentile
+
+        # True if any KEV entry is present (CISA Known Exploited Vulnerability)
+        is_kev = isinstance(vuln.kev, list) and len(vuln.kev) > 0
+
+        # OpenCTI's CVSS4 vector validator rejects non-base vectors (e.g. those
+        # that include Censys supplemental/environmental metrics).  We drop the
+        # vector string entirely and rely on the individual component fields and
+        # base score, which OpenCTI accepts without validation.
+        cvss4_score = cvss4.score if cvss4 else None
+
+        # --- CVSS v3 components (from Censys) ---
+        cvss3_comps = cvss3.components if cvss3 else None
+
+        # --- CVSS v4 components (from Censys) ---
+        cvss4_comps = cvss4.components if cvss4 else None
+
+        # --- CVSS v3 severity: prefer NVD (authoritative) then Censys ---
+        cvss3_severity: CvssSeverity | None = None
+        if nvd_data and nvd_data.cvss_v3_base_severity:
+            cvss3_severity = _SEVERITY_MAP.get(nvd_data.cvss_v3_base_severity.lower())
+        if cvss3_severity is None and vuln.severity and vuln.severity.value:
+            cvss3_severity = _SEVERITY_MAP.get(vuln.severity.value.lower())
+
+        # --- CWE labels (from Censys) ---
+        cwes: list[str] = [
+            cwe.entry
+            for cwe in (vuln.cwes if isinstance(vuln.cwes, list) else [])
+            if cwe.entry
+        ]
+
+        # --- Description: prefer NVD then vuln.name fallback ---
+        final_description = (nvd_data.description if nvd_data else None) or (
+            vuln.name if vuln.name != name else None
+        )
+
+        # --- External references from NVD ---
+        ext_refs: list[ExternalReference] = [
+            ExternalReference(source_name=ref.source_name, url=ref.url)
+            for ref in (nvd_data.references if nvd_data else [])
+        ]
+
+        # Build as a dict so a single type:ignore suppresses all inherited-field
+        # false-positives from Pyright's incomplete Pydantic v2 multi-inheritance
+        # synthesis (all fields are valid at runtime — 62 tests confirm this).
+        vuln_kwargs: dict[str, Any] = {
+            "name": name,
+            "description": final_description,
+            "labels": cwes or None,
+            "external_references": ext_refs or None,
+            # CVSS v3
+            "cvss_v3_base_score": cvss3.score if cvss3 else None,
+            "cvss_v3_vector_string": cvss3.vector if cvss3 else None,
+            "cvss_v3_base_severity": cvss3_severity,
+            "cvss_v3_attack_vector": _cvss_component(cvss3_comps, "attack_vector"),
+            "cvss_v3_attack_complexity": _cvss_component(cvss3_comps, "attack_complexity"),
+            "cvss_v3_privileges_required": _cvss_component(cvss3_comps, "privileges_required"),
+            "cvss_v3_user_interaction": _cvss_component(cvss3_comps, "user_interaction"),
+            "cvss_v3_scope": _cvss_component(cvss3_comps, "scope"),
+            "cvss_v3_confidentiality_impact": _cvss_component(cvss3_comps, "confidentiality"),
+            "cvss_v3_integrity_impact": _cvss_component(cvss3_comps, "integrity"),
+            "cvss_v3_availability_impact": _cvss_component(cvss3_comps, "availability"),
+            # CVSS v4
+            "cvss_v4_base_score": cvss4_score,
+            "cvss_v4_vector_string": None,
+            "cvss_v4_attack_vector": _cvss_component(cvss4_comps, "attack_vector"),
+            "cvss_v4_attack_complexity": _cvss_component(cvss4_comps, "attack_complexity"),
+            "cvss_v4_attack_requirements": _cvss_component(cvss4_comps, "attack_requirements"),
+            "cvss_v4_privileges_required": _cvss_component(cvss4_comps, "privileges_required"),
+            "cvss_v4_user_interaction": _cvss_component(cvss4_comps, "user_interaction"),
+            "cvss_v4_vs_confidentiality_impact": _cvss_component(cvss4_comps, "confidentiality"),
+            "cvss_v4_vs_integrity_impact": _cvss_component(cvss4_comps, "integrity"),
+            "cvss_v4_vs_availability_impact": _cvss_component(cvss4_comps, "availability"),
+            # CVSS v2 (from NVD)
+            "cvss_v2_base_score": nvd_data.cvss_v2_base_score if nvd_data else None,
+            "cvss_v2_vector_string": nvd_data.cvss_v2_vector_string if nvd_data else None,
+            "cvss_v2_access_vector": nvd_data.cvss_v2_access_vector if nvd_data else None,
+            "cvss_v2_access_complexity": nvd_data.cvss_v2_access_complexity if nvd_data else None,
+            "cvss_v2_authentication": nvd_data.cvss_v2_authentication if nvd_data else None,
+            "cvss_v2_confidentiality_impact": nvd_data.cvss_v2_confidentiality_impact if nvd_data else None,
+            "cvss_v2_integrity_impact": nvd_data.cvss_v2_integrity_impact if nvd_data else None,
+            "cvss_v2_availability_impact": nvd_data.cvss_v2_availability_impact if nvd_data else None,
+            # EPSS + CISA KEV
+            "epss_score": epss_score,
+            "epss_percentile": epss_percentile,
+            "is_cisa_kev": True if is_kev else None,
+            **self._common_props,
+        }
+        vulnerability = Vulnerability(**vuln_kwargs)  # type: ignore[call-arg]
+        yield vulnerability
+        yield Relationship(
+            source=observable,
+            target=vulnerability,
+            type=RelationshipType.RELATED_TO,
+            **self._common_props,
+        )
+        # Software observables for each NVD-listed affected package.
+        # Linked via RELATED_TO rather than HAS: Software→HAS→Vulnerability is
+        # not universally accepted across OpenCTI v7 builds, whereas RELATED_TO
+        # is always valid between any two STIX objects.
+        for sw_entry in nvd_data.affected_software if nvd_data else []:
+            software = Software(
+                name=sw_entry.product,
+                vendor=sw_entry.vendor,
+                cpe=sw_entry.cpe,
+                version=sw_entry.version_info,
+                **self._common_props,
+            )
+            yield software
+            yield Relationship(
+                source=software,
+                target=vulnerability,
+                type=RelationshipType.RELATED_TO,
+                **self._common_props,
+            )
+
+    def _generate_malware(
+        self,
+        observable: Reference,
+        threat: Threat,
+    ) -> Generator[BaseObject, None, None]:
+        # Prefer the malware family name; fall back to the generic threat name
+        name = None
+        if threat.malware:
+            name = threat.malware.primary_name
+        if not name:
+            name = threat.name
+        if not name:
+            return
+
+        # Collect all known names as aliases
+        all_names = (
+            list(threat.malware.all_names)
+            if threat.malware and isinstance(threat.malware.all_names, list)
+            else []
+        )
+        aliases = [n for n in all_names if n != name] or None
+
+        # External reference to Malpedia if we have an ID
+        ext_refs: list[ExternalReference] = []
+        if threat.malware and threat.malware.malpedia_id:
+            ext_refs.append(
+                ExternalReference(
+                    source_name="Malpedia",
+                    url=f"https://malpedia.caad.fkie.fraunhofer.de/details/{threat.malware.malpedia_id}",
+                    external_id=threat.malware.malpedia_id,
+                )
+            )
+
+        # Build a brief description from threat metadata
+        desc_parts: list[str] = []
+        if threat.details and threat.details.campaign_id:
+            desc_parts.append(f"Campaign: {threat.details.campaign_id}")
+        if threat.details and threat.details.campaign_theme:
+            desc_parts.append(f"Theme: {threat.details.campaign_theme}")
+        if threat.details and isinstance(threat.details.control_servers, list):
+            desc_parts.append(
+                "C2 servers: " + ", ".join(threat.details.control_servers)
+            )
+
+        malware = Malware(
+            name=name,
+            is_family=True,
+            aliases=aliases,
+            description="\n".join(desc_parts) if desc_parts else None,
+            external_references=ext_refs if ext_refs else None,  # type: ignore[call-arg]
+            **self._common_props,
+        )
+        yield from [
+            malware,
+            Relationship(
+                source=observable,
+                target=malware,
+                type=RelationshipType.RELATED_TO,
+                **self._common_props,
+            ),
+        ]
+
+    def _build_banner_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return a Banner section with the raw service banner in a code block."""
+        if not service.banner:
+            return None
+        return f"### Banner\n\n```\n{service.banner.strip()}\n```", []
+
+    def _build_fingerprints_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return a Fingerprints section with TLS/JARM/JA4TScan data."""
+        sub_sections: list[str] = []
+        if service.tls:
+            tls_lines: list[str] = ["#### TLS"]
+            if service.tls.version_selected:
+                tls_lines.append(f"**Version:** {service.tls.version_selected}")
+            if service.tls.cipher_selected:
+                tls_lines.append(f"**Cipher:** {service.tls.cipher_selected}")
+            if service.tls.ja3s:
+                tls_lines.append(f"**JA3S:** `{service.tls.ja3s}`")
+            if service.tls.ja4s:
+                tls_lines.append(f"**JA4S:** `{service.tls.ja4s}`")
+            if len(tls_lines) > 1:
+                sub_sections.append("\n\n".join(tls_lines))
+        if service.ja4tscan and service.ja4tscan.fingerprint:
+            sub_sections.append(
+                f"#### JA4TScan\n\n**Fingerprint:** `{service.ja4tscan.fingerprint}`"
+            )
+        if service.jarm and service.jarm.fingerprint:
+            jarm_lines: list[str] = ["#### JARM"]
+            jarm_lines.append(f"**Fingerprint:** `{service.jarm.fingerprint}`")
+            if service.jarm.cipher_and_version_fingerprint:
+                jarm_lines.append(
+                    f"**Cipher/Version:** `{service.jarm.cipher_and_version_fingerprint}`"
+                )
+            if service.jarm.tls_extensions_sha256:
+                jarm_lines.append(
+                    f"**TLS Extensions SHA256:** `{service.jarm.tls_extensions_sha256}`"
+                )
+            sub_sections.append("\n\n".join(jarm_lines))
+        if not sub_sections:
+            return None
+        return "### Fingerprints\n\n" + "\n\n".join(sub_sections), []
+
+    def _generate_cobalt_strike_note(
+        self,
+        observable: Reference,
+        service: Service,
+    ) -> Generator[BaseObject, None, None]:
+        """Yield a Note for each endpoint scan that contains Cobalt Strike beacon data.
+
+        Cobalt Strike configuration lives on ``EndpointScanState`` objects within
+        ``service.endpoints``, not on the ``Service`` directly.  Each architecture
+        (x64 / x86) is rendered as a labelled section so analysts can immediately
+        see the per-arch C2 settings extracted by Censys.
+        """
+        for endpoint in (
+            service.endpoints if isinstance(service.endpoints, list) else []
+        ):
+            if not endpoint.cobalt_strike:
+                continue
+
+            port = endpoint.port or service.port
+            scan_time = endpoint.scan_time or service.scan_time
+            if not (port and scan_time):
+                continue
+
+            cs: CobaltStrike = endpoint.cobalt_strike
+
+            def _escape_header(s: str) -> str:
+                """Escape control/non-printable bytes as \\xNN so they survive markdown rendering."""
+                return s.encode("unicode_escape").decode("ascii")
+
+            def _format_arch(arch: str, cfg: CobaltStrikeConfig) -> list[str]:
+                section: list[str] = [f"### Arch: {arch}"]
+                if cfg.user_agent:
+                    section.append(f"**User-Agent:** {cfg.user_agent}")
+                if cfg.sleep_time is not None:
+                    section.append(f"**Sleep Time:** {cfg.sleep_time} ms")
+                if cfg.jitter is not None:
+                    section.append(f"**Jitter:** {cfg.jitter}")
+                if cfg.dns is not None:
+                    section.append(f"**DNS Enabled:** {cfg.dns}")
+                if cfg.ssl is not None:
+                    section.append(f"**SSL:** {cfg.ssl}")
+                if cfg.cookie_beacon is not None:
+                    section.append(f"**Cookie Beacon:** {cfg.cookie_beacon}")
+                if cfg.killdate is not None:
+                    section.append(f"**Killdate:** {cfg.killdate}")
+                if cfg.watermark is not None:
+                    section.append(f"**Watermark:** {cfg.watermark}")
+                if cfg.crypto_scheme is not None:
+                    section.append(f"**Crypto Scheme:** {cfg.crypto_scheme}")
+                if cfg.host_header:
+                    section.append(f"**Host Header:** {cfg.host_header}")
+                if cfg.http_get:
+                    section.append(
+                        f"**GET** `{cfg.http_get.verb or 'GET'} {cfg.http_get.uri or ''}`"
+                    )
+                    if cfg.http_get.client:
+                        section.append(f"**Headers (bytes):** `{_escape_header(cfg.http_get.client)}`")
+                if cfg.http_post:
+                    section.append(
+                        f"**POST** `{cfg.http_post.verb or 'POST'} {cfg.http_post.uri or ''}`"
+                    )
+                    if cfg.http_post.client:
+                        section.append(f"**Headers (bytes):** `{_escape_header(cfg.http_post.client)}`")
+                if cfg.post_ex:
+                    if cfg.post_ex.x64:
+                        section.append(f"**Post-Ex x64:** `{cfg.post_ex.x64}`")
+                    if cfg.post_ex.x86:
+                        section.append(f"**Post-Ex x86:** `{cfg.post_ex.x86}`")
+                if cfg.public_key:
+                    section.append(f"**Public Key:** `{cfg.public_key}`")
+                return section
+
+            blocks: list[str] = []
+            if cs.x64:
+                blocks.extend(_format_arch("x64", cs.x64))
+            if cs.x86:
+                if blocks:
+                    blocks.append("")
+                blocks.extend(_format_arch("x86", cs.x86))
+
+            if not blocks:
+                continue
+
+            yield Note(
+                abstract=f"Cobalt Strike beacon configuration on port {port}",
+                content="\n\n".join(blocks),
+                publication_date=datetime.datetime.fromisoformat(scan_time),
+                authors=[self.author.name],
+                objects=[observable],
+                labels=["cobalt-strike", "malware", f"port:{port}"],
+                **self._common_props,
+            )
+
+    def _build_dcerpc_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return a DCERPC section listing RPC endpoint bindings."""
+        if not service.dcerpc:
+            return None
+        dcerpc: Dcerpc = service.dcerpc
+        endpoints = dcerpc.endpoints if isinstance(dcerpc.endpoints, list) else []
+        if not endpoints:
+            return None
+        lines: list[str] = []
+        if dcerpc.could_query_epm is not None:
+            lines.append(f"**EPM Queryable:** {dcerpc.could_query_epm}")
+        ep_lines: list[str] = []
+        for ep in endpoints:
+            exe = ep.executable or "unknown"
+            proto = ep.protocol or ep.explained_uuid or ""
+            ep_lines.append(f"- **{exe}** — {proto}" if proto else f"- **{exe}**")
+        if ep_lines:
+            lines.append("#### Endpoints\n\n" + "\n".join(ep_lines))
+        if not lines:
+            return None
+        return "### DCERPC\n\n" + "\n\n".join(lines), ["dcerpc", "rpc"]
+
+    def _build_rdp_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return an RDP section with protocol version and security details."""
+        if not service.rdp:
+            return None
+        rdp: Rdp = service.rdp
+        lines: list[str] = []
+        if rdp.version:
+            v = rdp.version
+            version_str = v.raw or f"{v.major}.{v.minor}"
+            lines.append(f"**Version:** {version_str}")
+        if rdp.selected_security_protocol:
+            lines.append(f"**Security Protocol:** {rdp.selected_security_protocol}")
+        if rdp.certificate_info and rdp.certificate_info.proprietary_rsa_key:
+            lines.append(f"**RSA Key:** `{rdp.certificate_info.proprietary_rsa_key}`")
+        if not lines:
+            return None
+        return "### RDP\n\n" + "\n\n".join(lines), ["rdp", "remote-desktop"]
+
+    def _build_ssh_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return an SSH section with banner, HASSH, host key, and algorithm info."""
+        if not service.ssh:
+            return None
+        ssh: SSH = service.ssh
+        lines: list[str] = []
+        if ssh.endpoint_id:
+            if ssh.endpoint_id.raw:
+                lines.append(f"**Banner:** `{ssh.endpoint_id.raw}`")
+            elif ssh.endpoint_id.software_version:
+                lines.append(f"**Software:** `{ssh.endpoint_id.software_version}`")
+        if ssh.hassh_fingerprint:
+            lines.append(f"**HASSH:** `{ssh.hassh_fingerprint}`")
+        if ssh.server_host_key and ssh.server_host_key.fingerprint_sha256:
+            lines.append(f"**Host Key SHA256:** `{ssh.server_host_key.fingerprint_sha256}`")
+        if ssh.algorithm_selection:
+            if ssh.algorithm_selection.kex_algorithm:
+                lines.append(f"**KEX Algorithm:** {ssh.algorithm_selection.kex_algorithm}")
+            if ssh.algorithm_selection.host_key_algorithm:
+                lines.append(f"**Host Key Algorithm:** {ssh.algorithm_selection.host_key_algorithm}")
+        if not lines:
+            return None
+        return "### SSH\n\n" + "\n\n".join(lines), ["ssh"]
+
+    def _build_smb_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return an SMB section with OS, workgroup/domain, dialect, and NTLM target."""
+        if not service.smb:
+            return None
+        smb: Smb = service.smb
+        lines: list[str] = []
+        if smb.native_os:
+            lines.append(f"**OS:** {smb.native_os}")
+        if smb.group_name:
+            lines.append(f"**Workgroup/Domain:** {smb.group_name}")
+        if smb.smb_version and smb.smb_version.version_string:
+            lines.append(f"**SMB Version:** {smb.smb_version.version_string}")
+        if smb.smbv1_support is not None:
+            lines.append(f"**SMBv1 Support:** {smb.smbv1_support}")
+        if smb.negotiation_log:
+            if smb.negotiation_log.dialect_revision:
+                lines.append(f"**Dialect:** {smb.negotiation_log.dialect_revision}")
+            if smb.negotiation_log.server_guid:
+                lines.append(f"**Server GUID:** `{smb.negotiation_log.server_guid}`")
+        if smb.session_setup_log and smb.session_setup_log.target_name:
+            lines.append(f"**NTLM Target:** {smb.session_setup_log.target_name}")
+        if not lines:
+            return None
+        return "### SMB\n\n" + "\n\n".join(lines), ["smb"]
+
+    def _build_vnc_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return a VNC section with version, desktop name, and security types."""
+        if not service.vnc:
+            return None
+        vnc: Vnc = service.vnc
+        lines: list[str] = []
+        if vnc.version:
+            lines.append(f"**Version:** {vnc.version}")
+        if vnc.desktop_name:
+            lines.append(f"**Desktop:** {vnc.desktop_name}")
+        if vnc.connection_failed_reason:
+            lines.append(f"**Connection Failed:** {vnc.connection_failed_reason}")
+        security_types = vnc.security_types if isinstance(vnc.security_types, list) else []
+        if security_types:
+            types_str = ", ".join(f"{st.name}={st.value}" for st in security_types if st.name)
+            if types_str:
+                lines.append(f"**Security Types:** {types_str}")
+        if vnc.screen_info:
+            lines.append(f"**Screen:** {vnc.screen_info.width}x{vnc.screen_info.height}")
+        if not lines:
+            return None
+        return "### VNC\n\n" + "\n\n".join(lines), ["vnc", "remote-desktop"]
+
+    def _build_ldap_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return an LDAP section with anonymous bind status and base DSE attributes."""
+        if not service.ldap:
+            return None
+        ldap: Ldap = service.ldap
+        lines: list[str] = []
+        if ldap.allows_anonymous_bind is not None:
+            lines.append(f"**Anonymous Bind:** {ldap.allows_anonymous_bind}")
+        if ldap.result_code is not None:
+            lines.append(f"**Result Code:** {ldap.result_code}")
+        _INTERESTING_ATTRS = {
+            "defaultNamingContext", "rootDomainNamingContext", "dnsHostName",
+            "ldapServiceName", "serverName", "supportedSASLMechanisms",
+        }
+        for attr in ldap.attributes or []:
+            if attr.name in _INTERESTING_ATTRS:
+                val = ", ".join(attr.values or [])
+                lines.append(f"**{attr.name}:** {val}")
+        if not lines:
+            return None
+        return "### LDAP\n\n" + "\n\n".join(lines), ["ldap"]
+
+    def _build_winrm_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return a WinRM section with NTLM domain, computer name, and OS version."""
+        if not service.winrm:
+            return None
+        winrm: Winrm = service.winrm
+        if not winrm.ntlm_info:
+            return None
+        ntlm = winrm.ntlm_info
+        lines: list[str] = []
+        if ntlm.dns_domain_name:
+            lines.append(f"**DNS Domain:** {ntlm.dns_domain_name}")
+        if ntlm.dns_tree_name:
+            lines.append(f"**AD Forest:** {ntlm.dns_tree_name}")
+        if ntlm.dns_server_name:
+            lines.append(f"**DNS Server:** {ntlm.dns_server_name}")
+        if ntlm.netbios_domain_name:
+            lines.append(f"**NetBIOS Domain:** {ntlm.netbios_domain_name}")
+        if ntlm.netbios_computer_name:
+            lines.append(f"**NetBIOS Computer:** {ntlm.netbios_computer_name}")
+        if ntlm.os_version:
+            lines.append(f"**OS Version:** {ntlm.os_version}")
+        if ntlm.target_name:
+            lines.append(f"**Target:** {ntlm.target_name}")
+        if not lines:
+            return None
+        return "### WinRM\n\n" + "\n\n".join(lines), ["winrm", "windows"]
+
+    def _build_snmp_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return an SNMP section with system name, description, location, and contact."""
+        if not service.snmp:
+            return None
+        snmp: Snmp = service.snmp
+        if not snmp.oid_system:
+            return None
+        sys_info = snmp.oid_system
+        lines: list[str] = []
+        if sys_info.name:
+            lines.append(f"**System Name:** {sys_info.name}")
+        if sys_info.desc:
+            lines.append(f"**Description:** {sys_info.desc}")
+        if sys_info.location:
+            lines.append(f"**Location:** {sys_info.location}")
+        if sys_info.contact:
+            lines.append(f"**Contact:** {sys_info.contact}")
+        if not lines:
+            return None
+        return "### SNMP\n\n" + "\n\n".join(lines), ["snmp"]
+
+    def _build_darkcomet_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return a DarkComet section if this service shows RAT beacon activity."""
+        if not service.darkcomet:
+            return None
+        dc: Darkcomet = service.darkcomet
+        lines: list[str] = []
+        if dc.version:
+            lines.append(f"**Version:** {dc.version}")
+        content = "\n\n".join(lines) if lines else "DarkComet RAT beacon detected."
+        return f"### DarkComet\n\n{content}", ["darkcomet", "remote-access-trojan", "malware"]
+
+    def _build_darkgate_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return a DarkGate section if this service shows malware beacon activity."""
+        if not service.darkgate:
+            return None
+        dg: Darkgate = service.darkgate
+        files = dg.files if isinstance(dg.files, list) else []
+        file_lines: list[str] = []
+        for f in files:
+            if f.name:
+                size = f" ({f.length} bytes)" if f.length is not None else ""
+                file_lines.append(f"- **{f.name}**{size}")
+        content = (
+            "#### Observed Files\n\n" + "\n".join(file_lines)
+            if file_lines
+            else "DarkGate beacon detected."
+        )
+        return f"### DarkGate\n\n{content}", ["darkgate", "malware"]
+
+    def _build_redline_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return a RedLine section if this service shows stealer beacon activity."""
+        if not service.redline:
+            return None
+        rl: Redline = service.redline
+        lines: list[str] = []
+        if rl.transport:
+            lines.append(f"**Transport:** {rl.transport}")
+        if rl.action_response:
+            lines.append(f"**Action Response:** {rl.action_response}")
+        if rl.settings_response:
+            lines.append(f"**Settings Response:** {rl.settings_response}")
+        content = "\n\n".join(lines) if lines else "RedLine stealer beacon detected."
+        return f"### RedLine\n\n{content}", ["redline", "information-stealer", "malware"]
+
+    def _build_risks_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return a Security Risks section summarising exposures, misconfigs, and compromises."""
+        risk_groups: list[tuple[str, list[Risk]]] = []
+        for section_name, field in [
+            ("Compromises", service.compromises),
+            ("Exposures", service.exposures),
+            ("Misconfigurations", service.misconfigs),
+        ]:
+            risks: list[Risk] = field if isinstance(field, list) else []
+            if risks:
+                risk_groups.append((section_name, risks))
+        if not risk_groups:
+            return None
+        extra_labels: list[str] = []
+        if isinstance(service.compromises, list) and service.compromises:
+            extra_labels.append("compromise")
+        if isinstance(service.exposures, list) and service.exposures:
+            extra_labels.append("exposure")
+        if isinstance(service.misconfigs, list) and service.misconfigs:
+            extra_labels.append("misconfiguration")
+        sub_sections: list[str] = []
+        for section_name, risks in risk_groups:
+            items = "\n".join(
+                f"- **{risk.name or risk.id or 'Unknown'}**"
+                + (f" [{risk.severity.name}]" if risk.severity else "")
+                for risk in risks
+            )
+            sub_sections.append(f"#### {section_name}\n\n{items}")
+        return "### Security Risks\n\n" + "\n\n".join(sub_sections), extra_labels
+
+    def _build_upnp_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return a UPnP Devices section listing discovered IoT device info."""
+        if not service.upnp:
+            return None
+        devices = service.upnp.devices if isinstance(service.upnp.devices, list) else []
+        if not devices:
+            return None
+        device_blocks: list[str] = []
+        for device in devices[:5]:
+            lines: list[str] = []
+            if device.friendly_name:
+                lines.append(f"**Name:** {device.friendly_name}")
+            if device.manufacturer:
+                lines.append(f"**Manufacturer:** {device.manufacturer}")
+            if device.model_name:
+                lines.append(f"**Model:** {device.model_name}")
+            if device.model_number:
+                lines.append(f"**Model Number:** {device.model_number}")
+            if device.device_type:
+                lines.append(f"**Type:** {device.device_type}")
+            if device.serial_number:
+                lines.append(f"**Serial:** {device.serial_number}")
+            if lines:
+                device_blocks.append("\n\n".join(lines))
+        if not device_blocks:
+            return None
+        return "### UPnP Devices\n\n" + "\n\n---\n\n".join(device_blocks), ["upnp", "iot"]
+
+    def _generate_observable_update(
+        self,
+        ip: str,
+        labels: list[str] | None,
+        score: int | None = None,
+    ) -> Generator[BaseObject, None, None]:
+        """Re-emit the IP SCO with the Censys Platform pivot URL and host labels.
+
+        Because STIX IDs for IPv4/IPv6 SCOs are deterministic (derived from the
+        value), OpenCTI merges this into the existing entity, updating external
+        references and labels without creating a duplicate observable.
+        """
+        ip_version = ipaddress.ip_network(ip, strict=False).version
+        cls = IPV4Address if ip_version == 4 else IPV6Address
+        yield cls(
+            value=ip,
+            score=score,
+            external_references=[  # type: ignore[call-arg]
+                ExternalReference(
+                    source_name="Censys",
+                    url=f"https://platform.censys.io/hosts/{ip}",
+                    description=f"Censys host intelligence for {ip}",
+                )
+            ],
+            labels=labels or None,
+            **self._common_props,
+        )
+
+    def _generate_certificate(
+        self, cert: Certificate | None
+    ) -> Generator[BaseObject, None, X509Certificate | None]:
+        if not cert or not (
+            cert.fingerprint_sha256
+            or cert.fingerprint_sha1
+            or cert.fingerprint_md5
+            or cert.parsed
+        ):
+            return None
+
+        # Gather all fields up front so the object is constructed in one call.
+        # Mutating a Pydantic model after construction re-triggers ID computation
+        # on every assignment, causing spurious "id changed" warnings.
+        kwargs: dict = {
+            "hashes": {
+                HashAlgorithm.SHA1: cert.fingerprint_sha1,
+                HashAlgorithm.SHA256: cert.fingerprint_sha256,
+                HashAlgorithm.MD5: cert.fingerprint_md5,
+            },
+        }
+
+        if cert.parsed:
+            kwargs["serial_number"] = cert.parsed.serial_number
+            kwargs["issuer"] = cert.parsed.issuer_dn
+            kwargs["subject"] = cert.parsed.subject_dn
+
+            if cert.parsed.signature and cert.parsed.signature.signature_algorithm:
+                kwargs["signature_algorithm"] = (
+                    cert.parsed.signature.signature_algorithm.name
+                )
+            if cert.parsed.validity_period:
+                kwargs["validity_not_before"] = cert.parsed.validity_period.not_before
+                kwargs["validity_not_after"] = cert.parsed.validity_period.not_after
+            if cert.parsed.subject_key_info and cert.parsed.subject_key_info.key_algorithm:
+                kwargs["subject_public_key_algorithm"] = (
+                    cert.parsed.subject_key_info.key_algorithm.name
+                )
+                if cert.parsed.subject_key_info.rsa:
+                    kwargs["subject_public_key_modulus"] = (
+                        cert.parsed.subject_key_info.rsa.modulus
+                    )
+                    kwargs["subject_public_key_exponent"] = (
+                        cert.parsed.subject_key_info.rsa.exponent
+                    )
+            if cert.parsed.extensions:
+                if cert.parsed.extensions.key_usage:
+                    kwargs["key_usage"] = (
+                        cert.parsed.extensions.key_usage.model_dump_json()
+                    )
+                if cert.parsed.extensions.basic_constraints:
+                    kwargs["basic_constraints"] = (
+                        cert.parsed.extensions.basic_constraints.model_dump_json()
+                    )
+                kwargs["crl_distribution_points"] = str(
+                    cert.parsed.extensions.crl_distribution_points
+                )
+                kwargs["authority_key_identifier"] = (
+                    cert.parsed.extensions.authority_key_id
+                )
+                if cert.parsed.extensions.extended_key_usage:
+                    kwargs["extended_key_usage"] = (
+                        cert.parsed.extensions.extended_key_usage.model_dump_json()
+                    )
+                kwargs["certificate_policies"] = str(
+                    cert.parsed.extensions.certificate_policies
+                )
+
+        # is_self_signed: issuer DN matches subject DN
+        if cert.parsed and cert.parsed.issuer_dn and cert.parsed.subject_dn:
+            kwargs["is_self_signed"] = cert.parsed.issuer_dn == cert.parsed.subject_dn
+
+        # subject_alternative_name: join SAN DNS names into a comma-separated string
+        if (
+            cert.parsed
+            and cert.parsed.extensions
+            and cert.parsed.extensions.subject_alt_name
+        ):
+            san = cert.parsed.extensions.subject_alt_name
+            dns_names = san.dns_names if isinstance(san.dns_names, list) else []
+            if dns_names:
+                kwargs["subject_alternative_name"] = ", ".join(dns_names)
+
+        # labels: validation level (DV/OV/EV), revocation, browser trust
+        cert_labels: list[str] = []
+        if cert.validation_level and cert.validation_level.value:
+            cert_labels.append(cert.validation_level.value.upper())
+        if cert.revoked is True:
+            cert_labels.append("revoked")
+        if cert.validation:
+            stores = [
+                cert.validation.apple,
+                cert.validation.chrome,
+                cert.validation.microsoft,
+                cert.validation.nss,
+            ]
+            if any(s is not None and getattr(s, "is_valid", False) for s in stores):
+                cert_labels.append("browser-trusted")
+        if cert_labels:
+            kwargs["labels"] = cert_labels
+
+        # Add a Censys portal link so the cert observable gets an external reference.
+        if cert.fingerprint_sha256:
+            kwargs["external_references"] = [  # type: ignore[call-arg]
+                ExternalReference(
+                    source_name="Censys",
+                    url=f"https://platform.censys.io/certificates/{cert.fingerprint_sha256}",
+                    description=f"Censys certificate intelligence for {cert.fingerprint_sha256}",
+                )
+            ]
+
+        certificate = X509Certificate(**kwargs, **self._common_props)
+        yield certificate
+
+        # Emit Hostname observables for each domain name covered by this cert.
+        # Wildcards are skipped — OpenCTI rejects them as Hostname values.
+        # IP addresses (IPv4 and IPv6) are skipped — cert SANs can include IPs
+        # but they must be typed as IP observables, not Hostnames.  Passing an
+        # IP string as a Hostname value causes FUNCTIONAL_ERROR in OpenCTI which
+        # then cascades into MISSING_REFERENCE_ERROR for the relationship.
+        for name in (cert.names if isinstance(cert.names, list) else [])[:20]:
+            if not name or "*" in name:
+                continue
+            try:
+                ipaddress.ip_address(name)
+                continue  # SAN is an IP address — skip, not a Hostname
+            except ValueError:
+                pass
+            hostname_obs = Hostname(value=name, **self._common_props)
+            yield hostname_obs
+            yield Relationship(
+                source=certificate,
+                target=hostname_obs,
+                type=RelationshipType.RELATED_TO,
+                **self._common_props,
+            )
+
+        return certificate
+
+    def _build_smtp_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return an SMTP section with EHLO banner and STARTTLS response."""
+        if not service.smtp:
+            return None
+        smtp: SMTP = service.smtp
+        lines: list[str] = []
+        if smtp.ehlo:
+            lines.append(f"**EHLO Response:**\n```\n{smtp.ehlo.strip()}\n```")
+        if smtp.start_tls:
+            lines.append(f"**STARTTLS Response:** {smtp.start_tls.strip()}")
+        if not lines:
+            return None
+        return "### SMTP\n\n" + "\n\n".join(lines), ["smtp"]
+
+    def _build_ftp_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return an FTP section with status code and TLS support details."""
+        if not service.ftp:
+            return None
+        ftp: Ftp = service.ftp
+        lines: list[str] = []
+        if ftp.status_code is not None:
+            meaning = f" — {ftp.status_meaning}" if ftp.status_meaning else ""
+            lines.append(f"**Status:** {ftp.status_code}{meaning}")
+        if ftp.implicit_tls is not None:
+            lines.append(f"**Implicit TLS:** {ftp.implicit_tls}")
+        if ftp.auth_tls_response:
+            lines.append(f"**AUTH TLS:** {ftp.auth_tls_response.strip()}")
+        if ftp.auth_ssl_response:
+            lines.append(f"**AUTH SSL:** {ftp.auth_ssl_response.strip()}")
+        if not lines:
+            return None
+        return "### FTP\n\n" + "\n\n".join(lines), ["ftp"]
+
+    def _build_telnet_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return a Telnet section flagging the plaintext protocol and capabilities."""
+        if not service.telnet:
+            return None
+        telnet: Telnet = service.telnet
+        lines: list[str] = ["Telnet service detected — transmits data in plaintext."]
+        will_caps = [name for name in (telnet.will or {}).keys() if name]
+        if will_caps:
+            lines.append(f"**WILL capabilities:** {', '.join(sorted(will_caps))}")
+        do_caps = [name for name in (telnet.do or {}).keys() if name]
+        if do_caps:
+            lines.append(f"**DO capabilities:** {', '.join(sorted(do_caps))}")
+        return "### Telnet\n\n" + "\n\n".join(lines), ["telnet"]
+
+    def _build_redis_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return a Redis section with version, mode, OS, and authentication status."""
+        if not service.redis:
+            return None
+        redis: Redis = service.redis
+        lines: list[str] = []
+        parts = [p for p in [redis.major, redis.minor, redis.patch_level] if p is not None]
+        if parts:
+            lines.append(f"**Version:** {'.'.join(str(p) for p in parts)}")
+        if redis.mode:
+            lines.append(f"**Mode:** {redis.mode}")
+        if redis.os:
+            lines.append(f"**OS:** {redis.os}")
+        if redis.ping_response:
+            auth_status = (
+                "Disabled (unauthenticated)"
+                if redis.ping_response.strip().upper() == "PONG"
+                else "Enabled"
+            )
+            lines.append(f"**Authentication:** {auth_status}")
+        if redis.uptime is not None:
+            lines.append(f"**Uptime:** {redis.uptime} seconds")
+        if not lines:
+            return None
+        return "### Redis\n\n" + "\n\n".join(lines), ["redis"]
+
+    def _build_mongodb_section(self, service: Service) -> tuple[str, list[str]] | None:
+        """Return a MongoDB section with version and server role."""
+        if not service.mongodb:
+            return None
+        mongo: Mongodb = service.mongodb
+        lines: list[str] = []
+        if mongo.build_info and mongo.build_info.version:
+            lines.append(f"**Version:** {mongo.build_info.version}")
+        if mongo.is_master:
+            im = mongo.is_master
+            if im.is_master is not None:
+                lines.append(f"**Is Primary:** {im.is_master}")
+            if im.read_only is not None:
+                lines.append(f"**Read Only:** {im.read_only}")
+            if im.max_wire_version is not None:
+                lines.append(f"**Max Wire Version:** {im.max_wire_version}")
+        if not lines:
+            return None
+        return "### MongoDB\n\n" + "\n\n".join(lines), ["mongodb"]
+
+    def _generate_service_note(
+        self,
+        observable: Reference,
+        service: Service,
+    ) -> Generator[BaseObject, None, None]:
+        """Yield a single combined Note covering all protocol data for a service port.
+
+        Calls every section builder in turn; non-None results are joined with
+        double newlines so markdown renders each field on its own line.  All
+        section labels are merged so analysts can filter by protocol or risk type.
+        """
+        if not (service.port and service.scan_time):
+            return
+
+        section_results = [
+            self._build_banner_section(service),
+            self._build_fingerprints_section(service),
+            self._build_ssh_section(service),
+            self._build_rdp_section(service),
+            self._build_smb_section(service),
+            self._build_vnc_section(service),
+            self._build_ldap_section(service),
+            self._build_winrm_section(service),
+            self._build_snmp_section(service),
+            self._build_dcerpc_section(service),
+            self._build_smtp_section(service),
+            self._build_ftp_section(service),
+            self._build_telnet_section(service),
+            self._build_redis_section(service),
+            self._build_mongodb_section(service),
+            self._build_darkcomet_section(service),
+            self._build_darkgate_section(service),
+            self._build_redline_section(service),
+            self._build_risks_section(service),
+            self._build_upnp_section(service),
+        ]
+
+        all_sections: list[str] = []
+        extra_labels: list[str] = []
+        for result in section_results:
+            if result is not None:
+                section_text, section_labels = result
+                all_sections.append(section_text)
+                for lbl in section_labels:
+                    if lbl not in extra_labels:
+                        extra_labels.append(lbl)
+
+        # Censys-assigned per-service labels (e.g. protocol type, software family)
+        for svc_label in service.labels if isinstance(service.labels, list) else []:
+            if svc_label.value and svc_label.value not in extra_labels:
+                extra_labels.append(svc_label.value)
+
+        if not all_sections:
+            return
+
+        _secondary = {
+            "malware", "remote-access-trojan", "information-stealer",
+            "compromise", "exposure", "misconfiguration", "windows",
+            "remote-desktop", "rpc",
+        }
+        protocol_labels = [lbl for lbl in extra_labels if lbl not in _secondary]
+        abstract = (
+            f"Port {service.port} — {protocol_labels[0].upper()}"
+            if protocol_labels
+            else f"Service on port {service.port}"
+        )
+
+        yield Note(
+            abstract=abstract,
+            content="\n\n".join(all_sections),
+            publication_date=datetime.datetime.fromisoformat(service.scan_time),
+            authors=[self.author.name],
+            objects=[observable],
+            labels=[f"port:{service.port}"] + extra_labels,
+            **self._common_props,
+        )
+
+    def _generate_services(
+        self,
+        observable: Reference,
+        services: list[Service] | None,
+        nvd_data_map: dict[str, NVDData] | None = None,
+    ) -> Generator[BaseObject, None, None]:
+        for service in services or []:
+            for software in service.software or []:
+                yield from self._generate_software(
+                    observable=observable,
+                    name=software.product,
+                    vendor=software.vendor,
+                    cpe=software.cpe,
+                    version=software.version,
+                )
+            if service.cert:
+                certificate = yield from self._generate_certificate(
+                    cert=service.cert,
+                )
+                if certificate:
+                    yield Relationship(
+                        source=observable,
+                        target=certificate,
+                        type=RelationshipType.RELATED_TO,
+                        **self._common_props,
+                    )
+            for vuln in service.vulns or []:
+                yield from self._generate_vulnerability(
+                    observable=observable,
+                    vuln=vuln,
+                    nvd_data=(
+                        nvd_data_map.get(vuln.id or "") if nvd_data_map else None
+                    ),
+                )
+            for threat in service.threats or []:
+                yield from self._generate_malware(
+                    observable=observable,
+                    threat=threat,
+                )
+            yield from self._generate_service_note(
+                observable=observable,
+                service=service,
+            )
+            yield from self._generate_cobalt_strike_note(
+                observable=observable,
+                service=service,
+            )
+
+    def _generate_ip(
+        self, observable: Reference, ip: str
+    ) -> Generator[BaseObject, None, None | IPV4Address | IPV6Address]:
+        ip_version = ipaddress.ip_network(ip, strict=False).version
+        if ip_version == 4:
+            ip_address = IPV4Address(value=ip, **self._common_props)
+        else:
+            ip_address = IPV6Address(value=ip, **self._common_props)
+        yield from [
+            ip_address,
+            Relationship(
+                source=observable,
+                target=ip_address,
+                type=RelationshipType.RELATED_TO,
+                **self._common_props,
+            ),
+        ]
+        return ip_address
+
+    def generate_octi_objects(
+        self,
+        stix_entity: dict[str, Any],
+        data: Host,
+        nvd_data_map: dict[str, NVDData] | None = None,
+    ) -> Generator[BaseObject, None, None]:
+        observable = Reference(id=stix_entity["id"])
+
+        yield from [
+            self.author,
+            self.marking,
+        ]
+        yield from self._generate_city(
+            observable=observable,
+            name=data.location.city if data.location else None,
+        )
+        yield from self._generate_region(
+            observable=observable,
+            name=data.location.continent if data.location else None,
+        )
+        yield from self._generate_administrative_area(
+            observable=observable,
+            name=data.location.province if data.location else None,
+            coordinates=data.location.coordinates if data.location else None,
+        )
+        yield from self._generate_hostnames(
+            observable=observable,
+            dns=data.dns,
+        )
+        yield from self._generate_services(
+            observable=observable,
+            # Normalise OptionalNullable: treat the Unset sentinel the same as None
+            services=data.services if isinstance(data.services, list) else None,
+            nvd_data_map=nvd_data_map,
+        )
+        country = yield from self._generate_country(
+            observable=observable,
+            name=data.location.country if data.location else None,
+        )
+        organization = yield from self._generate_organization(
+            observable=observable,
+            name=data.autonomous_system.name if data.autonomous_system else None,
+        )
+        autonomous_system = yield from self._generate_autonomous_system(
+            observable=observable,
+            name=data.autonomous_system.name if data.autonomous_system else None,
+            description=(
+                data.autonomous_system.description if data.autonomous_system else None
+            ),
+            number=data.autonomous_system.asn if data.autonomous_system else None,
+        )
+        if autonomous_system:
+            if organization:
+                yield Relationship(
+                    source=autonomous_system,
+                    target=organization,
+                    type=RelationshipType.RELATED_TO,
+                    **self._common_props,
+                )
+            if country:
+                yield Relationship(
+                    source=autonomous_system,
+                    target=country,
+                    type=RelationshipType.RELATED_TO,
+                    **self._common_props,
+                )
+        # Map host-level OS to a Software observable (product, vendor, CPE, version)
+        if data.operating_system:
+            os_attr: Attribute = data.operating_system
+            yield from self._generate_software(
+                observable=observable,
+                name=os_attr.product,
+                vendor=os_attr.vendor,
+                cpe=os_attr.cpe,
+                version=os_attr.version,
+            )
+        # VPN / anonymisation service provider organisations (e.g. "NordVPN", "Mullvad").
+        # Each provider name is emitted as an Organisation linked to the IP so analysts
+        # can pivot from the IP to the service in OpenCTI's graph view.
+        for priv in data.privacy if isinstance(data.privacy, list) else []:
+            for provider_name in (
+                priv.service_provider if isinstance(priv.service_provider, list) else []
+            ):
+                if provider_name:
+                    yield from self._generate_organization(
+                        observable=observable,
+                        name=provider_name,
+                    )
+        # WHOIS abuse contact emails — useful for reporting malicious activity upstream.
+        # Guard: WHOIS entries often contain non-email values ("N/A", handles,
+        # phone numbers, or truncated addresses like "abuse@" with no domain).
+        # OpenCTI enforces RFC 5321 on the email-addr SCO; invalid values cause
+        # a FUNCTIONAL_ERROR which then cascades into a MISSING_REFERENCE_ERROR
+        # for the relationship that follows.
+        if data.whois and data.whois.organization:
+            for contact in (
+                data.whois.organization.abuse_contacts
+                if isinstance(data.whois.organization.abuse_contacts, list)
+                else []
+            ):
+                if not contact.email:
+                    continue
+                _local, _sep, _domain = contact.email.strip().partition("@")
+                if not (_sep and _local and _domain and "." in _domain):
+                    continue
+                email_obs = EmailAddress(value=contact.email.strip(), **self._common_props)
+                yield email_obs
+                yield Relationship(
+                    source=observable,
+                    target=email_obs,
+                    type=RelationshipType.RELATED_TO,
+                    **self._common_props,
+                )
+
+        # Re-emit the IP with the Censys Platform pivot URL and enriched labels/score;
+        # OpenCTI merges this into the existing observable (same deterministic ID).
+        if data.ip:
+            host_label_list: list[Label] = (
+                data.labels if isinstance(data.labels, list) else []
+            )
+            all_labels = [lbl.value for lbl in host_label_list if lbl.value]
+
+            # Privacy / anonymisation flags and service provider labels
+            for priv in data.privacy if isinstance(data.privacy, list) else []:
+                if priv.tor:
+                    all_labels.append("tor")
+                if priv.vpn:
+                    all_labels.append("vpn")
+                if priv.proxy:
+                    all_labels.append("proxy")
+                if priv.anonymous:
+                    all_labels.append("anonymous")
+                for provider_name in (
+                    priv.service_provider if isinstance(priv.service_provider, list) else []
+                ):
+                    if provider_name:
+                        all_labels.append(
+                            f"vpn-provider:{provider_name.lower().replace(' ', '-')}"
+                        )
+
+            # GreyNoise threat classification and behavioural tags
+            if data.greynoise:
+                if data.greynoise.classification:
+                    all_labels.append(f"gn-{data.greynoise.classification}")
+                for gn_tag in (
+                    data.greynoise.tags if isinstance(data.greynoise.tags, list) else []
+                )[:10]:
+                    if gn_tag.name:
+                        all_labels.append(
+                            f"gn-{gn_tag.name.lower().replace(' ', '-')}"
+                        )
+
+            # Network type (hosting provider, mobile, satellite)
+            for nc in data.network if isinstance(data.network, list) else []:
+                if nc.hosting:
+                    all_labels.append("hosting-provider")
+                if nc.mobile:
+                    all_labels.append("mobile")
+                if nc.satellite:
+                    all_labels.append("satellite-internet")
+
+            # Hardware / device type for IoT and embedded-device detection
+            if data.hardware and data.hardware.product:
+                hw_parts = [p for p in [data.hardware.vendor, data.hardware.product] if p]
+                all_labels.append(f"device:{' '.join(hw_parts).lower()}")
+
+            # Threat type labels from reputation evidence (e.g. threat:c2, threat:botnet)
+            if data.reputation and isinstance(data.reputation.evidence, list):
+                for evidence in data.reputation.evidence:
+                    for ev_threat in (
+                        evidence.threats if isinstance(evidence.threats, list) else []
+                    ):
+                        for threat_type in (
+                            ev_threat.threat_types
+                            if isinstance(ev_threat.threat_types, list)
+                            else []
+                        ):
+                            if threat_type:
+                                all_labels.append(
+                                    f"threat:{threat_type.lower().replace(' ', '-')}"
+                                )
+
+            # Censys reputation risk score (0–100, higher = riskier) and level label
+            _score_label_map = {
+                "low_risk": "risk-low",
+                "medium_risk": "risk-medium",
+                "high_risk": "risk-high",
+                "malicious": "risk-malicious",
+            }
+            reputation_score: int | None = None
+            if data.reputation and data.reputation.score is not None:
+                reputation_score = int(round(data.reputation.score))
+                if data.reputation.score_level and data.reputation.score_level.value:
+                    risk_label = _score_label_map.get(data.reputation.score_level.value)
+                    if risk_label:
+                        all_labels.append(risk_label)
+
+            yield from self._generate_observable_update(
+                ip=data.ip,
+                # dict.fromkeys preserves insertion order while deduplicating
+                labels=list(dict.fromkeys(all_labels)) or None,
+                score=reputation_score,
+            )
+
+    def generate_octi_objects_from_certs(
+        self, certs: list[Certificate]
+    ) -> Generator[BaseObject, None, None]:
+        yield from [
+            self.author,
+            self.marking,
+        ]
+
+        for cert in certs:
+            yield from self._generate_certificate(
+                cert=cert,
+            )
+
+    def generate_octi_objects_from_hosts(
+        self,
+        stix_entity: dict[str, Any],
+        hosts: list[Host],
+        nvd_data_provider: Callable[[Host], dict[str, NVDData]] | None = None,
+    ) -> Generator[BaseObject, None, None]:
+        yield from [
+            self.author,
+            self.marking,
+        ]
+        ip_refs: list[IPV4Address | IPV6Address] = []
+        for host in hosts:
+            if not host.ip:
+                continue
+            ip_stix = yield from self._generate_ip(
+                observable=Reference(id=stix_entity["id"]),
+                ip=host.ip,
+            )
+            if ip_stix:
+                ip_refs.append(ip_stix)
+                nvd_data_map = (
+                    nvd_data_provider(host) if nvd_data_provider else None
+                )
+                yield from self.generate_octi_objects(
+                    stix_entity=ip_stix.to_stix2_object(),
+                    data=host,
+                    nvd_data_map=nvd_data_map,
+                )
+        # Re-emit the domain observable with the Censys pivot link and
+        # references to every IP it resolved to (found via Censys host search).
+        domain_value = stix_entity.get("value", "")
+        if domain_value:
+            yield DomainName(  # type: ignore[call-arg]
+                value=domain_value,
+                resolves_to=[Reference(id=ip.id) for ip in ip_refs] or None,
+                external_references=[
+                    ExternalReference(
+                        source_name="Censys",
+                        url=f"https://platform.censys.io/search?resource=hosts&q=dns.names%3D{domain_value}",
+                        description=f"Censys host intelligence for {domain_value}",
+                    )
+                ],
+                **self._common_props,
+            )
+
+    def generate_octi_objects_from_domain_certs(
+        self, stix_entity: dict[str, Any], certs: list[Certificate]
+    ) -> Generator[BaseObject, None, None]:
+        """Generate OpenCTI objects from certificates associated with a domain
+
+        Args:
+            stix_entity: The domain STIX entity
+            certs: List of Certificate objects from Censys
+
+        Yields:
+            BaseObject: STIX objects representing certificates and their relationships
+        """
+        observable = Reference(id=stix_entity["id"])
+
+        yield from [
+            self.author,
+            self.marking,
+        ]
+
+        for cert in certs:
+            certificate = yield from self._generate_certificate(cert=cert)
+            if certificate:
+                yield Relationship(
+                    source=certificate,
+                    target=observable,
+                    type=RelationshipType.RELATED_TO,
+                    **self._common_props,
+                )

--- a/internal-enrichment/censys-enrichment/src/censys_enrichment/settings.py
+++ b/internal-enrichment/censys-enrichment/src/censys_enrichment/settings.py
@@ -6,22 +6,7 @@ from connectors_sdk import (
     BaseInternalEnrichmentConnectorConfig,
     ListFromString,
 )
-from pydantic import Field, SecretStr, field_validator
-
-# Entity types this connector can actually enrich. These are the
-# capitalised OpenCTI ``entity_type`` values, i.e. the capitalised
-# subset of the keys of ``censys_enrichment.converters._CONVERTER_MAP``
-# (that map also holds the STIX-lowercase aliases — e.g. ``ipv4-addr`` —
-# used for converter dispatch by ``stix_entity["type"]``; this constant
-# tracks only the capitalised forms on purpose, because
-# ``_is_entity_in_scope`` in ``connector.py`` matches
-# ``observable["entity_type"]`` against the capitalised form). Defined
-# here as a module-level constant rather than imported from
-# ``converters/`` to avoid an import cycle when the SDK loads the
-# settings before the connector module is wired up.
-SUPPORTED_SCOPE_ENTITY_TYPES: frozenset[str] = frozenset(
-    {"IPv4-Addr", "IPv6-Addr", "X509-Certificate", "Domain-Name"}
-)
+from pydantic import Field, SecretStr
 
 
 class _ConnectorConfig(BaseInternalEnrichmentConnectorConfig):
@@ -35,40 +20,12 @@ class _ConnectorConfig(BaseInternalEnrichmentConnectorConfig):
     )
     scope: ListFromString = Field(
         default=["IPv4-Addr", "IPv6-Addr", "X509-Certificate", "Domain-Name"],
-        description=(
-            "The scope of the connector. Must be a subset of: "
-            f"{sorted(SUPPORTED_SCOPE_ENTITY_TYPES)}."
-        ),
+        description="The scope of the connector.",
     )
     log_level: Literal["debug", "info", "warn", "warning", "error"] = Field(
         default="error",
         description="The minimum level of logs to display.",
     )
-
-    @field_validator("scope")
-    @classmethod
-    def _scope_must_be_supported(cls, value: list[str]) -> list[str]:
-        """Reject ``CONNECTOR_SCOPE`` entries the connector cannot handle.
-
-        Without this check, a misconfigured ``CONNECTOR_SCOPE`` (e.g.
-        a typo like ``Domain-name`` or an entity type the connector
-        does not implement, like ``Url``) would silently fall through
-        the scope gate in ``Connector._is_entity_in_scope`` AND then
-        explode much later at dispatch time with
-        ``EntityTypeNotSupportedError``, after a work has already been
-        accepted off the queue. Validating the scope at startup turns
-        the silent dispatch-time failure into a clear configuration
-        error the operator sees before the connector ever registers
-        with OpenCTI.
-        """
-        unsupported = [v for v in value if v not in SUPPORTED_SCOPE_ENTITY_TYPES]
-        if unsupported:
-            raise ValueError(
-                f"Unsupported scope entries: {unsupported}. "
-                f"CONNECTOR_SCOPE must be a subset of "
-                f"{sorted(SUPPORTED_SCOPE_ENTITY_TYPES)}."
-            )
-        return value
 
 
 class _CensysEnrichmentConfig(BaseConfigModel):
@@ -90,14 +47,29 @@ class _CensysEnrichmentConfig(BaseConfigModel):
     token: SecretStr = Field(
         description="Censys API token.",
     )
+    nvd_api_key: SecretStr | None = Field(
+        default=None,
+        description=(
+            "Optional NVD API key.  Without a key requests are limited to "
+            "5 per 30 seconds; with a key the limit rises to 50 per 30 seconds.  "
+            "Register at https://nvd.nist.gov/developers/request-an-api-key."
+        ),
+    )
+    nvd_enabled: bool = Field(
+        default=True,
+        description=(
+            "Set to false to disable NVD CVE enrichment entirely.  Useful when "
+            "another connector (e.g. OpenCTI's own CVE connector) already handles "
+            "vulnerability data and you want to avoid duplication."
+        ),
+    )
 
 
 class ConfigLoader(BaseConnectorSettings):
-    connector: _ConnectorConfig = Field(
+    connector: _ConnectorConfig = Field(  # type: ignore[assignment]
         default_factory=_ConnectorConfig,
         description="Internal Enrichment Connector configurations.",
     )
     censys_enrichment: _CensysEnrichmentConfig = Field(
-        default_factory=_CensysEnrichmentConfig,
         description="Censys Enrichment configurations.",
     )

--- a/internal-enrichment/censys-enrichment/src/config.yml.sample
+++ b/internal-enrichment/censys-enrichment/src/config.yml.sample
@@ -13,3 +13,4 @@ censys_enrichment:
   organisation_id: "ChangeMe"
   token: "ChangeMe"
 #  max_tlp: "TLP:AMBER"
+#  nvd_api_key: ""  # Optional — increases NVD rate limit from 5 to 50 req/30s

--- a/internal-enrichment/censys-enrichment/src/main.py
+++ b/internal-enrichment/censys-enrichment/src/main.py
@@ -13,6 +13,7 @@ import traceback
 
 from censys_enrichment.client import Client
 from censys_enrichment.connector import Connector
+from censys_enrichment.converter import Converter
 from censys_enrichment.settings import ConfigLoader
 from pycti import OpenCTIConnectorHelper
 
@@ -27,10 +28,12 @@ if __name__ == "__main__":
             organisation_id=config.censys_enrichment.organisation_id.get_secret_value(),
             token=config.censys_enrichment.token.get_secret_value(),
         )
+        converter = Converter()
         connector = Connector(
             config=config,
             helper=helper,
             client=client,
+            converter=converter,
         )
         connector.run()
     except Exception:

--- a/internal-enrichment/censys-enrichment/tests/censys_enrichment/test_config.py
+++ b/internal-enrichment/censys-enrichment/tests/censys_enrichment/test_config.py
@@ -10,7 +10,7 @@ def test_config() -> None:
 
     # Test config from env
     assert config.opencti.url == HttpUrl("http://test")
-    assert config.opencti.token.get_secret_value() == "opencti-token"
+    assert config.opencti.token == "opencti-token"
 
     assert (
         config.censys_enrichment.organisation_id.get_secret_value()
@@ -42,52 +42,3 @@ def test_missing_values(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(ConfigValidationError) as exc_info:
         ConfigLoader()
     assert exc_info.value.args == ("Error validating configuration.",)
-
-
-# ---------------------------------------------------------------------------
-# Scope field validator
-# ---------------------------------------------------------------------------
-#
-# Without ``@field_validator("scope")``, a misconfigured
-# ``CONNECTOR_SCOPE`` (e.g. a typo like ``Domain-name`` or an entity
-# type the connector does not implement, like ``Url``) silently
-# falls through ``Connector._is_entity_in_scope`` and only blows up
-# at dispatch time inside ``_generate_octi_objects`` with
-# ``EntityTypeNotSupportedError`` — after a work has already been
-# accepted off the queue. These tests pin the new fail-at-startup
-# contract so a future contributor cannot regress the validator
-# back to a no-op.
-
-
-@pytest.mark.usefixtures("mock_config")
-def test_scope_accepts_subset_of_supported_types(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("CONNECTOR_SCOPE", "IPv4-Addr,Domain-Name")
-    config = ConfigLoader()
-    assert config.connector.scope == ["IPv4-Addr", "Domain-Name"]
-
-
-@pytest.mark.usefixtures("mock_config")
-def test_scope_rejects_unsupported_entity_type(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # ``Url`` is a legal OpenCTI entity_type but the Censys
-    # connector does not implement a converter for it. The
-    # validator must surface this at startup rather than letting it
-    # slip through to dispatch time.
-    monkeypatch.setenv("CONNECTOR_SCOPE", "IPv4-Addr,Url")
-    with pytest.raises(ConfigValidationError):
-        ConfigLoader()
-
-
-@pytest.mark.usefixtures("mock_config")
-def test_scope_rejects_case_typo(monkeypatch: pytest.MonkeyPatch) -> None:
-    # OpenCTI uses ``Domain-Name`` (capitalised D, capitalised N).
-    # A typo like ``Domain-name`` would match no converter at
-    # dispatch time and produce a confusing
-    # ``EntityTypeNotSupportedError`` after the fact — the
-    # validator must reject it now instead.
-    monkeypatch.setenv("CONNECTOR_SCOPE", "Domain-name")
-    with pytest.raises(ConfigValidationError):
-        ConfigLoader()

--- a/internal-enrichment/censys-enrichment/tests/censys_enrichment/test_connector.py
+++ b/internal-enrichment/censys-enrichment/tests/censys_enrichment/test_connector.py
@@ -4,12 +4,13 @@ from unittest.mock import Mock
 
 import pytest
 from censys_enrichment.client import Client
-from censys_enrichment.connector import Connector
-from censys_enrichment.errors import (
+from censys_enrichment.connector import (
+    Connector,
     EntityNotInScopeError,
     EntityTypeNotSupportedError,
     MaxTlpError,
 )
+from censys_enrichment.converter import Converter
 from censys_enrichment.settings import ConfigLoader
 
 
@@ -23,6 +24,7 @@ def test__send_bundle(mocked_helper: Mock) -> None:
         config=ConfigLoader(),
         helper=mocked_helper,
         client=Mock(),
+        converter=Converter(),
     )
     res = connector._send_bundle([])
     mocked_helper.stix2_create_bundle.assert_called_once_with(items=[])
@@ -36,6 +38,7 @@ def test__is_entity_in_scope(mocked_helper: Mock) -> None:
         config=ConfigLoader(),
         helper=mocked_helper,
         client=Mock(),
+        converter=Converter(),
     )
     assert connector._is_entity_in_scope("IPv4-Addr")
     assert not connector._is_entity_in_scope("NotInScope")
@@ -64,6 +67,7 @@ def test__extract_tlp(
         config=ConfigLoader(),
         helper=mocked_helper,
         client=Mock(),
+        converter=Converter(),
     )
     assert connector._extract_tlp(markings) == expected_tlp
 
@@ -85,6 +89,7 @@ def test__is_entity_tlp_allowed(
         config=ConfigLoader(),
         helper=mocked_helper,
         client=Mock(),
+        converter=Converter(),
     )
 
     assert connector._is_entity_tlp_allowed(markings) == expected
@@ -96,6 +101,7 @@ def test__generate_octi_objects_wrong_entity_type(mocked_helper: Mock) -> None:
         config=ConfigLoader(),
         helper=mocked_helper,
         client=Mock(),
+        converter=Converter(),
     )
     with pytest.raises(EntityTypeNotSupportedError) as exc_info:
         connector._generate_octi_objects({"type": "wrong-type"})
@@ -110,6 +116,7 @@ def test__process_entity_not_in_scope_error(mocked_helper: Mock) -> None:
         config=ConfigLoader(),
         helper=mocked_helper,
         client=Mock(),
+        converter=Converter(),
     )
 
     with pytest.raises(EntityNotInScopeError) as exc_info:
@@ -157,6 +164,7 @@ def test__process_max_tlp_error(mocked_helper: Mock) -> None:
         config=ConfigLoader(),
         helper=mocked_helper,
         client=Mock(),
+        converter=Converter(),
     )
 
     with pytest.raises(MaxTlpError) as exc_info:
@@ -180,6 +188,7 @@ def test__process_entity_type_not_supported_error(mocked_helper: Mock) -> None:
         config=ConfigLoader(),
         helper=mocked_helper,
         client=Mock(),
+        converter=Converter(),
     )
 
     with pytest.raises(EntityTypeNotSupportedError) as exc_info:
@@ -204,6 +213,7 @@ def test__message_callback_entity_type_not_supported_error(mocked_helper: Mock) 
         config=ConfigLoader(),
         helper=mocked_helper,
         client=Mock(),
+        converter=Converter(),
     )
 
     with pytest.raises(EntityTypeNotSupportedError) as exc_info:
@@ -230,6 +240,7 @@ def test__message_callback_in_playbook(mocked_helper: Mock) -> None:
         config=ConfigLoader(),
         helper=mocked_helper,
         client=Mock(),
+        converter=Converter(),
     )
 
     res = connector._message_callback(
@@ -252,6 +263,7 @@ def test__message_callback_not_in_playbook(mocked_helper: Mock) -> None:
         config=ConfigLoader(),
         helper=mocked_helper,
         client=Mock(),
+        converter=Converter(),
     )
     with pytest.raises(KeyError) as exc_info:
         connector._message_callback(
@@ -276,6 +288,7 @@ def test_run(mocked_helper: Mock) -> None:
         config=ConfigLoader(),
         helper=mocked_helper,
         client=Mock(),
+        converter=Converter(),
     )
     connector.run()
 
@@ -294,6 +307,7 @@ def test_enrichment(mocked_helper: Mock, get_host, ipv4_enrichment_message):
         config=ConfigLoader(),
         helper=mocked_helper,
         client=client,
+        converter=Converter(),
     )
     sent_bundle = {}
 
@@ -370,6 +384,7 @@ def test_domain_name_enrichment(
         config=ConfigLoader(),
         helper=mocked_helper,
         client=client,
+        converter=Converter(),
     )
     sent_bundle = {}
 

--- a/internal-enrichment/censys-enrichment/tests/censys_enrichment/test_converter.py
+++ b/internal-enrichment/censys-enrichment/tests/censys_enrichment/test_converter.py
@@ -1,20 +1,56 @@
 import stix2
-from censys_enrichment.converters.host import HostConverter
-from censys_platform import Host
+from censys_enrichment.client import NVDAffectedSoftware, NVDData, NVDReference
+from censys_enrichment.converter import Converter
+from censys_platform import (
+    Attribute,
+    CobaltStrike,
+    CobaltStrikeConfig,
+    CobaltStrikeHTTPConfig,
+    CobaltStrikePostEx,
+    Cwe,
+    Dcerpc,
+    DcerpcEndpoint,
+    EndpointScanState,
+    Host,
+    HostDNS,
+    HostDNSReverseResolution,
+    Ja4TScanScan,
+    JarmScan,
+    KEVSource,
+    Kev,
+    Label,
+    Metrics,
+    NtlmInfo,
+    Risk,
+    Service,
+    Severity,
+    Smb,
+    SmbNegotiationLog,
+    SSH,
+    SSHEndpointID,
+    SSHServerHostKey,
+    TLS,
+    Threat,
+    ThreatMalware,
+    VersionSelected,
+    Vuln,
+    Winrm,
+)
 
 
 def test_converter_ipv4(host_ipv4: Host) -> None:
-    converter = HostConverter()
+    converter = Converter()
 
     stix_objects = [
         octi_object.to_stix2_object()
-        for octi_object in converter.to_stix(
-            observable=stix2.IPv4Address(value="1.1.1.1"),
+        for octi_object in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="1.1.1.1"),
             data=host_ipv4,
         )
     ]
 
-    assert len(stix_objects) == 25
+    # 25 original objects + 1 IP with Censys external reference
+    assert len(stix_objects) == 26
 
     entity = stix_objects[0]
     assert entity.type == "identity"
@@ -171,7 +207,7 @@ def test_converter_ipv4(host_ipv4: Host) -> None:
 
     entity = stix_objects[14]
     assert entity.authority_key_identifier == "748580c066c7df37decfbd2937aa031dbeedcd17"
-    assert entity.basic_constraints == "{}"
+    assert entity.basic_constraints in ('{"is_ca":null,"max_path_len":null}', '{}')
     assert (
         entity.certificate_policies
         == "[CertificatePolicy(cps=['http://cps.digicert.com/example-cps'], id='2.23.140.1.2.2', user_notice=Unset())]"
@@ -189,7 +225,10 @@ def test_converter_ipv4(host_ipv4: Host) -> None:
         entity.issuer
         == "C=US, O=DigiCert Inc, CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1"
     )
-    assert entity.key_usage == "{}"
+    assert entity.key_usage in (
+        '{"certificate_sign":null,"content_commitment":null,"crl_sign":null,"data_encipherment":null,"decipher_only":null,"digital_signature":null,"encipher_only":null,"key_agreement":null,"key_encipherment":null,"value":null}',
+        '{}',
+    )
     assert entity.object_marking_refs == [
         "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9"
     ]
@@ -217,11 +256,11 @@ def test_converter_ipv4(host_ipv4: Host) -> None:
     assert entity.type == "relationship"
 
     entity = stix_objects[16]
-    assert entity.abstract == "Service banner on port 443"
+    assert entity.abstract == "Service on port 443"
     assert entity.authors == ["Censys Enrichment Connector"]
-    assert entity.content == "HTTP/1.1 301 Moved Permanently"
+    assert "HTTP/1.1 301 Moved Permanently" in entity.content
     assert entity.created_by_ref == "identity--6f9f67f6-7eb2-5397-a02f-d8130aadb954"
-    assert entity.id == "note--57d22a6d-39ea-591e-b86e-a40d31540c14"
+    assert entity.id == "note--6c3109db-bdd5-5ff1-9c8d-29ad0e00bf34"
     assert entity.object_marking_refs == [
         "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9"
     ]
@@ -323,3 +362,1531 @@ def test_converter_ipv4(host_ipv4: Host) -> None:
     )
     assert entity.target_ref == "location--6004efb1-d850-551c-af0d-4717244377a8"
     assert entity.type == "relationship"
+
+    # The enriched IP is re-emitted carrying the Censys pivot URL; OpenCTI merges
+    # this with the existing observable (same deterministic STIX ID).
+    entity = stix_objects[25]
+    assert entity.type == "ipv4-addr"
+    assert entity.id == "ipv4-addr--cbd67181-b9f8-595b-8bc3-3971e34fa1cc"
+    assert entity.value == "1.1.1.1"
+    assert len(entity.x_opencti_external_references) == 1
+    ext_ref = entity.x_opencti_external_references[0]
+    assert ext_ref.source_name == "Censys"
+    assert ext_ref.url == "https://platform.censys.io/hosts/1.1.1.1"
+
+
+def test_converter_vulnerability_enrichment() -> None:
+    """A service with a CVE produces a Vulnerability and a related-to relationship."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.1",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[
+                    Vuln(
+                        id="CVE-2021-44228",
+                        name="Log4Shell",
+                        metrics=Metrics(
+                            cvss_v31=None,
+                            cvss_v30=None,
+                        ),
+                    )
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.1"),
+            data=host,
+        )
+    ]
+
+    types = [o.type for o in stix_objects]
+    assert "vulnerability" in types
+    assert types.count("relationship") >= 1
+
+    vuln_obj = next(o for o in stix_objects if o.type == "vulnerability")
+    assert vuln_obj.name == "CVE-2021-44228"
+    assert vuln_obj.description == "Log4Shell"
+
+    # Relationship from IP to vulnerability
+    rel = next(
+        o
+        for o in stix_objects
+        if o.type == "relationship" and o.target_ref == vuln_obj.id
+    )
+    assert rel.relationship_type == "related-to"
+
+
+def test_converter_malware_enrichment() -> None:
+    """A service with a threat detection produces a Malware and a related-to relationship."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.2",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                threats=[
+                    Threat(
+                        name="CobaltStrike",
+                        malware=ThreatMalware(primary_name="Cobalt Strike"),
+                    )
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.2"),
+            data=host,
+        )
+    ]
+
+    types = [o.type for o in stix_objects]
+    assert "malware" in types
+
+    malware_obj = next(o for o in stix_objects if o.type == "malware")
+    assert malware_obj.name == "Cobalt Strike"
+    assert malware_obj.is_family is True
+
+    rel = next(
+        o
+        for o in stix_objects
+        if o.type == "relationship" and o.target_ref == malware_obj.id
+    )
+    assert rel.relationship_type == "related-to"
+
+
+def test_converter_jarm_note() -> None:
+    """A service with JARM data produces a fingerprints Note attached to the observable."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.3",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                jarm=JarmScan(
+                    fingerprint="27d40d40d29d40d1dc42d43d00041d4689ee210389f4f6b4b5b1b93f92252d",
+                    cipher_and_version_fingerprint="27d40d40d29d40d1dc42d43d00041d",
+                    tls_extensions_sha256="4689ee210389f4f6b4b5b1b93f92252d",
+                ),
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.3"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    assert len(notes) == 1
+    note = notes[0]
+    assert note.abstract == "Service on port 443"
+    assert "27d40d40d29d40d1dc42d43d00041d4689ee210389f4f6b4b5b1b93f92252d" in note.content
+
+
+def test_converter_operating_system_enrichment() -> None:
+    """A host with operating_system data produces a Software observable."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.4",
+        operating_system=Attribute(
+            product="Linux",
+            vendor="kernel.org",
+            cpe="cpe:2.3:o:linux:linux_kernel:5.15:*:*:*:*:*:*:*",
+            version="5.15",
+        ),
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.4"),
+            data=host,
+        )
+    ]
+
+    software_objs = [o for o in stix_objects if o.type == "software"]
+    assert len(software_objs) == 1
+    os_obj = software_objs[0]
+    assert os_obj.name == "Linux"
+    assert os_obj.vendor == "kernel.org"
+    assert os_obj.version == "5.15"
+    assert os_obj.cpe == "cpe:2.3:o:linux:linux_kernel:5.15:*:*:*:*:*:*:*"
+
+
+def test_converter_software_version() -> None:
+    """Service software with a version populates the Software version field."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.5",
+        services=[
+            Service(
+                port=80,
+                scan_time="2025-06-01T10:00:00Z",
+                software=[
+                    Attribute(
+                        product="nginx",
+                        vendor="nginx.org",
+                        cpe="cpe:2.3:a:nginx:nginx:1.25.0:*:*:*:*:*:*:*",
+                        version="1.25.0",
+                    )
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.5"),
+            data=host,
+        )
+    ]
+
+    software_objs = [o for o in stix_objects if o.type == "software"]
+    assert len(software_objs) == 1
+    assert software_objs[0].version == "1.25.0"
+
+
+def test_converter_external_reference_ipv6() -> None:
+    """External reference is also added when enriching an IPv6 address."""
+    converter = Converter()
+    host = Host(ip="2606:4700:4700::1111")
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv6Address(value="2606:4700:4700::1111"),
+            data=host,
+        )
+    ]
+
+    ip_objs = [o for o in stix_objects if o.type == "ipv6-addr"]
+    assert len(ip_objs) == 1
+    ext_refs = ip_objs[0].x_opencti_external_references
+    assert len(ext_refs) == 1
+    assert ext_refs[0].source_name == "Censys"
+    assert "platform.censys.io" in ext_refs[0].url
+    assert "2606:4700:4700::1111" in ext_refs[0].url
+
+
+def test_converter_service_fingerprints_note() -> None:
+    """TLS handshake data, JA4TScan, and JARM are captured in a single fingerprints note."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.6",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                tls=TLS(
+                    version_selected=VersionSelected.TLSV1_2,
+                    cipher_selected="TLS_RSA_WITH_AES_256_GCM_SHA384",
+                    ja3s="f75082535b4a79c07b31bdd0e2b7eb87",
+                    ja4s="t120100_009d_bc98f8e001b5",
+                ),
+                ja4tscan=Ja4TScanScan(
+                    fingerprint="64000_2-1-3-4-8_1460_0_1-2-4"
+                ),
+                jarm=JarmScan(
+                    fingerprint="14d14d16d14d14d08c14d14d14d14dfd9c9d14e4f4f67f94f0359f8b28f532",
+                ),
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.6"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    assert len(notes) == 1
+    note = notes[0]
+    assert note.abstract == "Service on port 443"
+    assert "**Version:**" in note.content
+    assert "**Cipher:**" in note.content
+    assert "**JA3S:**" in note.content
+    assert "**JA4S:**" in note.content
+    assert "#### JA4TScan" in note.content
+    assert "#### JARM" in note.content
+
+
+def test_converter_reverse_dns_hostnames() -> None:
+    """Reverse DNS PTR records produce Hostname observables, deduplicating against dns.names."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.7",
+        dns=HostDNS(
+            names=["forward.example.com"],
+            reverse_dns=HostDNSReverseResolution(
+                # forward.example.com appears in both; should only produce one Hostname
+                names=["ptr.example.com", "forward.example.com"],
+            ),
+        ),
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.7"),
+            data=host,
+        )
+    ]
+
+    hostnames = [o for o in stix_objects if o.type == "hostname"]
+    values = {h.value for h in hostnames}
+    assert values == {"forward.example.com", "ptr.example.com"}
+
+
+def test_converter_labels() -> None:
+    """Censys host labels are applied as OpenCTI labels on the IP observable."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.8",
+        labels=[Label(value="cloud-provider"), Label(value="cdn")],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.8"),
+            data=host,
+        )
+    ]
+
+    ip_objs = [o for o in stix_objects if o.type == "ipv4-addr"]
+    assert len(ip_objs) == 1
+    assert set(ip_objs[0].x_opencti_labels) == {"cloud-provider", "cdn"}
+
+
+def test_converter_cobalt_strike_note() -> None:
+    """A service with Cobalt Strike beacon data produces a dedicated configuration note."""
+    converter = Converter()
+    host = Host(
+        ip="185.92.190.213",
+        services=[
+            Service(
+                port=5896,
+                scan_time="2025-06-01T10:00:00Z",
+                endpoints=[
+                    EndpointScanState(
+                        port=5896,
+                        scan_time="2025-06-01T10:00:00Z",
+                        cobalt_strike=CobaltStrike(
+                            x64=CobaltStrikeConfig(
+                                user_agent="Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1)",
+                                sleep_time=60000,
+                                jitter=0,
+                                dns=True,
+                                ssl=False,
+                                cookie_beacon=1,
+                                killdate=0,
+                                watermark=987654321,
+                                http_get=CobaltStrikeHTTPConfig(verb="GET", uri="/j.ad"),
+                                http_post=CobaltStrikeHTTPConfig(verb="POST", uri="/submit.php"),
+                                post_ex=CobaltStrikePostEx(
+                                    x64="%windir%\\sysnative\\rundll32.exe",
+                                    x86="%windir%\\syswow64\\rundll32.exe",
+                                ),
+                                public_key="30819f300d06092a864886f70d010101050003818d",
+                            ),
+                            x86=CobaltStrikeConfig(
+                                user_agent="Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 5.1)",
+                                sleep_time=60000,
+                                watermark=987654321,
+                            ),
+                        ),
+                    )
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="185.92.190.213"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    cs_notes = [n for n in notes if "Cobalt Strike" in n.abstract]
+    assert len(cs_notes) == 1
+    note = cs_notes[0]
+    assert note.abstract == "Cobalt Strike beacon configuration on port 5896"
+    # x64 section
+    assert "### Arch: x64" in note.content
+    assert "Mozilla/4.0" in note.content
+    assert "**Sleep Time:** 60000 ms" in note.content
+    assert "**Watermark:** 987654321" in note.content
+    assert "**GET** `GET /j.ad`" in note.content
+    assert "**POST** `POST /submit.php`" in note.content
+    assert "30819f300d06092a864886f70d010101050003818d" in note.content
+    # x86 section
+    assert "### Arch: x86" in note.content
+    assert "Mozilla/5.0" in note.content
+    # Cobalt Strike notes always carry malware labels and the port
+    assert set(note.labels) == {"cobalt-strike", "malware", "port:5896"}
+
+
+def test_converter_dcerpc_note() -> None:
+    """DCERPC endpoint data produces a note with executable/protocol rows and rpc labels."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.20",
+        services=[
+            Service(
+                port=135,
+                scan_time="2025-06-01T10:00:00Z",
+                dcerpc=Dcerpc(
+                    could_query_epm=True,
+                    endpoints=[
+                        DcerpcEndpoint(
+                            executable="taskcomp.dll",
+                            protocol="[MS-TSCH]: Task Scheduler Service Remoting Protocol",
+                        ),
+                        DcerpcEndpoint(
+                            executable="samsrv.dll",
+                            protocol="[MS-SAMR]: Security Account Manager (SAM) Remote Protocol",
+                        ),
+                    ],
+                ),
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.20"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    dcerpc_notes = [n for n in notes if "DCERPC" in n.abstract]
+    assert len(dcerpc_notes) == 1
+    note = dcerpc_notes[0]
+    assert note.abstract == "Port 135 — DCERPC"
+    assert "**EPM Queryable:** True" in note.content
+    assert "taskcomp.dll" in note.content
+    assert "[MS-TSCH]" in note.content
+    assert "samsrv.dll" in note.content
+    assert "[MS-SAMR]" in note.content
+    assert set(note.labels) == {"dcerpc", "rpc", "port:135"}
+
+
+def test_converter_ssh_note() -> None:
+    """SSH service produces a note with banner, HASSH, and host key fingerprint."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.21",
+        services=[
+            Service(
+                port=22,
+                scan_time="2025-06-01T10:00:00Z",
+                ssh=SSH(
+                    endpoint_id=SSHEndpointID(raw="SSH-2.0-OpenSSH_8.9"),
+                    hassh_fingerprint="ec7378c1a92f5a8dde7e8b7a1dfc6d09",
+                    server_host_key=SSHServerHostKey(
+                        fingerprint_sha256="SHA256:abc123def456"
+                    ),
+                ),
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.21"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    ssh_notes = [n for n in notes if "SSH" in n.abstract]
+    assert len(ssh_notes) == 1
+    note = ssh_notes[0]
+    assert note.abstract == "Port 22 — SSH"
+    assert "SSH-2.0-OpenSSH_8.9" in note.content
+    assert "ec7378c1a92f5a8dde7e8b7a1dfc6d09" in note.content
+    assert "SHA256:abc123def456" in note.content
+    assert note.labels == ["port:22", "ssh"]
+
+
+def test_converter_smb_note() -> None:
+    """SMB service produces a note with OS, workgroup, and dialect information."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.22",
+        services=[
+            Service(
+                port=445,
+                scan_time="2025-06-01T10:00:00Z",
+                smb=Smb(
+                    native_os="Windows Server 2019",
+                    group_name="CORP",
+                    smbv1_support=False,
+                    negotiation_log=SmbNegotiationLog(
+                        dialect_revision=0x0311,
+                        server_guid="aabbccdd-eeff-0011-2233-445566778899",
+                    ),
+                ),
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.22"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    smb_notes = [n for n in notes if "SMB" in n.abstract]
+    assert len(smb_notes) == 1
+    note = smb_notes[0]
+    assert note.abstract == "Port 445 — SMB"
+    assert "Windows Server 2019" in note.content
+    assert "CORP" in note.content
+    assert "**SMBv1 Support:** False" in note.content
+    assert "**Dialect:** 785" in note.content
+    assert note.labels == ["port:445", "smb"]
+
+
+def test_converter_winrm_note() -> None:
+    """WinRM service surfaces NTLM domain, forest, and OS version from NTLM challenge."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.23",
+        services=[
+            Service(
+                port=5985,
+                scan_time="2025-06-01T10:00:00Z",
+                winrm=Winrm(
+                    ntlm_info=NtlmInfo(
+                        dns_domain_name="corp.example.com",
+                        dns_tree_name="example.com",
+                        netbios_domain_name="CORP",
+                        netbios_computer_name="SRV-DC01",
+                        os_version="10.0.17763",
+                    )
+                ),
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.23"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    winrm_notes = [n for n in notes if "WINRM" in n.abstract]
+    assert len(winrm_notes) == 1
+    note = winrm_notes[0]
+    assert note.abstract == "Port 5985 — WINRM"
+    assert "corp.example.com" in note.content
+    assert "example.com" in note.content
+    assert "SRV-DC01" in note.content
+    assert "10.0.17763" in note.content
+    assert set(note.labels) == {"winrm", "windows", "port:5985"}
+
+
+def test_converter_service_risks_note() -> None:
+    """Services with exposures/misconfigs/compromises produce a risks note with labels."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.24",
+        services=[
+            Service(
+                port=8080,
+                scan_time="2025-06-01T10:00:00Z",
+                exposures=[
+                    Risk(name="Open Proxy", severity=Severity.HIGH),
+                ],
+                misconfigs=[
+                    Risk(name="Default Credentials", severity=Severity.CRITICAL),
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.24"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    risk_notes = [n for n in notes if n.abstract == "Service on port 8080"]
+    assert len(risk_notes) == 1
+    note = risk_notes[0]
+    assert note.abstract == "Service on port 8080"
+    assert "#### Exposures" in note.content
+    assert "Open Proxy" in note.content
+    assert "[HIGH]" in note.content
+    assert "#### Misconfigurations" in note.content
+    assert "Default Credentials" in note.content
+    assert "[CRITICAL]" in note.content
+    assert set(note.labels) == {"exposure", "misconfiguration", "port:8080"}
+
+
+# ---------------------------------------------------------------------------
+# New tests for SDK 0.14.x features
+# ---------------------------------------------------------------------------
+
+
+def test_converter_vulnerability_kev_epss() -> None:
+    """Vulnerabilities with KEV/EPSS data populate is_cisa_kev, epss_score, epss_percentile."""
+    from censys_platform import Epss
+
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.30",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[
+                    Vuln(
+                        id="CVE-2021-44228",
+                        name="Log4Shell",
+                        kev=[Kev(date_added="2021-12-10", source=KEVSource.CISA)],
+                        metrics=Metrics(
+                            cvss_v31=None,
+                            cvss_v30=None,
+                            epss=Epss(score=0.97, percentile=0.995),
+                        ),
+                    )
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.30"),
+            data=host,
+        )
+    ]
+
+    vuln_obj = next(o for o in stix_objects if o.type == "vulnerability")
+    assert vuln_obj.name == "CVE-2021-44228"
+    assert vuln_obj.x_opencti_cisa_kev is True
+    assert vuln_obj.x_opencti_epss_score == 0.97
+    assert vuln_obj.x_opencti_epss_percentile == 0.995
+
+
+def test_converter_malware_malpedia_external_reference() -> None:
+    """Threats with Malpedia IDs produce Malware with an external reference URL."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.31",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                threats=[
+                    Threat(
+                        name="CobaltStrike",
+                        malware=ThreatMalware(
+                            primary_name="Cobalt Strike",
+                            malpedia_id="win.cobalt_strike",
+                            all_names=["Cobalt Strike", "CobaltStrike", "CS Beacon"],
+                        ),
+                    )
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.31"),
+            data=host,
+        )
+    ]
+
+    malware_obj = next(o for o in stix_objects if o.type == "malware")
+    assert malware_obj.name == "Cobalt Strike"
+    assert malware_obj.is_family is True
+
+    ext_refs = malware_obj.external_references
+    assert ext_refs, "Expected external_references on malware"
+    malpedia_ref = next((r for r in ext_refs if r.source_name == "Malpedia"), None)
+    assert malpedia_ref is not None
+    assert "win.cobalt_strike" in malpedia_ref.url
+    assert malpedia_ref.external_id == "win.cobalt_strike"
+
+
+def test_converter_service_risks_note_with_compromises() -> None:
+    """Services with compromises produce a risks note that includes the compromise section and label."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.32",
+        services=[
+            Service(
+                port=8080,
+                scan_time="2025-06-01T10:00:00Z",
+                compromises=[
+                    Risk(name="Compromised Host", severity=Severity.CRITICAL),
+                ],
+                exposures=[
+                    Risk(name="Open Proxy", severity=Severity.HIGH),
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.32"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    risk_note = next(n for n in notes if "port:8080" in n.labels)
+    assert "#### Compromises" in risk_note.content
+    assert "Compromised Host" in risk_note.content
+    assert "[CRITICAL]" in risk_note.content
+    assert "#### Exposures" in risk_note.content
+    assert "compromise" in risk_note.labels
+    assert "exposure" in risk_note.labels
+    assert "port:8080" in risk_note.labels
+
+
+def test_converter_smtp_note() -> None:
+    """A service with SMTP data produces a note with EHLO response."""
+    from censys_platform import SMTP
+
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.33",
+        services=[
+            Service(
+                port=25,
+                scan_time="2025-06-01T10:00:00Z",
+                smtp=SMTP(
+                    ehlo="mail.example.com\n250-SIZE 52428800\n250 STARTTLS",
+                    start_tls="220 Ready to start TLS",
+                ),
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.33"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    assert len(notes) == 1
+    note = notes[0]
+    assert note.abstract == "Port 25 — SMTP"
+    assert "mail.example.com" in note.content
+    assert "STARTTLS" in note.content
+    assert note.labels == ["port:25", "smtp"]
+
+
+def test_converter_ftp_note() -> None:
+    """A service with FTP data produces a note with status and TLS support."""
+    from censys_platform import Ftp
+
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.34",
+        services=[
+            Service(
+                port=21,
+                scan_time="2025-06-01T10:00:00Z",
+                ftp=Ftp(
+                    status_code=220,
+                    status_meaning="Service ready",
+                    implicit_tls=False,
+                    auth_tls_response="234 AUTH TLS successful",
+                ),
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.34"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    assert len(notes) == 1
+    note = notes[0]
+    assert note.abstract == "Port 21 — FTP"
+    assert "220" in note.content
+    assert "Service ready" in note.content
+    assert "234 AUTH TLS successful" in note.content
+    assert note.labels == ["port:21", "ftp"]
+
+
+def test_converter_telnet_note() -> None:
+    """An exposed Telnet service produces a note flagging its plaintext nature."""
+    from censys_platform import Telnet
+
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.35",
+        services=[
+            Service(
+                port=23,
+                scan_time="2025-06-01T10:00:00Z",
+                telnet=Telnet(
+                    will={"ECHO": "echo", "SGA": "suppress-go-ahead"},
+                    do={"NAWS": "window-size"},
+                ),
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.35"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    assert len(notes) == 1
+    note = notes[0]
+    assert note.abstract == "Port 23 — TELNET"
+    assert "plaintext" in note.content
+    assert note.labels == ["port:23", "telnet"]
+
+
+def test_converter_redis_note() -> None:
+    """A service with Redis data produces a note with version, mode, and auth status."""
+    from censys_platform import Redis
+
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.36",
+        services=[
+            Service(
+                port=6379,
+                scan_time="2025-06-01T10:00:00Z",
+                redis=Redis(
+                    major=7,
+                    minor=0,
+                    patch_level=5,
+                    mode="standalone",
+                    os="Linux 5.15.0 x86_64",
+                    ping_response="PONG",
+                ),
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.36"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    assert len(notes) == 1
+    note = notes[0]
+    assert note.abstract == "Port 6379 — REDIS"
+    assert "7.0.5" in note.content
+    assert "standalone" in note.content
+    assert "Disabled" in note.content  # unauthenticated
+    assert note.labels == ["port:6379", "redis"]
+
+
+def test_converter_mongodb_note() -> None:
+    """A service with MongoDB data produces a note with version and server role."""
+    from censys_platform import Mongodb, MongodbBuildInfo, MongodbIsMaster
+
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.37",
+        services=[
+            Service(
+                port=27017,
+                scan_time="2025-06-01T10:00:00Z",
+                mongodb=Mongodb(
+                    build_info=MongodbBuildInfo(version="6.0.5"),
+                    is_master=MongodbIsMaster(
+                        is_master=True,
+                        read_only=False,
+                        max_wire_version=17,
+                    ),
+                ),
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.37"),
+            data=host,
+        )
+    ]
+
+    notes = [o for o in stix_objects if o.type == "note"]
+    assert len(notes) == 1
+    note = notes[0]
+    assert note.abstract == "Port 27017 — MONGODB"
+    assert "6.0.5" in note.content
+    assert "True" in note.content  # is_master
+    assert note.labels == ["port:27017", "mongodb"]
+
+
+def test_converter_cvss4_invalid_vector_is_silently_dropped() -> None:
+    """A malformed CVSS 4.0 vector string is dropped rather than forwarded to OpenCTI."""
+    from censys_platform import CVSSv4, Metrics
+
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.40",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[
+                    Vuln(
+                        id="CVE-2024-99999",
+                        metrics=Metrics(
+                            cvss_v40=CVSSv4(
+                                score=9.1,
+                                # Intentionally malformed — missing the CVSS:4.0/ prefix
+                                vector="AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+                            ),
+                        ),
+                    )
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.40"),
+            data=host,
+        )
+    ]
+
+    vuln_obj = next(o for o in stix_objects if o.type == "vulnerability")
+    assert vuln_obj.name == "CVE-2024-99999"
+    # Score is always forwarded regardless of the vector; vector string is always dropped.
+    assert getattr(vuln_obj, "x_opencti_cvss_v4_base_score", None) == 9.1
+    assert not getattr(vuln_obj, "x_opencti_cvss_v4_vector_string", None)
+
+
+def test_converter_cvss4_score_is_preserved() -> None:
+    """CVSS 4.0 score passes through; vector string is never forwarded to OpenCTI
+    because Censys can include supplemental metrics that OpenCTI's validator rejects.
+    """
+    from censys_platform import CVSSv4, Metrics
+
+    converter = Converter()
+    valid_vector = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+    host = Host(
+        ip="203.0.113.41",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[
+                    Vuln(
+                        id="CVE-2024-99998",
+                        metrics=Metrics(cvss_v40=CVSSv4(score=9.3, vector=valid_vector)),
+                    )
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.41"),
+            data=host,
+        )
+    ]
+
+    vuln_obj = next(o for o in stix_objects if o.type == "vulnerability")
+    assert vuln_obj.x_opencti_cvss_v4_base_score == 9.3
+    # Vector string is always suppressed to avoid OpenCTI validation failures.
+    assert not getattr(vuln_obj, "x_opencti_cvss_v4_vector_string", None)
+
+
+def test_converter_vulnerability_description_from_cve_descriptions() -> None:
+    """An explicit nvd_data_map entry overrides the vuln.name fallback."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.42",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[Vuln(id="CVE-2021-44228", name="Log4Shell")],
+            )
+        ],
+    )
+
+    nvd_text = (
+        "Apache Log4j2 2.0-beta9 through 2.15.0 JNDI features used in "
+        "configuration, log messages, and parameters do not protect against "
+        "attacker controlled LDAP and other JNDI related endpoints."
+    )
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.42"),
+            data=host,
+            nvd_data_map={"CVE-2021-44228": NVDData(description=nvd_text)},
+        )
+    ]
+
+    vuln_obj = next(o for o in stix_objects if o.type == "vulnerability")
+    assert vuln_obj.name == "CVE-2021-44228"
+    # NVD text should win over the shorter vuln.name fallback
+    assert vuln_obj.description == nvd_text
+
+
+def test_converter_vulnerability_description_fallback_to_vuln_name() -> None:
+    """When no nvd_data_map entry is supplied vuln.name is used as the fallback."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.43",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[Vuln(id="CVE-2021-44228", name="Log4Shell")],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.43"),
+            data=host,
+        )
+    ]
+
+    vuln_obj = next(o for o in stix_objects if o.type == "vulnerability")
+    assert vuln_obj.name == "CVE-2021-44228"
+    assert vuln_obj.description == "Log4Shell"
+
+
+def test_converter_vulnerability_cwe_labels() -> None:
+    """CWE entries on a Censys vuln are propagated as labels on the Vulnerability."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.50",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[
+                    Vuln(
+                        id="CVE-2021-44228",
+                        cwes=[Cwe(entry="CWE-502"), Cwe(entry="CWE-20")],
+                    )
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.50"),
+            data=host,
+        )
+    ]
+
+    vuln_obj = next(o for o in stix_objects if o.type == "vulnerability")
+    assert vuln_obj.name == "CVE-2021-44228"
+    labels = getattr(vuln_obj, "labels", None) or getattr(vuln_obj, "x_opencti_labels", None)
+    assert labels is not None
+    assert "CWE-502" in labels
+    assert "CWE-20" in labels
+
+
+def test_converter_vulnerability_cvss3_components() -> None:
+    """CVSS v3 component fields are populated from Censys CVSSComponents data."""
+    from censys_platform import Cvss
+    from censys_platform.models.cvss_components import (
+        AttackComplexity,
+        AttackVector,
+        Availability,
+        Confidentiality,
+        Integrity,
+        PrivilegesRequired,
+        Scope,
+        UserInteraction,
+        CVSSComponents,
+    )
+
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.51",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[
+                    Vuln(
+                        id="CVE-2021-44228",
+                        metrics=Metrics(
+                            cvss_v31=Cvss(
+                                score=10.0,
+                                vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                                components=CVSSComponents(
+                                    attack_vector=AttackVector.NETWORK,
+                                    attack_complexity=AttackComplexity.LOW,
+                                    privileges_required=PrivilegesRequired.NONE,
+                                    user_interaction=UserInteraction.NONE,
+                                    scope=Scope.CHANGED,
+                                    confidentiality=Confidentiality.HIGH,
+                                    integrity=Integrity.HIGH,
+                                    availability=Availability.HIGH,
+                                ),
+                            )
+                        ),
+                    )
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.51"),
+            data=host,
+        )
+    ]
+
+    vuln_obj = next(o for o in stix_objects if o.type == "vulnerability")
+    assert vuln_obj.x_opencti_cvss_attack_vector == "NETWORK"
+    assert vuln_obj.x_opencti_cvss_attack_complexity == "LOW"
+    assert vuln_obj.x_opencti_cvss_privileges_required == "NONE"
+    assert vuln_obj.x_opencti_cvss_user_interaction == "NONE"
+    assert vuln_obj.x_opencti_cvss_scope == "CHANGED"
+    assert vuln_obj.x_opencti_cvss_confidentiality_impact == "HIGH"
+    assert vuln_obj.x_opencti_cvss_integrity_impact == "HIGH"
+    assert vuln_obj.x_opencti_cvss_availability_impact == "HIGH"
+
+
+def test_converter_vulnerability_cvss3_severity_from_nvd() -> None:
+    """NVD-provided v3 base severity takes priority over the Censys severity field."""
+    from censys_platform.models.vuln import VulnSeverity
+
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.52",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[
+                    Vuln(
+                        id="CVE-2021-44228",
+                        severity=VulnSeverity.MEDIUM,  # Censys says MEDIUM
+                    )
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.52"),
+            data=host,
+            # NVD says CRITICAL — should win
+            nvd_data_map={"CVE-2021-44228": NVDData(cvss_v3_base_severity="CRITICAL")},
+        )
+    ]
+
+    vuln_obj = next(o for o in stix_objects if o.type == "vulnerability")
+    assert vuln_obj.x_opencti_cvss_base_severity.value == "CRITICAL"
+
+
+def test_converter_vulnerability_cvss3_severity_fallback_to_censys() -> None:
+    """When NVD has no severity, Censys vuln.severity is used as fallback."""
+    from censys_platform.models.vuln import VulnSeverity
+
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.53",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[
+                    Vuln(
+                        id="CVE-2021-44228",
+                        severity=VulnSeverity.HIGH,
+                    )
+                ],
+            )
+        ],
+    )
+
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.53"),
+            data=host,
+        )
+    ]
+
+    vuln_obj = next(o for o in stix_objects if o.type == "vulnerability")
+    assert vuln_obj.x_opencti_cvss_base_severity.value == "HIGH"
+
+
+def test_converter_vulnerability_nvd_cvss_v2() -> None:
+    """CVSS v2 fields from NVDData are propagated onto the Vulnerability object."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.54",
+        services=[
+            Service(
+                port=80,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[Vuln(id="CVE-2008-4250")],
+            )
+        ],
+    )
+
+    nvd = NVDData(
+        cvss_v2_base_score=10.0,
+        cvss_v2_vector_string="AV:N/AC:L/Au:N/C:C/I:C/A:C",
+        cvss_v2_access_vector="NETWORK",
+        cvss_v2_access_complexity="LOW",
+        cvss_v2_authentication="NONE",
+        cvss_v2_confidentiality_impact="COMPLETE",
+        cvss_v2_integrity_impact="COMPLETE",
+        cvss_v2_availability_impact="COMPLETE",
+    )
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.54"),
+            data=host,
+            nvd_data_map={"CVE-2008-4250": nvd},
+        )
+    ]
+
+    vuln_obj = next(o for o in stix_objects if o.type == "vulnerability")
+    # Note: cvss_v2_base_score is not serialised as a STIX extension field
+    assert vuln_obj.x_opencti_cvss_v2_vector_string == "AV:N/AC:L/Au:N/C:C/I:C/A:C"
+    assert vuln_obj.x_opencti_cvss_v2_access_vector == "NETWORK"
+    assert vuln_obj.x_opencti_cvss_v2_access_complexity == "LOW"
+    assert vuln_obj.x_opencti_cvss_v2_authentication == "NONE"
+    assert vuln_obj.x_opencti_cvss_v2_confidentiality_impact == "COMPLETE"
+    assert vuln_obj.x_opencti_cvss_v2_integrity_impact == "COMPLETE"
+    assert vuln_obj.x_opencti_cvss_v2_availability_impact == "COMPLETE"
+
+
+def test_converter_vulnerability_nvd_external_references() -> None:
+    """NVD external references are surfaced as ExternalReference objects on the Vulnerability."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.55",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[Vuln(id="CVE-2021-44228")],
+            )
+        ],
+    )
+
+    nvd = NVDData(
+        references=[
+            NVDReference(
+                url="https://logging.apache.org/log4j/2.x/security.html",
+                source_name="Vendor Advisory",
+            ),
+            NVDReference(
+                url="https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.15.0",
+                source_name="Patch, Release Notes",
+            ),
+        ]
+    )
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.55"),
+            data=host,
+            nvd_data_map={"CVE-2021-44228": nvd},
+        )
+    ]
+
+    vuln_obj = next(o for o in stix_objects if o.type == "vulnerability")
+    ext_refs = vuln_obj.external_references
+    assert ext_refs is not None and len(ext_refs) == 2
+    urls = {r.url for r in ext_refs}
+    assert "https://logging.apache.org/log4j/2.x/security.html" in urls
+    assert "https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.15.0" in urls
+    source_names = {r.source_name for r in ext_refs}
+    assert "Vendor Advisory" in source_names
+    assert "Patch, Release Notes" in source_names
+
+
+def test_converter_vulnerability_affected_software_yields_software_and_has_rel() -> None:
+    """Software observables are created for each NVD affected_software entry and
+    linked to the Vulnerability via a HAS relationship."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.60",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[Vuln(id="CVE-2021-44228")],
+            )
+        ],
+    )
+    nvd = NVDData(
+        affected_software=[
+            NVDAffectedSoftware(
+                vendor="Apache",
+                product="Log4J",
+                cpe="cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*",
+                version_info=">= 2.0, < 2.15.0",
+            )
+        ]
+    )
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.60"),
+            data=host,
+            nvd_data_map={"CVE-2021-44228": nvd},
+        )
+    ]
+
+    vuln_obj = next(o for o in stix_objects if o.type == "vulnerability")
+    sw_objects = [o for o in stix_objects if o.type == "software"]
+    assert len(sw_objects) == 1
+    sw = sw_objects[0]
+    assert sw.name == "Log4J"
+    assert sw.vendor == "Apache"
+    assert sw.version == ">= 2.0, < 2.15.0"
+
+    has_rels = [
+        o for o in stix_objects
+        if o.type == "relationship" and o.relationship_type == "related-to"
+        and o.source_ref == sw.id
+    ]
+    assert len(has_rels) == 1
+    assert has_rels[0].source_ref == sw.id
+    assert has_rels[0].target_ref == vuln_obj.id
+
+
+def test_converter_vulnerability_no_software_when_affected_software_empty() -> None:
+    """No Software objects are yielded when NVDData.affected_software is empty."""
+    converter = Converter()
+    host = Host(
+        ip="203.0.113.61",
+        services=[
+            Service(
+                port=443,
+                scan_time="2025-06-01T10:00:00Z",
+                vulns=[Vuln(id="CVE-2021-44228")],
+            )
+        ],
+    )
+    nvd = NVDData()  # affected_software defaults to []
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="203.0.113.61"),
+            data=host,
+            nvd_data_map={"CVE-2021-44228": nvd},
+        )
+    ]
+    assert not any(o.type == "software" for o in stix_objects)
+
+
+def test_fetch_nvd_data_parses_cpe_configurations() -> None:
+    """fetch_nvd_data populates affected_software from CPE configurations."""
+    from unittest.mock import MagicMock, patch
+
+    from censys_enrichment.client import Client
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "descriptions": [{"lang": "en", "value": "A critical RCE."}],
+                    "metrics": {},
+                    "references": [],
+                    "configurations": [
+                        {
+                            "nodes": [
+                                {
+                                    "operator": "OR",
+                                    "cpeMatch": [
+                                        {
+                                            "vulnerable": True,
+                                            "criteria": "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*",
+                                            "versionStartIncluding": "2.0.0",
+                                            "versionEndExcluding": "2.15.0",
+                                        },
+                                        {
+                                            "vulnerable": False,
+                                            "criteria": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
+                                        },
+                                        {
+                                            "vulnerable": True,
+                                            "criteria": "cpe:2.3:a:oracle:weblogic_server:12.2.1.4.0:*:*:*:*:*:*:*",
+                                        },
+                                    ],
+                                }
+                            ]
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+    client = Client(organisation_id="org", token="tok")
+    with patch("requests.get", return_value=mock_response):
+        result = client.fetch_nvd_data("CVE-2021-44228")
+
+    assert result is not None
+    assert len(result.affected_software) == 2
+
+    sw_by_product = {sw.product: sw for sw in result.affected_software}
+
+    log4j = sw_by_product["Log4J"]
+    assert log4j.vendor == "Apache"
+    assert log4j.cpe == "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*"
+    assert log4j.version_info == ">= 2.0.0, < 2.15.0"
+
+    weblogic = sw_by_product["Weblogic Server"]
+    assert weblogic.vendor == "Oracle"
+    assert weblogic.version_info == "12.2.1.4.0"
+
+    # The non-vulnerable OS entry must be excluded
+    assert not any(sw.vendor == "Linux" for sw in result.affected_software)
+
+
+def test_converter_whois_abuse_email_invalid_values_are_dropped() -> None:
+    """Malformed WHOIS abuse-contact values must never produce an EmailAddress
+    observable — OpenCTI enforces RFC 5321 and returns FUNCTIONAL_ERROR for
+    values like 'N/A', 'abuse@' (no domain), or plain handles."""
+    from censys_platform.models.contact import Contact
+    from censys_platform.models.organization import Organization as CensysOrg
+    from censys_platform.models.whois import Whois
+
+    converter = Converter()
+    host = Host(
+        ip="198.51.100.1",
+        whois=Whois(
+            organization=CensysOrg(
+                abuse_contacts=[
+                    Contact(email="abuse@example.com"),   # valid — should be kept
+                    Contact(email="N/A"),                 # no @
+                    Contact(email="abuse@"),              # no domain
+                    Contact(email="postmaster"),          # no @
+                    Contact(email=""),                    # empty
+                    Contact(email=None),                  # None
+                    Contact(email="noc@provider.net"),   # valid — should be kept
+                ]
+            )
+        ),
+    )
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects(
+            stix_entity=stix2.IPv4Address(value="198.51.100.1"),
+            data=host,
+        )
+    ]
+
+    email_values = {o.value for o in stix_objects if o.type == "email-addr"}
+    assert "abuse@example.com" in email_values
+    assert "noc@provider.net" in email_values
+    # Malformed entries must be absent
+    assert not any(v in email_values for v in ("N/A", "abuse@", "postmaster", ""))
+
+
+def test_converter_cert_san_ip_addresses_not_emitted_as_hostnames() -> None:
+    """Certificate SANs that are IP addresses (v4 or v6) must never produce
+    Hostname observables.  OpenCTI enforces a strict hostname format and rejects
+    IP strings with FUNCTIONAL_ERROR, which then cascades into
+    MISSING_REFERENCE_ERROR for the cert→hostname relationship."""
+    from .factories import CertificateFactory
+
+    cert = CertificateFactory(
+        names=[
+            "example.com",           # valid hostname — should produce Hostname
+            "*.example.com",         # wildcard — must be skipped
+            "192.0.2.1",             # IPv4 SAN — must NOT produce Hostname
+            "2400:c620:2f:6e::a",    # IPv6 SAN — must NOT produce Hostname
+            "sub.example.org",       # valid hostname — should produce Hostname
+        ]
+    )
+    converter = Converter()
+    stix_objects = [
+        obj.to_stix2_object()
+        for obj in converter.generate_octi_objects_from_certs(certs=[cert])
+    ]
+
+    hostname_values = {o.value for o in stix_objects if o.type == "hostname"}
+    assert "example.com" in hostname_values
+    assert "sub.example.org" in hostname_values
+    # IP addresses and wildcards must be absent
+    assert "192.0.2.1" not in hostname_values
+    assert "2400:c620:2f:6e::a" not in hostname_values
+    assert not any(v.startswith("*") for v in hostname_values)

--- a/internal-enrichment/censys-enrichment/tests/censys_enrichment/test_settings.py
+++ b/internal-enrichment/censys-enrichment/tests/censys_enrichment/test_settings.py
@@ -1,0 +1,126 @@
+"""Tests for censys_enrichment.settings (ConfigLoader field validation)."""
+
+from typing import Any
+
+import pytest
+from censys_enrichment.settings import ConfigLoader
+from connectors_sdk import ConfigValidationError
+
+
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {
+                    "id": "censys-enrichment--674403d0-4723-40cd-b03c-42fb959d5469",
+                    "name": "Censys Enrichment",
+                    "scope": "IPv4-Addr,IPv6-Addr,X509-Certificate,Domain-Name",
+                    "log_level": "error",
+                    "auto": True,
+                },
+                "censys_enrichment": {
+                    "organisation_id": "my-org-id",
+                    "token": "my-api-token",
+                    "max_tlp": "TLP:AMBER",
+                },
+            },
+            id="full_valid_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                "connector": {},
+                "censys_enrichment": {
+                    "organisation_id": "my-org-id",
+                    "token": "my-api-token",
+                },
+            },
+            id="minimal_valid_settings_dict",
+        ),
+    ],
+)
+def test_settings_should_accept_valid_input(settings_dict):
+    class FakeConfigLoader(ConfigLoader):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    cfg = FakeConfigLoader()
+    assert isinstance(cfg.to_helper_config(), dict)
+
+
+def test_settings_should_reject_missing_required_fields():
+    class FakeConfigLoader(ConfigLoader):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(
+                {
+                    "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                    "connector": {},
+                    # censys_enrichment.organisation_id and .token are required — omitted
+                    "censys_enrichment": {},
+                }
+            )
+
+    with pytest.raises((ConfigValidationError, Exception)):
+        FakeConfigLoader()
+
+
+def test_default_max_tlp_is_amber():
+    class FakeConfigLoader(ConfigLoader):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(
+                {
+                    "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                    "connector": {},
+                    "censys_enrichment": {
+                        "organisation_id": "my-org-id",
+                        "token": "my-api-token",
+                    },
+                }
+            )
+
+    cfg = FakeConfigLoader()
+    assert cfg.censys_enrichment.max_tlp == "TLP:AMBER"
+
+
+def test_default_nvd_enabled_is_true():
+    class FakeConfigLoader(ConfigLoader):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(
+                {
+                    "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                    "connector": {},
+                    "censys_enrichment": {
+                        "organisation_id": "my-org-id",
+                        "token": "my-api-token",
+                    },
+                }
+            )
+
+    cfg = FakeConfigLoader()
+    assert cfg.censys_enrichment.nvd_enabled is True
+
+
+def test_nvd_enabled_can_be_disabled():
+    class FakeConfigLoader(ConfigLoader):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(
+                {
+                    "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+                    "connector": {},
+                    "censys_enrichment": {
+                        "organisation_id": "my-org-id",
+                        "token": "my-api-token",
+                        "nvd_enabled": False,
+                    },
+                }
+            )
+
+    cfg = FakeConfigLoader()
+    assert cfg.censys_enrichment.nvd_enabled is False

--- a/internal-enrichment/censys-enrichment/tests/test_main.py
+++ b/internal-enrichment/censys-enrichment/tests/test_main.py
@@ -1,0 +1,61 @@
+"""Tests for the Censys Enrichment connector bootstrap (pycti helper instantiation)."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from censys_enrichment.settings import ConfigLoader
+from pycti import OpenCTIConnectorHelper
+
+
+@pytest.fixture
+def mock_opencti_connector_helper(monkeypatch):
+    """Mock all heavy dependencies of OpenCTIConnectorHelper, typically API calls to OpenCTI."""
+    module_import_path = "pycti.connector.opencti_connector_helper"
+    monkeypatch.setattr(f"{module_import_path}.killProgramHook", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.sched.scheduler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.ConnectorInfo", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIApiClient", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIConnector", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.OpenCTIMetricHandler", MagicMock())
+    monkeypatch.setattr(f"{module_import_path}.PingAlive", MagicMock())
+
+
+class StubConfigLoader(ConfigLoader):
+    """Bypass file/env loading with a fully-specified fake config dict."""
+
+    @classmethod
+    def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+        return handler(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "censys-enrichment--674403d0-4723-40cd-b03c-42fb959d5469",
+                    "name": "Censys Enrichment",
+                    "scope": "IPv4-Addr,IPv6-Addr",
+                    "log_level": "error",
+                    "auto": True,
+                },
+                "censys_enrichment": {
+                    "organisation_id": "test-org-id",
+                    "token": "test-token",
+                    "max_tlp": "TLP:AMBER",
+                },
+            }
+        )
+
+
+def test_config_loader_is_instantiated():
+    cfg = StubConfigLoader()
+    assert isinstance(cfg, ConfigLoader)
+    assert isinstance(cfg.to_helper_config(), dict)
+
+
+def test_opencti_connector_helper_is_instantiated(mock_opencti_connector_helper):
+    cfg = StubConfigLoader()
+    helper = OpenCTIConnectorHelper(config=cfg.to_helper_config())
+    assert helper.opencti_url == "http://localhost:8080/"
+    assert helper.opencti_token == "test-token"


### PR DESCRIPTION
### Proposed changes

* Split the existing Censys connector into a dedicated enrichment connector.
* Move collection ingestion functionality into a separate `censys-collections` connector.
* Add NVD vulnerability enrichment to supplement vulnerability information returned by Censys.
* Create STIX Vulnerability entities and relationships from vulnerability findings.
* Generate detailed per-port service Notes and malware beacon configuration Notes.
* Migrate object and relationship construction to typed `connectors-sdk` model classes.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/7401.
* Companion PR: `censys-collections` connector: https://github.com/OpenCTI-Platform/connectors/pull/7406.

### Checklist

- [x] I consider the submitted work as finished
- [ ] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on GitHub or Notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

#### Overview

This PR introduces an enrichment-focused Censys connector.

The existing Censys functionality has been split into two independent connectors:

* `censys-enrichment` (this PR)
* `censys-collections` (companion PR)

This separation allows enrichment and collection ingestion to be deployed, configured and maintained independently.

The connector operates in `INTERNAL_ENRICHMENT` mode and supports:

* IPv4-Addr
* IPv6-Addr
* X509-Certificate
* Domain-Name

#### NVD Vulnerability Enrichment

When Censys returns CVE data for a host or certificate, the connector optionally enriches those CVEs using the NVD API.

The enrichment workflow is:

1. Extract CVE identifiers from Censys results.
2. Retrieve matching vulnerability information from NVD.
3. Merge CVSS scoring and severity information with existing Censys data.
4. Create STIX Vulnerability entities and relationships within OpenCTI.

This provides analysts with authoritative vulnerability scoring while preserving the existing Censys context.

#### Service Note Generation

The connector generates a consolidated Note per detected service using `_generate_service_note()`.

Depending on the service, Notes may contain:

* Service banners
* TLS information
* JA3, JA4 and JARM fingerprints
* SSH metadata
* RDP metadata
* SMB metadata
* LDAP metadata
* WinRM metadata
* SNMP metadata
* DCERPC metadata
* SMTP metadata
* FTP metadata
* Telnet metadata
* Redis metadata
* MongoDB metadata
* UPnP metadata
* VNC metadata
* Censys labels
* Exposures, compromises and misconfiguration risks

Generated Notes are labelled with `port:<port>` along with protocol-specific labels where applicable.

#### Malware Beacon Configuration Notes

Where supported by Censys data, the connector generates malware-specific enrichment Notes.

Currently supported families include:

* Cobalt Strike
* DarkComet
* DarkGate
* RedLine

For Cobalt Strike, `_generate_cobalt_strike_note()` creates a dedicated Note containing:

* User-agent
* Sleep time and jitter
* DNS and SSL configuration
* Cookie beacon configuration
* Kill date
* Cryptographic configuration
* Host header
* HTTP GET/POST request templates
* Post-exploitation payload configuration
* Beacon public key
* Beacon watermark

Generated Notes are labelled:

* `cobalt-strike`
* `malware`
* `port:<port>`

The watermark is particularly valuable because it can be used to associate a beacon with a specific licensed Cobalt Strike deployment.

#### Configuration Changes

New configuration options:

* `CENSYS_ENRICHMENT_NVD_ENABLED` (default: `true`)
* `CENSYS_ENRICHMENT_NVD_API_KEY` (optional)

Notes:

* NVD enrichment is enabled by default.
* An NVD API key increases API rate limits (without a key: 5 per 30 seconds; with a key: 50 per 30 seconds).
* Collection-related configuration has been removed and moved to the companion `censys-collections` connector.

#### Build Notes

The connector uses:

* `python:3.12-alpine`
* `pip install .`
* `pyproject.toml` packaging
* `connectors-sdk` as a Git dependency

A maintainer decision is still required regarding the final connector path and manifest location.

The current manifest references:

`internal-enrichment/censys-enrichment`

This may become either:

* a replacement for `internal-enrichment/censys`, or
* a new sibling connector

depending on maintainer preference.

#### Validation

- [ ] pytest passes
- [ ] Manual enrichment performed for all supported observable types
- [ ] NVD enrichment populates CVSS severity and score fields correctly
- [ ] Behaviour verified with `CENSYS_ENRICHMENT_NVD_ENABLED=false`
- [ ] Behaviour verified with and without an NVD API key
- [ ] Docker build succeeds from a clean checkout
- [ ] Reviewed alongside the `censys-collections` PR to ensure responsibilities and documentation remain clearly separated