### PR TITLE
fix(mitre-attack): stop overriding CONNECTOR_SCOPE with invalid STIX type value (#7178)

### DIFF
--- a/external-import/mitre/README.md
+++ b/external-import/mitre/README.md
@@ -46,34 +46,10 @@ All data is imported in native STIX 2.1 format from MITRE's official GitHub repo
 
 ## Configuration variables
 
-There are a number of configuration options, which are set either in `docker-compose.yml` (for Docker) or in `config.yml` (for manual deployment).
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-### OpenCTI environment variables
-
-| Parameter     | config.yml | Docker environment variable | Mandatory | Description                                          |
-|---------------|------------|-----------------------------|-----------|------------------------------------------------------|
-| OpenCTI URL   | url        | `OPENCTI_URL`               | Yes       | The URL of the OpenCTI platform.                     |
-| OpenCTI Token | token      | `OPENCTI_TOKEN`             | Yes       | The default admin token set in the OpenCTI platform. |
-
-### Base connector environment variables
-
-| Parameter         | config.yml      | Docker environment variable   | Default         | Mandatory | Description                                                                 |
-|-------------------|-----------------|-------------------------------|-----------------|-----------|-----------------------------------------------------------------------------|
-| Connector ID      | id              | `CONNECTOR_ID`                |                 | Yes       | A unique `UUIDv4` identifier for this connector instance.                   |
-| Connector Name    | name            | `CONNECTOR_NAME`              | MITRE ATT&CK    | No        | Name of the connector.                                                      |
-| Connector Scope   | scope           | `CONNECTOR_SCOPE`             | mitre           | No        | The scope or type of data the connector is importing.                       |
-| Log Level         | log_level       | `CONNECTOR_LOG_LEVEL`         | error           | No        | Determines the verbosity of the logs: `debug`, `info`, `warn`, or `error`.  |
-
-### Connector extra parameters environment variables
-
-| Parameter                | config.yml                   | Docker environment variable      | Default                                                                              | Mandatory | Description                                                    |
-|--------------------------|------------------------------|----------------------------------|--------------------------------------------------------------------------------------|-----------|----------------------------------------------------------------|
-| Remove Statement Marking | mitre.remove_statement_marking | `MITRE_REMOVE_STATEMENT_MARKING` | false                                                                              | No        | Remove statement markings from ingested MITRE data.            |
-| Interval                 | mitre.interval               | `MITRE_INTERVAL`                 | 7                                                                                    | Yes       | Interval in days between connector runs.                       |
-| Enterprise File URL      | mitre.enterprise_file_url    | `MITRE_ENTERPRISE_FILE_URL`      | https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json | No | URL to MITRE Enterprise ATT&CK JSON. |
-| Mobile File URL          | mitre.mobile_attack_file_url | `MITRE_MOBILE_ATTACK_FILE_URL`   | https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/mobile-attack/mobile-attack.json | No | URL to MITRE Mobile ATT&CK JSON. |
-| ICS File URL             | mitre.ics_attack_file_url    | `MITRE_ICS_ATTACK_FILE_URL`      | https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/ics-attack/ics-attack.json | No | URL to MITRE ICS ATT&CK JSON. |
-| CAPEC File URL           | mitre.capec_file_url         | `MITRE_CAPEC_FILE_URL`           | https://raw.githubusercontent.com/mitre/cti/master/capec/2.1/stix-capec.json         | No        | URL to CAPEC JSON.                                             |
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
 ## Deployment
 
@@ -94,11 +70,11 @@ Configure the connector in `docker-compose.yml`:
       - OPENCTI_URL=http://localhost
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
-      - CONNECTOR_NAME=MITRE ATT&CK
-      - CONNECTOR_SCOPE=mitre
-      - CONNECTOR_LOG_LEVEL=error
-      - MITRE_INTERVAL=7 # In days
-      # - MITRE_REMOVE_STATEMENT_MARKING=true
+      # - CONNECTOR_NAME=MITRE ATT&CK
+      # - CONNECTOR_SCOPE=tool,report,malware,identity,campaign,intrusion-set,attack-pattern,course-of-action,x-mitre-data-source,x-mitre-data-component,x-mitre-matrix,x-mitre-tactic,x-mitre-collection
+      # - CONNECTOR_LOG_LEVEL=error
+      # - MITRE_INTERVAL=7 # In days
+      # # - MITRE_REMOVE_STATEMENT_MARKING=true
     restart: always
 ```
 

--- a/external-import/mitre/docker-compose.yml
+++ b/external-import/mitre/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
       - CONNECTOR_NAME=MITRE ATT&CK
-      - CONNECTOR_SCOPE=mitre
+      # - CONNECTOR_SCOPE=tool,report,malware,identity,campaign,intrusion-set,attack-pattern,course-of-action,x-mitre-data-source,x-mitre-data-component,x-mitre-matrix,x-mitre-tactic,x-mitre-collection
       - CONNECTOR_LOG_LEVEL=error
       # - MITRE_INTERVAL=7 # In days
       # - MITRE_REMOVE_STATEMENT_MARKING=true # Optional

--- a/external-import/mitre/src/models/configs/config_loader.py
+++ b/external-import/mitre/src/models/configs/config_loader.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Any
 
 from connectors_sdk import ListFromString
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import (
     BaseSettings,
     DotEnvSettingsSource,
@@ -17,6 +17,22 @@ from src.models.configs import (
     _ConfigLoaderOCTI,
 )
 
+VALID_SCOPE_VALUES = [
+    "tool",
+    "report",
+    "malware",
+    "identity",
+    "campaign",
+    "intrusion-set",
+    "attack-pattern",
+    "course-of-action",
+    "x-mitre-data-source",
+    "x-mitre-data-component",
+    "x-mitre-matrix",
+    "x-mitre-tactic",
+    "x-mitre-collection",
+]
+
 
 class ConfigLoaderConnector(_ConfigLoaderConnector):
     """A concrete implementation of _ConfigLoaderConnector defining default connector configuration values."""
@@ -30,23 +46,20 @@ class ConfigLoaderConnector(_ConfigLoaderConnector):
         description="Name of the connector.",
     )
     scope: ListFromString = Field(
-        default=[
-            "tool",
-            "report",
-            "malware",
-            "identity",
-            "campaign",
-            "intrusion-set",
-            "attack-pattern",
-            "course-of-action",
-            "x-mitre-data-source",
-            "x-mitre-data-component",
-            "x-mitre-matrix",
-            "x-mitre-tactic",
-            "x-mitre-collection",
-        ],
+        default=VALID_SCOPE_VALUES,
         description="The scope or type of data the connector is importing, either a MIME type or Stix Object (for information only).",
     )
+
+    @field_validator("scope")
+    @classmethod
+    def validate_scope(cls, value: ListFromString) -> ListFromString:
+        invalid_values = [item for item in value if item not in VALID_SCOPE_VALUES]
+        if invalid_values:
+            raise ValueError(
+                f"Invalid scope value(s) {invalid_values}. "
+                f"CONNECTOR_SCOPE must only contain values from {VALID_SCOPE_VALUES}."
+            )
+        return value
 
 
 class ConfigLoader(ConfigBaseSettings):

--- a/external-import/mitre/tests/conftest.py
+++ b/external-import/mitre/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Add the connector root (parent of tests/) to the path so that `src.*` imports resolve.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))

--- a/external-import/mitre/tests/test-requirements.txt
+++ b/external-import/mitre/tests/test-requirements.txt
@@ -1,0 +1,3 @@
+# Main dependencies needs to be installed
+-r ../src/requirements.txt
+pytest

--- a/external-import/mitre/tests/test_config_loader.py
+++ b/external-import/mitre/tests/test_config_loader.py
@@ -1,0 +1,55 @@
+import pytest
+from pydantic import ValidationError
+from src.models.configs.config_loader import (
+    VALID_SCOPE_VALUES,
+    ConfigLoaderConnector,
+)
+
+
+def _minimal_kwargs(**overrides):
+    kwargs = {
+        "id": "test-connector-id",
+        "name": "Test Connector",
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_scope_default_value_is_used_when_not_provided():
+    """When CONNECTOR_SCOPE is not provided, the default valid scope list should apply."""
+    config = ConfigLoaderConnector(**_minimal_kwargs())
+
+    assert config.scope == VALID_SCOPE_VALUES
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        pytest.param(VALID_SCOPE_VALUES, id="full_valid_scope_list"),
+        pytest.param(["attack-pattern"], id="single_valid_scope_value"),
+        pytest.param(
+            ["tool", "campaign", "intrusion-set"], id="subset_of_valid_scope_values"
+        ),
+    ],
+)
+def test_scope_accepts_valid_values(scope):
+    """CONNECTOR_SCOPE should accept any subset of the supported STIX types."""
+    config = ConfigLoaderConnector(**_minimal_kwargs(scope=scope))
+
+    assert config.scope == scope
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        pytest.param("mitre", id="legacy_invalid_scope_value"),
+        pytest.param(["attack-pattern", "mitre"], id="valid_value_mixed_with_invalid"),
+        pytest.param(["not-a-stix-type"], id="unknown_stix_type"),
+    ],
+)
+def test_scope_rejects_invalid_values(scope):
+    """CONNECTOR_SCOPE must only contain values from the supported STIX type list."""
+    with pytest.raises(ValidationError) as err:
+        ConfigLoaderConnector(**_minimal_kwargs(scope=scope))
+
+    assert "Invalid scope value(s)" in str(err.value)


### PR DESCRIPTION
### Proposed changes

* Comment out `CONNECTOR_SCOPE=mitre` in `docker-compose.yml` (and the equivalent example in `README.md`) so the connector falls back to its correct default STIX entity type list, instead of the invalid `mitre` value that caused every imported entity to be silently dropped.
* Regenerate the `README.md` configuration section to reference the shared `CONNECTOR_CONFIG_DOC.md` table, keeping docs in sync with the fix.
* Add a Pydantic `field_validator` on the `scope` config field rejecting any `CONNECTOR_SCOPE` value not in the supported STIX type list, so the connector fails fast at startup instead of silently dropping data.
* Add `tests/` (`conftest.py`, `test-requirements.txt`, `test_config_loader.py`) with 7 unit tests covering the default, valid, and invalid scope values.

### Related issues

* Fixes #7178

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Root cause: `docker-compose.yml` set `CONNECTOR_SCOPE=mitre`, overriding the connector's correct default entity type list. That value was passed as `entities_types` to `send_stix2_bundle()`; since `mitre` matches no real STIX type, the worker silently discarded every entity (only relationships/marking-definitions bypass the filter), causing ~23,000 relationships to fail with MISSING_REFERENCE_ERROR. The validator now prevents this misconfiguration from being silently reintroduced, and the new tests lock in the behavior.