### PR TITLE
refactor(templates): simplify Dockerfile entrypoint and README config docs (#5271)

### DIFF
--- a/templates/external-import/Dockerfile
+++ b/templates/external-import/Dockerfile
@@ -1,19 +1,25 @@
-FROM python:3.12-alpine
-ENV CONNECTOR_TYPE=EXTERNAL_IMPORT
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-alpine AS base
 
-# Copy the connector
-COPY src /opt/opencti-connector-template
+# Prevents Python from writing pyc files.
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Keeps Python from buffering stdout and stderr to avoid situations where
+# the application crashes without emitting any logs due to buffering.
+ENV PYTHONUNBUFFERED=1
 
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apk update && apk upgrade && \
     apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
 
-RUN cd /opt/opencti-connector-template && \
-    pip3 install --no-cache-dir -r requirements.txt && \
+# Copy the connector
+COPY src /opt/opencti-connector-template
+WORKDIR /opt/opencti-connector-template
+
+# Install Python dependencies and remove build dependencies
+RUN pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
 # Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["python", "main.py"]

--- a/templates/external-import/README.md
+++ b/templates/external-import/README.md
@@ -16,9 +16,6 @@ Table of Contents
   - [Installation](#installation)
     - [Requirements](#requirements)
   - [Configuration variables](#configuration-variables)
-    - [OpenCTI environment variables](#opencti-environment-variables)
-    - [Base connector environment variables](#base-connector-environment-variables)
-    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
   - [Deployment](#deployment)
     - [Docker Deployment](#docker-deployment)
     - [Manual Deployment](#manual-deployment)
@@ -40,38 +37,13 @@ Table of Contents
 
 ## Configuration variables
 
-There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
-in `config.yml` (for manual deployment).
 
-### OpenCTI environment variables
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-Below are the parameters you'll need to set for OpenCTI:
 
-| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
-| ------------- | ---------- | --------------------------- | --------- | ---------------------------------------------------- |
-| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
-| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
-### Base connector environment variables
-
-Below are the parameters you'll need to set for running the connector properly:
-
-| Parameter       | config.yml | Docker environment variable | Default         | Mandatory | Description                                                                              |
-| --------------- | ---------- | --------------------------- | --------------- | --------- | ---------------------------------------------------------------------------------------- |
-| Connector ID    | id         | `CONNECTOR_ID`              | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
-| Connector Type  | type       | `CONNECTOR_TYPE`            | EXTERNAL_IMPORT | Yes       | Should always be set to `EXTERNAL_IMPORT` for this connector.                            |
-| Connector Name  | name       | `CONNECTOR_NAME`            |                 | Yes       | Name of the connector.                                                                   |
-| Connector Scope | scope      | `CONNECTOR_SCOPE`           |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
-| Log Level       | log_level  | `CONNECTOR_LOG_LEVEL`       | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
-
-### Connector extra parameters environment variables
-
-Below are the parameters you'll need to set for the connector:
-
-| Parameter    | config.yml   | Docker environment variable | Default | Mandatory | Description |
-| ------------ | ------------ | --------------------------- | ------- | --------- | ----------- |
-| API base URL | api_base_url |                             |         | Yes       |             |
-| API key      | api_key      |                             |         | Yes       |             |
 
 ## Deployment
 

--- a/templates/external-import/entrypoint.sh
+++ b/templates/external-import/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-template
-
-# Launch the worker
-python3 main.py

--- a/templates/internal-enrichment/Dockerfile
+++ b/templates/internal-enrichment/Dockerfile
@@ -1,19 +1,25 @@
-FROM python:3.12-alpine
-ENV CONNECTOR_TYPE=INTERNAL_ENRICHMENT
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-alpine AS base
 
-# Copy the connector
-COPY src /opt/opencti-connector-template
+# Prevents Python from writing pyc files.
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Keeps Python from buffering stdout and stderr to avoid situations where
+# the application crashes without emitting any logs due to buffering.
+ENV PYTHONUNBUFFERED=1
 
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apk update && apk upgrade && \
     apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
 
-RUN cd /opt/opencti-connector-template && \
-    pip3 install --no-cache-dir -r requirements.txt && \
+# Copy the connector
+COPY src /opt/opencti-connector-template
+WORKDIR /opt/opencti-connector-template
+
+# Install Python dependencies and remove build dependencies
+RUN pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
 # Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["python", "main.py"]

--- a/templates/internal-enrichment/README.md
+++ b/templates/internal-enrichment/README.md
@@ -18,9 +18,6 @@ Table of Contents
   - [Installation](#installation)
     - [Requirements](#requirements)
   - [Configuration variables](#configuration-variables)
-    - [OpenCTI environment variables](#opencti-environment-variables)
-    - [Base connector environment variables](#base-connector-environment-variables)
-    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
   - [Deployment](#deployment)
     - [Docker Deployment](#docker-deployment)
     - [Manual Deployment](#manual-deployment)
@@ -42,39 +39,13 @@ Table of Contents
 
 ## Configuration variables
 
-There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
-in `config.yml` (for manual deployment).
 
-### OpenCTI environment variables
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-Below are the parameters you'll need to set for OpenCTI:
 
-| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
-| ------------- | ---------- | --------------------------- | --------- | ---------------------------------------------------- |
-| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
-| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
-### Base connector environment variables
-
-Below are the parameters you'll need to set for running the connector properly:
-
-| Parameter       | config.yml     | Docker environment variable | Default         | Mandatory | Description                                                                              |
-| --------------- | -------------- | --------------------------- | --------------- | --------- | ---------------------------------------------------------------------------------------- |
-| Connector ID    | id             | `CONNECTOR_ID`              | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
-| Connector Type  | type           | `CONNECTOR_TYPE`            | EXTERNAL_IMPORT | Yes       | Should always be set to `INTERNAL_ENRICHMENT` for this connector.                        |
-| Connector Name  | name           | `CONNECTOR_NAME`            |                 | Yes       | Name of the connector.                                                                   |
-| Connector Scope | scope          | `CONNECTOR_SCOPE`           |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
-| Log Level       | log_level      | `CONNECTOR_LOG_LEVEL`       | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
-| Connector Auto  | connector_auto | `CONNECTOR_AUTO`            | True            | Yes       | Must be `true` or `false` to enable or disable auto-enrichment of observables            |
-
-### Connector extra parameters environment variables
-
-Below are the parameters you'll need to set for the connector:
-
-| Parameter    | config.yml   | Docker environment variable | Default | Mandatory | Description |
-| ------------ | ------------ | --------------------------- | ------- | --------- | ----------- |
-| API base URL | api_base_url |                             |         | Yes       |             |
-| API key      | api_key      |                             |         | Yes       |             |
 
 ## Deployment
 

--- a/templates/internal-enrichment/entrypoint.sh
+++ b/templates/internal-enrichment/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-template
-
-# Launch the worker
-python3 main.py

--- a/templates/internal-export-file/Dockerfile
+++ b/templates/internal-export-file/Dockerfile
@@ -1,19 +1,25 @@
-FROM python:3.12-alpine
-ENV CONNECTOR_TYPE=INTERNAL_EXPORT_FILE
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-alpine AS base
 
-# Copy the connector
-COPY src /opt/opencti-connector-template
+# Prevents Python from writing pyc files.
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Keeps Python from buffering stdout and stderr to avoid situations where
+# the application crashes without emitting any logs due to buffering.
+ENV PYTHONUNBUFFERED=1
 
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apk update && apk upgrade && \
     apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
 
-RUN cd /opt/opencti-connector-template && \
-    pip3 install --no-cache-dir -r requirements.txt && \
+# Copy the connector
+COPY src /opt/opencti-connector-template
+WORKDIR /opt/opencti-connector-template
+
+# Install Python dependencies and remove build dependencies
+RUN pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
 # Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["python", "main.py"]

--- a/templates/internal-export-file/README.md
+++ b/templates/internal-export-file/README.md
@@ -16,9 +16,6 @@ Table of Contents
   - [Installation](#installation)
     - [Requirements](#requirements)
   - [Configuration variables](#configuration-variables)
-    - [OpenCTI environment variables](#opencti-environment-variables)
-    - [Base connector environment variables](#base-connector-environment-variables)
-    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
   - [Deployment](#deployment)
     - [Docker Deployment](#docker-deployment)
     - [Manual Deployment](#manual-deployment)
@@ -40,38 +37,13 @@ Table of Contents
 
 ## Configuration variables
 
-There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
-in `config.yml` (for manual deployment).
 
-### OpenCTI environment variables
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-Below are the parameters you'll need to set for OpenCTI:
 
-| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
-| ------------- | ---------- | --------------------------- | --------- | ---------------------------------------------------- |
-| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
-| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
-### Base connector environment variables
-
-Below are the parameters you'll need to set for running the connector properly:
-
-| Parameter       | config.yml | Docker environment variable | Default         | Mandatory | Description                                                                              |
-| --------------- | ---------- | --------------------------- | --------------- | --------- | ---------------------------------------------------------------------------------------- |
-| Connector ID    | id         | `CONNECTOR_ID`              | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
-| Connector Type  | type       | `CONNECTOR_TYPE`            | EXTERNAL_IMPORT | Yes       | Should always be set to `INTERNAL_EXPORT_FILE` for this connector.                       |
-| Connector Name  | name       | `CONNECTOR_NAME`            |                 | Yes       | Name of the connector.                                                                   |
-| Connector Scope | scope      | `CONNECTOR_SCOPE`           |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
-| Log Level       | log_level  | `CONNECTOR_LOG_LEVEL`       | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
-
-### Connector extra parameters environment variables
-
-Below are the parameters you'll need to set for the connector:
-
-| Parameter    | config.yml   | Docker environment variable | Default | Mandatory | Description |
-| ------------ | ------------ | --------------------------- | ------- | --------- | ----------- |
-| API base URL | api_base_url |                             |         | Yes       |             |
-| API key      | api_key      |                             |         | Yes       |             |
 
 ## Deployment
 

--- a/templates/internal-export-file/entrypoint.sh
+++ b/templates/internal-export-file/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-template
-
-# Launch the worker
-python3 main.py

--- a/templates/internal-import-file/Dockerfile
+++ b/templates/internal-import-file/Dockerfile
@@ -1,19 +1,26 @@
-FROM python:3.12-alpine
-ENV CONNECTOR_TYPE=INTERNAL_IMPORT_FILE
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-alpine AS base
 
-# Copy the connector
-COPY src /opt/opencti-connector-template
+# Prevents Python from writing pyc files.
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Keeps Python from buffering stdout and stderr to avoid situations where
+# the application crashes without emitting any logs due to buffering.
+ENV PYTHONUNBUFFERED=1
 
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apk update && apk upgrade && \
     apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
 
-RUN cd /opt/opencti-connector-template && \
-    pip3 install --no-cache-dir -r requirements.txt && \
+# Copy the connector
+COPY src /opt/opencti-connector-template
+WORKDIR /opt/opencti-connector-template
+
+# Install Python dependencies and remove build dependencies
+RUN pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
 # Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["python", "main.py"]
+

--- a/templates/internal-import-file/README.md
+++ b/templates/internal-import-file/README.md
@@ -16,9 +16,6 @@ Table of Contents
   - [Installation](#installation)
     - [Requirements](#requirements)
   - [Configuration variables](#configuration-variables)
-    - [OpenCTI environment variables](#opencti-environment-variables)
-    - [Base connector environment variables](#base-connector-environment-variables)
-    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
   - [Deployment](#deployment)
     - [Docker Deployment](#docker-deployment)
     - [Manual Deployment](#manual-deployment)
@@ -40,38 +37,12 @@ Table of Contents
 
 ## Configuration variables
 
-There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
-in `config.yml` (for manual deployment).
 
-### OpenCTI environment variables
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-Below are the parameters you'll need to set for OpenCTI:
 
-| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
-| ------------- | ---------- | --------------------------- | --------- | ---------------------------------------------------- |
-| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
-| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
-
-### Base connector environment variables
-
-Below are the parameters you'll need to set for running the connector properly:
-
-| Parameter       | config.yml | Docker environment variable | Default         | Mandatory | Description                                                                              |
-| --------------- | ---------- | --------------------------- | --------------- | --------- | ---------------------------------------------------------------------------------------- |
-| Connector ID    | id         | `CONNECTOR_ID`              | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                |
-| Connector Type  | type       | `CONNECTOR_TYPE`            | EXTERNAL_IMPORT | Yes       | Should always be set to `INTERNAL_IMPORT_FILE` for this connector.                       |
-| Connector Name  | name       | `CONNECTOR_NAME`            |                 | Yes       | Name of the connector.                                                                   |
-| Connector Scope | scope      | `CONNECTOR_SCOPE`           |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object. |
-| Log Level       | log_level  | `CONNECTOR_LOG_LEVEL`       | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.   |
-
-### Connector extra parameters environment variables
-
-Below are the parameters you'll need to set for the connector:
-
-| Parameter    | config.yml   | Docker environment variable | Default | Mandatory | Description |
-| ------------ | ------------ | --------------------------- | ------- | --------- | ----------- |
-| API base URL | api_base_url |                             |         | Yes       |             |
-| API key      | api_key      |                             |         | Yes       |             |
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
 ## Deployment
 

--- a/templates/internal-import-file/entrypoint.sh
+++ b/templates/internal-import-file/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-template
-
-# Launch the worker
-python3 main.py

--- a/templates/stream/Dockerfile
+++ b/templates/stream/Dockerfile
@@ -1,19 +1,25 @@
-FROM python:3.12-alpine
-ENV CONNECTOR_TYPE=STREAM
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-alpine AS base
 
-# Copy the connector
-COPY src /opt/opencti-connector-template
+# Prevents Python from writing pyc files.
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Keeps Python from buffering stdout and stderr to avoid situations where
+# the application crashes without emitting any logs due to buffering.
+ENV PYTHONUNBUFFERED=1
 
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apk update && apk upgrade && \
     apk --no-cache add git build-base libmagic libffi-dev libxml2-dev libxslt-dev
 
-RUN cd /opt/opencti-connector-template && \
-    pip3 install --no-cache-dir -r requirements.txt && \
+# Copy the connector
+COPY src /opt/opencti-connector-template
+WORKDIR /opt/opencti-connector-template
+
+# Install Python dependencies and remove build dependencies
+RUN pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
 # Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["python", "main.py"]

--- a/templates/stream/README.md
+++ b/templates/stream/README.md
@@ -16,9 +16,6 @@ Table of Contents
   - [Installation](#installation)
     - [Requirements](#requirements)
   - [Configuration variables](#configuration-variables)
-    - [OpenCTI environment variables](#opencti-environment-variables)
-    - [Base connector environment variables](#base-connector-environment-variables)
-    - [Connector extra parameters environment variables](#connector-extra-parameters-environment-variables)
   - [Deployment](#deployment)
     - [Docker Deployment](#docker-deployment)
     - [Manual Deployment](#manual-deployment)
@@ -40,41 +37,12 @@ Table of Contents
 
 ## Configuration variables
 
-There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or
-in `config.yml` (for manual deployment).
 
-### OpenCTI environment variables
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-Below are the parameters you'll need to set for OpenCTI:
 
-| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
-| ------------- | ---------- | --------------------------- | --------- | ---------------------------------------------------- |
-| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
-| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
-
-### Base connector environment variables
-
-Below are the parameters you'll need to set for running the connector properly:
-
-| Parameter                             | config.yml                  | Docker environment variable             | Default         | Mandatory | Description                                                                                                                                            |
-| ------------------------------------- | --------------------------- | --------------------------------------- | --------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Connector ID                          | id                          | `CONNECTOR_ID`                          | /               | Yes       | A unique `UUIDv4` identifier for this connector instance.                                                                                              |
-| Connector Type                        | type                        | `CONNECTOR_TYPE`                        | EXTERNAL_IMPORT | Yes       | Should always be set to `STREAM` for this connector.                                                                                                   |
-| Connector Name                        | name                        | `CONNECTOR_NAME`                        |                 | Yes       | Name of the connector.                                                                                                                                 |
-| Connector Scope                       | scope                       | `CONNECTOR_SCOPE`                       |                 | Yes       | The scope or type of data the connector is importing, either a MIME type or Stix Object.                                                               |
-| Log Level                             | log_level                   | `CONNECTOR_LOG_LEVEL`                   | info            | Yes       | Determines the verbosity of the logs. Options are `debug`, `info`, `warn`, or `error`.                                                                 |
-| Connector Live Stream ID              | live_stream_id              | `CONNECTOR_LIVE_STREAM_ID`              | /               | Yes       | ID of the live stream created in the OpenCTI UI                                                                                                        |
-| Connector Live Stream Listen Delete   | live_stream_listen_delete   | `CONNECTOR_LIVE_STREAM_LISTEN_DELETE`   | true            | Yes       | Listen to all delete events concerning the entity, depending on the filter set for the OpenCTI stream.                                                 |
-| Connector Live Stream No dependencies | live_stream_no_dependencies | `CONNECTOR_LIVE_STREAM_NO_DEPENDENCIES` | true            | Yes       | Always set to `True` unless you are synchronizing 2 OpenCTI platforms and you want to get an entity and all context (relationships and related entity) |
-
-### Connector extra parameters environment variables
-
-Below are the parameters you'll need to set for the connector:
-
-| Parameter    | config.yml   | Docker environment variable | Default | Mandatory | Description |
-| ------------ | ------------ | --------------------------- | ------- | --------- | ----------- |
-| API base URL | api_base_url |                             |         | Yes       |             |
-| API key      | api_key      |                             |         | Yes       |             |
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
 ## Deployment
 

--- a/templates/stream/entrypoint.sh
+++ b/templates/stream/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-template
-
-# Launch the worker
-python3 main.py


### PR DESCRIPTION
### Proposed changes

* Switch all 5 connector templates (external-import, internal-enrichment, internal-export-file, internal-import-file, stream) to a parameterized base image via `ARG PYTHON_VERSION=3.12` + `FROM python:${PYTHON_VERSION}-alpine AS base`
* Add `PYTHONDONTWRITEBYTECODE=1` and `PYTHONUNBUFFERED=1` environment variables to all template Dockerfiles
* Add `WORKDIR /opt/opencti-connector-template` to all template Dockerfiles
* Replace the `COPY entrypoint.sh` + `chmod +x` + `ENTRYPOINT [\"/entrypoint.sh\"]` pattern with a direct `ENTRYPOINT [\"python\", \"main.py\"]`
* Remove the hardcoded `ENV CONNECTOR_TYPE=...` line from all template Dockerfiles, since the connector type is supplied via config rather than baked into the image
* Delete the now-unused `entrypoint.sh` script from all 5 templates
* Simplify the \"Configuration variables\" section in each template's README.md, removing the manually-maintained \"OpenCTI environment variables\", \"Base connector environment variables\", and \"Connector extra parameters environment variables\" tables
* Replace the removed tables with a pointer to the generated configuration documentation (`./__metadata__/CONNECTOR_CONFIG_DOC.md`) and a note referencing OpenCTI's official connector documentation
* Update the README table of contents in each template to drop the now-removed configuration subsections

### Related issues

* Closes #5271

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This is a scoped step of the broader templates rework tracked in #5271, split into two commits:

1. **Dockerfile simplification**: the templates previously relied on a separate `entrypoint.sh` script just to `exec python main.py`. Inlining this as a direct `ENTRYPOINT` removes an unnecessary layer of indirection, one fewer file to maintain per template, and one fewer moving part to go wrong (missing `chmod +x`, shell quoting, etc.). Dropping the hardcoded `CONNECTOR_TYPE` env var is intentional: connector type should come from configuration (config.yml/docker-compose env vars), not be baked into the image, which keeps templates generic and consistent with how the platform actually resolves connector type at runtime.

2. **README config simplification**: each template's README previously hand-maintained three separate parameter tables (OpenCTI vars, base connector vars, extra connector vars). These duplicated information that is already generated from the connector's config schema, so they routinely drifted out of sync with the actual settings model. Replacing them with a link to `__metadata__/CONNECTOR_CONFIG_DOC.md` (plus a pointer to the official OpenCTI connector documentation) removes that duplication and ensures the README always reflects the current, generated set of configuration variables instead of a manually curated snapshot. Note: the `CONNECTOR_CONFIG_DOC.md` generator/file is planned as a follow-up and does not yet exist in this PR.