### PR TITLE
fix(cve): preserve cvss 3.0 vector string so cvss3 filters match (#7133)

### DIFF
--- a/external-import/cve/src/services/converter/const.py
+++ b/external-import/cve/src/services/converter/const.py
@@ -1,4 +1,5 @@
 CVSS31_MAPPING = {
+    "x_opencti_cvss_vector_string": "vectorString",
     "x_opencti_base_score": "baseScore",
     "x_opencti_base_severity": "baseSeverity",
     "x_opencti_attack_vector": "attackVector",

--- a/external-import/cve/tests/tests_connector/test_cvss_metrics.py
+++ b/external-import/cve/tests/tests_connector/test_cvss_metrics.py
@@ -58,6 +58,7 @@ def test_vulnerability_to_stix2_maps_cvss_30_when_31_absent():
             {
                 "type": "Primary",
                 "cvssData": {
+                    "vectorString": "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
                     "baseScore": 5.2,
                     "baseSeverity": "MEDIUM",
                     "attackVector": "NETWORK",
@@ -79,6 +80,12 @@ def test_vulnerability_to_stix2_maps_cvss_30_when_31_absent():
     assert stix_dict["x_opencti_base_score"] == 5.2
     assert stix_dict["x_opencti_base_severity"] == "MEDIUM"
     assert stix_dict["x_opencti_cvss_scope"] == "UNCHANGED"
+    # The exact NVD vector string must be preserved so the CVSS:3.0/ prefix is
+    # kept and OpenCTI does not fall back to reconstructing it as CVSS:3.1/.
+    assert (
+        stix_dict["x_opencti_cvss_vector_string"]
+        == "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N"
+    )
 
 
 def test_vulnerability_to_stix2_prefers_cvss_31_over_30():
@@ -90,6 +97,7 @@ def test_vulnerability_to_stix2_prefers_cvss_31_over_30():
             {
                 "type": "Primary",
                 "cvssData": {
+                    "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
                     "baseScore": 9.8,
                     "baseSeverity": "CRITICAL",
                     "attackVector": "NETWORK",
@@ -107,6 +115,7 @@ def test_vulnerability_to_stix2_prefers_cvss_31_over_30():
             {
                 "type": "Primary",
                 "cvssData": {
+                    "vectorString": "CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L",
                     "baseScore": 4.3,
                     "baseSeverity": "MEDIUM",
                     "attackVector": "LOCAL",
@@ -128,6 +137,10 @@ def test_vulnerability_to_stix2_prefers_cvss_31_over_30():
     assert stix_dict["x_opencti_base_score"] == 9.8
     assert stix_dict["x_opencti_base_severity"] == "CRITICAL"
     assert stix_dict["x_opencti_cvss_scope"] == "CHANGED"
+    assert (
+        stix_dict["x_opencti_cvss_vector_string"]
+        == "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+    )
 
 
 def test_vulnerability_to_stix2_cvss_30_secondary_selected_when_no_primary():


### PR DESCRIPTION
### Proposed changes

* Map the NVD `vectorString` field to `x_opencti_cvss_vector_string` in the CVSS3 mapping so the exact vector (with its `CVSS:3.0/` or `CVSS:3.1/` prefix) is sent to OpenCTI instead of being reconstructed and defaulted to `CVSS:3.1/`.
* Add/extend unit tests to assert the CVSS 3.0 vector prefix is preserved and that CVSS 3.1 keeps precedence with its own vector.

### Related issues

* Fixes #7133

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

CVEs that only expose CVSS 3.0 metrics (e.g. CVE-2025-0182) were not visible when filtering with `cvss3 contains "cvss:3.0/"`. The connector never passed the CVSS3 `vectorString`, so OpenCTI reconstructed it from the individual metrics and defaulted the version prefix to `CVSS:3.1/`, storing 3.0 vulnerabilities under a 3.1 vector.

The fix explicitly forwards NVD's `vectorString` (already correctly prefixed) through `CVSS31_MAPPING`. Verified end-to-end against a local OpenCTI: after ingestion, a CVSS 3.0 vulnerability (CVE-2015-1862) is stored with `CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H`, while 3.1 CVEs keep their `CVSS:3.1/` prefix.