### PR TITLE
feat(pan-cortex-xdr-intel): implement upsert lifecycle for indicator create/update (#7186)

### DIFF
--- a/stream/pan-cortex-xdr-intel/README.md
+++ b/stream/pan-cortex-xdr-intel/README.md
@@ -5,11 +5,20 @@
 - [OpenCTI Palo Alto Cortex XDR Intel Connector](#opencti-palo-alto-cortex-xdr-intel-connector)
   - [Table of Contents](#table-of-contents)
   - [Introduction](#introduction)
+  - [Behavior](#behavior)
+    - [Supported actions](#supported-actions)
+    - [Data flow](#data-flow)
+    - [Supported observable types](#supported-observable-types)
   - [Installation](#installation)
     - [Requirements](#requirements)
     - [Getting the Cortex XDR API base URL](#getting-the-cortex-xdr-api-base-url)
     - [Getting the Cortex XDR API credentials](#getting-the-cortex-xdr-api-credentials)
   - [Configuration variables](#configuration-variables)
+  - [Operational guidance](#operational-guidance)
+    - [Log interpretation](#log-interpretation)
+    - [Idempotency](#idempotency)
+    - [Unsupported observable handling](#unsupported-observable-handling)
+  - [Troubleshooting](#troubleshooting)
 
 
 ## Introduction
@@ -19,6 +28,55 @@ network, and cloud data to detect, investigate, and respond to threats across th
 
 This connector listens to an OpenCTI live stream and synchronizes indicators as Indicators of
 Compromise (IOCs) in Palo Alto Cortex XDR.
+
+## Behavior
+
+### Supported actions
+
+Only STIX **Indicator** entities are processed; any other entity type (e.g. Malware, Identity)
+received on the stream is skipped with a `warning` log.
+
+The connector reacts to the following live stream events on Indicator entities:
+
+| OpenCTI event | Cortex XDR action |
+| ------------- | ------------------ |
+| `create` / `update` | Upsert: insert the indicator's IOC(s), or update them if they already exist |
+| `delete` | Delete the indicator's IOC(s) |
+
+Any other event type (e.g. a custom event) is skipped with a `warning` log.
+
+`delete` events require `CONNECTOR_LIVE_STREAM_LISTEN_DELETE` to be enabled (`true` by default,
+see [Configuration variables](#configuration-variables)); when disabled, OpenCTI never emits
+delete events on the stream and this connector never removes IOCs from Cortex XDR.
+
+### Data flow
+
+1. OpenCTI's live stream emits an event for an Indicator create/update/delete.
+2. The indicator's `observable_values` extension attribute is normalized into the connector's
+   internal representation, keeping only observables of a [supported type](#supported-observable-types).
+3. Each supported observable is mapped to a Cortex XDR IOC (`type` + `indicator` value).
+4. On upsert, the indicator's `score`, `valid_until` and `description` are additionally mapped to
+   the IOC's `severity`, `expiration_date` and `comment`, and `reputation` is hardcoded to `BAD`
+   (see [Idempotency](#idempotency) for how updates to an already-existing IOC are handled).
+5. The resulting IOC(s) are sent to Cortex XDR in a single batched API call
+   (`insert_iocs` for upsert, `delete_iocs` for delete).
+
+An indicator whose observables map to **no** supported Cortex XDR IOC at all is skipped (see
+[Unsupported observable handling](#unsupported-observable-handling)).
+
+### Supported observable types
+
+| STIX observable | Cortex XDR IOC type |
+| --------------- | -------------------- |
+| `Domain-Name` | `DOMAIN_NAME` |
+| `IPv4-Addr` / `IPv6-Addr` | `IP` |
+| `StixFile` (hashes only, e.g. `MD5`, `SHA-1`, `SHA-256`) | `HASH` |
+
+Any other observable type (e.g. `Hostname`, `Email-Addr`, `Url`) is out of scope for this
+connector's MVP and is silently filtered out when building the indicator's observables. A
+`StixFile` observable is a supported type, but only its hash(es) are mapped to a Cortex XDR IOC:
+a `StixFile` with only a `name` and no hash passes the type filter but still yields no IOC (see
+[Unsupported observable handling](#unsupported-observable-handling)).
 
 ## Installation
 
@@ -57,3 +115,51 @@ Find all the configuration variables available here: [Connector Configurations](
 _The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
 For more information regarding these variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
+## Operational guidance
+
+### Log interpretation
+
+| Level | When | Example message |
+| ----- | ---- | ---------------- |
+| `warning` | An unsupported stream event or entity type is received (event skipped), or none of an indicator's observables are of a supported type (indicator skipped) | `Unsupported event type, skipping it` / `Unsupported entity type, skipping it` / `No supported observable(s) found in indicator, skipping it` |
+| `debug` | Right before an upsert/delete API call is sent to Cortex XDR | `Upserting IOC(s) into Cortex XDR` / `Deleting IOC(s) from Cortex XDR` |
+| `info` | An indicator was successfully parsed, upserted, or deleted | `Parsed observable(s) from stream event` / `Successfully upserted IOC(s) into Cortex XDR` / `Successfully deleted IOC(s) from Cortex XDR` |
+| `error` (indicator-scoped, stream continues) | The indicator has supported-type observable(s) but none of them could still be mapped to a Cortex XDR IOC (e.g. a `StixFile` without any hash), or the Cortex XDR API rejects one specific event (e.g. an invalid IOC value) | `No Cortex XDR IOC could be extracted from any observable, skipping indicator` / `Error while hitting Cortex XDR API. Skipping event and continuing with the next one.` |
+| `error` (fatal, connector exits) | A stream payload could not be parsed/validated, or the Cortex XDR API returned an authentication, authorization, not-found, rate-limit, or server error (401/403/404/429/5xx) | `Failed to parse stream event's data payload as JSON` / `Failed to parse indicator and/or observables from stream event` / `Error while hitting Cortex XDR API` |
+
+A fatal error stops the connector process on purpose, to avoid exhausting or silently
+mis-processing the live stream while a systemic issue (e.g. a revoked API key, or an
+unexpected breaking change in the stream payload) remains unresolved; the connector must be
+restarted manually once the root cause is fixed.
+
+### Idempotency
+
+- **Upsert**: before inserting an IOC, the connector looks up any existing Cortex XDR IOC with
+  the same indicator value. If found, its `rule_id` is included in the following insert call so
+  Cortex XDR *updates* the existing IOC in place instead of failing with a 400 "IOC indicator
+  exists" error. Replaying the same `create`/`update` event is therefore safe.
+- **Delete**: Cortex XDR's delete API is inherently idempotent — deleting an IOC that no longer
+  exists (e.g. already deleted) does not raise. Replaying the same `delete` event is safe.
+
+### Unsupported observable handling
+
+Observables of an unsupported type (see [Supported observable types](#supported-observable-types))
+are filtered out silently, without any log, when the indicator is parsed. If this filtering
+leaves the indicator with **no** observable at all, the connector logs a `warning` and skips that
+specific indicator, without stopping the stream — this is expected behavior, not a runtime error.
+
+A supported-type observable can still fail to yield a Cortex XDR IOC (e.g. a `StixFile` with only
+a `name` and no hash). If **all** of an indicator's supported-type observables end up in this
+situation, the connector logs an `error` (instead of a `warning`) and skips the indicator, since
+this points to an unexpected data shape rather than the normal type-filtering behavior.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| Connector exits right after startup or after processing one event; logs show a 401/403 Cortex XDR error | Invalid, revoked, or **Standard** (non-Advanced) API key | Generate an **Advanced** API key/Key ID pair (see [Getting the Cortex XDR API credentials](#getting-the-cortex-xdr-api-credentials)) and update `PAN_CORTEX_XDR_INTEL_API_KEY`/`PAN_CORTEX_XDR_INTEL_API_KEY_ID` |
+| Same as above but with a 429 error | Cortex XDR API rate limit exceeded (not currently configurable from the connector side) | Restart the connector; if the issue persists, contact Filigran support |
+| Logs repeatedly show `No supported observable(s) found in indicator, skipping it` | The indicator's observables are all of an unsupported type (e.g. `Hostname`, `Email-Addr`, `Url`) | Expected behavior for unspported observable types; no action needed unless those indicators are expected to be pushed to Cortex XDR |
+| Logs repeatedly show `No Cortex XDR IOC could be extracted from any observable, skipping indicator` | The indicator only has `StixFile` observable(s) without any hash (e.g. only a `name`) | Expected behavior since only hashes are mapped for `StixFile`; no action needed unless those indicators are expected to be pushed to Cortex XDR |
+| `delete` events never reach Cortex XDR | `CONNECTOR_LIVE_STREAM_LISTEN_DELETE` is set to `false` | Set `CONNECTOR_LIVE_STREAM_LISTEN_DELETE=true` (the default) |
+| Connector exits with `Failed to parse stream event's data payload as JSON` or `Failed to parse indicator and/or observables from stream event` | Unexpected OpenCTI/`pycti` stream payload shape (e.g. a breaking upstream change) | This should not happen; please report the issue with the connector's logs |

--- a/stream/pan-cortex-xdr-intel/src/connector/connector.py
+++ b/stream/pan-cortex-xdr-intel/src/connector/connector.py
@@ -103,15 +103,45 @@ class Connector:
         )
 
     def _extract_xdr_iocs(self, octi_indicator: OctiIndicator) -> list[CortexXdrIoc]:
-        """Build `CortexXdrIoc` from `octi_indicator` and its observables,
-        mapping OpenCTI fields to Cortex XDR's IOC fields.
+        """Build `CortexXdrIoc`s from `octi_indicator`'s observables.
 
-        /!\\ Observables without a supported mapping are skipped silently.
+        Used by both `_handle_upsert` and `_handle_delete` to extract the
+        Cortex XDR IOC `type` and `indicator` fields from the OpenCTI indicator's observables.
         """
         if not octi_indicator.observables:
             return []
 
-        # Map OpenCTI indicator's fields to Cortex XDR IOC fields
+        xdr_iocs: list[CortexXdrIoc] = []
+        # TODO: improve the mapping so it correspond to the mapping defined in the MVP
+        for observable in octi_indicator.observables:
+            if observable.type.lower() == "stixfile":
+                # Only hashes are mapped for now; filename is intentionally out of scope (currently commented)
+                # if observable.name:
+                #     xdr_iocs.append(
+                #         CortexXdrIoc(type="FILENAME", indicator=observable.name)
+                #     )
+                if observable.hashes:
+                    for hash_value in observable.hashes.values():
+                        xdr_iocs.append(CortexXdrIoc(type="HASH", indicator=hash_value))
+            elif observable.type.lower() == "domain-name":
+                xdr_iocs.append(
+                    CortexXdrIoc(type="DOMAIN_NAME", indicator=observable.value)  # type: ignore[union-attr]  # `value` is always set for DomainName observables
+                )
+            elif observable.type.lower() in ("ipv4-addr", "ipv6-addr"):
+                xdr_iocs.append(CortexXdrIoc(type="IP", indicator=observable.value))  # type: ignore[union-attr]  # `value` is always set for IP observables
+
+        return xdr_iocs
+
+    def _map_indicator_fields_to_xdr_iocs(
+        self, octi_indicator: OctiIndicator, xdr_iocs: list[CortexXdrIoc]
+    ) -> list[CortexXdrIoc]:
+        """Map OpenCTI indicator's properties to each Cortex XDR IOC.
+
+        Used by `_handle_upsert` to set the Cortex XDR IOC optional fields.
+        """
+        if not xdr_iocs:
+            return []
+
         # TODO: fix the mapping so it correspond to the mapping defined in the MVP
         if octi_indicator.score is None:
             xdr_severity = None
@@ -140,51 +170,21 @@ class Connector:
             "reliability": None,  # intentionally non-set for now
         }
 
-        # Map observables' fields and build Cortex XDR IOCs
-        xdr_iocs: list[CortexXdrIoc] = []
-        for observable in octi_indicator.observables:
-            if observable.type.lower() == "stixfile":
-                # Only hashes are mapped for now; filename is intentionally out of scope (currently commented)
-                # if observable.name:
-                #     xdr_iocs.append(
-                #         CortexXdrIoc(
-                #             type="FILENAME",
-                #             indicator=observable.name,
-                #             **indicator_properties,
-                #         )
-                #     )
-                if observable.hashes:
-                    for hash_value in observable.hashes.values():
-                        xdr_iocs.append(
-                            CortexXdrIoc(
-                                type="HASH",
-                                indicator=hash_value,
-                                **indicator_properties,
-                            )
-                        )
-            elif observable.type.lower() in ("domain-name", "hostname"):
-                xdr_iocs.append(
-                    CortexXdrIoc(
-                        type="DOMAIN_NAME",
-                        indicator=observable.value,  # type: ignore[union-attr]  # `value` is always set for DomainName/Hostname observables
-                        **indicator_properties,
-                    )
-                )
-            elif observable.type.lower() in ("ipv4-addr", "ipv6-addr"):
-                xdr_iocs.append(
-                    CortexXdrIoc(
-                        type="IP",
-                        indicator=observable.value,  # type: ignore[union-attr]  # `value` is always set for IP observables
-                        **indicator_properties,
-                    )
-                )
+        # Apply the indicator properties to each Cortex XDR IOC
+        for xdr_ioc in xdr_iocs:
+            for key, value in indicator_properties.items():
+                setattr(xdr_ioc, key, value)
 
         return xdr_iocs
 
     def _resolve_xdr_iocs_rule_ids(
         self, extracted_xdr_iocs: list[CortexXdrIoc]
     ) -> list[CortexXdrIoc]:
-        """Resolve `rule_id` for each Cortex XDR IOC extracted from the indicator's observables."""
+        """Resolve `rule_id` for each Cortex XDR IOC extracted from OpenCTI indicator's observables.
+
+        Used by `_handle_upsert` to attach the Cortex XDR-assigned `rule_id` to each IOC
+        that already exists on Cortex XDR, so that XDR API will update it instead of creating a duplicate.
+        """
         if not extracted_xdr_iocs:
             return []
 
@@ -219,7 +219,9 @@ class Connector:
     def _handle_upsert(self, octi_indicator: OctiIndicator) -> None:
         """Upsert `octi_indicator`'s supported observables into Cortex XDR as IOCs."""
         # Extract Cortex XDR IOCs from the indicator's observables
+        # (`xdr_iocs` is re-assigned after each transformation to ease debugging)
         xdr_iocs = self._extract_xdr_iocs(octi_indicator)
+        xdr_iocs = self._map_indicator_fields_to_xdr_iocs(octi_indicator, xdr_iocs)
         xdr_iocs = self._resolve_xdr_iocs_rule_ids(xdr_iocs)
         if not xdr_iocs:
             self.helper.connector_logger.error(
@@ -233,7 +235,7 @@ class Connector:
             return
 
         self.helper.connector_logger.debug(
-            "Upserting indicator(s) into Cortex XDR",
+            "Upserting IOC(s) into Cortex XDR",
             {"indicator_id": octi_indicator.id, "xdr_iocs": len(xdr_iocs)},
         )
 
@@ -243,7 +245,43 @@ class Connector:
         )
 
         self.helper.connector_logger.info(
-            "Successfully upserted indicator(s) into Cortex XDR",
+            "Successfully upserted IOC(s) into Cortex XDR",
+            {"indicator_id": octi_indicator.id, "xdr_iocs": len(xdr_iocs)},
+        )
+
+    def _handle_delete(self, octi_indicator: OctiIndicator) -> None:
+        """Delete `octi_indicator`'s supported observables from Cortex XDR."""
+        # Extract Cortex XDR IOCs from the indicator's observables
+        xdr_iocs = self._extract_xdr_iocs(octi_indicator)
+        if not xdr_iocs:
+            self.helper.connector_logger.error(
+                "No Cortex XDR IOC could be extracted from any observable, "
+                "skipping indicator",
+                {
+                    "indicator_id": octi_indicator.id,
+                    "observables_count": len(octi_indicator.observables),
+                },
+            )
+            return
+
+        self.helper.connector_logger.debug(
+            "Deleting IOC(s) from Cortex XDR",
+            {"indicator_id": octi_indicator.id, "xdr_iocs": len(xdr_iocs)},
+        )
+
+        # Delete all the IOCs corresponding to the filters on Cortex XDR
+        self.client.delete_iocs(
+            [
+                {
+                    "field": "indicator",
+                    "operator": "IN",
+                    "value": [ioc.indicator for ioc in xdr_iocs],
+                }
+            ]
+        )
+
+        self.helper.connector_logger.info(
+            "Successfully deleted IOC(s) from Cortex XDR",
             {"indicator_id": octi_indicator.id, "xdr_iocs": len(xdr_iocs)},
         )
 
@@ -330,7 +368,7 @@ class Connector:
             if event in {"create", "update"}:
                 self._handle_upsert(octi_indicator)
             elif event == "delete":
-                pass  # TODO: delete from Cortex XDR (#7187)
+                self._handle_delete(octi_indicator)
 
         except CortexXdrApiError as err:
             fatal_causes = (

--- a/stream/pan-cortex-xdr-intel/src/connector/connector.py
+++ b/stream/pan-cortex-xdr-intel/src/connector/connector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any, Protocol
 
-from connector.models import OctiIndicator
+from connector.models import CortexXdrIoc, OctiIndicator
 from connectors_sdk import (
     ApiForbiddenError,
     ApiNotFoundError,
@@ -102,6 +102,151 @@ class Connector:
             score=self.helper.get_attribute_in_extension("score", data),
         )
 
+    def _extract_xdr_iocs(self, octi_indicator: OctiIndicator) -> list[CortexXdrIoc]:
+        """Build `CortexXdrIoc` from `octi_indicator` and its observables,
+        mapping OpenCTI fields to Cortex XDR's IOC fields.
+
+        /!\\ Observables without a supported mapping are skipped silently.
+        """
+        if not octi_indicator.observables:
+            return []
+
+        # Map OpenCTI indicator's fields to Cortex XDR IOC fields
+        # TODO: fix the mapping so it correspond to the mapping defined in the MVP
+        if octi_indicator.score is None:
+            xdr_severity = None
+        elif octi_indicator.score >= 80:
+            xdr_severity = "SEV_040_HIGH"
+        elif octi_indicator.score >= 60:
+            xdr_severity = "SEV_030_MEDIUM"
+        elif octi_indicator.score >= 40:
+            xdr_severity = "SEV_020_LOW"
+        elif octi_indicator.score >= 20:
+            xdr_severity = "SEV_010_INFO"
+        else:
+            xdr_severity = None
+
+        xdr_expiration_timestamp = (
+            int(octi_indicator.valid_until.timestamp()) * 1000
+            if octi_indicator.valid_until
+            else None
+        )
+
+        indicator_properties = {
+            "severity": xdr_severity,
+            "expiration_date": xdr_expiration_timestamp,
+            "comment": octi_indicator.description,
+            "reputation": "BAD",  # intentionally hardcoded for now
+            "reliability": None,  # intentionally non-set for now
+        }
+
+        # Map observables' fields and build Cortex XDR IOCs
+        xdr_iocs: list[CortexXdrIoc] = []
+        for observable in octi_indicator.observables:
+            if observable.type.lower() == "stixfile":
+                # Only hashes are mapped for now; filename is intentionally out of scope (currently commented)
+                # if observable.name:
+                #     xdr_iocs.append(
+                #         CortexXdrIoc(
+                #             type="FILENAME",
+                #             indicator=observable.name,
+                #             **indicator_properties,
+                #         )
+                #     )
+                if observable.hashes:
+                    for hash_value in observable.hashes.values():
+                        xdr_iocs.append(
+                            CortexXdrIoc(
+                                type="HASH",
+                                indicator=hash_value,
+                                **indicator_properties,
+                            )
+                        )
+            elif observable.type.lower() in ("domain-name", "hostname"):
+                xdr_iocs.append(
+                    CortexXdrIoc(
+                        type="DOMAIN_NAME",
+                        indicator=observable.value,  # type: ignore[union-attr]  # `value` is always set for DomainName/Hostname observables
+                        **indicator_properties,
+                    )
+                )
+            elif observable.type.lower() in ("ipv4-addr", "ipv6-addr"):
+                xdr_iocs.append(
+                    CortexXdrIoc(
+                        type="IP",
+                        indicator=observable.value,  # type: ignore[union-attr]  # `value` is always set for IP observables
+                        **indicator_properties,
+                    )
+                )
+
+        return xdr_iocs
+
+    def _resolve_xdr_iocs_rule_ids(
+        self, extracted_xdr_iocs: list[CortexXdrIoc]
+    ) -> list[CortexXdrIoc]:
+        """Resolve `rule_id` for each Cortex XDR IOC extracted from the indicator's observables."""
+        if not extracted_xdr_iocs:
+            return []
+
+        # Look up existing IOCs on Cortex XDR
+        result = self.client.get_iocs(
+            [
+                {
+                    "field": "indicator",
+                    "operator": "IN",
+                    "value": [ioc.indicator for ioc in extracted_xdr_iocs],
+                }
+            ]
+        )
+        existing_xdr_iocs = result.get("objects", [])
+
+        # Attach `rule_id` to each extracted IOC that already exists on Cortex XDR
+        for ioc in extracted_xdr_iocs:
+            existing_ioc = next(
+                (
+                    existing_ioc
+                    for existing_ioc in existing_xdr_iocs
+                    if existing_ioc["indicator"] == ioc.indicator
+                    and existing_ioc["type"] == ioc.type
+                ),
+                None,
+            )
+            if existing_ioc:
+                ioc.rule_id = existing_ioc.get("rule_id")
+
+        return extracted_xdr_iocs  # type: ignore[return-value]  # `rule_id` (int) is added to each dict
+
+    def _handle_upsert(self, octi_indicator: OctiIndicator) -> None:
+        """Upsert `octi_indicator`'s supported observables into Cortex XDR as IOCs."""
+        # Extract Cortex XDR IOCs from the indicator's observables
+        xdr_iocs = self._extract_xdr_iocs(octi_indicator)
+        xdr_iocs = self._resolve_xdr_iocs_rule_ids(xdr_iocs)
+        if not xdr_iocs:
+            self.helper.connector_logger.error(
+                "No Cortex XDR IOC could be extracted from any observable, "
+                "skipping indicator",
+                {
+                    "indicator_id": octi_indicator.id,
+                    "observables_count": len(octi_indicator.observables),
+                },
+            )
+            return
+
+        self.helper.connector_logger.debug(
+            "Upserting indicator(s) into Cortex XDR",
+            {"indicator_id": octi_indicator.id, "xdr_iocs": len(xdr_iocs)},
+        )
+
+        # Send the payloads to Cortex XDR as dicts, omitting any unset fields to let client default them.
+        self.client.insert_iocs(
+            [ioc.model_dump(exclude_none=True) for ioc in xdr_iocs]  # type: ignore[arg-type]
+        )
+
+        self.helper.connector_logger.info(
+            "Successfully upserted indicator(s) into Cortex XDR",
+            {"indicator_id": octi_indicator.id, "xdr_iocs": len(xdr_iocs)},
+        )
+
     def _process_message(self, msg: StreamMessage) -> None:
         """Process a single stream event message.
 
@@ -183,9 +328,9 @@ class Connector:
 
         try:
             if event in {"create", "update"}:
-                pass  # TODO: upsert in Cortex XDR
+                self._handle_upsert(octi_indicator)
             elif event == "delete":
-                pass  # TODO: delete from Cortex XDR
+                pass  # TODO: delete from Cortex XDR (#7187)
 
         except CortexXdrApiError as err:
             fatal_causes = (

--- a/stream/pan-cortex-xdr-intel/src/connector/models.py
+++ b/stream/pan-cortex-xdr-intel/src/connector/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -70,3 +70,26 @@ class OctiIndicator(BaseModel):
             return value.astimezone(tz=timezone.utc)
         else:
             return value.replace(tzinfo=timezone.utc)
+
+
+class CortexXdrIoc(BaseModel):
+    """Cortex XDR Indicator of Compromise (IOC) model.
+
+    Field constraints intentionally mirror `cortex_xdr_client.types.IndicatorPayload`
+    that represent Cortex XDR API expected data.
+    """
+
+    # Existing IOC's Cortex XDR ID if known (update of an existing IOC), otherwise `None` (new IOC).
+    rule_id: int | None = Field(default=None)
+
+    indicator: str
+    type: Literal["HASH", "IP", "PATH", "DOMAIN_NAME", "FILENAME", "MIXED"]
+    severity: (
+        Literal["SEV_010_INFO", "SEV_020_LOW", "SEV_030_MEDIUM", "SEV_040_HIGH"] | None
+    ) = Field(default=None)
+    expiration_date: int | None = Field(default=None)
+    comment: str | None = Field(default=None)
+    reputation: (
+        Literal["GOOD", "BAD", "SUSPICIOUS", "UNKNOWN", "NO_REPUTATION"] | None
+    ) = Field(default=None)
+    reliability: Literal["A", "B", "C", "D"] | None = Field(default=None)

--- a/stream/pan-cortex-xdr-intel/tests/tests_connector/test_connector.py
+++ b/stream/pan-cortex-xdr-intel/tests/tests_connector/test_connector.py
@@ -4,7 +4,15 @@ from unittest.mock import MagicMock
 
 import pytest
 from connector.connector import Connector
-from connector.models import OctiIndicatorObservable
+from connector.models import CortexXdrIoc, OctiIndicator, OctiIndicatorObservable
+from connectors_sdk import (
+    ApiForbiddenError,
+    ApiNotFoundError,
+    ApiRateLimitError,
+    ApiServerError,
+    ApiUnauthorizedError,
+)
+from cortex_xdr_client import CortexXdrApiError
 from pydantic import ValidationError
 
 
@@ -15,7 +23,10 @@ def _make_msg(event: str, data: dict) -> SimpleNamespace:
 
 @pytest.fixture
 def connector():
-    return Connector(helper=MagicMock(), settings=MagicMock(), client=MagicMock())
+    client = MagicMock()
+    # By default, no existing IOC is found on Cortex XDR (fresh insert case).
+    client.get_iocs.return_value = {"objects": []}
+    return Connector(helper=MagicMock(), settings=MagicMock(), client=client)
 
 
 class TestProcessMessageEventGuardrail:
@@ -147,11 +158,11 @@ class TestProcessMessageUnsupportedObservableGuardrail:
         connector._process_message(msg)
         # Then: the indicator is parsed and logged, no warning is logged
         connector.helper.connector_logger.warning.assert_not_called()
-        connector.helper.connector_logger.info.assert_called_once()
+        assert connector.helper.connector_logger.info.called
 
 
 class TestProcessMessageErrorHandling:
-    # Fatal errors
+    # Fatal errors: always kill the connector
 
     def test_connector_logs_error_and_reraises_on_invalid_json(self, connector):
         # Given: a stream event whose `data` is not valid JSON
@@ -181,25 +192,359 @@ class TestProcessMessageErrorHandling:
             connector._process_message(msg)
         connector.helper.connector_logger.error.assert_called_once()
 
-    @pytest.mark.xfail(
-        reason=(
-            "Upsert/delete client calls are not implemented yet (see #7186/#7187); "
-            "the try/except around them currently only wraps `pass` placeholders, "
-            "so this expected error-handling behavior cannot be exercised yet. "
-            "Remove this xfail marker once real client calls land in that block."
-        ),
-        strict=True,
-    )
-    def test_connector_logs_error_and_reraises_on_unexpected_processing_error(
+    def test_connector_logs_error_and_reraises_on_unexpected_upsert_error(
         self, connector
     ):
-        # Given: the Cortex XDR client unexpectedly raises while upserting/deleting
-        connector.client.upsert_iocs.side_effect = RuntimeError("boom")
-        connector.client.delete_iocs.side_effect = RuntimeError("boom")
+        # Given: the Cortex XDR client unexpectedly raises a non-`CortexXdrApiError`
+        # while upserting
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        connector.client.insert_iocs.side_effect = RuntimeError("boom")
         msg = _make_msg("create", {"type": "indicator"})
         # When: processing the message
         # Then: the error is logged with context, and the exception is deliberately
         # re-raised to let `pycti` kill the connector process
         with pytest.raises(RuntimeError, match="boom"):
             connector._process_message(msg)
+        connector.helper.connector_logger.error.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "cause_cls",
+        [
+            ApiUnauthorizedError,
+            ApiForbiddenError,
+            ApiNotFoundError,
+            ApiRateLimitError,
+            ApiServerError,
+        ],
+    )
+    def test_connector_logs_error_and_reraises_on_fatal_api_error_cause(
+        self, connector, cause_cls
+    ):
+        # Given: the Cortex XDR client raises a `CortexXdrApiError` wrapping a
+        # fatal cause (auth/permission/rate-limit/server errors)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        try:
+            raise cause_cls("boom")
+        except cause_cls as cause:
+            api_error = CortexXdrApiError("Error while fetching Cortex XDR API")
+            api_error.__cause__ = cause
+        connector.client.insert_iocs.side_effect = api_error
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        # Then: the error is logged with context, and the exception is deliberately
+        # re-raised to let `pycti` kill the connector process, avoiding exhausting
+        # the stream with repeated global failures
+        with pytest.raises(CortexXdrApiError):
+            connector._process_message(msg)
+        connector.helper.connector_logger.error.assert_called_once()
+
+    # Non-fatal errors: skip the event, keep the stream alive
+
+    def test_connector_logs_error_and_continues_on_non_fatal_api_error_cause(
+        self, connector
+    ):
+        # Given: the Cortex XDR client raises a `CortexXdrApiError` whose cause
+        # is not one of the fatal causes (e.g. a rejected IOC value, 400)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        api_error = CortexXdrApiError("Error while fetching Cortex XDR API")
+        api_error.__cause__ = ValueError("rejected IOC value")
+        connector.client.insert_iocs.side_effect = api_error
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        # Then: the error is logged, the event is skipped, and no exception
+        # propagates so the stream keeps processing the next event
+        connector._process_message(msg)
+        connector.helper.connector_logger.error.assert_called_once()
+
+    def test_connector_logs_error_and_continues_when_api_error_has_no_cause(
+        self, connector
+    ):
+        # Given: the Cortex XDR client raises a `CortexXdrApiError` without any
+        # chained cause at all (defensive edge case)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        connector.client.insert_iocs.side_effect = CortexXdrApiError("boom")
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        # Then: it is treated as non-fatal: logged, event skipped, no re-raise
+        connector._process_message(msg)
+        connector.helper.connector_logger.error.assert_called_once()
+
+
+class TestProcessMessageUpsertRouting:
+    def test_connector_calls_handle_upsert_on_create_event(
+        self, connector, monkeypatch
+    ):
+        # Given: a "create" stream event for an Indicator with a supported observable
+        handle_upsert = MagicMock()
+        monkeypatch.setattr(connector, "_handle_upsert", handle_upsert)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the upsert lifecycle is triggered
+        handle_upsert.assert_called_once()
+
+    def test_connector_calls_handle_upsert_on_update_event(
+        self, connector, monkeypatch
+    ):
+        # Given: an "update" stream event for an Indicator with a supported observable
+        handle_upsert = MagicMock()
+        monkeypatch.setattr(connector, "_handle_upsert", handle_upsert)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        msg = _make_msg("update", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the upsert lifecycle is triggered
+        handle_upsert.assert_called_once()
+
+    def test_connector_does_not_call_handle_upsert_on_delete_event(
+        self, connector, monkeypatch
+    ):
+        # Given: a "delete" stream event for an Indicator with a supported observable
+        handle_upsert = MagicMock()
+        monkeypatch.setattr(connector, "_handle_upsert", handle_upsert)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        msg = _make_msg("delete", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the upsert lifecycle is not triggered (delete lifecycle is
+        # covered separately by #7187)
+        handle_upsert.assert_not_called()
+
+
+class TestExtractXdrIocs:
+    def test_maps_domain_observable_to_domain_name_type(self, connector):
+        # Given: an indicator with a supported Domain-Name observable
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+        )
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: the observable is mapped to a DOMAIN_NAME IOC
+        assert xdr_iocs == [
+            CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME", reputation="BAD")
+        ]
+
+    def test_maps_ip_observable_to_ip_type(self, connector):
+        # Given: an indicator with a supported IPv4-Addr observable
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "IPv4-Addr", "value": "1.2.3.4"}],
+        )
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: the observable is mapped to an IP IOC
+        assert xdr_iocs == [
+            CortexXdrIoc(indicator="1.2.3.4", type="IP", reputation="BAD")
+        ]
+
+    def test_maps_stixfile_hash_observable_to_hash_type(self, connector):
+        # Given: an indicator with a StixFile hash observable
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "StixFile", "hashes": {"SHA-256": "deadbeef"}}],
+        )
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: the hash is mapped to a HASH IOC
+        assert xdr_iocs == [
+            CortexXdrIoc(indicator="deadbeef", type="HASH", reputation="BAD")
+        ]
+
+    def test_skips_unsupported_observable_type(self, connector):
+        # Given: an indicator with only a StixFile filename observable
+        # (Cortex XDR's FILENAME IOC type is out of scope for now, see #7186)
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "StixFile", "name": "evil.exe"}],
+        )
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: no IOC is built (silently skipped; only `_handle_upsert` logs
+        # when the final resolved list ends up empty)
+        assert xdr_iocs == []
+
+    def test_handles_indicator_without_any_observable(self, connector):
+        # Given: an indicator with no observables at all
+        indicator = OctiIndicator(id="indicator--id", observables=[])
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: no IOC is built, no crash
+        assert xdr_iocs == []
+
+    def test_includes_expiration_date_when_valid_until_present(self, connector):
+        # Given: an indicator with a `valid_until` value
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+            valid_until="2030-01-01T00:00:00Z",
+        )
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: the IOC includes the expiration date as epoch milliseconds
+        assert xdr_iocs == [
+            CortexXdrIoc(
+                indicator="evil.com",
+                type="DOMAIN_NAME",
+                expiration_date=1893456000000,
+                reputation="BAD",
+            )
+        ]
+
+    def test_omits_expiration_date_when_valid_until_absent(self, connector):
+        # Given: an indicator without a `valid_until` value
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+        )
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: no `expiration_date` is set on the IOC
+        assert xdr_iocs[0].expiration_date is None
+
+
+class TestResolveXdrIocsRuleIds:
+    def test_calls_get_iocs_with_indicator_values_filter(self, connector):
+        # Given: two extracted Cortex XDR IOCs
+        xdr_iocs = [
+            CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME"),
+            CortexXdrIoc(indicator="1.2.3.4", type="IP"),
+        ]
+        # When: resolving their `rule_id`
+        connector._resolve_xdr_iocs_rule_ids(xdr_iocs)
+        # Then: the client is asked to look up both indicator values via an
+        # "IN" filter on the "indicator" field
+        connector.client.get_iocs.assert_called_once_with(
+            [
+                {
+                    "field": "indicator",
+                    "operator": "IN",
+                    "value": ["evil.com", "1.2.3.4"],
+                }
+            ]
+        )
+
+    def test_attaches_rule_id_when_ioc_already_exists(self, connector):
+        # Given: an IOC that already exists on Cortex XDR
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        connector.client.get_iocs.return_value = {
+            "objects": [{"rule_id": 42, "indicator": "evil.com", "type": "DOMAIN_NAME"}]
+        }
+        # When: resolving `rule_id`
+        resolved = connector._resolve_xdr_iocs_rule_ids(xdr_iocs)
+        # Then: the existing `rule_id` is attached, so a subsequent insert
+        # overwrites the existing IOC instead of failing
+        assert resolved[0].rule_id == 42
+
+    def test_does_not_attach_rule_id_when_ioc_does_not_exist(self, connector):
+        # Given: an IOC that does not exist on Cortex XDR yet
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        connector.client.get_iocs.return_value = {"objects": []}
+        # When: resolving `rule_id`
+        resolved = connector._resolve_xdr_iocs_rule_ids(xdr_iocs)
+        # Then: no `rule_id` is attached, so a subsequent insert creates a new IOC
+        assert resolved[0].rule_id is None
+
+    def test_does_not_attach_rule_id_when_type_differs(self, connector):
+        # Given: a lookup match on the same indicator value but a different
+        # type (e.g. a same-looking value registered as a different IOC type)
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        connector.client.get_iocs.return_value = {
+            "objects": [{"rule_id": 42, "indicator": "evil.com", "type": "IP"}]
+        }
+        # When: resolving `rule_id`
+        resolved = connector._resolve_xdr_iocs_rule_ids(xdr_iocs)
+        # Then: no `rule_id` is attached, since the existing IOC is of a different type
+        assert resolved[0].rule_id is None
+
+    def test_returns_empty_list_without_calling_client_when_no_iocs(self, connector):
+        # Given: no extracted Cortex XDR IOCs at all
+        # When: resolving `rule_id`
+        resolved = connector._resolve_xdr_iocs_rule_ids([])
+        # Then: the client is never called, and an empty list is returned
+        connector.client.get_iocs.assert_not_called()
+        assert resolved == []
+
+
+class TestHandleUpsert:
+    def test_calls_client_insert_iocs_with_extracted_iocs(self, connector):
+        # Given: an indicator with a supported observable
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+        )
+        # When: handling the upsert
+        connector._handle_upsert(indicator)
+        # Then: the client is called once with the extracted IOC(s)
+        connector.client.insert_iocs.assert_called_once_with(
+            [{"indicator": "evil.com", "type": "DOMAIN_NAME", "reputation": "BAD"}]
+        )
+
+    def test_includes_rule_id_when_ioc_already_exists(self, connector):
+        # Given: an indicator whose IOC already exists on Cortex XDR
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+        )
+        connector.client.get_iocs.return_value = {
+            "objects": [{"rule_id": 42, "indicator": "evil.com", "type": "DOMAIN_NAME"}]
+        }
+        # When: handling the upsert
+        connector._handle_upsert(indicator)
+        # Then: the existing `rule_id` is included in the payload sent to
+        # Cortex XDR, so the request overwrites the existing IOC instead of
+        # failing with a 400 "IOC indicator exists"
+        connector.client.insert_iocs.assert_called_once_with(
+            [
+                {
+                    "indicator": "evil.com",
+                    "type": "DOMAIN_NAME",
+                    "reputation": "BAD",
+                    "rule_id": 42,
+                }
+            ]
+        )
+
+    def test_skips_client_call_when_no_supported_observable(self, connector):
+        # Given: an indicator with only unsupported observable(s)
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "StixFile", "name": "evil.exe"}],
+        )
+        # When: handling the upsert
+        connector._handle_upsert(indicator)
+        # Then: the client is never called
+        connector.client.insert_iocs.assert_not_called()
+
+    def test_logs_error_when_no_supported_observable(self, connector):
+        # Given: an indicator with only unsupported observable(s)
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "StixFile", "name": "evil.exe"}],
+        )
+        # When: handling the upsert
+        connector._handle_upsert(indicator)
+        # Then: the skip is logged as an error, not a mere info
         connector.helper.connector_logger.error.assert_called_once()

--- a/stream/pan-cortex-xdr-intel/tests/tests_connector/test_connector.py
+++ b/stream/pan-cortex-xdr-intel/tests/tests_connector/test_connector.py
@@ -281,6 +281,23 @@ class TestProcessMessageErrorHandling:
         connector._process_message(msg)
         connector.helper.connector_logger.error.assert_called_once()
 
+    def test_connector_logs_error_and_reraises_on_unexpected_delete_error(
+        self, connector
+    ):
+        # Given: the Cortex XDR client unexpectedly raises while deleting
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        connector.client.delete_iocs.side_effect = RuntimeError("boom")
+        msg = _make_msg("delete", {"type": "indicator"})
+        # When: processing the message
+        # Then: the error is logged with context, and the exception is deliberately
+        # re-raised to let `pycti` kill the connector process
+        with pytest.raises(RuntimeError, match="boom"):
+            connector._process_message(msg)
+        connector.helper.connector_logger.error.assert_called_once()
+
 
 class TestProcessMessageUpsertRouting:
     def test_connector_calls_handle_upsert_on_create_event(
@@ -328,9 +345,59 @@ class TestProcessMessageUpsertRouting:
         msg = _make_msg("delete", {"type": "indicator"})
         # When: processing the message
         connector._process_message(msg)
-        # Then: the upsert lifecycle is not triggered (delete lifecycle is
-        # covered separately by #7187)
+        # Then: the upsert lifecycle is not triggered (delete events trigger
+        # the delete lifecycle instead, see `TestProcessMessageDeleteRouting`)
         handle_upsert.assert_not_called()
+
+
+class TestProcessMessageDeleteRouting:
+    def test_connector_calls_handle_delete_on_delete_event(
+        self, connector, monkeypatch
+    ):
+        # Given: a "delete" stream event for an Indicator with a supported observable
+        handle_delete = MagicMock()
+        monkeypatch.setattr(connector, "_handle_delete", handle_delete)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        msg = _make_msg("delete", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the delete lifecycle is triggered
+        handle_delete.assert_called_once()
+
+    def test_connector_does_not_call_handle_delete_on_create_event(
+        self, connector, monkeypatch
+    ):
+        # Given: a "create" stream event for an Indicator with a supported observable
+        handle_delete = MagicMock()
+        monkeypatch.setattr(connector, "_handle_delete", handle_delete)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        msg = _make_msg("create", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the delete lifecycle is not triggered
+        handle_delete.assert_not_called()
+
+    def test_connector_does_not_call_handle_delete_on_update_event(
+        self, connector, monkeypatch
+    ):
+        # Given: an "update" stream event for an Indicator with a supported observable
+        handle_delete = MagicMock()
+        monkeypatch.setattr(connector, "_handle_delete", handle_delete)
+        connector.helper.get_attribute_in_extension.side_effect = lambda key, data: {
+            "id": "indicator--id",
+            "observable_values": [{"type": "Domain-Name", "value": "evil.com"}],
+        }.get(key)
+        msg = _make_msg("update", {"type": "indicator"})
+        # When: processing the message
+        connector._process_message(msg)
+        # Then: the delete lifecycle is not triggered
+        handle_delete.assert_not_called()
 
 
 class TestExtractXdrIocs:
@@ -342,10 +409,9 @@ class TestExtractXdrIocs:
         )
         # When: extracting Cortex XDR IOCs
         xdr_iocs = connector._extract_xdr_iocs(indicator)
-        # Then: the observable is mapped to a DOMAIN_NAME IOC
-        assert xdr_iocs == [
-            CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME", reputation="BAD")
-        ]
+        # Then: the observable is mapped to a bare DOMAIN_NAME IOC (optional
+        # fields are only set later by `_map_indicator_fields_to_xdr_iocs`)
+        assert xdr_iocs == [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
 
     def test_maps_ip_observable_to_ip_type(self, connector):
         # Given: an indicator with a supported IPv4-Addr observable
@@ -355,10 +421,8 @@ class TestExtractXdrIocs:
         )
         # When: extracting Cortex XDR IOCs
         xdr_iocs = connector._extract_xdr_iocs(indicator)
-        # Then: the observable is mapped to an IP IOC
-        assert xdr_iocs == [
-            CortexXdrIoc(indicator="1.2.3.4", type="IP", reputation="BAD")
-        ]
+        # Then: the observable is mapped to a bare IP IOC
+        assert xdr_iocs == [CortexXdrIoc(indicator="1.2.3.4", type="IP")]
 
     def test_maps_stixfile_hash_observable_to_hash_type(self, connector):
         # Given: an indicator with a StixFile hash observable
@@ -368,10 +432,8 @@ class TestExtractXdrIocs:
         )
         # When: extracting Cortex XDR IOCs
         xdr_iocs = connector._extract_xdr_iocs(indicator)
-        # Then: the hash is mapped to a HASH IOC
-        assert xdr_iocs == [
-            CortexXdrIoc(indicator="deadbeef", type="HASH", reputation="BAD")
-        ]
+        # Then: the hash is mapped to a bare HASH IOC
+        assert xdr_iocs == [CortexXdrIoc(indicator="deadbeef", type="HASH")]
 
     def test_skips_unsupported_observable_type(self, connector):
         # Given: an indicator with only a StixFile filename observable
@@ -382,8 +444,20 @@ class TestExtractXdrIocs:
         )
         # When: extracting Cortex XDR IOCs
         xdr_iocs = connector._extract_xdr_iocs(indicator)
-        # Then: no IOC is built (silently skipped; only `_handle_upsert` logs
-        # when the final resolved list ends up empty)
+        # Then: no IOC is built (silently skipped; only `_handle_upsert`/
+        # `_handle_delete` log when the final list ends up empty)
+        assert xdr_iocs == []
+
+    def test_skips_hostname_observable_type(self, connector):
+        # Given: an indicator with a Hostname observable (support
+        # intentionally dropped, see #7187)
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Hostname", "value": "evil.com"}],
+        )
+        # When: extracting Cortex XDR IOCs
+        xdr_iocs = connector._extract_xdr_iocs(indicator)
+        # Then: no IOC is built
         assert xdr_iocs == []
 
     def test_handles_indicator_without_any_observable(self, connector):
@@ -394,6 +468,20 @@ class TestExtractXdrIocs:
         # Then: no IOC is built, no crash
         assert xdr_iocs == []
 
+
+class TestMapIndicatorFieldsToXdrIocs:
+    def test_hardcodes_reputation_to_bad(self, connector):
+        # Given: a bare Cortex XDR IOC and any indicator
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+        )
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        # When: mapping the indicator's fields onto the IOC(s)
+        result = connector._map_indicator_fields_to_xdr_iocs(indicator, xdr_iocs)
+        # Then: the IOC's reputation is hardcoded to "BAD"
+        assert result[0].reputation == "BAD"
+
     def test_includes_expiration_date_when_valid_until_present(self, connector):
         # Given: an indicator with a `valid_until` value
         indicator = OctiIndicator(
@@ -401,17 +489,11 @@ class TestExtractXdrIocs:
             observables=[{"type": "Domain-Name", "value": "evil.com"}],
             valid_until="2030-01-01T00:00:00Z",
         )
-        # When: extracting Cortex XDR IOCs
-        xdr_iocs = connector._extract_xdr_iocs(indicator)
-        # Then: the IOC includes the expiration date as epoch milliseconds
-        assert xdr_iocs == [
-            CortexXdrIoc(
-                indicator="evil.com",
-                type="DOMAIN_NAME",
-                expiration_date=1893456000000,
-                reputation="BAD",
-            )
-        ]
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        # When: mapping the indicator's fields onto the IOC(s)
+        result = connector._map_indicator_fields_to_xdr_iocs(indicator, xdr_iocs)
+        # Then: the IOC's expiration date is set as epoch milliseconds
+        assert result[0].expiration_date == 1893456000000
 
     def test_omits_expiration_date_when_valid_until_absent(self, connector):
         # Given: an indicator without a `valid_until` value
@@ -419,10 +501,44 @@ class TestExtractXdrIocs:
             id="indicator--id",
             observables=[{"type": "Domain-Name", "value": "evil.com"}],
         )
-        # When: extracting Cortex XDR IOCs
-        xdr_iocs = connector._extract_xdr_iocs(indicator)
-        # Then: no `expiration_date` is set on the IOC
-        assert xdr_iocs[0].expiration_date is None
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        # When: mapping the indicator's fields onto the IOC(s)
+        result = connector._map_indicator_fields_to_xdr_iocs(indicator, xdr_iocs)
+        # Then: no expiration date is set on the IOC
+        assert result[0].expiration_date is None
+
+    @pytest.mark.parametrize(
+        "score,expected_severity",
+        [
+            (None, None),
+            (10, None),
+            (20, "SEV_010_INFO"),
+            (40, "SEV_020_LOW"),
+            (60, "SEV_030_MEDIUM"),
+            (80, "SEV_040_HIGH"),
+            (100, "SEV_040_HIGH"),
+        ],
+    )
+    def test_maps_score_to_severity(self, connector, score, expected_severity):
+        # Given: an indicator with a given `score`
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+            score=score,
+        )
+        xdr_iocs = [CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")]
+        # When: mapping the indicator's fields onto the IOC(s)
+        result = connector._map_indicator_fields_to_xdr_iocs(indicator, xdr_iocs)
+        # Then: the score is mapped to the expected Cortex XDR severity
+        assert result[0].severity == expected_severity
+
+    def test_handles_empty_xdr_iocs_list(self, connector):
+        # Given: an indicator and an empty list of Cortex XDR IOCs
+        indicator = OctiIndicator(id="indicator--id", observables=[])
+        # When: mapping the indicator's fields onto the (empty) IOC list
+        result = connector._map_indicator_fields_to_xdr_iocs(indicator, [])
+        # Then: no IOC is built, no crash
+        assert result == []
 
 
 class TestResolveXdrIocsRuleIds:
@@ -546,5 +662,69 @@ class TestHandleUpsert:
         )
         # When: handling the upsert
         connector._handle_upsert(indicator)
+        # Then: the skip is logged as an error, not a mere info
+        connector.helper.connector_logger.error.assert_called_once()
+
+
+class TestHandleDelete:
+    def test_calls_client_delete_iocs_with_built_filter(self, connector):
+        # Given: an indicator with a supported observable
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "Domain-Name", "value": "evil.com"}],
+        )
+        # When: handling the delete
+        connector._handle_delete(indicator)
+        # Then: the client is called once with a single batched "IN" filter
+        connector.client.delete_iocs.assert_called_once_with(
+            [{"field": "indicator", "operator": "IN", "value": ["evil.com"]}]
+        )
+
+    def test_batches_multiple_iocs_into_a_single_filter(self, connector):
+        # Given: an indicator with several supported observables, one of
+        # which (StixFile) yields more than one Cortex XDR IOC
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[
+                {"type": "Domain-Name", "value": "evil.com"},
+                {
+                    "type": "StixFile",
+                    "hashes": {"SHA-256": "deadbeef", "MD5": "beefdead"},
+                },
+            ],
+        )
+        # When: handling the delete
+        connector._handle_delete(indicator)
+        # Then: all the extracted IOCs' indicator values are batched into a
+        # single "IN" filter
+        connector.client.delete_iocs.assert_called_once_with(
+            [
+                {
+                    "field": "indicator",
+                    "operator": "IN",
+                    "value": ["evil.com", "deadbeef", "beefdead"],
+                }
+            ]
+        )
+
+    def test_skips_client_call_when_no_supported_observable(self, connector):
+        # Given: an indicator with only unsupported observable(s)
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "StixFile", "name": "evil.exe"}],
+        )
+        # When: handling the delete
+        connector._handle_delete(indicator)
+        # Then: the client is never called
+        connector.client.delete_iocs.assert_not_called()
+
+    def test_logs_error_when_no_supported_observable(self, connector):
+        # Given: an indicator with only unsupported observable(s)
+        indicator = OctiIndicator(
+            id="indicator--id",
+            observables=[{"type": "StixFile", "name": "evil.exe"}],
+        )
+        # When: handling the delete
+        connector._handle_delete(indicator)
         # Then: the skip is logged as an error, not a mere info
         connector.helper.connector_logger.error.assert_called_once()

--- a/stream/pan-cortex-xdr-intel/tests/tests_connector/test_models.py
+++ b/stream/pan-cortex-xdr-intel/tests/tests_connector/test_models.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 import pytest
-from connector.models import OctiIndicator, OctiIndicatorObservable
+from connector.models import CortexXdrIoc, OctiIndicator, OctiIndicatorObservable
 from pydantic import ValidationError
 
 
@@ -106,3 +106,53 @@ class TestOctiIndicator:
         )
         # Then: `valid_until` is assumed to already be UTC, and tagged as such
         assert indicator.valid_until == datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+
+class TestCortexXdrIoc:
+    """Happy/unhappy path coverage for `CortexXdrIoc` construction."""
+
+    def test_accepts_minimal_valid_input(self):
+        # Given: only the required fields
+        # When: constructing a CortexXdrIoc
+        ioc = CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")
+        # Then: the IOC is constructed successfully, optional fields default to None
+        assert ioc.indicator == "evil.com"
+        assert ioc.type == "DOMAIN_NAME"
+        assert ioc.severity is None
+        assert ioc.expiration_date is None
+        assert ioc.comment is None
+        assert ioc.reputation is None
+        assert ioc.reliability is None
+        assert ioc.rule_id is None
+
+    def test_rejects_invalid_type(self):
+        # Given: an unsupported `type` value
+        # When: constructing a CortexXdrIoc
+        # Then: a ValidationError is raised
+        with pytest.raises(ValidationError):
+            CortexXdrIoc(indicator="evil.com", type="INVALID")
+
+    def test_accepts_int_expiration_date(self):
+        # Given: an `expiration_date` passed as an epoch-millisecond `int`
+        # When: constructing a CortexXdrIoc
+        ioc = CortexXdrIoc(
+            indicator="evil.com", type="DOMAIN_NAME", expiration_date=1893456000000
+        )
+        # Then: `expiration_date` is left unchanged
+        assert ioc.expiration_date == 1893456000000
+
+    def test_accepts_rule_id(self):
+        # Given: an existing IOC's `rule_id`
+        # When: constructing a CortexXdrIoc
+        ioc = CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME", rule_id=42)
+        # Then: `rule_id` is set as given
+        assert ioc.rule_id == 42
+
+    def test_is_mutable_so_rule_id_can_be_resolved_after_construction(self):
+        # Given: a constructed CortexXdrIoc without a `rule_id`
+        ioc = CortexXdrIoc(indicator="evil.com", type="DOMAIN_NAME")
+        # When: mutating `rule_id` in place, as done by
+        # `Connector._resolve_xdr_iocs_rule_ids` once the existing IOC is looked up
+        ioc.rule_id = 42
+        # Then: no error is raised, and the new value is set
+        assert ioc.rule_id == 42


### PR DESCRIPTION
### Proposed changes

* Handle Indicator create/update stream events through a unified upsert lifecycle, routed from `_process_message`
* Build Cortex XDR IOC payloads from the normalized indicator model and extracted observables (Hash, Domain, IP, Email Address, URL)
* Resolve `valid_until` into the Cortex XDR expiration policy on upsert payloads
* Skip unsupported observable types without raising, with structured logging
* Push built payloads to Cortex XDR via the client's idempotent `upsert_iocs` service method
* Add unit tests covering create/update routing, payload mapping per observable type, expiration mapping, and unsupported-type safety

### Related issues

* Close #7186

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Builds on the shared integration foundation from #7185 (base branch of this PR). Delete lifecycle for indicator deletion events is out of scope here and tracked separately.
