### PR TITLE
fix(deps): update pytest to 9.0.3 to fix vulnerable tmpdir handling (#7449)

### DIFF
--- a/internal-enrichment/import-external-reference/tests/test-requirements.txt
+++ b/internal-enrichment/import-external-reference/tests/test-requirements.txt
@@ -1,2 +1,2 @@
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3

--- a/internal-import-file/import-file-misp/tests/test-requirements.txt
+++ b/internal-import-file/import-file-misp/tests/test-requirements.txt
@@ -1,3 +1,3 @@
 # Main dependencies need to be installed
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3

--- a/internal-import-file/import-file-yara/tests/test-requirements.txt
+++ b/internal-import-file/import-file-yara/tests/test-requirements.txt
@@ -1,3 +1,3 @@
 # Main dependencies needs to be installed
 -r ../src/requirements.txt
-pytest==8.4.2
+pytest==9.0.3


### PR DESCRIPTION
### Proposed changes

* Update `pytest` from `8.4.2` to `9.0.3` in three `test-requirements.txt` files to fix CVE-2025-71176 (vulnerable tmpdir handling)
* Affected connectors: `import-external-reference`, `import-file-misp`, `import-file-yara`

### Related issues

* Fixes #7449 

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Dependabot flagged pytest 8.4.2 as vulnerable to CVE-2025-71176 (GHSA-6w46-j5rx-g56g), a moderate-severity issue where pytest relies on predictable `/tmp/pytest-of-{user}` directories, allowing local users to cause a denial of service or potentially gain privileges. The advisory's patched version is 9.0.3, so all three flagged test-requirements files are bumped accordingly.