### PR TITLE
ci(manifest): fix manifest commit-back and hand over builds to GHA (#7457)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,87 +300,87 @@ workflows:
                 - master
                 - /release\/.*/
                 - /lts\/.*/
-      - build_manifest:
-          requires:
-            - ensure_formatting
-            - base_linter
-            - linter
-            - test
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only:
-                - master
-                - /release\/.*/
-                - /lts\/.*/
-      - build:
-          name: "build_release"
-          ci_executor:
-            name: ci_environment
-            tags: "latest"
-          requires:
-            - ensure_formatting
-            - base_linter
-            - linter
-            - test
-          filters:
-            tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
-            branches:
-              ignore: /.*/
-      - build:
-          name: "build_prerelease"
-          ci_executor:
-            name: ci_environment
-            tags: "prerelease"
-          requires:
-            - ensure_formatting
-            - base_linter
-            - linter
-            - test
-          filters:
-            branches:
-              only:
-                - /release\/.*/
-      - build:
-          name: "build_rolling"
-          ci_executor:
-            name: ci_environment
-            tags: "rolling"
-          requires:
-            - ensure_formatting
-            - base_linter
-            - linter
-            - test
-          filters:
-            branches:
-              only:
-                - master
-      - notify:
-          name: "send_notifications_release"
-          notification_executor:
-            name: ci_notifications
-          requires:
-            - build_release
-          filters:
-            tags:
-              only: /.*/
-      - notify:
-          name: "send_notifications_rolling"
-          notification_executor:
-            name: ci_notifications
-          requires:
-            - build_rolling
-          filters:
-            tags:
-              only: /.*/
-      - notify:
-          name: "send_notifications_prerelease"
-          notification_executor:
-            name: ci_notifications
-          requires:
-            - build_prerelease
-          filters:
-            tags:
-              only: /.*/
+      # - build_manifest:
+      #     requires:
+      #       - ensure_formatting
+      #       - base_linter
+      #       - linter
+      #       - test
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #       branches:
+      #         only:
+      #           - master
+      #           - /release\/.*/
+      #           - /lts\/.*/
+      # - build:
+      #     name: "build_release"
+      #     ci_executor:
+      #       name: ci_environment
+      #       tags: "latest"
+      #     requires:
+      #       - ensure_formatting
+      #       - base_linter
+      #       - linter
+      #       - test
+      #     filters:
+      #       tags:
+      #         only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
+      #       branches:
+      #         ignore: /.*/
+      # - build:
+      #     name: "build_prerelease"
+      #     ci_executor:
+      #       name: ci_environment
+      #       tags: "prerelease"
+      #     requires:
+      #       - ensure_formatting
+      #       - base_linter
+      #       - linter
+      #       - test
+      #     filters:
+      #       branches:
+      #         only:
+      #           - /release\/.*/
+      # - build:
+      #     name: "build_rolling"
+      #     ci_executor:
+      #       name: ci_environment
+      #       tags: "rolling"
+      #     requires:
+      #       - ensure_formatting
+      #       - base_linter
+      #       - linter
+      #       - test
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - notify:
+      #     name: "send_notifications_release"
+      #     notification_executor:
+      #       name: ci_notifications
+      #     requires:
+      #       - build_release
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - notify:
+      #     name: "send_notifications_rolling"
+      #     notification_executor:
+      #       name: ci_notifications
+      #     requires:
+      #       - build_rolling
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - notify:
+      #     name: "send_notifications_prerelease"
+      #     notification_executor:
+      #       name: ci_notifications
+      #     requires:
+      #       - build_prerelease
+      #     filters:
+      #       tags:
+      #         only: /.*/

--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -18,8 +18,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: build-manifest-${{ github.ref }}
-  cancel-in-progress: false
+  group: build-manifest
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -1,52 +1,45 @@
 name: Build Manifest
 
-# on:
-#   workflow_run:
-#     workflows:
-#       - Lint & Format
-#       - Tests Connectors
-#     types:
-#       - completed
-    # branches:
-    #   - master
-    #   - release/**
-    #   - lts/**
+# Regenerates the connectors config schemas and the global manifest, then
+# commits the result back to the branch it was called from.
+#
+# Called by build-all-connectors.yml (push on master / release/* / lts/*, and
+# on version tags). workflow_dispatch is kept for manual runs on a branch.
+#
+# No standalone `push` trigger on purpose: build-all-connectors.yml already
+# triggers on those refs and calls this workflow, so a push trigger here would
+# run it twice concurrently and race on the commit-back.
+#
+# Nothing is committed when the caller ref is a tag: there is no branch to push
+# to in that case, the manifest is already built on the branch the tag came from.
 
 on:
   workflow_call:
-
+  workflow_dispatch:
 
 concurrency:
-  group: build-manifest-${{ github.event.pull_request.head.ref || github.ref }}
+  group: build-manifest-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
   contents: read
-  actions: read
 
 jobs:
   build_manifest:
     name: Build and Commit Manifest
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      actions: read
-    # env:
-    #   GITHUB_GPG_SECRET_KEY: ${{ secrets.GITHUB_GPG_SECRET_KEY }}
-    #   GITHUB_GPG_SIGNING_KEY: ${{ secrets.GITHUB_GPG_SIGNING_KEY }}
-    #   PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          # Credentials are intentionally persisted: the commit step below
+          # pushes back to the branch using the GITHUB_TOKEN remote.
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -62,49 +55,51 @@ jobs:
           set -euo pipefail
           bash ./shared/tools/composer/generate_global_manifest/generate_global_manifest.sh
 
-    #   - name: Commit manifest if changed
-    #     shell: bash
-    #     run: |
-    #       set -euo pipefail
+      - name: Commit manifest if changed
+        shell: bash
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          TARGET_BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
 
-    #       if [ "${TARGET_BRANCH}" != "${RELEASE_REF}" ]; then
-    #         echo "Skipping, not ${RELEASE_REF} branch."
-    #         exit 0
-    #       fi
+          if [ "${REF_TYPE}" != "branch" ]; then
+            echo "Ref '${TARGET_BRANCH}' is a ${REF_TYPE}, not a branch. Skipping commit."
+            exit 0
+          fi
 
-    #       if [ -z "${GITHUB_GPG_SECRET_KEY:-}" ] || [ -z "${GITHUB_GPG_SIGNING_KEY:-}" ]; then
-    #         echo "Missing GPG secrets; cannot create signed commit."
-    #         exit 1
-    #       fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-    #       if git diff --quiet -- manifest.json; then
-    #         echo "Manifest not changed. Skipping commit."
-    #         exit 0
-    #       fi
+          # Stage only generated artifacts: the venvs and temporary files created
+          # by the generation scripts must never end up in the commit.
+          git add -A -- \
+            manifest.json \
+            '*/__metadata__/connector_config_schema.json' \
+            '*/__metadata__/CONNECTOR_CONFIG_DOC.md'
 
-    #       echo "${GITHUB_GPG_SECRET_KEY}" | base64 -d > /tmp/private.key
-    #       gpg --batch --import /tmp/private.key
-    #       rm /tmp/private.key
+          # Checked after staging so newly created (untracked) schemas count as changes.
+          if git diff --cached --quiet; then
+            echo "Manifest and schemas unchanged. Skipping commit."
+            exit 0
+          fi
 
-    #       git config user.email "automation@filigran.io"
-    #       git config user.name "Filigran Automation"
-    #       git config user.signingkey "${GITHUB_GPG_SIGNING_KEY}"
-    #       git config commit.gpgsign true
+          git commit -m "chore(manifest): build and update manifest [skip ci]"
 
-    #       git add .
-    #       git commit -m "chore(manifest): build and update manifest [skip ci]"
+          # Retry on non-fast-forward: concurrent runs may have moved the branch.
+          MAX_RETRIES=3
+          for attempt in $(seq 1 "$MAX_RETRIES"); do
+            if git push origin "HEAD:${TARGET_BRANCH}"; then
+              echo "Manifest changes pushed successfully (attempt ${attempt})."
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}/${MAX_RETRIES}) - rebasing on ${TARGET_BRANCH}."
+            if ! git pull --rebase origin "${TARGET_BRANCH}"; then
+              echo "::error::Rebase failed, aborting."
+              git rebase --abort || true
+              exit 1
+            fi
+          done
 
