### PR TITLE
fix(proofpoint-et-intelligence): stop crashing on an unresolvable country code (#7414)

### DIFF
--- a/internal-enrichment/proofpoint-et-intelligence/src/connector/connector.py
+++ b/internal-enrichment/proofpoint-et-intelligence/src/connector/connector.py
@@ -621,6 +621,15 @@ class ProofpointEtIntelligenceConnector:
                 for entity in entities:
                     if key == "get_geolocation":
                         entity = self.utils.get_location_info(entity)
+                        # A Location cannot be built without a country: skip it
+                        # rather than losing the whole enrichment over it.
+                        if not entity.get("country") or not entity.get("country_code"):
+                            self.helper.connector_logger.info(
+                                "[CONNECTOR] Geolocation skipped, the country could "
+                                "not be determined",
+                                {"geolocation": entity},
+                            )
+                            continue
 
                     prepare_args = (
                         (

--- a/internal-enrichment/proofpoint-et-intelligence/src/connector/services/utils.py
+++ b/internal-enrichment/proofpoint-et-intelligence/src/connector/services/utils.py
@@ -87,6 +87,12 @@ class Utils:
     def get_location_info(geolocation: dict) -> dict:
         """This method allows you to retrieve the official name of the country based only on the country code.
 
+        The code is not always resolvable: ET Intelligence also returns codes
+        that are not part of ISO 3166-1, such as `XK` (Kosovo) or the MaxMind
+        pseudo-codes `EU`, `AP`, `A1` and `A2`, for which pycountry has no
+        entry. The name carried by the payload is then kept, and `country` is
+        left empty when there is none either.
+
         Args:
             geolocation:
 
@@ -94,13 +100,18 @@ class Utils:
 
         """
         country_code = geolocation.get("country_code")
-        country_info = pycountry.countries.get(alpha_2=country_code)
+        # pycountry returns None for a code it does not know, and raises a
+        # LookupError on alpha_2=None.
+        country_info = (
+            pycountry.countries.get(alpha_2=country_code) if country_code else None
+        )
 
         # If possible get official country name and update country name
-        if hasattr(country_info, "official_name"):
-            country_name = country_info.official_name
-        else:
-            country_name = geolocation.get("country", country_info.name)
+        country_name = (
+            getattr(country_info, "official_name", None)
+            or geolocation.get("country")
+            or getattr(country_info, "name", None)
+        )
         geolocation["country"] = country_name
 
         # If possible update region name

--- a/internal-enrichment/proofpoint-et-intelligence/src/connector/services/utils.py
+++ b/internal-enrichment/proofpoint-et-intelligence/src/connector/services/utils.py
@@ -85,7 +85,7 @@ class Utils:
 
     @staticmethod
     def get_location_info(geolocation: dict) -> dict:
-        """This method allows you to retrieve the official name of the country based only on the country code.
+        """Retrieve the official country name from the country code when possible.
 
         The code is not always resolvable: ET Intelligence also returns codes
         that are not part of ISO 3166-1, such as `XK` (Kosovo) or the MaxMind

--- a/internal-enrichment/proofpoint-et-intelligence/tests/test_get_location_info.py
+++ b/internal-enrichment/proofpoint-et-intelligence/tests/test_get_location_info.py
@@ -1,0 +1,101 @@
+"""Tests for `Utils.get_location_info`.
+
+ET Intelligence returns country codes that are not always part of
+ISO 3166-1, so pycountry has no entry for them. These tests pin that an
+unresolvable code no longer raises: the Location is then built from the name
+carried by the payload, or skipped by the caller when there is none.
+"""
+
+import pytest
+from connector.services.utils import Utils
+
+
+def _geolocation(**overrides):
+    geolocation = {"country_code": "FR", "country": "France", "region": "IDF"}
+    geolocation.update(overrides)
+    return geolocation
+
+
+# --------------------------------------------------------------------------
+# A resolvable code is upgraded to its official name, as before
+# --------------------------------------------------------------------------
+
+
+def test_a_known_code_gives_the_official_name():
+    result = Utils.get_location_info(_geolocation())
+
+    assert result["country"] == "French Republic"
+    assert result["region"] == "Île-de-France"
+
+
+def test_a_known_code_without_an_official_name_keeps_the_payload_name():
+    """Not every ISO country has an official_name in pycountry."""
+    result = Utils.get_location_info(
+        _geolocation(country_code="AW", country="Aruba", region=None)
+    )
+
+    assert result["country"] == "Aruba"
+
+
+# --------------------------------------------------------------------------
+# An unresolvable code no longer raises
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "country_code",
+    ["XK", "EU", "AP", "A1", "A2", "ZZ", ""],
+    ids=[
+        "kosovo",
+        "europe",
+        "asia_pacific",
+        "anon_proxy",
+        "satellite",
+        "junk",
+        "empty",
+    ],
+)
+def test_an_unresolvable_code_falls_back_on_the_payload_name(country_code):
+    """The reported bug: pycountry returns None, `country_info.name` raised."""
+    result = Utils.get_location_info(
+        _geolocation(country_code=country_code, country="Kosovo", region=None)
+    )
+
+    assert result["country"] == "Kosovo"
+
+
+def test_a_missing_code_does_not_raise_a_lookup_error():
+    """pycountry.countries.get(alpha_2=None) raises, it does not return None."""
+    result = Utils.get_location_info({"country": "Kosovo"})
+
+    assert result["country"] == "Kosovo"
+
+
+def test_no_country_at_all_leaves_the_field_empty():
+    """The caller skips the Location on this one."""
+    result = Utils.get_location_info({"country_code": "XK"})
+
+    assert result["country"] is None
+
+
+# --------------------------------------------------------------------------
+# The region is derived from the code, which may be unresolvable too
+# --------------------------------------------------------------------------
+
+
+def test_an_unresolvable_subdivision_keeps_the_raw_region():
+    result = Utils.get_location_info(_geolocation(region="ZZZ"))
+
+    assert result["region"] == "ZZZ"
+
+
+def test_a_region_without_a_country_code_keeps_the_raw_region():
+    result = Utils.get_location_info({"country": "Kosovo", "region": "01"})
+
+    assert result["region"] == "01"
+
+
+def test_no_region_gives_none():
+    result = Utils.get_location_info(_geolocation(region=None))
+
+    assert result["region"] is None


### PR DESCRIPTION
### Proposed changes

* Guard the `pycountry` lookup in `get_location_info`: it returns `None` for an unknown code and raises `LookupError` on `alpha_2=None`. The country name is now resolved through `official_name` → payload name → short name, without
  dereferencing a missing entry.
* Stop passing `country_info.name` as the default of `geolocation.get("country", ...)` — that default is evaluated eagerly, so the attribute was read on every call even when the payload already carried a usable name.
* Skip the geolocation and log at `info` in `_transform_intelligence` when no country can be determined: a Location cannot be built without one, and the exception used to discard the IP, domain, malware and ASN entities built in the same run.
* Add `tests/test_get_location_info.py` — 8 tests covering resolvable, unresolvable, missing and absent country codes, plus region resolution.

### Related issues

* Fixes #7414


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
