### PR TITLE
fix(proofpoint-tap): make SIEM email and threatUrl validation permissive (#4172)

### DIFF
--- a/external-import/proofpoint-tap/src/client_api/v2/siem.py
+++ b/external-import/proofpoint-tap/src/client_api/v2/siem.py
@@ -4,6 +4,9 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
+from client_api.common import BaseClient, ResponseModel
+from proofpoint_tap.errors import ProofPointAPIRequestParamsError
+from proofpoint_tap.warnings import PermissiveEmailStr, PermissiveLiteral, Recommended
 from pydantic import (
     AwareDatetime,
     Field,
@@ -11,10 +14,6 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-
-from client_api.common import BaseClient, ResponseModel
-from proofpoint_tap.errors import ProofPointAPIRequestParamsError
-from proofpoint_tap.warnings import PermissiveEmailStr, PermissiveLiteral, Recommended
 
 if TYPE_CHECKING:
     from yarl import URL

--- a/external-import/proofpoint-tap/src/client_api/v2/siem.py
+++ b/external-import/proofpoint-tap/src/client_api/v2/siem.py
@@ -4,17 +4,17 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
-from client_api.common import BaseClient, ResponseModel
-from proofpoint_tap.errors import ProofPointAPIRequestParamsError
-from proofpoint_tap.warnings import PermissiveLiteral, Recommended
 from pydantic import (
     AwareDatetime,
-    EmailStr,
     Field,
     IPvAnyAddress,
     field_validator,
     model_validator,
 )
+
+from client_api.common import BaseClient, ResponseModel
+from proofpoint_tap.errors import ProofPointAPIRequestParamsError
+from proofpoint_tap.warnings import PermissiveEmailStr, PermissiveLiteral, Recommended
 
 if TYPE_CHECKING:
     from yarl import URL
@@ -122,7 +122,7 @@ class ThreatInfo(ResponseModel):
 class MessageEvent(ResponseModel):
     """Model MessageEvent from /v2/siem/* responses."""
 
-    cc_addresses: Optional[list[EmailStr]] = Field(
+    cc_addresses: Optional[list[PermissiveEmailStr]] = Field(
         None, alias="ccAddresses", description="List of CC email addresses."
     )
     cluster: str = Field(
@@ -132,7 +132,7 @@ class MessageEvent(ResponseModel):
     completely_rewritten: Optional[bool] = Field(
         None, alias="completelyRewritten", description="URL rewrite status."
     )
-    from_address: list[EmailStr] = Field(
+    from_address: list[PermissiveEmailStr] = Field(
         ...,
         alias="fromAddress",
         description="Email address in the From header. Note: The documentation specifies a single email address but the API response is a list.",
@@ -199,12 +199,12 @@ class MessageEvent(ResponseModel):
         ...,
         description="SMTP recipient email address. Note: The documentation specifies a single email address but the API response is a list.",
     )
-    reply_to_address: Optional[list[EmailStr]] = Field(
+    reply_to_address: Optional[list[PermissiveEmailStr]] = Field(
         None,
         alias="replyToAddress",
         description="Email address in the Reply-To header.",
     )
-    sender: EmailStr = Field(..., description="SMTP sender email address.")
+    sender: PermissiveEmailStr = Field(..., description="SMTP sender email address.")
     sender_ip: str = Field(..., alias="senderIP", description="Sender's IP address.")
     spam_score: Optional[int] = Field(
         None,
@@ -217,7 +217,7 @@ class MessageEvent(ResponseModel):
     threats_info_map: list[ThreatInfo] = Field(
         ..., alias="threatsInfoMap", description="Details about detected threats."
     )
-    to_addresses: Optional[list[EmailStr]] = Field(
+    to_addresses: Optional[list[PermissiveEmailStr]] = Field(
         None, alias="toAddresses", description="list of To email addresses."
     )
     xmailer: Optional[str] = Field(None, description="Content of the X-Mailer header.")
@@ -261,8 +261,8 @@ class ClickEvent(ResponseModel):
     threat_time: AwareDatetime = Field(
         ..., alias="threatTime", description="Time the threat was identified."
     )
-    threat_url: str = Field(
-        ..., alias="threatUrl", description="Theurl to follow for threat description."
+    threat_url: Recommended[str] = Field(
+        None, alias="threatUrl", description="Theurl to follow for threat description."
     )
     threat_status: Literal["active", "falsepositive", "cleared"] = Field(
         ..., alias="threatStatus", description="Current state of the threat."

--- a/external-import/proofpoint-tap/src/client_api/v2/siem.py
+++ b/external-import/proofpoint-tap/src/client_api/v2/siem.py
@@ -261,7 +261,7 @@ class ClickEvent(ResponseModel):
         ..., alias="threatTime", description="Time the threat was identified."
     )
     threat_url: Recommended[str] = Field(
-        None, alias="threatUrl", description="Theurl to follow for threat description."
+        None, alias="threatUrl", description="The url to follow for threat description."
     )
     threat_status: Literal["active", "falsepositive", "cleared"] = Field(
         ..., alias="threatStatus", description="Current state of the threat."

--- a/external-import/proofpoint-tap/src/proofpoint_tap/adapters/events.py
+++ b/external-import/proofpoint-tap/src/proofpoint_tap/adapters/events.py
@@ -5,6 +5,8 @@ from datetime import timedelta
 from math import ceil
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generator, Literal, Optional
 
+from pydantic import IPvAnyAddress
+
 from client_api.v2.siem import (
     ClickEvent,
     MessageEvent,
@@ -19,7 +21,6 @@ from proofpoint_tap.ports.event import (
     EventThreatPort,
     MessageEventPort,
 )
-from pydantic import IPvAnyAddress
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -250,7 +251,7 @@ class ClickEventAPIV2(ClickEventPort):
     @property
     def threats(self) -> Optional[list[EventThreatPort]]:
         """Get the threats."""
-        return [EventThreatAPIV2.from_threat_url(self._event.threat_url)]
+        return [EventThreatAPIV2.from_threat_url(self._event.threat_url or "")]
 
     @property
     def sender_address(self) -> str:

--- a/external-import/proofpoint-tap/src/proofpoint_tap/adapters/events.py
+++ b/external-import/proofpoint-tap/src/proofpoint_tap/adapters/events.py
@@ -5,8 +5,6 @@ from datetime import timedelta
 from math import ceil
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generator, Literal, Optional
 
-from pydantic import IPvAnyAddress
-
 from client_api.v2.siem import (
     ClickEvent,
     MessageEvent,
@@ -21,6 +19,7 @@ from proofpoint_tap.ports.event import (
     EventThreatPort,
     MessageEventPort,
 )
+from pydantic import IPvAnyAddress
 
 if TYPE_CHECKING:
     from datetime import datetime

--- a/external-import/proofpoint-tap/src/proofpoint_tap/warnings.py
+++ b/external-import/proofpoint-tap/src/proofpoint_tap/warnings.py
@@ -118,7 +118,7 @@ def _validate_permissive_email(value: str, info: ValidationInfo) -> str:
             FieldWarning(
                 type_="invalid_email",
                 loc=(str(info.field_name),),
-                msg=f"Value '{value}' is not a valid email address. Validation will pass.",
+                msg=f"Value {value!r} is not a valid email address. Validation will pass.",
                 input_=value,
             ),
             stacklevel=2,

--- a/external-import/proofpoint-tap/src/proofpoint_tap/warnings.py
+++ b/external-import/proofpoint-tap/src/proofpoint_tap/warnings.py
@@ -10,6 +10,9 @@ from pydantic import (
     AfterValidator,
     BaseModel,
     ConfigDict,
+    EmailStr,
+    TypeAdapter,
+    ValidationError,
     ValidationInfo,
     model_validator,
 )
@@ -93,6 +96,42 @@ Recommended = Annotated[Optional[T], AfterValidator(_validate_recommended_field)
 #     my_model = MyModel(toto="an invalid string")
 # except ValidationError as e:
 #     print("Validation error in my_model:", e)
+
+
+_email_type_adapter: TypeAdapter[str] = TypeAdapter(EmailStr)
+
+
+def _validate_permissive_email(value: str, info: ValidationInfo) -> str:
+    """Raise a FieldWarning instead of failing when an email address is invalid.
+
+    Notes:
+        The Proofpoint TAP API derives these values from raw email headers, so they
+        are not guaranteed to be RFC-valid (empty strings, RFC 2047 encoded display
+        names, quoted local parts, etc.). Failing hard would drop the whole polling
+        window (silent data loss), so we keep the raw value and only warn.
+
+    """
+    try:
+        _email_type_adapter.validate_python(value)
+    except ValidationError:
+        warnings.warn(
+            FieldWarning(
+                type_="invalid_email",
+                loc=(str(info.field_name),),
+                msg=f"Value '{value}' is not a valid email address. Validation will pass.",
+                input_=value,
+            ),
+            stacklevel=2,
+        )
+    return value
+
+
+PermissiveEmailStr = Annotated[str, AfterValidator(_validate_permissive_email)]
+# A string type that only raises a warning (not an error) when it is not a valid email.
+# Usage:
+# class MyModel(BaseModel):
+#     email: PermissiveEmailStr = Field(...)
+#     emails: list[PermissiveEmailStr] = Field(...)
 
 
 class PermissiveLiteral(Generic[T]):

--- a/external-import/proofpoint-tap/tests/tests_connector/test_client_api/test_v2/test_siem.py
+++ b/external-import/proofpoint-tap/tests/tests_connector/test_client_api/test_v2/test_siem.py
@@ -16,14 +16,15 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 import pytest
 from aiohttp import ClientResponse, ClientResponseError
 from aiohttp_retry import Any
-from client_api.v2.siem import SIEMClient, SIEMResponse
+from pydantic import SecretStr
+from yarl import URL
+
+from client_api.v2.siem import ClickEvent, MessageEvent, SIEMClient, SIEMResponse
 from proofpoint_tap.errors import (
     ProofpointAPIError,
     ProofpointAPIInvalidResponseError,
     ProofPointAPIRequestParamsError,
 )
-from pydantic import SecretStr
-from yarl import URL
 
 
 def make_fake_get_client_response() -> ClientResponse:
@@ -224,3 +225,121 @@ async def test_model_responses(client_instance: SIEMClient, method_name: str) ->
             start_time=datetime.now(timezone.utc) - timedelta(minutes=60),
             end_time=datetime.now(timezone.utc) - timedelta(minutes=30),
         )
+
+
+# Test permissive validation of malformed API data
+def _make_threat_info() -> dict[str, Any]:
+    """Return a minimal valid threatsInfoMap entry."""
+    return {
+        "classification": "malware",
+        "threat": "some-threat",
+        "threatID": "threat-id",
+        "threatStatus": "active",
+        "threatTime": "2025-01-10T10:00:00Z",
+        "threatType": "attachment",
+    }
+
+
+def _make_message_event(**overrides: Any) -> dict[str, Any]:
+    """Return a minimal valid messagesBlocked/messagesDelivered entry."""
+    payload: dict[str, Any] = {
+        "cluster": "cluster-name",
+        "fromAddress": ["sender@example.com"],
+        "GUID": "message-guid",
+        "messageParts": [{"contentType": "text/plain", "disposition": "inline"}],
+        "messageTime": "2025-01-10T10:00:00Z",
+        "QID": "queue-id",
+        "recipient": ["recipient@example.com"],
+        "sender": "sender@example.com",
+        "senderIP": "127.0.0.1",
+        "threatsInfoMap": [_make_threat_info()],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _make_click_event(**overrides: Any) -> dict[str, Any]:
+    """Return a minimal valid clicksPermitted/clicksBlocked entry."""
+    payload: dict[str, Any] = {
+        "classification": "malware",
+        "clickIP": "127.0.0.1",
+        "clickTime": "2025-01-10T10:00:00Z",
+        "GUID": "click-guid",
+        "recipient": "recipient@example.com",
+        "sender": "sender@example.com",
+        "senderIP": "127.0.0.1",
+        "threatID": "threat-id",
+        "threatTime": "2025-01-10T10:00:00Z",
+        "threatUrl": "https://dashboard.example.com/threat",
+        "threatStatus": "active",
+        "url": "https://malicious.example.com",
+        "userAgent": "Mozilla/5.0",
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.parametrize(
+    "overrides, expected",
+    [
+        pytest.param(
+            {"sender": ""},
+            {"field": "sender", "value": ""},
+            id="empty sender",
+        ),
+        pytest.param(
+            {"fromAddress": ['"quoted.local"@example.com']},
+            {"field": "from_address", "value": ['"quoted.local"@example.com']},
+            id="quoted local part in fromAddress",
+        ),
+        pytest.param(
+            {"replyToAddress": ["=?utf-8?Q?Some=20Name?=<info@example.co.za>"]},
+            {
+                "field": "reply_to_address",
+                "value": ["=?utf-8?Q?Some=20Name?=<info@example.co.za>"],
+            },
+            id="encoded display name in replyToAddress",
+        ),
+    ],
+)
+def test_message_event_accepts_malformed_emails(
+    overrides: dict[str, Any], expected: dict[str, Any]
+) -> None:
+    """Malformed email values must not fail validation but be kept as-is."""
+    # Given a message event payload with a malformed email value
+    payload = _make_message_event(**overrides)
+    # When validating the MessageEvent model
+    event = MessageEvent.model_validate(payload)
+    # Then validation passes and the raw value is preserved
+    assert getattr(event, expected["field"]) == expected["value"]  # noqa: S101
+
+
+def test_click_event_accepts_missing_threat_url() -> None:
+    """A click event without threatUrl must not fail validation."""
+    # Given a click event payload without a threatUrl key
+    payload = _make_click_event()
+    del payload["threatUrl"]
+    # When validating the ClickEvent model
+    event = ClickEvent.model_validate(payload)
+    # Then validation passes and threat_url is None
+    assert event.threat_url is None  # noqa: S101
+
+
+def test_siem_response_preserves_window_with_malformed_email() -> None:
+    """One malformed record must not drop the whole polling window."""
+    # Given a SIEM response with one valid and one malformed message
+    payload = {
+        "queryEndTime": "2025-01-10T10:00:00Z",
+        "messagesBlocked": [
+            _make_message_event(),
+            _make_message_event(sender=""),
+        ],
+        "clicksPermitted": [],
+        "clicksBlocked": [],
+        "messagesDelivered": [],
+    }
+    # When validating the SIEMResponse model
+    response = SIEMResponse.model_validate(payload)
+    # Then both messages are preserved (no silent data loss)
+    assert response.messages_blocked is not None  # noqa: S101
+    assert len(response.messages_blocked) == 2  # noqa: S101

--- a/external-import/proofpoint-tap/tests/tests_connector/test_client_api/test_v2/test_siem.py
+++ b/external-import/proofpoint-tap/tests/tests_connector/test_client_api/test_v2/test_siem.py
@@ -10,18 +10,18 @@ This module tests:
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import Callable
+from typing import Any, Callable
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 from aiohttp import ClientResponse, ClientResponseError
-from aiohttp_retry import Any
 from client_api.v2.siem import ClickEvent, MessageEvent, SIEMClient, SIEMResponse
 from proofpoint_tap.errors import (
     ProofpointAPIError,
     ProofpointAPIInvalidResponseError,
     ProofPointAPIRequestParamsError,
 )
+from proofpoint_tap.warnings import ValidationWarning
 from pydantic import SecretStr
 from yarl import URL
 
@@ -292,12 +292,12 @@ def _make_click_event(**overrides: Any) -> dict[str, Any]:
             id="quoted local part in fromAddress",
         ),
         pytest.param(
-            {"replyToAddress": ["=?utf-8?Q?Some=20Name?=<info@example.co.za>"]},
+            {"replyToAddress": ["Some. Name <info@example.co.za>"]},
             {
                 "field": "reply_to_address",
-                "value": ["=?utf-8?Q?Some=20Name?=<info@example.co.za>"],
+                "value": ["Some. Name <info@example.co.za>"],
             },
-            id="encoded display name in replyToAddress",
+            id="unquoted display name with period in replyToAddress",
         ),
     ],
 )
@@ -308,7 +308,8 @@ def test_message_event_accepts_malformed_emails(
     # Given a message event payload with a malformed email value
     payload = _make_message_event(**overrides)
     # When validating the MessageEvent model
-    event = MessageEvent.model_validate(payload)
+    with pytest.warns(ValidationWarning):
+        event = MessageEvent.model_validate(payload)
     # Then validation passes and the raw value is preserved
     assert getattr(event, expected["field"]) == expected["value"]  # noqa: S101
 

--- a/external-import/proofpoint-tap/tests/tests_connector/test_client_api/test_v2/test_siem.py
+++ b/external-import/proofpoint-tap/tests/tests_connector/test_client_api/test_v2/test_siem.py
@@ -16,15 +16,14 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 import pytest
 from aiohttp import ClientResponse, ClientResponseError
 from aiohttp_retry import Any
-from pydantic import SecretStr
-from yarl import URL
-
 from client_api.v2.siem import ClickEvent, MessageEvent, SIEMClient, SIEMResponse
 from proofpoint_tap.errors import (
     ProofpointAPIError,
     ProofpointAPIInvalidResponseError,
     ProofPointAPIRequestParamsError,
 )
+from pydantic import SecretStr
+from yarl import URL
 
 
 def make_fake_get_client_response() -> ClientResponse:


### PR DESCRIPTION
### Proposed changes

* Add a `PermissiveEmailStr` type that keeps the raw value and emits a warning instead of raising when the Proofpoint TAP API returns non-RFC email values (empty senders, RFC 2047 encoded display names, quoted local parts).
* Apply it to the `MessageEvent` email fields (`sender`, `from_address`, `reply_to_address`, `cc_addresses`, `to_addresses`).
* Make `ClickEvent.threat_url` optional (`Recommended[str]`) to tolerate click events returned without a `threatUrl` key, and guard the events adapter accordingly.
* Add unit tests covering the malformed-email and missing-`threatUrl` cases and verifying the whole polling window is preserved.

### Related issues

* Fixes #4172

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments
Fixed without reproducing the issue, only with the description.

The root cause was strict Pydantic validation on SIEM responses: a single malformed record (invalid email or missing `threatUrl`) raised a `ValidationError` that dropped the entire polling window, causing silent data loss. Real-world email traffic frequently contains header-derived values that are not RFC-valid, so failing hard is inappropriate here.

The fix follows the connector's existing permissive philosophy (`Recommended`, `PermissiveLiteral`): invalid emails now pass validation while emitting a `FieldWarning`, and absent `threatUrl` values are tolerated. Downstream adapters already consume these fields as plain strings, so behaviour is unchanged for valid data.