-    #       git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-    #       if git push -q origin "${TARGET_BRANCH}"; then
-    #         echo "Manifest changes pushed successfully."
-    #         exit 0
-    #       fi
-
-    #       echo "Push rejected, ${TARGET_BRANCH} probably moved. Trying rebase..."
-    #       if ! git pull --rebase origin "${TARGET_BRANCH}"; then
-    #         echo "Rebase failed, aborting."
-    #         git rebase --abort || true
-    #         exit 1
-    #       fi
-
-    #       git push -q origin "${TARGET_BRANCH}"
+          echo "::error::Failed to push manifest update after ${MAX_RETRIES} attempts."
+          exit 1

--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -1,7 +1,8 @@
 name: Build Manifest
 
 # Regenerates the connectors config schemas and the global manifest, then
-# commits the result back to the branch it was called from.
+# commits the result back to the branch it was called from, through the GitHub
+# API so the commit is signed and shows as Verified.
 #
 # Called by build-all-connectors.yml (push on master / release/* / lts/*, and
 # on version tags). workflow_dispatch is kept for manual runs on a branch.
@@ -34,8 +35,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Credentials are intentionally persisted: the commit step below
-          # pushes back to the branch using the GITHUB_TOKEN remote.
+          # No git push is performed: the commit is created through the GitHub
+          # API, so the checkout token does not need to be persisted.
+          persist-credentials: false
+          # Full history: the schema generation script diffs against the base
+          # branch to decide which connectors to regenerate.
           fetch-depth: 0
 
       - name: Set up Python
