### PR TITLE
ci: enforce VC105 (no absolute date) alongside VC305 for new connectors (#7451)

### DIFF
--- a/.github/workflows/ci-connector-verified-linter.yml
+++ b/.github/workflows/ci-connector-verified-linter.yml
@@ -265,10 +265,10 @@ jobs:
   # Newly-added connectors are not yet "verified" or "manager_supported", so
   # they are skipped by the `vclint` job above (which only targets eligible
   # connectors and is blocking only for the "verified-with-date" subset). This
-  # job enforces VC305 (connectors-sdk BaseConnectorSettings) as a hard,
-  # blocking requirement for any connector introduced for the first time in
-  # this PR, so new code never lands using the legacy get_config_variable()
-  # pattern.
+  # job enforces VC105 (no absolute date) and VC305 (connectors-sdk 
+  # BaseConnectorSettings) as a hard, blocking requirement for any connector 
+  # introduced for the first time in this PR, so new code never lands 
+  # using the legacy get_config_variable() pattern.
   vclint-new-connector-settings:
     name: VC305 (new connector) ${{ matrix.name }}
     needs:
@@ -294,13 +294,13 @@ jobs:
       - name: Install connector-linter
         run: uv pip install ./shared/tools/connector_linter
 
-      - name: Run VC305 (connectors-sdk settings) on new connectors
+      - name: Run VC105/VC305 (connectors-sdk settings) on new connectors
         run: |
           exit_code=0
           while IFS= read -r connector_path; do
             [ -z "$connector_path" ] && continue
-            echo "::group::Checking VC305 for ${connector_path}"
-            uv run connector-linter check "$connector_path" --select VC305 --format github || exit_code=$?
+            echo "::group::Checking VC105/VC305 for ${connector_path}"
+            uv run connector-linter check "$connector_path" --select VC105,VC305 --format github || exit_code=$?
             echo "::endgroup::"
           done <<< "${{ matrix.connector_paths }}"
           exit "$exit_code"

--- a/.github/workflows/ci-connector-verified-linter.yml
+++ b/.github/workflows/ci-connector-verified-linter.yml
@@ -265,10 +265,10 @@ jobs:
   # Newly-added connectors are not yet "verified" or "manager_supported", so
   # they are skipped by the `vclint` job above (which only targets eligible
   # connectors and is blocking only for the "verified-with-date" subset). This
-  # job enforces VC105 (no absolute date) and VC305 (connectors-sdk 
-  # BaseConnectorSettings) as a hard, blocking requirement for any connector 
-  # introduced for the first time in this PR, so new code never lands 
-  # using the legacy get_config_variable() pattern.
+  # job enforces VC105 (no absolute date) and VC305 (connectors-sdk
+  # BaseConnectorSettings) as hard, blocking requirements for any connector
+  # introduced for the first time in this PR, so new code never lands with
+  # absolute dates in config/scheduling or the legacy get_config_variable() pattern.
   vclint-new-connector-settings:
     name: VC305 (new connector) ${{ matrix.name }}
     needs:
@@ -300,7 +300,7 @@ jobs:
           while IFS= read -r connector_path; do
             [ -z "$connector_path" ] && continue
             echo "::group::Checking VC105/VC305 for ${connector_path}"
-            uv run connector-linter check "$connector_path" --select VC105,VC305 --format github || exit_code=$?
+            uv run connector-linter check "$connector_path" --select VC105 --select VC305 --format github || exit_code=$?
             echo "::endgroup::"
           done <<< "${{ matrix.connector_paths }}"
           exit "$exit_code"


### PR DESCRIPTION
### Proposed changes

* Extend the `vclint-new-connector-settings` job in `ci-connector-verified-linter.yml` to also run VC105 (no absolute date) in addition to VC305 (connectors-sdk `BaseConnectorSettings`) for connectors introduced for the first time in a PR.
* Update the `--select` flag passed to `connector-linter check` from `VC305` to `VC105,VC305` so both checks are enforced as blocking requirements.
* Update step name, log group name, and job comment to reflect that VC105 is now enforced alongside VC305, so new connectors never land with absolute dates or the legacy `get_config_variable()` pattern.

### Related issues

* Closes #7451

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

N/A — small, self-contained CI workflow change; no functional connector code affected.