### PR TITLE
chore(renovate): restrict updates on lts/* branches to security fixes only (#7435)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,28 @@
     "dependencies",
     "filigran team"
   ],
+  "baseBranchPatterns": [
+    "master",
+    "/^lts\\/.*/"
+  ],
+  "branchConcurrentLimit": 5,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": [
+      "security"
+    ]
+  },
   "packageRules": [
+    {
+      "description": "On lts/* branches, only raise vulnerability/security-fix PRs; all other (non-security) updates are disabled. vulnerabilityAlerts always bypass this 'enabled: false' rule.",
+      "matchBaseBranches": [
+        "/^lts\\/.*/"
+      ],
+      "matchPackageNames": [
+        "*"
+      ],
+      "enabled": false
+    },
     {
       "description": "Disable updates to pinned Python interpreter versions (e.g. .python-version files); connectors intentionally pin specific Python versions and should not be bumped automatically",
       "matchDatasources": [


### PR DESCRIPTION
### Proposed changes

* Added `baseBranchPatterns` to include both the default branch and any `lts/*` branch, so Renovate now also processes LTS release branches instead of only the default branch.
* Added a new `packageRules` entry that disables all package updates when the base branch matches `/^lts\\//`, preventing regular dependency version bumps on LTS branches.
* Enabled `osvVulnerabilityAlerts` and explicit `vulnerabilityAlerts` (with a `security` label) so vulnerability/critical security-fix PRs are still raised on LTS branches, since these always bypass the `enabled: false` rule above.

### Related issues

* Closes #7435

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This is a config-only change to `renovate.json`, no connector code is affected. Renovate's `vulnerabilityAlerts` PRs always bypass `packageRules` entries with `enabled: false` (per Renovate documentation), so even though the new rule disables all updates on `lts/*` branches, security/vulnerability fixes will still be proposed there. The default branch behavior is unchanged and continues to receive regular, unrestricted Renovate updates.