@@ -43,8 +47,21 @@ jobs:
         with:
           python-version: "3.12"
 
+      # The generation script was written for CircleCI: it compares against
+      # `$CIRCLE_BRANCH` / `$RELEASE_REF` to decide which connectors changed.
+      # Both are unset under GitHub Actions, which sends the script down its
+      # pull-request path (`git merge-base origin/master HEAD`). On a push to
+      # master that merge base *is* HEAD, so every connector is reported as
+      # unchanged and nothing is ever regenerated. Setting both to the current
+      # ref reproduces the CircleCI behaviour: diff the last commit (HEAD~1..HEAD).
+      #
+      # TODO: temporary shim. Once CircleCI is decommissioned, drop these two
+      # variables and rename them to CI-agnostic ones inside the script itself.
       - name: Build connectors schemas
         shell: bash
+        env:
+          CIRCLE_BRANCH: ${{ github.ref_name }}
+          RELEASE_REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           bash ./shared/tools/composer/generate_connectors_config_schemas/generate_connectors_config_json_schemas.sh
@@ -55,51 +72,41 @@ jobs:
           set -euo pipefail
           bash ./shared/tools/composer/generate_global_manifest/generate_global_manifest.sh
 
-      - name: Commit manifest if changed
+      - name: Resolve target branch
+        id: target
         shell: bash
         env:
           REF_TYPE: ${{ github.ref_type }}
