### PR TITLE
fix(recorded-future): map email address indicators to STIX email-addr observables (#5835)

### DIFF
--- a/external-import/recorded-future/src/rflib/rf_to_stix2.py
+++ b/external-import/recorded-future/src/rflib/rf_to_stix2.py
@@ -166,6 +166,7 @@ class Indicator(RFStixEntity):
         """Handle x_opencti_main_observable_type for filtering"""
         stix_main_observable_mapping = {
             "domain-name:value": "Domain-Name",
+            "email-addr:value": "Email-Addr",
             "file:hashes": "StixFile",
             "ipv4-addr:value": "IPv4-Addr",
             "ipv6-addr:value": "IPv6-Addr",
@@ -364,6 +365,25 @@ class URL(Indicator):
 
     def _create_obs(self):
         return stix2.URL(
+            value=self.name,
+            object_marking_refs=self.tlp,
+            custom_properties={"x_opencti_created_by_ref": self.author.id},
+        )
+
+
+class EmailAddress(Indicator):
+    """Converts Email Address to Email Address indicator and observable"""
+
+    def __init__(
+        self, name, _type, author=None, tlp=None, first_seen=None, last_seen=None
+    ):
+        super().__init__(name, _type, author, tlp, first_seen, last_seen)
+
+    def _create_pattern(self):
+        return f"[email-addr:value = '{self.name}']"
+
+    def _create_obs(self):
+        return stix2.EmailAddress(
             value=self.name,
             object_marking_refs=self.tlp,
             custom_properties={"x_opencti_created_by_ref": self.author.id},
@@ -1038,6 +1058,7 @@ ENTITY_TYPE_MAPPER = {
     "IpAddress": IPAddress,
     "InternetDomainName": Domain,
     "URL": URL,
+    "EmailAddress": EmailAddress,
     "Hash": FileHash,
     "MitreAttackIdentifier": TTP,
     "Company": Identity,
@@ -1437,7 +1458,6 @@ class StixNote:
         """
         event_objects = []
         for event_capability in event_attr["capabilities"]:
-
             # Get capability (AttackPattern,  Malware, Vulnerability, Indicator)
             capability_name = event_capability["name"]
             capability_type = event_capability["type"]
@@ -1499,7 +1519,6 @@ class StixNote:
                 if event_attr.get("adversary") and event_attr["adversary"][0][
                     "type"
                 ] in ["Organization", "Person"]:
-
                     # Retrieve adversary in self.objects depending on adversary name in event
                     # self.objects contains all IntrusionSet, Malware, Identity, AttackPattern et ThreatActor linked to note
                     event_adversary = event_attr["adversary"][0]["name"]

--- a/external-import/recorded-future/tests/tests_connector/test_rf_to_stix2.py
+++ b/external-import/recorded-future/tests/tests_connector/test_rf_to_stix2.py
@@ -12,6 +12,7 @@ from stix2 import (
     AttackPattern,
     Campaign,
     DomainName,
+    EmailAddress,
     File,
     Identity,
     Indicator,
@@ -38,6 +39,11 @@ from stix2 import (
             [Indicator, DomainName, Relationship],
         ),
         ("URL", "test.com", [Indicator, URL, Relationship]),
+        (
+            "EmailAddress",
+            "test@test.com",
+            [Indicator, EmailAddress, Relationship],
+        ),
         (
             "Hash",
             "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",


### PR DESCRIPTION
### Proposed changes

* Added an `EmailAddress` indicator class (mirroring `Domain`/`URL`) that converts Recorded Future Email Address entities into a STIX Indicator + `stix2.EmailAddress` observable linked via a `based-on` relationship.
* Registered `EmailAddress` in `ENTITY_TYPE_MAPPER` so Analyst Notes (and any other code path relying on this mapper) can resolve the entity type instead of failing with a `NameError`/`KeyError`.
* Added `"email-addr:value": "Email-Addr"` to the `_add_main_observable_type_to_indicators()` STIX pattern mapping so OpenCTI correctly sets `x_opencti_main_observable_type` for Email-Addr indicators, ensuring proper filtering in the UI.
* Added a unit test case to `test_maps_rf_types_to_the_corresponding_stix_object` verifying that an `EmailAddress` entity produces the expected `[Indicator, EmailAddress, Relationship]` STIX objects.

### Related issues

* Closes #5835

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This fix specifically targets Analyst Notes / general entity mapping via `ENTITY_TYPE_MAPPER`. Alerts ingestion (`rf_alerts.py`) already handled `EmailAddress` correctly before this change, so no modification was needed there. Risk List ingestion's related-entity allowlists (`INDICATOR_TYPE_URL_MAPPER`) were intentionally NOT extended for email, since Recorded Future's Connect risk-score API has no dedicated per-email endpoint — supporting that would require integrating a separate Identity Intelligence API, which is out of scope for this fix.