### PR TITLE
feat(threatfox): improve relationships, scoring and reference handling (#7403)

### DIFF
--- a/external-import/threatfox/Dockerfile
+++ b/external-import/threatfox/Dockerfile
@@ -1,15 +1,17 @@
 FROM python:3.12-alpine
+
 ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
 
-# Copy the connector
+# hadolint ignore=DL3003
+RUN apk update && apk upgrade && \
+    apk --no-cache add git build-base libmagic libffi-dev
+
 COPY src /opt/opencti-connector-threatfox/src
+COPY pyproject.toml /opt/opencti-connector-threatfox/pyproject.toml
 WORKDIR /opt/opencti-connector-threatfox
 
-# Install Python modules
-# hadolint ignore=DL3003
-RUN apk --no-cache add git build-base libmagic libffi-dev && \
-    cd /opt/opencti-connector-threatfox/src && \
-    pip3 install --no-cache-dir -r requirements.txt && \
+# git is required to resolve the connectors-sdk VCS dependency declared in pyproject.toml
+RUN pip3 install --no-cache-dir . && \
     apk del git build-base
 
-CMD ["python", "-m", "src"]
+CMD ["threatfox-connector"]

--- a/external-import/threatfox/README.md
+++ b/external-import/threatfox/README.md
@@ -117,13 +117,13 @@ docker compose up -d
 2. Install dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install .
 ```
 
-3. Start the connector from the `src` directory:
+3. Start the connector:
 
 ```bash
-python3 -m __main__
+threatfox-connector
 ```
 
 ## Usage

--- a/external-import/threatfox/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/threatfox/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -10,7 +10,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | OPENCTI_TOKEN | `string` | ✅ | string |  |  | The token of the user who represents the connector in the OpenCTI platform. |
 | CONNECTOR_NAME | `string` |  | string |  | `"Abuse.ch | ThreatFox"` | Name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string |  | `["ThreatFox"]` | The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only). |
-| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` |  | `"EXTERNAL_IMPORT"` | Should always be set to EXTERNAL_IMPORT for this connector. |
+| CONNECTOR_TYPE | `string` |  | string |  | `"EXTERNAL_IMPORT"` | Should always be set to EXTERNAL_IMPORT for this connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` |  | `"error"` | Determines the verbosity of the logs. |
 | THREATFOX_CSV_URL | `string` |  | string |  | `"https://threatfox.abuse.ch/export/csv/recent/"` | The Threat Fox URL |
 | THREATFOX_IMPORT_OFFLINE | `boolean` |  | boolean |  | `true` | Create records for indicators that are offline. |

--- a/external-import/threatfox/__metadata__/connector_config_schema.json
+++ b/external-import/threatfox/__metadata__/connector_config_schema.json
@@ -30,7 +30,6 @@
       "type": "array"
     },
     "CONNECTOR_TYPE": {
-      "const": "EXTERNAL_IMPORT",
       "default": "EXTERNAL_IMPORT",
       "description": "Should always be set to EXTERNAL_IMPORT for this connector.",
       "type": "string"

--- a/external-import/threatfox/__metadata__/connector_manifest.json
+++ b/external-import/threatfox/__metadata__/connector_manifest.json
@@ -1,17 +1,12 @@
 {
   "title": "ThreatFox",
   "slug": "threatfox",
-  "description": "ThreatFox is a platform from abuse.ch and Spamhaus dedicated to sharing indicators of compromise (IOCs) associated with malware, with the infosec community, AV vendors and cyber threat intelligence providers.\n\nThe integration of ThreatFox with OpenCTI facilitates the automatic import of IOCs into the threat intelligence platform. This integration imports data for the following OpenCTI observables/indicators: file-md5, file-sha1, file-sha256, ipv4-addr, domain-name, and url. It also incorporates the Malware entity, enhancing the platform's capability to effectively manage and respond to threats.",
+  "description": "ThreatFox is a platform from abuse.ch and Spamhaus dedicated to sharing indicators of compromise (IOCs) associated with malware, with the infosec community, AV vendors and cyber threat intelligence providers\n\nThe integration of ThreatFox with OpenCTI facilitates the automatic import of IOCs into the threat intelligence platform. This integration imports data for the following OpenCTI observables/indicators: file-md5, file-sha1, file-sha256, ipv4-addr, domain-name, and url. It also incorporates the Malware entity, enhancing the platform's capability to effectively manage and respond to threats.",
   "short_description": "ThreatFox is a platform from abuse.ch and Spamhaus dedicated to sharing indicators of compromise (IOCs) associated with malware, with the infosec community, AV vendors and cyber threat intelligence providers.",
   "logo": "external-import/threatfox/__metadata__/logo.png",
   "use_cases": [
-    "Adversary & Campaign Insights"
+    "Open Source Threat Intel"
   ],
-  "solution_categories": [
-    "Threat Intelligence Feed"
-  ],
-  "license_type": "Free",
-  "contact": null,
   "verified": true,
   "last_verified_date": null,
   "playbook_supported": false,

--- a/external-import/threatfox/config.yml.sample
+++ b/external-import/threatfox/config.yml.sample
@@ -1,0 +1,12 @@
+opencti:
+  url: 'http://opencti:8080'
+  token: 'CHANGEME'
+  opencti_admin_email: 'admin@opencti.io'
+  opencti_admin_password: 'CHANGEME'
+  
+connector:
+  id: 'CHANGEME'
+  type: 'EXTERNAL_IMPORT'
+  name: 'ThreatFox' # Required
+  
+

--- a/external-import/threatfox/pyproject.toml
+++ b/external-import/threatfox/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ThreatFoxConnector"
+description = "External Import connector for ThreatFox threat intelligence."
+dynamic = ["version"]
+requires-python = ">=3.11"
+
+dependencies = [
+    "pycti==7.260811.0",
+    "urllib3>=2.5.0",
+    "validators==0.35.0",
+    "pydantic>=2.10,<3",
+    "pydantic-settings==2.9.1",
+    "connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk",
+]
+
+[project.scripts]
+threatfox-connector = "src.__main__:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.2",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["./tests"]

--- a/external-import/threatfox/src/__main__.py
+++ b/external-import/threatfox/src/__main__.py
@@ -1,4 +1,17 @@
-"""ThreatFox connector"""
+"""
+ThreatFox connector (STIX-bundle ingestion + API post-pass for observable external references)
+
+- Ingests via STIX bundle.
+    - Same behaviour as before: process as bundles
+- STRICT REQUIREMENT: external reference is ONLY the 12th CSV column ('reference') exactly as provided by the API.
+    - We don't want to mistake malicious domains as a clickable reference!!
+- Adds external references to Indicator & Malware in STIX.
+- After bundle ingestion, attaches the same external reference to the Observable via OpenCTI API.
+    - A limitation of the bundle approach. It does not allow you to append references on creation. Has to be done using the API.
+- Maps ThreatFox confidence_level (0-100) to x_opencti_score on Observables & Indicators.
+    - Fixes the "fixed score" issue. Now it reflects what Abuse.ch is saying.
+- Creates Observable --related-to--> Malware family (is_family=True) for graph linkage even without indicators.
+"""
 
 from __future__ import annotations
 
@@ -16,15 +29,16 @@ from datetime import UTC, datetime
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import stix2
-import validators
 from pycti import (
     Indicator,
     Malware,
     OpenCTIConnectorHelper,
     StixCoreRelationship,
 )
-from src.models.configs.config_loader import ConfigLoader
 from stix2.base import _Observable as Observable
+
+from src.models.configs.config_loader import ConfigLoader
+
 
 ALL_TYPES = "all_types"
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
@@ -32,7 +46,7 @@ BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 
 # pylint:disable=too-many-instance-attributes
 class ThreatFox:
-    """ThreatFox connector"""
+    """ThreatFox connector (STIX bundle ingestion with post-attach of refs to SCOs)"""
 
     def __init__(self):
         """Initializer"""
@@ -41,7 +55,7 @@ class ThreatFox:
         self.config = ConfigLoader()
         self.helper = OpenCTIConnectorHelper(config=self.config.model_dump_pycti())
 
-        # Extra config
+        # ThreatFox config
         self.threatfox_csv_url = self.config.threatfox.csv_url
         self.threatfox_import_offline = self.config.threatfox.import_offline
         self.threatfox_interval = self.config.threatfox.interval
@@ -52,40 +66,50 @@ class ThreatFox:
         self.x_opencti_score_url = self.config.threatfox.x_opencti_score_url
         self.x_opencti_score_hash = self.config.threatfox.x_opencti_score_hash
 
-        self.ioc_to_import = self.config.threatfox.ioc_to_import.split(",")
-        self.ioc_to_import = [ioc.strip() for ioc in self.ioc_to_import]
+        self.ioc_to_import = [
+            ioc.strip() for ioc in self.config.threatfox.ioc_to_import.split(",") if ioc.strip()
+        ]
         if len(self.ioc_to_import) == 0:
             self.ioc_to_import = [ALL_TYPES]
 
-        self.identity: str = self.helper.api.identity.create(
+        # Producer identity
+        self.identity: Dict = self.helper.api.identity.create(
             type="Organization",
             name="Threat Fox | Abuse.ch",
-            description="abuse.ch is operated by a random swiss guy fighting malware for "
-            "non-profit, running a couple of projects helping internet service providers "
-            "and network operators protecting their infrastructure from malware.",
+            description=(
+                "abuse.ch is operated by a random swiss guy fighting malware for non-profit, "
+                "running a couple of projects helping internet service providers and network operators "
+                "protecting their infrastructure from malware."
+            ),
         )
+        # Prefer a STIX id for created_by_ref; fallback if needed
+        self.identity_id = self.identity.get("standard_id") or self.identity["id"]
 
+        # Pending observables to process post-ingestion (external refs + relationships)
+        # Each item: {
+        #   "entity_type": str, "value": str, "hash_field": Optional[str],
+        #   "urls": List[str], "indicator_id": Optional[str], "stix_id": str,
+        #   "malware_stix_id": Optional[str], "confidence": Optional[int]
+        # }
+        self._pending_observables: List[Dict] = []
+
+        # Cache to reduce ext-ref recreation during the post-pass
+        self._cache_ext_ref_ids: Dict[str, str] = {}
+
+        # Optional extra delay (seconds) before post-pass to allow indexing to settle
+        try:
+            self.postpass_delay = float(os.getenv("THREATFOX_POSTPASS_DELAY_SEC", "5"))
+        except Exception:
+            self.postpass_delay = 5.0
+
+    # ------------------------ Utility & config ------------------------ #
     def get_interval(self) -> float:
-        """Convert the threatfox_interval from days to millis"""
-
+        """Convert the threatfox_interval (days) to seconds"""
         return float(self.threatfox_interval) * 60 * 60 * 24
 
-    def get_x_opencti_score(self, observable_type: str) -> int:
-        """Get the x_opencti_score for the observable type"""
-
-        if observable_type == "IPv4-Addr":
-            return self.x_opencti_score_ip or self.default_x_opencti_score
-        if observable_type == "Domain-Name":
-            return self.x_opencti_score_domain or self.default_x_opencti_score
-        if observable_type == "Url":
-            return self.x_opencti_score_url or self.default_x_opencti_score
-        if observable_type == "StixFile":
-            return self.x_opencti_score_hash or self.default_x_opencti_score
-        return self.default_x_opencti_score
-
+    # ----------------------------- Run/Loop --------------------------- #
     def run(self):
-        """Run the connector"""
-
+        """Run the connector loop."""
         while True:
             try:
                 self.loop()
@@ -103,9 +127,7 @@ class ThreatFox:
             time.sleep(60)
 
     def loop(self) -> None:
-        """Main connector loop"""
-
-        # Get the current timestamp and check
+        """Main connector loop."""
         now_dt = datetime.now(UTC)
         now_ts = now_dt.timestamp()
         state = self.helper.get_state()
@@ -130,20 +152,16 @@ class ThreatFox:
                 f"Connector will not run, next run in: {next_dt - now_dt}"
             )
 
+    # -------------------------- Import pipeline ----------------------- #
     def import_data(self, state: Dict, now_dt: datetime, now_ts: int) -> None:
-        """Pull and import ThreatFox data"""
+        """Pull and import ThreatFox data via STIX; then post-attach external refs to SCOs."""
 
         work_id = self.helper.api.work.initiate_work(
             self.helper.connect_id,
             "Threat Fox run @ " + now_dt.strftime("%Y-%m-%d %H:%M:%S"),
         )
 
-        csv.register_dialect(
-            "custom",
-            delimiter=",",
-            quotechar='"',
-            skipinitialspace=True,
-        )
+        csv.register_dialect("custom", delimiter=",", quotechar='"', skipinitialspace=True)
 
         last_processed_entry_running_max = 0
 
@@ -151,7 +169,7 @@ class ThreatFox:
             lines = self.download_csv()
             csv_reader = csv.reader(lines, dialect="custom")
 
-            bundle_objects = []
+            bundle_objects: List[stix2._STIXBase] = []
 
             last_processed_entry = state.get("last_processed_entry")  # epoch
             if last_processed_entry is None:
@@ -161,6 +179,10 @@ class ThreatFox:
                 last_processed_entry = 0
 
             last_processed_entry_running_max = last_processed_entry
+
+            # reset per run
+            self._pending_observables = []
+            self._cache_ext_ref_ids = {}
 
             for i, row in enumerate(csv_reader):
                 if len(row) > 15:
@@ -197,8 +219,11 @@ class ThreatFox:
                         self.helper.log_info(f"Skipping offline IOC: {ioc.value}")
                         continue
 
-                bundle_objects.extend(self.process_row(ioc))
+                # ---- STIX creation path ----
+                for obj in self.process_row(ioc):
+                    bundle_objects.append(obj)
 
+            # Build and send bundle
             bundle = stix2.Bundle(
                 objects=bundle_objects,
                 allow_custom=True,
@@ -210,6 +235,14 @@ class ThreatFox:
                     bundle,
                     work_id=work_id,
                 )
+
+            # ---- delay before post-pass (tunable) ----
+            if self.postpass_delay > 0:
+                self.helper.log_info(f"[ThreatFox] sleeping {self.postpass_delay:.1f}s before post-pass attach")
+                time.sleep(self.postpass_delay)
+
+            # ---- 2nd pass: attach external references to Observables via API ----
+            self._attach_external_refs_to_observables()
 
         except Exception:  # pylint:disable=broad-exception-caught
             self.helper.log_error(traceback.format_exc())
@@ -253,10 +286,15 @@ class ThreatFox:
                 continue
             yield line
 
-    def process_row(self, ioc: FeedRow) -> Iterable[Dict]:
+    # ------------------- STIX creation (primary path) -------------------
+    def process_row(self, ioc: "FeedRow") -> Iterable[stix2._STIXBase]:
         """Process the IOC record and generate SCO/SDO/SRO objects."""
 
-        stix_observable, stix_indicator = self.process_row_observable(ioc)
+        result = self.process_row_observable(ioc)
+        if result is None:
+            return
+        
+        stix_observable, stix_indicator, obs_metadata = result
         if stix_observable:
             yield stix_observable
         if stix_indicator:
@@ -266,22 +304,54 @@ class ThreatFox:
         if stix_observable is None:
             return
 
+        # Create malware SDO (as FAMILY) and add refs; then relationships
         stix_malware = self.process_row_malware(ioc)
         if stix_malware:
             yield stix_malware
 
+        # Relationships with confidence
         if stix_indicator and stix_observable:
-            yield self.create_relationship(stix_indicator, "based-on", stix_observable)
+            yield self.create_relationship(
+                stix_indicator, "based-on", stix_observable, ioc.confidence_level
+            )
 
         if stix_indicator and stix_malware:
-            yield self.create_relationship(stix_indicator, "indicates", stix_malware)
+            yield self.create_relationship(
+                stix_indicator, "indicates", stix_malware, ioc.confidence_level
+            )
+
+        # Always relate observable to malware (even if no indicator)
+        if stix_observable and stix_malware:
+            yield self.create_relationship(
+                stix_observable, "related-to", stix_malware, ioc.confidence_level
+            )
+
+        # --- Queue for post-pass API processing (external refs + relationships) ---
+        self._pending_observables.append(
+            {
+                "entity_type": obs_metadata["observable_type"],
+                "value": obs_metadata["value_for_lookup"],
+                "hash_field": obs_metadata["hash_field"],
+                "urls": self._reference_urls(ioc),
+                "indicator_id": stix_indicator.id if stix_indicator else None,
+                "stix_id": stix_observable.id,
+                "malware_stix_id": stix_malware.id if stix_malware else None,
+                "confidence": ioc.confidence_level,
+            }
+        )
 
     def process_row_observable(
-        self, ioc: FeedRow
-    ) -> Tuple[Optional[Observable], Optional[stix2.Indicator]]:
-        """Process the IOC record and return an observable and indicator"""
+        self, ioc: "FeedRow"
+    ) -> Optional[Tuple[Observable, Optional[stix2.Indicator], Dict[str, Union[str, None]]]]:
+        """Process the IOC record and return an observable, indicator, and metadata for post-pass."""
 
         description = None
+        score_from_conf = int(ioc.confidence_level)
+
+        # --- Map the IOC to a STIX SCO (+ pattern metadata) ---
+        # NOTE: external_references is NOT valid on STIX SCOs, only SDOs
+        # External references are attached via API in the post-pass
+
         if ioc.type == "ip:port":
             ioc.value, port = ioc.value.split(":", maxsplit=1)
             description = f"Traffic seen on port {port}"
@@ -292,14 +362,15 @@ class ThreatFox:
                 value=ioc.value,
                 object_marking_refs=[stix2.TLP_WHITE],
                 custom_properties={
-                    "created_by_ref": self.identity["standard_id"],
+                    "created_by_ref": self.identity_id,
                     "x_opencti_description": description,
                     "x_opencti_labels": ioc.tags,
-                    "x_opencti_score": (
-                        self.x_opencti_score_ip or self.default_x_opencti_score
-                    ),
+                    "x_opencti_score": score_from_conf,
                 },
             )
+            value_for_lookup = ioc.value
+            hash_field = None
+
         elif ioc.type == "domain":
             pattern_value = f"[domain-name:value = '{ioc.value}']"
             indicator_type = "domain"
@@ -308,14 +379,15 @@ class ThreatFox:
                 value=ioc.value,
                 object_marking_refs=[stix2.TLP_WHITE],
                 custom_properties={
-                    "created_by_ref": self.identity["standard_id"],
+                    "created_by_ref": self.identity_id,
                     "x_opencti_description": description,
                     "x_opencti_labels": ioc.tags,
-                    "x_opencti_score": (
-                        self.x_opencti_score_domain or self.default_x_opencti_score
-                    ),
+                    "x_opencti_score": score_from_conf,
                 },
             )
+            value_for_lookup = ioc.value
+            hash_field = None
+
         elif ioc.type == "url":
             pattern_value = f"[url:value = '{ioc.value}']"
             indicator_type = "url"
@@ -324,14 +396,15 @@ class ThreatFox:
                 value=ioc.value,
                 object_marking_refs=[stix2.TLP_WHITE],
                 custom_properties={
-                    "created_by_ref": self.identity["standard_id"],
+                    "created_by_ref": self.identity_id,
                     "x_opencti_description": description,
                     "x_opencti_labels": ioc.tags,
-                    "x_opencti_score": (
-                        self.x_opencti_score_url or self.default_x_opencti_score
-                    ),
+                    "x_opencti_score": score_from_conf,
                 },
             )
+            value_for_lookup = ioc.value
+            hash_field = None
+
         elif ioc.type == "md5_hash":
             pattern_value = f"[file:hashes.MD5 = '{ioc.value}']"
             indicator_type = "md5"
@@ -341,14 +414,15 @@ class ThreatFox:
                 hashes={"MD5": ioc.value},
                 object_marking_refs=[stix2.TLP_WHITE],
                 custom_properties={
-                    "created_by_ref": self.identity["standard_id"],
+                    "created_by_ref": self.identity_id,
                     "x_opencti_description": description,
                     "x_opencti_labels": ioc.tags,
-                    "x_opencti_score": (
-                        self.x_opencti_score_hash or self.default_x_opencti_score
-                    ),
+                    "x_opencti_score": score_from_conf,
                 },
             )
+            value_for_lookup = ioc.value
+            hash_field = "hashes.MD5"
+
         elif ioc.type == "sha1_hash":
             pattern_value = f"[file:hashes.SHA1 = '{ioc.value}']"
             indicator_type = "sha1"
@@ -358,14 +432,15 @@ class ThreatFox:
                 hashes={"SHA-1": ioc.value},
                 object_marking_refs=[stix2.TLP_WHITE],
                 custom_properties={
-                    "created_by_ref": self.identity["standard_id"],
+                    "created_by_ref": self.identity_id,
                     "x_opencti_description": description,
                     "x_opencti_labels": ioc.tags,
-                    "x_opencti_score": (
-                        self.x_opencti_score_hash or self.default_x_opencti_score
-                    ),
+                    "x_opencti_score": score_from_conf,
                 },
             )
+            value_for_lookup = ioc.value
+            hash_field = "hashes.SHA-1"  # IMPORTANT: exact key
+
         elif ioc.type == "sha256_hash":
             pattern_value = f"[file:hashes.'SHA-256' = '{ioc.value}']"
             indicator_type = "sha256"
@@ -375,78 +450,96 @@ class ThreatFox:
                 hashes={"SHA-256": ioc.value},
                 object_marking_refs=[stix2.TLP_WHITE],
                 custom_properties={
-                    "created_by_ref": self.identity["standard_id"],
+                    "created_by_ref": self.identity_id,
                     "x_opencti_description": description,
                     "x_opencti_labels": ioc.tags,
-                    "x_opencti_score": (
-                        self.x_opencti_score_hash or self.default_x_opencti_score
-                    ),
+                    "x_opencti_score": score_from_conf,
                 },
             )
+            value_for_lookup = ioc.value
+            hash_field = "hashes.SHA-256"
+
         else:
             self.helper.log_warning(f"Unrecognized ioc_type: {ioc.type}")
             return None
 
-        # Check if we have an external reference
-        if validators.url(ioc.reference):
-            ext_refs = [
-                stix2.ExternalReference(
-                    source_name="ThreatFox source reference",
-                    url=ioc.reference,
-                )
-            ]
-        else:
-            ext_refs = []
+        # Capture the STIX id of the observable we just created (deterministic)
+        observable_stix_id = stix_observable.id
+
+        # --- Indicator (optional) ---
+        indicator_id: Optional[str] = None
+        stix_indicator: Optional[stix2.Indicator] = None
 
         if self.create_indicators:
+            indicator_id = Indicator.generate_id(pattern_value)
             stix_indicator = stix2.Indicator(
                 name=ioc.value,
                 description=description,
-                id=Indicator.generate_id(pattern_value),
+                id=indicator_id,
                 indicator_types=[indicator_type],
                 pattern_type="stix",
                 pattern=pattern_value,
                 labels=ioc.tags,
                 object_marking_refs=[stix2.TLP_WHITE],
-                created_by_ref=self.identity["standard_id"],
+                created_by_ref=self.identity_id,
                 confidence=ioc.confidence_level,
-                external_references=ext_refs,
+                external_references=[
+                    stix2.ExternalReference(source_name="ThreatFox", url=u)
+                    for u in self._reference_urls(ioc)
+                ],
                 custom_properties={
                     "x_opencti_main_observable_type": observable_type,
-                    "x_opencti_score": self.get_x_opencti_score(observable_type),
+                    "x_opencti_score": score_from_conf,
                 },
             )
             self.helper.log_debug(f"Indicator created: {stix_indicator}")
-        else:
-            stix_indicator = None
 
-        return stix_observable, stix_indicator
+        # Return metadata for post-pass queueing (done in process_row)
+        obs_metadata = {
+            "observable_type": observable_type,
+            "value_for_lookup": value_for_lookup,
+            "hash_field": hash_field,
+        }
 
-    def process_row_malware(self, ioc: FeedRow) -> stix2.Malware:
-        """Process the IOC record and generate a malware SDO"""
+        return stix_observable, stix_indicator, obs_metadata
 
-        if not ioc.malware_printable:
+    def process_row_malware(self, ioc: "FeedRow") -> Optional[stix2.Malware]:
+        """Process the IOC record and generate a malware SDO (family)"""
+
+        # Determine family (prefer printable)
+        family_name = self._normalize_family_name(ioc)
+        if not family_name:
             return None
 
+        # Normalize malware_types (STIX open-vocab requires lowercase)
         if ioc.threat_type == "botnet_cc":
-            malware_types = ["Bot"]
+            malware_types = ["bot"]
         elif ioc.threat_type == "payload_delivery":
             malware_types = ["dropper"]
         else:
             malware_types = None
 
-        # Create the malware object
+        # Build aliases (preserve ThreatFox aliases and fk_malware)
+        aliases = list(ioc.malware_aliases) if ioc.malware_aliases else []
+        if ioc.fk_malware and ioc.fk_malware not in aliases:
+            aliases.append(ioc.fk_malware)
+
+        # External references for Malware SDO (OK in STIX)
+        ext_refs = [stix2.ExternalReference(source_name="ThreatFox", url=u) for u in self._reference_urls(ioc)]
+
+        # Create the malware object (as FAMILY)
         stix_malware = stix2.Malware(
-            id=Malware.generate_id(ioc.fk_malware),
-            name=ioc.fk_malware,
-            aliases=ioc.malware_aliases,
-            created_by_ref=self.identity["standard_id"],
+            id=Malware.generate_id(family_name),
+            name=family_name,
+            aliases=aliases or None,
+            created_by_ref=self.identity_id,
             object_marking_refs=[stix2.TLP_WHITE],
             confidence=ioc.confidence_level,
-            description=f"Threat: {ioc.fk_malware}\nReporter: {ioc.reporter}",
-            is_family=False,
+            description=f"Threat: {family_name}\nReporter: {ioc.reporter}",
+            is_family=True,
             labels=ioc.tags,
             malware_types=malware_types,
+            external_references=ext_refs or None,
         )
         self.helper.log_debug(f"Malware object created: {stix_malware}")
 
@@ -454,9 +547,10 @@ class ThreatFox:
 
     def create_relationship(
         self,
-        source: Observable,
+        source: stix2._STIXBase,
         rel_type: str,
-        target: Observable,
+        target: stix2._STIXBase,
+        confidence: Optional[int] = None,
     ) -> stix2.Relationship:
         """Create a relationship between two objects"""
 
@@ -465,14 +559,309 @@ class ThreatFox:
             source_ref=source.id,
             target_ref=target.id,
             relationship_type=rel_type,
-            created_by_ref=self.identity["standard_id"],
+            created_by_ref=self.identity_id,
             object_marking_refs=[stix2.TLP_WHITE],
+            confidence=int(confidence) if confidence is not None else None,
         )
         self.helper.log_debug(f"Relationship created: {source.id} -> {target.id}")
 
         return stix_rel
 
+    # ---------------------- 2nd pass (post-ingestion) ----------------------
+    def _reference_urls(self, ioc: "FeedRow") -> List[str]:
+        """
+        STRICT requirement:
+        Use ONLY the value from the 12th CSV column ('reference') exactly as provided by the API.
+        No regex, no inference, no validation.
+        """
+        ref = (ioc.reference or "").strip()
+        if not ref or ref.lower() == "none":
+            return []
+        return [ref]
 
+    def _resolve_via_indicator(self, indicator_id: str) -> Optional[str]:
+        """
+        Resolve the observable by following the Indicator --based-on--> Observable relationship.
+        Uses 6.8.x-style kwargs (no filters payload).
+        """
+        try:
+            # Primary: indicator is the 'from' side in "based-on"
+            rels = self.helper.api.stix_core_relationship.list(
+                fromId=indicator_id,
+                relationship_type="based-on",
+                first=1,
+            ) or []
+            if rels:
+                rel = rels[0]
+                to_obj = rel.get("to") or {}
+                to_id = to_obj.get("id") or rel.get("toId") or rel.get("to_id")
+                if to_id:
+                    return to_id
+
+            # Fallback: direction-agnostic variant
+            rels = self.helper.api.stix_core_relationship.list(
+                fromOrToId=indicator_id,
+                relationship_type="based-on",
+                first=1,
+            ) or []
+            if rels:
+                rel = rels[0]
+                to_obj = rel.get("to") or {}
+                to_id = to_obj.get("id") or rel.get("toId") or rel.get("to_id")
+                if to_id:
+                    return to_id
+        except Exception:
+            # swallow and fallback to value-based lookup
+            pass
+        return None
+
+    def _read_observable_by_stix_id(self, stix_id: str) -> Optional[str]:
+        """Return the OpenCTI internal id for a SCO given its STIX (standard) id."""
+        try:
+            obj = self.helper.api.stix_cyber_observable.read(id=stix_id)
+            if obj:
+                return obj["id"]  # OpenCTI internal id
+        except Exception:
+            pass
+        return None
+
+    def _find_observable_id(
+        self,
+        entity_type: str,
+        value: str,
+        hash_field: Optional[str],
+        max_attempts: int = 12,
+        initial_sleep: float = 0.8,
+    ) -> Optional[str]:
+        """
+        Value-based fallback with normalization & retries.
+        entity_type: "Url" | "Domain-Name" | "IPv4-Addr" | "StixFile"
+        value:       original value we emitted in STIX (or the hash string for files)
+        hash_field:  "hashes.MD5" | "hashes.SHA-1" | "hashes.SHA-256" | None
+        """
+        def _read(filters_dict) -> Optional[str]:
+            try:
+                oid_obj = self.helper.api.stix_cyber_observable.read(filters=filters_dict)
+                if oid_obj:
+                    return oid_obj["id"]
+            except Exception:
+                pass
+            try:
+                oid_obj = self.helper.api.stix_cyber_observable.read(
+                    filters=filters_dict.get("filters", filters_dict)
+                )
+                if oid_obj:
+                    return oid_obj["id"]
+            except Exception:
+                pass
+            try:
+                items = self.helper.api.stix_cyber_observable.list(
+                    filters=filters_dict, first=1
+                ) or []
+                if items:
+                    return items[0]["id"]
+            except Exception:
+                pass
+            try:
+                items = self.helper.api.stix_cyber_observable.list(
+                    filters=filters_dict.get("filters", filters_dict), first=1
+                ) or []
+                if items:
+                    return items[0]["id"]
+            except Exception:
+                pass
+            return None
+
+        # Candidates to try (ordered)
+        candidates: List[Dict] = []
+        if entity_type == "StixFile":
+            if hash_field:
+                candidates.append(
+                    {"mode": "and", "filters": [
+                        {"key": "entity_type", "values": [entity_type]},
+                        {"key": hash_field,    "values": [value]},
+                    ]}
+                )
+            candidates.append(
+                {"mode": "and", "filters": [
+                    {"key": "entity_type", "values": [entity_type]},
+                    {"key": "value",       "values": [value]},
+                ]}
+            )
+        elif entity_type == "Url":
+            v = value.strip()
+            candidates.append(
+                {"mode": "and", "filters": [
+                    {"key": "entity_type", "values": [entity_type]},
+                    {"key": "value",       "values": [v]},
+                ]}
+            )
+            if v.endswith("/"):
+                candidates.append(
+                    {"mode": "and", "filters": [
+                        {"key": "entity_type", "values": [entity_type]},
+                        {"key": "value",       "values": [v[:-1]]},
+                    ]}
+                )
+        elif entity_type == "Domain-Name":
+            v = value.strip()
+            candidates.append(
+                {"mode": "and", "filters": [
+                    {"key": "entity_type", "values": [entity_type]},
+                    {"key": "value",       "values": [v]},
+                ]}
+            )
+            if v.lower() != v:
+                candidates.append(
+                    {"mode": "and", "filters": [
+                        {"key": "entity_type", "values": [entity_type]},
+                        {"key": "value",       "values": [v.lower()]},
+                    ]}
+                )
+        elif entity_type == "IPv4-Addr":
+            candidates.append(
+                {"mode": "and", "filters": [
+                    {"key": "entity_type", "values": [entity_type]},
+                    {"key": "value",       "values": [value.strip()]},
+                ]}
+            )
+
+        # Retry loop (trimmed to reduce noise)
+        sleep = initial_sleep
+        for _attempt in range(1, max_attempts + 1):
+            for f in candidates:
+                oid = _read(f)
+                if oid:
+                    return oid
+            time.sleep(sleep)
+            sleep *= 1.4
+        return None
+
+    def _attach_external_refs_to_observables(self) -> None:
+        """Attach ThreatFox external refs and relationships to SCOs via API (post-ingestion)."""
+        total = len(self._pending_observables or [])
+        if total == 0:
+            self.helper.log_info("[ThreatFox] post-pass: no pending observables to update")
+            return
+
+        self.helper.log_info(f"[ThreatFox] post-pass starting with {total} pending observable(s)")
+
+        refs_attached = 0
+        rels_created = 0
+        not_found = 0
+        errors = 0
+
+        for entry in self._pending_observables:
+            entity_type: str = entry["entity_type"]            # "Url" | "Domain-Name" | "IPv4-Addr" | "StixFile"
+            value: str = entry["value"]
+            hash_field: Optional[str] = entry["hash_field"]    # "hashes.MD5" | "hashes.SHA-1" | "hashes.SHA-256" | None
+            urls: List[str] = entry.get("urls") or []
+            indicator_id: Optional[str] = entry.get("indicator_id")  # type: ignore[assignment]
+            stix_id: Optional[str] = entry.get("stix_id")            # type: ignore[assignment]
+            malware_stix_id: Optional[str] = entry.get("malware_stix_id")  # type: ignore[assignment]
+            confidence: Optional[int] = entry.get("confidence")  # type: ignore[assignment]
+
+            # 0) Best-effort: resolve directly by the STIX id we emitted in the bundle
+            obs_id = None
+            if stix_id:
+                obs_id = self._read_observable_by_stix_id(stix_id)
+
+            # 1) If not found, try via Indicator --based-on--> Observable
+            if not obs_id and indicator_id:
+                obs_id = self._resolve_via_indicator(indicator_id)
+
+            # 2) Fallback: value/hash lookup with retries
+            if not obs_id:
+                obs_id = self._find_observable_id(entity_type, value, hash_field)
+
+            if not obs_id:
+                not_found += 1
+                self.helper.log_warning(
+                    f"[ThreatFox] Observable not found for post-pass after all strategies: "
+                    f"{entity_type} / {value} (hash_field={hash_field}, indicator_id={indicator_id}, stix_id={stix_id})"
+                )
+                continue
+
+            # --- Create/attach external references ---
+            for url in urls:
+                try:
+                    ext_ref_id = self._cache_ext_ref_ids.get(url)
+                    if not ext_ref_id:
+                        ext_ref = self.helper.api.external_reference.create(
+                            source_name="ThreatFox",
+                            url=url,
+                        )
+                        ext_ref_id = ext_ref["id"]
+                        self._cache_ext_ref_ids[url] = ext_ref_id
+
+                    # Primary: singular attach method
+                    try:
+                        self.helper.api.stix_cyber_observable.add_external_reference(
+                            id=obs_id, external_reference_id=ext_ref_id
+                        )
+                    except Exception:
+                        # Fallback: plural attach (for pycti variants)
+                        self.helper.api.stix_cyber_observable.add_external_references(
+                            id=obs_id, external_references_ids=[ext_ref_id]
+                        )
+
+                    refs_attached += 1
+                    self.helper.log_debug(
+                        f"[ThreatFox] attached ext-ref {url} to {entity_type}:{value} ({obs_id})"
+                    )
+
+                except Exception:  # pylint:disable=broad-exception-caught
+                    errors += 1
+                    self.helper.log_error(
+                        f"[ThreatFox] Failed attaching external ref '{url}' to observable {obs_id}:\n{traceback.format_exc()}"
+                    )
+
+            # --- Create observable --related-to--> malware relationship via API ---
+            if malware_stix_id:
+                try:
+                    # Resolve malware internal ID from STIX ID
+                    malware_obj = self.helper.api.malware.read(id=malware_stix_id)
+                    if malware_obj:
+                        malware_internal_id = malware_obj["id"]
+                        
+                        # Create relationship via API
+                        self.helper.api.stix_core_relationship.create(
+                            fromId=obs_id,
+                            toId=malware_internal_id,
+                            relationship_type="related-to",
+                            createdBy=self.identity["id"],
+                            confidence=int(confidence) if confidence is not None else None,
+                        )
+                        rels_created += 1
+                        self.helper.log_debug(
+                            f"[ThreatFox] created relationship {entity_type}:{value} --related-to--> malware ({malware_stix_id})"
+                        )
+                    else:
+                        self.helper.log_warning(
+                            f"[ThreatFox] Malware not found for relationship: {malware_stix_id}"
+                        )
+                except Exception:  # pylint:disable=broad-exception-caught
+                    errors += 1
+                    self.helper.log_error(
+                        f"[ThreatFox] Failed creating relationship for observable {obs_id} to malware {malware_stix_id}:\n{traceback.format_exc()}"
+                    )
+
+        self.helper.log_info(
+            f"[ThreatFox] post-pass finished: refs_attached={refs_attached} rels_created={rels_created} not_found={not_found} errors={errors}"
+        )
+
+    # ----------------------------- Utilities -----------------------------
+    def _normalize_family_name(self, ioc: "FeedRow") -> Optional[str]:
+        """Prefer printable/family; else derive from fk_malware like 'win.mirai' -> 'Mirai'."""
+        if ioc.malware_printable:
+            return ioc.malware_printable.strip()
+        if ioc.fk_malware:
+            base = ioc.fk_malware.split(".")[-1].strip()
+            return base[:1].upper() + base[1:] if base else None
+        return None
+
+
+# ----------------------------- FeedRow ------------------------------- #
 # pylint:disable=too-many-instance-attributes
 @dataclass(init=False)
 class FeedRow:
@@ -493,7 +882,7 @@ class FeedRow:
     anonymous: bool
     reporter: str
 
-    def __init__(self, row: Tuple) -> None:
+    def __init__(self, row: Tuple):
         """Initializer"""
 
         first_seen = row[0]
@@ -517,7 +906,8 @@ class FeedRow:
         if self.malware_printable == "Unknown malware":
             self.malware_printable = ""
         else:
-            self.malware_aliases.insert(0, self.malware_printable)
+            if self.malware_printable and self.malware_printable not in self.malware_aliases:
+                self.malware_aliases.insert(0, self.malware_printable)
 
         last_seen = row[8]
         if last_seen:
@@ -528,12 +918,11 @@ class FeedRow:
 
         self.confidence_level = int(row[9])
         self.is_compromised = str(row[10]).lower() == "true"
-        self.reference = row[11]
-
-        if self.reference == "None":
-            self.reference = ""
-
-        self.tags = list(filter(None, row[12].split(",")))
+        self.reference = row[11] if row[11] != "None" else ""
+        self.tags = [
+            t for t in row[12].split(",")
+            if t and t.lower() != "none"
+        ]
 
         if self.threat_type:
             self.tags.insert(0, self.threat_type)
@@ -542,11 +931,15 @@ class FeedRow:
         self.reporter = row[14]
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Run the ThreatFox connector."""
     try:
         ThreatFoxConnector = ThreatFox()
         ThreatFoxConnector.run()
     except Exception:  # pylint:disable=broad-exception-caught
         print(traceback.format_exc())
-        time.sleep(10)
-        sys.exit(0)
+
+
+# ----------------------------- Entrypoint ---------------------------- #
+if __name__ == "__main__":
+    main()

--- a/external-import/threatfox/src/models/configs/connector_configs.py
+++ b/external-import/threatfox/src/models/configs/connector_configs.py
@@ -38,7 +38,7 @@ class _ConfigLoaderConnector(ConfigBaseSettings):
     name: str
     scope: ListFromString
 
-    type: Literal["EXTERNAL_IMPORT"] = Field(
+    type: str = Field(
         default="EXTERNAL_IMPORT",
         description="Should always be set to EXTERNAL_IMPORT for this connector.",
     )

--- a/external-import/threatfox/tests/conftest.py
+++ b/external-import/threatfox/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Pytest fixtures for ThreatFox connector tests."""
+
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+MINIMAL_ENV = {
+    "OPENCTI_URL": "http://localhost:8080",
+    "OPENCTI_TOKEN": "test-token-00000000-0000-0000-0000-000000000000",
+}
+
+
+@pytest.fixture()
+def minimal_env(monkeypatch):
+    """Set the minimum required environment variables for the config loader."""
+    for key, value in MINIMAL_ENV.items():
+        monkeypatch.setenv(key, value)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def no_dotenv_or_yml(tmp_path, monkeypatch):
+    """Prevent ConfigLoader from picking up .env or config.yml from the src dir."""
+    # Point the config search to a temp dir where no .env or config.yml exists
+    monkeypatch.chdir(tmp_path)

--- a/external-import/threatfox/tests/test_connector.py
+++ b/external-import/threatfox/tests/test_connector.py
@@ -1,0 +1,89 @@
+"""Tests for the ThreatFox connector configuration loader.
+
+Tests verify that the Pydantic-based ConfigLoader can be populated from
+environment variables and that default values are applied correctly.
+"""
+
+import pytest
+
+from src.models.configs.config_loader import ConfigLoader
+from src.models.configs.threatfox_configs import _ConfigLoaderThreatFox
+
+
+class TestThreatFoxConfigDefaults:
+    """Tests for ThreatFox-specific config default values."""
+
+    def test_default_csv_url(self):
+        cfg = _ConfigLoaderThreatFox()
+        assert cfg.csv_url == "https://threatfox.abuse.ch/export/csv/recent/"
+
+    def test_default_import_offline_is_true(self):
+        cfg = _ConfigLoaderThreatFox()
+        assert cfg.import_offline is True
+
+    def test_default_create_indicators_is_true(self):
+        cfg = _ConfigLoaderThreatFox()
+        assert cfg.create_indicators is True
+
+    def test_default_score_is_50(self):
+        cfg = _ConfigLoaderThreatFox()
+        assert cfg.default_x_opencti_score == 50
+
+    def test_default_type_specific_scores_are_none(self):
+        cfg = _ConfigLoaderThreatFox()
+        assert cfg.x_opencti_score_ip is None
+        assert cfg.x_opencti_score_domain is None
+        assert cfg.x_opencti_score_url is None
+        assert cfg.x_opencti_score_hash is None
+
+    def test_default_ioc_to_import(self):
+        cfg = _ConfigLoaderThreatFox()
+        assert cfg.ioc_to_import == "all_types"
+
+
+class TestThreatFoxConfigFromEnv:
+    """Tests that env vars override defaults correctly."""
+
+    def test_csv_url_from_env(self, monkeypatch):
+        monkeypatch.setenv("CSV_URL", "https://custom.example.com/feed.csv")
+        cfg = _ConfigLoaderThreatFox()
+        assert cfg.csv_url == "https://custom.example.com/feed.csv"
+
+    def test_score_override_from_env(self, monkeypatch):
+        monkeypatch.setenv("DEFAULT_X_OPENCTI_SCORE", "80")
+        cfg = _ConfigLoaderThreatFox()
+        assert cfg.default_x_opencti_score == 80
+
+    def test_type_specific_score_from_env(self, monkeypatch):
+        monkeypatch.setenv("X_OPENCTI_SCORE_IP", "90")
+        cfg = _ConfigLoaderThreatFox()
+        assert cfg.x_opencti_score_ip == 90
+
+    def test_create_indicators_false_from_env(self, monkeypatch):
+        monkeypatch.setenv("CREATE_INDICATORS", "false")
+        cfg = _ConfigLoaderThreatFox()
+        assert cfg.create_indicators is False
+
+
+class TestConfigLoaderStructure:
+    """Tests for the top-level ConfigLoader composition."""
+
+    def test_config_loader_has_opencti_section(self, minimal_env):
+        cfg = ConfigLoader()
+        assert cfg.opencti is not None
+
+    def test_config_loader_has_connector_section(self, minimal_env):
+        cfg = ConfigLoader()
+        assert cfg.connector is not None
+
+    def test_config_loader_has_threatfox_section(self, minimal_env):
+        cfg = ConfigLoader()
+        assert cfg.threatfox is not None
+
+    def test_opencti_url_from_env(self, minimal_env):
+        cfg = ConfigLoader()
+        assert "localhost" in str(cfg.opencti.url)
+
+    def test_connector_name_default(self, minimal_env):
+        cfg = ConfigLoader()
+        assert cfg.connector.name == "Abuse.ch | ThreatFox"


### PR DESCRIPTION
### Proposed changes

* Create Observable-to-Malware relationships when malware family information is present.
* Populate `x_opencti_score` from ThreatFox confidence levels.
* Preserve ThreatFox tags as OpenCTI labels.
* Attach ThreatFox external references to Observables, Indicators and Malware.
* Add optional per-type score override configuration.
* Introduce a post-processing phase to attach external references to generated observables.

### Related issues

* #7403

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

#### Overview

This PR updates the ThreatFox connector mapping logic while preserving the existing ingestion flow.

A single STIX bundle is still generated from each ThreatFox CSV pull and sent to OpenCTI. The primary changes concern relationship creation, scoring, labels and external reference handling.

#### Relationship Improvements

Previously, malware relationships could be lost when indicator creation was disabled.

This PR creates:

```
Observable -> related-to -> Malware
```

whenever a malware family is present in the ThreatFox record.

This ensures malware context remains connected within the graph regardless of Indicator creation settings.

#### Scoring Improvements

The connector now maps:

```
confidence_level -> x_opencti_score
```

instead of assigning a fixed score.

Optional per-observable-type overrides have also been added for:

* IP addresses
* Domains
* URLs
* Hashes

#### Labels

ThreatFox tags are now preserved as OpenCTI labels.

Tags are sourced directly from the CSV feed and applied to generated entities, improving filtering and navigation within OpenCTI.

#### External References

External references are now derived exclusively from the ThreatFox reference column.

References are attached to:

* Observables
* Indicators
* Malware entities

Because STIX Cyber Observables cannot receive external references during bundle creation, a post-processing phase has been added.

Workflow:

1. Download and parse the ThreatFox CSV feed.
2. Build and ingest a STIX bundle.
3. Wait for indexing (`THREATFOX_POSTPASS_DELAY_SEC`, default 5 seconds).
4. Resolve generated observables through the OpenCTI API.
5. Attach external references once observable IDs have been resolved.

Resolution uses the following fallback sequence:

1. Direct lookup using emitted STIX IDs.
2. Indicator `based-on` relationships.
3. Observable value/hash lookup with retry logic.

#### CSV Mapping Updates

The connector now maps the following additional CSV fields:

| Column | Field |
|----------|----------|
| 10 | confidence_level |
| 11 | is_compromised |
| 12 | reference |
| 13 | tags |

Notes:

* The literal string `None` is ignored for references.
* Empty tag values are discarded.
* `threat_type` is prepended as the first label.

#### Configuration

New optional configuration values:

* `THREATFOX_DEFAULT_X_OPENCTI_SCORE`
* `THREATFOX_X_OPENCTI_SCORE_IP`
* `THREATFOX_X_OPENCTI_SCORE_DOMAIN`
* `THREATFOX_X_OPENCTI_SCORE_URL`
* `THREATFOX_X_OPENCTI_SCORE_HASH`
* `THREATFOX_POSTPASS_DELAY_SEC`

#### Build Notes

The connector continues to use:

* `python:3.12-alpine`
* `pip install .`
* `pyproject.toml` packaging

No `connectors-sdk` dependency has been introduced.

#### Validation

- [ ] pytest passes
- [ ] Manual run against live ThreatFox feed completed
- [ ] Observable, Indicator and Malware relationships verified in OpenCTI
- [ ] External references confirmed on generated Observables after post-processing
- [ ] Docker build succeeds from a clean checkout
- [ ] README and metadata updated for the new configuration options