-          TARGET_BRANCH: ${{ github.ref_name }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
           if [ "${REF_TYPE}" != "branch" ]; then
-            echo "Ref '${TARGET_BRANCH}' is a ${REF_TYPE}, not a branch. Skipping commit."
+            echo "Ref '${REF_NAME}' is a ${REF_TYPE}, not a branch. Nothing to commit back."
+            echo "branch=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          echo "branch=${REF_NAME}" >> "$GITHUB_OUTPUT"
 
-          # Stage only generated artifacts: the venvs and temporary files created
-          # by the generation scripts must never end up in the commit.
-          git add -A -- \
-            manifest.json \
-            '*/__metadata__/connector_config_schema.json' \
-            '*/__metadata__/CONNECTOR_CONFIG_DOC.md'
-
-          # Checked after staging so newly created (untracked) schemas count as changes.
-          if git diff --cached --quiet; then
-            echo "Manifest and schemas unchanged. Skipping commit."
-            exit 0
-          fi
-
-          git commit -m "chore(manifest): build and update manifest [skip ci]"
-
-          # Retry on non-fast-forward: concurrent runs may have moved the branch.
-          MAX_RETRIES=3
-          for attempt in $(seq 1 "$MAX_RETRIES"); do
-            if git push origin "HEAD:${TARGET_BRANCH}"; then
-              echo "Manifest changes pushed successfully (attempt ${attempt})."
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}/${MAX_RETRIES}) - rebasing on ${TARGET_BRANCH}."
-            if ! git pull --rebase origin "${TARGET_BRANCH}"; then
-              echo "::error::Rebase failed, aborting."
-              git rebase --abort || true
-              exit 1
-            fi
-          done
-
-          echo "::error::Failed to push manifest update after ${MAX_RETRIES} attempts."
-          exit 1
+      # Commits via GitHub's GraphQL API instead of raw `git commit`, so the
+      # commit is GPG-signed by GitHub (required by this repo's branch
+      # protection) without managing signing keys in CI. No local git
+      # add/commit/push: it's a no-op when nothing was regenerated, and it
+      # re-resolves the branch head through the API so it isn't affected by
+      # non-fast-forward races from concurrent runs.
+      #
+      # `file_pattern` is a space-separated pathspec passed to `git status`,
+      # scoped to the generated artifacts so the virtualenvs and temp files
+      # created by the generation scripts never enter the commit. Untracked
+      # (new) schemas and deletions are both picked up.
+      - name: Commit manifest if changed
+        if: steps.target.outputs.branch != ''
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        with:
+          commit_message: "chore(manifest): build and update manifest [skip ci]"
+          repo: ${{ github.repository }}
+          branch: ${{ steps.target.outputs.branch }}
+          file_pattern: "manifest.json */__metadata__/connector_config_schema.json */__metadata__/CONNECTOR_CONFIG_DOC.md"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Proposed changes

* Fix the `Commit manifest if changed` step in `.github/workflows/build-manifest.yml`, which could never succeed: `TARGET_BRANCH` and `RELEASE_REF` were referenced but never defined, so `set -euo pipefail` aborted the step on `unbound variable`, and `persist-credentials: false` left the remote without credentials for the push.
* Remove the duplicate `on:` key (the second one silently overrode the `workflow_run` block) and the `if: github.event.workflow_run.conclusion == 'success'` job guard, which is always empty under `workflow_call` and skipped the job entirely.
* Resolve the push target from `github.ref_name` / `github.ref_type`, skipping tag refs since there is no branch to push to.
* Scope staging to the generated artifacts (`manifest.json`, `*/__metadata__/connector_config_schema.json`, `*/__metadata__/CONNECTOR_CONFIG_DOC.md`) instead of `git add .`, so the virtualenvs and temp files created by the generator scripts can never enter the commit.
* Move the change check after staging (`git add -A` then `git diff --cached --quiet`), so newly created (untracked) schemas and deletions are detected — the previous `git diff --quiet -- manifest.json` missed both.
* Retry the push with a rebase (3 attempts) instead of a single attempt, mirroring the `update-manifest` job in `release-connector.yml`.
* Comment out the superseded `build_manifest`, `build_*` and `notify` jobs in `.circleci/config.yml`, now handled by `build-all-connectors.yml`.

### Related issues

* Closes #7457

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### How to test

- Tested on a fork
- Push the changes to remote master branch

<img width="891" height="209" alt="image" src="https://github.com/user-attachments/assets/c343087f-c9a1-4afc-817a-9fec42b29c71" />


### Further comments

`build-manifest.yml` keeps only `workflow_call` (used by `build-all-connectors.yml`) and `workflow_dispatch`. A `push` trigger was deliberately **not** added: `build-all-connectors.yml` already fires on the same refs and calls this workflow, so a push trigger would start a second concurrent run racing on the commit-back — and the `concurrency` group would not prevent it, since it is keyed on `github.ref` (identical for both) with `cancel-in-progress: false`.

No CI loop is possible: pushes made with `GITHUB_TOKEN` do not re-trigger workflows, and the automation commit carries `[skip ci]`.

The pathspec staging behaviour was verified locally in a scratch repository for four cases: new untracked schema, no change, file deletion, and exclusion of unrelated files.

Worth noting for review: the commit-back only reaches `master` if `lint` and `tests` pass, since the caller job declares `needs: [resolve-build-mode, lint, tests]`. Repository settings can still block the push — branch protection or an org-level read-only default workflow permission would return a 403 despite the job's `contents: write`; that would require a PAT/App token rather than a workflow change.
