### PR TITLE
refactor: replace html2text with markdownify (#6908)

### DIFF
--- a/external-import/orange-cyberdefense-v3/src/main.py
+++ b/external-import/orange-cyberdefense-v3/src/main.py
@@ -7,13 +7,13 @@ import zipfile
 from concurrent.futures import ThreadPoolExecutor
 from typing import Iterable
 
-import html2text
 import requests
 import stix2
 import utils
 import yaml
 from datalake import Datalake, Output
 from dateutil.parser import parse
+from markdownify import markdownify
 from pycti import (
     Note,
     OpenCTIConnectorHelper,
@@ -1031,18 +1031,9 @@ class OrangeCyberdefense:
         self.helper.log_info(f"{prefix} Processing the report description...")
         html_content = self.get_html_content_block(report["id"]) or ""
         # Convert HTML to Markdown
-        text_maker = html2text.HTML2Text()
-        text_maker.body_width = 0
-        text_maker.ignore_links = False
-        text_maker.ignore_images = False
-        text_maker.ignore_tables = False
-        text_maker.ignore_emphasis = False
-        text_maker.skip_internal_links = False
-        text_maker.inline_links = True
-        text_maker.protect_links = True
-        text_maker.mark_code = True
-        # Generate the report
-        report_md = text_maker.handle(html_content)
+        report_md = markdownify(
+            html_content, heading_style="ATX", table_infer_header=True
+        )
 
         report_object_refs = (
             [self.identity["standard_id"]]  # id from orange cyberdefense default entity

--- a/external-import/orange-cyberdefense-v3/src/requirements.txt
+++ b/external-import/orange-cyberdefense-v3/src/requirements.txt
@@ -1,3 +1,3 @@
 pycti==7.260904.0
 datalake-scripts==3.0.0
-html2text==2025.4.15
+markdownify==1.2.3

--- a/external-import/silobreaker/src/connector/connector.py
+++ b/external-import/silobreaker/src/connector/connector.py
@@ -8,12 +8,12 @@ import urllib.parse
 import urllib.request
 from datetime import datetime
 
-import html2text
 import pytz
 import stix2
 from connector.settings import ConnectorSettings
 from connectors_sdk.models import OrganizationAuthor
 from dateutil.parser import parse
+from markdownify import markdownify
 from pycti import (
     AttackPattern,
     CustomObservableHostname,
@@ -157,17 +157,7 @@ class Silobreaker:
             )
 
     def _convert_to_markdown(self, content):
-        text_maker = html2text.HTML2Text()
-        text_maker.body_width = 0
-        text_maker.ignore_links = False
-        text_maker.ignore_images = False
-        text_maker.ignore_tables = False
-        text_maker.ignore_emphasis = False
-        text_maker.skip_internal_links = False
-        text_maker.inline_links = True
-        text_maker.protect_links = True
-        text_maker.mark_code = True
-        content_md = text_maker.handle(content)
+        content_md = markdownify(content, heading_style="ATX", table_infer_header=True)
         content_md = content_md.replace("hxxps", "https")
         content_md = content_md.replace("](//", "](https://")
         return content_md

--- a/external-import/silobreaker/src/requirements.txt
+++ b/external-import/silobreaker/src/requirements.txt
@@ -1,4 +1,4 @@
 pycti==7.260904.0
-html2text==2025.4.15
+markdownify==1.2.3
 pydantic >=2.8.2, <3
 connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk

--- a/external-import/silobreaker/tests/test_main.py
+++ b/external-import/silobreaker/tests/test_main.py
@@ -99,3 +99,40 @@ def test_connector_is_instantiated(mock_opencti_connector_helper):
 
     assert connector.config == settings
     assert connector.helper == helper
+
+
+def test_convert_to_markdown(mock_opencti_connector_helper):
+    """
+    Test that `Silobreaker._convert_to_markdown` converts HTML to Markdown and applies
+    the Silobreaker-specific post-processing:
+        - headings MUST use the ATX style (`#`), as html2text produced before the migration
+        - a headerless table MUST keep its first row as the header
+        - defanged `hxxps` links MUST be restored to `https`
+        - protocol-relative links MUST be made absolute with `https://`
+
+    :param mock_opencti_connector_helper: `OpenCTIConnectorHelper` is mocked during this test to avoid any external calls to OpenCTI API
+    """
+    settings = StubConnectorSettings()
+    helper = OpenCTIConnectorHelper(config=settings.to_helper_config())
+    connector = Silobreaker(config=settings, helper=helper)
+
+    html = (
+        "<h1>Title</h1>"
+        "<p>Some <strong>bold</strong> text.</p>"
+        "<table><tr><td>IOC</td><td>Type</td></tr>"
+        "<tr><td>1.2.3.4</td><td>ip</td></tr></table>"
+        '<p><a href="hxxps://evil.example/payload">defanged</a> '
+        '<a href="//cdn.example/asset">relative</a></p>'
+    )
+
+    markdown = connector._convert_to_markdown(html)
+
+    assert "# Title" in markdown
+    assert "**bold**" in markdown
+    assert "| IOC | Type |" in markdown
+    assert "| --- | --- |" in markdown
+    assert "| 1.2.3.4 | ip |" in markdown
+    assert "[defanged](https://evil.example/payload)" in markdown
+    assert "[relative](https://cdn.example/asset)" in markdown
+    assert "hxxps" not in markdown
+    assert "](//" not in markdown

--- a/internal-enrichment/import-external-reference/src/import-external-reference.py
+++ b/internal-enrichment/import-external-reference/src/import-external-reference.py
@@ -14,8 +14,8 @@ import urllib.request
 from asyncio import Queue
 from typing import Dict
 
-import html2text
 from cachetools import TTLCache
+from markdownify import markdownify
 from pdfminer.converter import HTMLConverter
 from pdfminer.layout import LAParams
 from pdfminer.pdfinterp import PDFPageInterpreter, PDFResourceManager
@@ -608,22 +608,11 @@ class ImportExternalReferenceConnector:
             # Import as Markdown
             if self.import_as_md:
                 self.helper.connector_logger.debug("Beginning Markdown import logic")
-                # Configure html2text
-                text_maker = html2text.HTML2Text()
-                text_maker.body_width = 0
-                text_maker.ignore_links = False
-                text_maker.ignore_images = False
-                text_maker.ignore_tables = False
-                text_maker.ignore_emphasis = False
-                text_maker.skip_internal_links = False
-                text_maker.inline_links = True
-                text_maker.protect_links = True
-                text_maker.mark_code = True
 
                 try:
                     if is_pdf and self.import_pdf_as_md:
                         html_context = await self._pdf_to_html(pdf_data)
-                        md = text_maker.handle(html_context)
+                        md = self._html_to_markdown(html_context)
                         html_context.close()
 
                         file_name = os.path.basename(url) + ".md"
@@ -644,7 +633,7 @@ class ImportExternalReferenceConnector:
                             )
 
                     elif not is_pdf:
-                        md = text_maker.handle(html)
+                        md = self._html_to_markdown(html)
                         # Fix protocol-relative links
                         md = md.replace("](//", "](https://")
                         file_name = self._safe_filename_from_url(url, ".md")
@@ -691,6 +680,9 @@ class ImportExternalReferenceConnector:
                 f"Enrichment failed for {external_reference.get('url')}: {e}"
             )
             return f"Failed: {e}"
+
+    def _html_to_markdown(self, html: str) -> str:
+        return markdownify(html, heading_style="ATX", table_infer_header=True)
 
     async def _pdf_to_html(self, pdf_bytes: bytes) -> str:
         loop = asyncio.get_running_loop()

--- a/internal-enrichment/import-external-reference/src/import-external-reference.py
+++ b/internal-enrichment/import-external-reference/src/import-external-reference.py
@@ -533,7 +533,7 @@ class ImportExternalReferenceConnector:
                 if not is_pdf and pdf_data is None:
                     html, pdf_bytes = await self._fetch_with_browser(url)
 
-                if html is None and pdf_bytes is None:
+                if html is None and pdf_bytes is None and pdf_data is None:
                     return "Skipped: empty or protected page"
 
             except asyncio.TimeoutError:

--- a/internal-enrichment/import-external-reference/src/import-external-reference.py
+++ b/internal-enrichment/import-external-reference/src/import-external-reference.py
@@ -613,7 +613,6 @@ class ImportExternalReferenceConnector:
                     if is_pdf and self.import_pdf_as_md:
                         html_context = await self._pdf_to_html(pdf_data)
                         md = self._html_to_markdown(html_context)
-                        html_context.close()
 
                         file_name = os.path.basename(url) + ".md"
                         self.helper.connector_logger.info(
@@ -692,12 +691,15 @@ class ImportExternalReferenceConnector:
         pdf_stream = io.BytesIO(pdf_bytes)
         html_buf = io.StringIO()
         rsrcmgr = PDFResourceManager(caching=True)
-        device = HTMLConverter(rsrcmgr, html_buf, laparams=LAParams())
+        # codec must be None when the output is a text stream (StringIO)
+        device = HTMLConverter(rsrcmgr, html_buf, codec=None, laparams=LAParams())
         interpreter = PDFPageInterpreter(rsrcmgr, device)
-        for page in PDFPage.get_pages(pdf_stream, check_extractable=True):
-            interpreter.process_page(page)
-        device.close()
-        pdf_stream.close()
+        try:
+            for page in PDFPage.get_pages(pdf_stream, check_extractable=True):
+                interpreter.process_page(page)
+        finally:
+            device.close()
+            pdf_stream.close()
         return html_buf.getvalue()
 
     # ────────────────────────────────────────────────────────────────────────────────

--- a/internal-enrichment/import-external-reference/src/requirements.txt
+++ b/internal-enrichment/import-external-reference/src/requirements.txt
@@ -1,6 +1,6 @@
 pycti==7.260904.0
 weasyprint==68.1
-html2text==2025.4.15
+markdownify==1.2.3
 pdfminer.six==20251107
 playwright==1.58.0
 cachetools

--- a/internal-enrichment/import-external-reference/src/requirements.txt
+++ b/internal-enrichment/import-external-reference/src/requirements.txt
@@ -1,5 +1,4 @@
 pycti==7.260904.0
-weasyprint==68.1
 markdownify==1.2.3
 pdfminer.six==20251107
 playwright==1.58.0

--- a/internal-enrichment/import-external-reference/tests/test_main.py
+++ b/internal-enrichment/import-external-reference/tests/test_main.py
@@ -1,7 +1,10 @@
+import asyncio
 import importlib.util
 import os
 from typing import Any
 
+import pytest
+from pdfminer.pdfparser import PDFSyntaxError
 from pycti import OpenCTIConnectorHelper
 from settings import ConnectorSettings
 
@@ -110,3 +113,163 @@ def test_connector_is_instantiated(mock_opencti_connector_helper, monkeypatch):
     assert connector.cache_ttl == 3600
     assert connector.worker_count == 4
     assert connector.max_download_size == 52428800
+
+
+@pytest.fixture
+def connector(mock_opencti_connector_helper, monkeypatch):
+    """Build a connector instance on the stubbed settings, with the OpenCTI API mocked."""
+    monkeypatch.setattr(main_module, "ConnectorSettings", StubConnectorSettings)
+    return ImportExternalReferenceConnector()
+
+
+def _build_minimal_pdf(text: str) -> bytes:
+    """
+    Build the smallest valid single-page PDF that renders `text` with a standard font.
+
+    The xref table offsets are computed so that pdfminer parses the file without
+    falling back to its damaged-file recovery path.
+    """
+    content = f"BT /F1 12 Tf 72 720 Td ({text}) Tj ET".encode()
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        b"/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+        b"<< /Length %d >>\nstream\n" % len(content) + content + b"\nendstream",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+
+    pdf = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for number, body in enumerate(objects, start=1):
+        offsets.append(len(pdf))
+        pdf += b"%d 0 obj\n" % number + body + b"\nendobj\n"
+
+    xref_offset = len(pdf)
+    pdf += b"xref\n0 %d\n" % (len(objects) + 1)
+    pdf += b"0000000000 65535 f \n"
+    for offset in offsets:
+        pdf += b"%010d 00000 n \n" % offset
+    pdf += b"trailer\n<< /Size %d /Root 1 0 R >>\n" % (len(objects) + 1)
+    pdf += b"startxref\n%d\n%%%%EOF\n" % xref_offset
+    return bytes(pdf)
+
+
+def test_html_to_markdown(connector):
+    """
+    Test that `_html_to_markdown` converts HTML to Markdown with the options that
+    preserve the pre-migration (html2text) output shape:
+        - headings MUST use the ATX style (`#`)
+        - a headerless table MUST keep its first row as the header
+        - links MUST be kept inline
+    """
+    html = (
+        "<h2>Summary</h2>"
+        "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>"
+        '<p><a href="https://example.com/x">link</a></p>'
+    )
+
+    markdown = connector._html_to_markdown(html)
+
+    assert "## Summary" in markdown
+    assert "| a | b |" in markdown
+    assert "| --- | --- |" in markdown
+    assert "| c | d |" in markdown
+    assert "[link](https://example.com/x)" in markdown
+
+
+def test_pdf_to_html_sync_extracts_text(connector):
+    """
+    Test that `_pdf_to_html_sync` converts a PDF into HTML containing its text.
+    This is the path that used to fail on every call because `HTMLConverter`
+    was built without `codec=None` for a text output stream.
+    """
+    html = connector._pdf_to_html_sync(_build_minimal_pdf("Hello from PDF"))
+
+    assert "<html>" in html
+    assert "Hello from PDF" in html
+
+
+def test_pdf_to_html_sync_closes_resources_on_corrupt_pdf(connector, monkeypatch):
+    """
+    Test that `_pdf_to_html_sync` re-raises the parser error on a corrupt PDF and
+    still closes the converter, which the previous implementation skipped.
+    """
+    closed = []
+
+    class SpyHTMLConverter(main_module.HTMLConverter):
+        def close(self):
+            closed.append(True)
+            return super().close()
+
+    monkeypatch.setattr(main_module, "HTMLConverter", SpyHTMLConverter)
+
+    with pytest.raises(PDFSyntaxError):
+        connector._pdf_to_html_sync(b"%PDF-1.4\nthis is not a pdf")
+
+    assert closed == [True]
+
+
+def test_process_external_reference_attaches_markdown_from_html(connector, monkeypatch):
+    """
+    Test the HTML → Markdown import path of `_process_external_reference`:
+        - the page fetched by the browser MUST be converted to Markdown
+        - protocol-relative links MUST be made absolute
+        - the result MUST be attached to the external reference as a `.md` file
+    """
+    connector.import_as_pdf = False
+
+    async def fake_fetch_with_browser(url, timeout=180):
+        return (
+            '<h1>Report</h1><p><a href="//cdn.example/asset">asset</a></p>',
+            None,
+        )
+
+    monkeypatch.setattr(connector, "_fetch_with_browser", fake_fetch_with_browser)
+
+    result = asyncio.run(
+        connector._process_external_reference(
+            {"id": "external-reference--1", "url": "https://example.com/report"}
+        )
+    )
+
+    assert result == "Import complete."
+    add_file = connector.helper.api.external_reference.add_file
+    add_file.assert_called_once()
+    kwargs = add_file.call_args.kwargs
+    assert kwargs["id"] == "external-reference--1"
+    assert kwargs["file_name"] == "report.md"
+    assert kwargs["mime_type"] == "text/markdown"
+    assert "# Report" in kwargs["data"]
+    assert "[asset](https://cdn.example/asset)" in kwargs["data"]
+
+
+def test_process_external_reference_attaches_markdown_from_pdf(connector, monkeypatch):
+    """
+    Test the PDF → HTML → Markdown import path of `_process_external_reference`:
+        - the downloaded PDF MUST be converted to Markdown
+        - the result MUST be attached to the external reference as a `.md` file
+    Before the fix this path silently produced nothing (the conversion errors were
+    caught and only logged).
+    """
+    connector.import_as_pdf = False
+
+    async def fake_download_url(url):
+        return _build_minimal_pdf("Hello from PDF")
+
+    monkeypatch.setattr(connector, "_download_url", fake_download_url)
+
+    result = asyncio.run(
+        connector._process_external_reference(
+            {"id": "external-reference--2", "url": "https://example.com/report.pdf"}
+        )
+    )
+
+    assert result == "Import complete."
+    add_file = connector.helper.api.external_reference.add_file
+    add_file.assert_called_once()
+    kwargs = add_file.call_args.kwargs
+    assert kwargs["id"] == "external-reference--2"
+    assert kwargs["file_name"] == "report.pdf.md"
+    assert kwargs["mime_type"] == "text/markdown"
+    assert "Hello from PDF" in kwargs["data"]


### PR DESCRIPTION
### Proposed changes

* Replace `html2text` with `markdownify` in the three connectors that were still using it: `silobreaker`, `orange-cyberdefense-v3` and `import-external-reference`. All three carried an identical 10-line `HTML2Text` configuration block, now a single `markdownify()` call. `html2text` is no longer used anywhere in the repository.
* `heading_style="ATX"` preserves html2text's `#` headings (markdownify defaults to setext) and `table_infer_header=True` keeps a headerless table's first row as the header, as html2text did. Everything else — no line wrapping, links/images/emphasis kept, inline links, autolinks — is markdownify's default, so the existing `hxxps://` and protocol-relative link post-processing still applies unchanged.
* In `import-external-reference`, the conversion is called from two places, so it is extracted into a small `_html_to_markdown()` helper rather than duplicated.
* Drop the unused `weasyprint==68.0` dependency from `import-external-reference`. It was declared in `requirements.txt` but never imported anywhere in the connector — PDF generation goes through `playwright` instead. The Dockerfile also never installed weasyprint's native dependencies (cairo, pango), so it would most likely have failed on import had anything tried to use it. Flagged by the unused-deps bot on this PR; verified in a clean virtualenv built from the edited `requirements.txt` that the connector module imports and the test suite passes without it.
* Fix three pre-existing bugs in the `import-external-reference` PDF→Markdown path. The first two sat on lines this migration had to rewrite; the third was surfaced by the end-to-end test added for coverage. Together they made the feature unreachable:
  * `HTMLConverter` was constructed with a `StringIO` but without `codec=None`, so every call raised `PDFValueError: Codec must not be specified for a text I/O output`.
  * `close()` was called on `_pdf_to_html()`'s return value, which is a `str` — an `AttributeError` swallowed by the surrounding `except Exception`.
  * For a URL ending in `.pdf`, the file is pre-downloaded into `pdf_data` and the browser is never called, so `html` and `pdf_bytes` stay `None` and the early return `if html is None and pdf_bytes is None` fired before either import branch. Every PDF external reference was skipped as "empty or protected page", whatever the import mode, since the async rewrite (#4271). The check now also looks at `pdf_data`.

### Related issues

* Closes #6908

<!--
Note on the issue text: #6908 is titled "use BeautifulSoup", but BeautifulSoup's get_text() flattens HTML to plain text and loses structure, whereas these call sites all need Markdown (which is what OpenCTI renders for descriptions and attached .md files). markdownify is the appropriate library here; it uses BeautifulSoup internally for the parsing itself.
-->

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion) — not applicable, no user-facing configuration or behaviour options changed
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

**Why markdownify produces better output, not just less code.** For the same input, html2text emitted table rows without leading pipes and injected a spurious separator row into the middle of headerless tables, and `mark_code=True` produced non-standard `[code]...[/code]` markers instead of fenced code blocks. Comparison on a representative report fragment:

<details>
<summary>Before (html2text) vs after (markdownify)</summary>

Before, with html2text:

~~~text
IOC| Type
---|---
1.2.3.4| ip
ex.com| domain
a| b
---|---          <-- spurious separator injected mid-output
c| d
[code]
    powershell -enc AAAA
[/code]
~~~

After, with markdownify:

~~~text
| IOC | Type |
| --- | --- |
| 1.2.3.4 | ip |
| ex.com | domain |

| a | b |
| --- | --- |
| c | d |

```
powershell -enc AAAA
```
~~~

</details>

**Verification**

* Both test suites pass — `silobreaker` 9/9 and `import-external-reference` 13/13 — installed from the edited `requirements.txt` so the dependency swap is confirmed to resolve.
* Added unit tests for `Silobreaker._convert_to_markdown`, `_html_to_markdown`, `_pdf_to_html_sync` (valid and corrupt PDF) and `_process_external_reference` on both the HTML and the PDF path, bringing the patch coverage above the 80% Codecov target.
* Exercised `Silobreaker._convert_to_markdown()` on a representative report fragment (headings, bold, tables, fenced code, `hxxps://` links, protocol-relative links) and confirmed both post-processing replacements still fire.
* Exercised the full `_pdf_to_html_sync()` → `_html_to_markdown()` chain on a generated PDF to confirm the PDF→Markdown path works now that the two bugs above are fixed.
* `black` and `isort --profile black` clean on all three files.
* `orange-cyberdefense-v3` has no test suite; its change is the same mechanical substitution and was verified by inspection of the single call site.

**Separable if preferred.** The two PDF-path bug fixes and the `weasyprint` removal are each independent of the library migration, and are in their own commits. Happy to split any of them out if you'd rather keep this PR a pure dependency swap.

**Unrelated issue noticed in passing** (not touched here): `.isort.cfg` sets `profile = "black"` with literal quotes, which `.cfg` parsing does not strip, so a bare `isort` run fails with `ProfileDoesNotExist`. CI is unaffected because it passes `--profile black` explicitly, but it breaks local and editor-integrated runs.

<sub>Supersedes #7412, which was opened from a branch that did not follow the `issue/<number>-<slug>` naming convention. Same commits, same content.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

