### PR TITLE
fix(alienvault): default docker compose file missing "Z" timestamp (#7200)

### DIFF
--- a/external-import/alienvault/README.md
+++ b/external-import/alienvault/README.md
@@ -68,7 +68,7 @@ There are a number of configuration options, which are set either in `docker-com
 | TLP                             | alienvault.tlp                       | `ALIENVAULT_TLP`                              | White                        | No        | Default TLP marking if Pulse doesn't define one.                                 |
 | Create Observables              | alienvault.create_observables        | `ALIENVAULT_CREATE_OBSERVABLES`               | true                         | No        | Create observables from Pulse indicators.                                        |
 | Create Indicators               | alienvault.create_indicators         | `ALIENVAULT_CREATE_INDICATORS`                | true                         | No        | Create indicators from Pulse indicators.                                         |
-| Pulse Start Timestamp           | alienvault.pulse_start_timestamp     | `ALIENVAULT_PULSE_START_TIMESTAMP`            | 2020-05-01T00:00:00          | No        | ISO 8601 timestamp; import Pulses modified after this date.                      |
+| Pulse Start Timestamp           | alienvault.pulse_start_timestamp     | `ALIENVAULT_PULSE_START_TIMESTAMP`            | 2020-05-01T00:00:00Z         | No        | ISO 8601 timestamp; import Pulses modified after this date.                      |
 | Report Type                     | alienvault.report_type               | `ALIENVAULT_REPORT_TYPE`                      | threat-report                | No        | Report type in OpenCTI.                                                          |
 | Report Status                   | alienvault.report_status             | `ALIENVAULT_REPORT_STATUS`                    | New                          | No        | Report status: `New`, `In progress`, `Analyzed`, `Closed`.                       |
 | Guess Malware                   | alienvault.guess_malware             | `ALIENVAULT_GUESS_MALWARE`                    | false                        | No        | Use Pulse tags to guess related malware.                                         |
@@ -115,7 +115,7 @@ Configure the connector in `docker-compose.yml`:
       - ALIENVAULT_TLP=White
       - ALIENVAULT_CREATE_OBSERVABLES=true
       - ALIENVAULT_CREATE_INDICATORS=true
-      - ALIENVAULT_PULSE_START_TIMESTAMP=2020-05-01T00:00:00
+      - ALIENVAULT_PULSE_START_TIMESTAMP=2020-05-01T00:00:00Z
       - ALIENVAULT_REPORT_TYPE=threat-report
       - ALIENVAULT_REPORT_STATUS=New
       - ALIENVAULT_GUESS_MALWARE=false

--- a/external-import/alienvault/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/alienvault/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -18,7 +18,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | ALIENVAULT_TLP | `string` |  | string |  | `"White"` | The default TLP marking used if the Pulse does not define TLP. |
 | ALIENVAULT_CREATE_OBSERVABLES | `boolean` |  | boolean |  | `true` | If true then observables will be created from Pulse indicators and added to the report. |
 | ALIENVAULT_CREATE_INDICATORS | `boolean` |  | boolean |  | `true` | If true then indicators will be created from Pulse indicators and added to the report. |
-| ALIENVAULT_PULSE_START_TIMESTAMP | `string` |  | string |  | `"2020-05-01T00:00:00"` | The Pulses modified after this timestamp will be imported. Timestamp in ISO 8601 format, UTC. |
+| ALIENVAULT_PULSE_START_TIMESTAMP | `string` |  | string |  | `"2020-05-01T00:00:00Z"` | The Pulses modified after this timestamp will be imported. Timestamp in ISO 8601 format, UTC. |
 | ALIENVAULT_REPORT_TYPE | `string` |  | string |  | `"threat-report"` | The type of imported reports in the OpenCTI. |
 | ALIENVAULT_REPORT_STATUS | `string` |  | string |  | `"New"` | The status of imported reports in the OpenCTI. |
 | ALIENVAULT_GUESS_MALWARE | `boolean` |  | boolean |  | `false` | The Pulse tags are used to guess (queries malwares in the OpenCTI) malwares related to the given Pulse. |

--- a/external-import/alienvault/__metadata__/connector_config_schema.json
+++ b/external-import/alienvault/__metadata__/connector_config_schema.json
@@ -84,7 +84,7 @@
       "type": "boolean"
     },
     "ALIENVAULT_PULSE_START_TIMESTAMP": {
-      "default": "2020-05-01T00:00:00",
+      "default": "2020-05-01T00:00:00Z",
       "description": "The Pulses modified after this timestamp will be imported. Timestamp in ISO 8601 format, UTC.",
       "type": "string"
     },

--- a/external-import/alienvault/docker-compose.yml
+++ b/external-import/alienvault/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ALIENVAULT_TLP=White  # Optional (default: White)
       - ALIENVAULT_CREATE_OBSERVABLES=true  # Optional (default: true)
       - ALIENVAULT_CREATE_INDICATORS=true  # Optional (default: true)
-      - ALIENVAULT_PULSE_START_TIMESTAMP=2020-05-01T00:00:00  # Optional (default: 2020-05-01T00:00:00) - ISO 8601 format, UTC - BEWARE! Could be a lot of pulses!
+      - ALIENVAULT_PULSE_START_TIMESTAMP=2020-05-01T00:00:00Z  # Optional (default: 2020-05-01T00:00:00Z) - ISO 8601 format, UTC - BEWARE! Could be a lot of pulses!
       - ALIENVAULT_REPORT_TYPE=threat-report  # Optional (default: threat-report)
       - ALIENVAULT_REPORT_STATUS=New  # Optional (default: New) - New, In progress, Analyzed and Closed
       - ALIENVAULT_GUESS_MALWARE=false  # Optional (default: false) - Use tags to guess malware

--- a/external-import/alienvault/src/alienvault/settings.py
+++ b/external-import/alienvault/src/alienvault/settings.py
@@ -60,7 +60,7 @@ class AlienvaultConfig(BaseConfigModel):
     )
     pulse_start_timestamp: str = Field(
         description="The Pulses modified after this timestamp will be imported. Timestamp in ISO 8601 format, UTC.",
-        default="2020-05-01T00:00:00",
+        default="2020-05-01T00:00:00Z",
     )
     report_type: str = Field(
         description="The type of imported reports in the OpenCTI.",

--- a/external-import/alienvault/src/config.yml.sample
+++ b/external-import/alienvault/src/config.yml.sample
@@ -16,7 +16,7 @@ alienvault:
   tlp: 'White'  # Optional (default: White)
   create_observables: true  # Optional (default: true)
   create_indicators: true  # Optional (default: true)
-  pulse_start_timestamp: '2020-05-01T00:00:00'  # Optional (default: 2020-05-01T00:00:00) - ISO 8601 format, UTC
+  pulse_start_timestamp: '2020-05-01T00:00:00Z'  # Optional (default: 2020-05-01T00:00:00Z) - ISO 8601 format, UTC
   report_type: 'threat-report'  # Optional (default: threat-report)
   report_status: 'New'  # Optional (default: New) - New, In progress, Analyzed and Closed
   guess_malware: false  # Optional (default: false) - Use tags to guess malware


### PR DESCRIPTION
## Description

Fixes #7200

The default `ALIENVAULT_PULSE_START_TIMESTAMP` value (`2020-05-01T00:00:00`) was missing the `Z` UTC suffix, causing the connector to fail to ingest any Pulses when the default value was used.

## Changes

- Added `Z` suffix to default `pulse_start_timestamp` in `settings.py`
- Updated default value in `docker-compose.yml`, `config.yml.sample`, `README.md`, and generated `__metadata__` config schema/doc files