### PR TITLE
fix(export): Arabic Characters Render Incorrectly in CSV Export (#17217)

### DIFF
--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -15,6 +15,7 @@ class ExportFileCsv:
         # Instantiate the connector helper from config
         self.helper = OpenCTIConnectorHelper(config=self.config.to_helper_config())
         self.export_file_csv_delimiter = self.config.export_file_csv.delimiter
+        self.export_file_csv_add_bom = self.config.export_file_csv.add_bom
         self.errors: list[Exception] = (
             []
         )  # error holder to be reset before each new process
@@ -146,6 +147,8 @@ class ExportFileCsv:
 
     def export_dict_list_to_csv(self, data, columns=None):
         output = io.StringIO()
+        if self.export_file_csv_add_bom:
+            output.write("\ufeff")
         data_headers = sorted(set().union(*(d.keys() for d in data)))
         column_specs = self._select_export_columns(data_headers, columns)
         # Expand a "hashes" field into one column per algorithm. The expanded

--- a/internal-export-file/export-file-csv/src/export-file-csv.py
+++ b/internal-export-file/export-file-csv/src/export-file-csv.py
@@ -147,7 +147,7 @@ class ExportFileCsv:
 
     def export_dict_list_to_csv(self, data, columns=None):
         output = io.StringIO()
-        if self.export_file_csv_add_bom:
+        if getattr(self, "export_file_csv_add_bom", False):
             output.write("\ufeff")
         data_headers = sorted(set().union(*(d.keys() for d in data)))
         column_specs = self._select_export_columns(data_headers, columns)

--- a/internal-export-file/export-file-csv/src/settings.py
+++ b/internal-export-file/export-file-csv/src/settings.py
@@ -37,6 +37,16 @@ class ExportFileCsvConfig(BaseConfigModel):
         description="The delimiter character used to separate the values in the exported CSV files.",
         default=";",
     )
+    add_bom: bool = Field(
+        description=(
+            "Prepend a UTF-8 BOM (byte order mark) to exported CSV files. "
+            "Required for Microsoft Excel to correctly auto-detect UTF-8 encoding "
+            "Without it, Excel falls back to the system's local codepage"
+            "and non-ASCII text (Arabic, Cyrillic, CJK, "
+            "etc.) is rendered as garbled characters. Disabled by default."
+        ),
+        default=False,
+    )
 
 
 class ConnectorSettings(BaseConnectorSettings):

--- a/internal-export-file/export-file-csv/tests/test_export_file_csv.py
+++ b/internal-export-file/export-file-csv/tests/test_export_file_csv.py
@@ -68,9 +68,9 @@ class TestSelectExportColumns:
         assert ExportFileCsv._select_export_columns(
             data_headers, ["fromName", "fromType"]
         ) == [
-                   ("fromName", "from", None),
-                   ("fromType", "from", "entity_type"),
-               ]
+            ("fromName", "from", None),
+            ("fromType", "from", "entity_type"),
+        ]
 
     def test_deduplicates_exact_duplicate_columns(self):
         data_headers = ["from", "to"]
@@ -172,6 +172,7 @@ class TestExportDictListToCsv:
         # row-generation logic actually populates it (regression test).
         assert "hashes_MD5" in headers
         assert rows[1][headers.index("hashes_MD5")] == "abc"
+
 
 class TestExportDictListToCsvBom:
 

--- a/internal-export-file/export-file-csv/tests/test_export_file_csv.py
+++ b/internal-export-file/export-file-csv/tests/test_export_file_csv.py
@@ -23,12 +23,13 @@ _spec.loader.exec_module(export_file_csv)
 ExportFileCsv = export_file_csv.ExportFileCsv
 
 
-def _make_connector():
-    """Build an instance without running __init__ (which needs a live helper)."""
+def _make_connector(add_bom=None):
     connector = ExportFileCsv.__new__(ExportFileCsv)
     connector.export_file_csv_delimiter = ";"
     connector.errors = []
     connector.helper = MagicMock()
+    if add_bom is not None:
+        connector.export_file_csv_add_bom = add_bom
     return connector
 
 
@@ -67,9 +68,9 @@ class TestSelectExportColumns:
         assert ExportFileCsv._select_export_columns(
             data_headers, ["fromName", "fromType"]
         ) == [
-            ("fromName", "from", None),
-            ("fromType", "from", "entity_type"),
-        ]
+                   ("fromName", "from", None),
+                   ("fromType", "from", "entity_type"),
+               ]
 
     def test_deduplicates_exact_duplicate_columns(self):
         data_headers = ["from", "to"]
@@ -171,6 +172,40 @@ class TestExportDictListToCsv:
         # row-generation logic actually populates it (regression test).
         assert "hashes_MD5" in headers
         assert rows[1][headers.index("hashes_MD5")] == "abc"
+
+class TestExportDictListToCsvBom:
+
+    def test_no_bom_when_attribute_missing(self):
+        connector = _make_connector()
+        data = [{"name": "A"}]
+        out = connector.export_dict_list_to_csv(data)
+        assert not out.startswith("\ufeff")
+
+    def test_no_bom_when_disabled(self):
+        connector = _make_connector(add_bom=False)
+        data = [{"name": "A"}]
+        out = connector.export_dict_list_to_csv(data)
+        assert not out.startswith("\ufeff")
+
+    def test_bom_prefix_when_enabled(self):
+        connector = _make_connector(add_bom=True)
+        data = [{"name": "A", "entity_type": "Malware"}]
+        out = connector.export_dict_list_to_csv(data)
+
+        assert out.startswith("\ufeff")
+        stripped = out[len("\ufeff") :]
+        assert _csv_headers(stripped) == ["entity_type", "name"]
+
+    def test_bom_appears_only_once_at_the_start(self):
+        connector = _make_connector(add_bom=True)
+        data = [
+            {"name": "A", "entity_type": "Malware"},
+            {"name": "B", "entity_type": "Tool"},
+        ]
+        out = connector.export_dict_list_to_csv(data)
+
+        assert out.count("\ufeff") == 1
+        assert out.startswith("\ufeff")
 
 
 class TestExportListVisibleColumns:


### PR DESCRIPTION
### Proposed changes

* add env variable to add a BOM at csv export for Microsoft to be able to read arabic characters

### Related issues

* closes: https://github.com/OpenCTI-Platform/opencti/issues/17217