### PR TITLE
ci: decommission CircleCI builds and harden the GitHub Actions release flow (#7460)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,29 +225,29 @@ jobs:
       # Save logs/reports as downloadable artifacts
       - store_artifacts:
           path: test_outputs
-  build:
-    parameters:
-      ci_executor:
-        type: executor
-        description: Executor to use for this job.
-        default: ci_environment
-    executor: << parameters.ci_executor >>
-    steps:
-      - checkout
-      - resolve_release_ref
-      - run:
-          name: Install dependencies
-          command: pip install -r .circleci/scripts/requirements.txt
-      - run:
-          name: Execute Python Script
-          command: |
-            export LATEST_SEMANTIC_VERSION=$(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
-            python .circleci/scripts/generate_ci.py
-      - continuation/continue:
-          configuration_path: dynamic.yml
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
+  # build:
+  #   parameters:
+  #     ci_executor:
+  #       type: executor
+  #       description: Executor to use for this job.
+  #       default: ci_environment
+  #   executor: << parameters.ci_executor >>
+  #   steps:
+  #     - checkout
+  #     - resolve_release_ref
+  #     - run:
+  #         name: Install dependencies
+  #         command: pip install -r .circleci/scripts/requirements.txt
+  #     - run:
+  #         name: Execute Python Script
+  #         command: |
+  #           export LATEST_SEMANTIC_VERSION=$(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+  #           python .circleci/scripts/generate_ci.py
+  #     - continuation/continue:
+  #         configuration_path: dynamic.yml
+  #     - slack/notify:
+  #         event: fail
+  #         template: basic_fail_1
   notify:
     parameters:
       notification_executor:
@@ -264,10 +264,17 @@ jobs:
 workflows:
   connectors:
     jobs:
+      # Tags matching /.*/ used to trigger these jobs too, but per-connector
+      # release tags ({connector}/{version}) are pushed by release-connector.yml
+      # for both single and bulk connector releases (potentially hundreds at
+      # once) and are fully handled by GitHub Actions, not CircleCI. Restrict
+      # the tag trigger to platform CalVer tags only (same pattern as
+      # build_release below) so those connector tags no longer spin up
+      # redundant CircleCI runs.
       - ensure_formatting:
           filters:
             tags:
-              only: /.*/
+              only: /^[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]+)?$/
             branches:
               only:
                 - master
@@ -276,7 +283,7 @@ workflows:
       - base_linter:
           filters:
             tags:
-              only: /.*/
+              only: /^[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]+)?$/
             branches:
               only:
                 - master
@@ -285,7 +292,7 @@ workflows:
       - linter:
           filters:
             tags:
-              only: /.*/
+              only: /^[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]+)?$/
             branches:
               only:
                 - master
@@ -294,7 +301,7 @@ workflows:
       - test:
           filters:
             tags:
-              only: /.*/
+              only: /^[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]+)?$/
             branches:
               only:
                 - master
@@ -308,7 +315,7 @@ workflows:
       #       - test
       #     filters:
       #       tags:
-      #         only: /.*/
+      #         only: /^[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]+)?$/
       #       branches:
       #         only:
       #           - master

--- a/.github/workflows/build-all-connectors.yml
+++ b/.github/workflows/build-all-connectors.yml
@@ -69,8 +69,7 @@ jobs:
       packages: write
     with:
       build_mode: ${{ needs.resolve-build-mode.outputs.build_mode }}
-      # TODO: Set push to true once CircleCI is decommissioned for Alpine/FIPS builds
-      push: false
+      push: true
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME_UBI9 }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASS_UBI9 }}

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -766,6 +766,13 @@ jobs:
       needs.resolve.outputs.dry_run != 'true'
     # Non-blocking: a failure here must not prevent the release from succeeding
     continue-on-error: true
+    # Scoped by target branch, not connector: bulk releases dispatch one run
+    # per connector in parallel, and each one's commit here lands on the same
+    # branch. Serializing just this job (builds/releases above stay parallel)
+    # avoids racing ghcommit-action's branch-HEAD check across runs.
+    concurrency:
+      group: release-connector-manifest-${{ needs.resolve.outputs.is_tag_push == 'true' && github.event.repository.default_branch || github.ref_name }}
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -769,15 +769,29 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout default branch
+      # Tag push always targets the default branch; workflow_dispatch commits
+      # back to whichever branch it was run on instead (github.ref_name is a
+      # tag name on tag push, so it can't be used unconditionally here).
+      - name: Resolve target branch
+        id: target
+        run: |
+          if [ "${{ needs.resolve.outputs.is_tag_push }}" = "true" ]; then
+            BRANCH="${{ github.event.repository.default_branch }}"
+          else
+            BRANCH="${{ github.ref_name }}"
+          fi
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "🎯 Target branch: $BRANCH"
+
+      - name: Checkout target branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ steps.target.outputs.branch }}
 
-      - name: Patch and commit container_version
+      - name: Patch container_version
+        id: patch
         run: |
           CONNECTOR_DIR="${{ needs.resolve.outputs.connector_dir }}"
-          CONNECTOR_NAME="${{ needs.resolve.outputs.connector_name }}"
           VERSION="${{ needs.resolve.outputs.version }}"
           MANIFEST="${CONNECTOR_DIR}/__metadata__/connector_manifest.json"
 
@@ -793,31 +807,23 @@ jobs:
           # Validate the patched JSON
           jq empty "$MANIFEST"
 
-          # Commit
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "$MANIFEST"
+          echo "manifest=$MANIFEST" >> "$GITHUB_OUTPUT"
 
-          if git diff --cached --quiet; then
-            echo "ℹ️ container_version already set to $VERSION — nothing to commit"
-            exit 0
-          fi
-
-          git commit -m "chore(manifest): update ${CONNECTOR_NAME} container_version to ${VERSION} [skip ci]"
-
-          # Push with retry on non-fast-forward (concurrent releases for other connectors)
-          MAX_RETRIES=3
-          for attempt in $(seq 1 "$MAX_RETRIES"); do
-            if git push; then
-              echo "✅ Manifest update pushed (attempt $attempt)"
-              exit 0
-            fi
-            echo "⚠️ Push rejected (attempt $attempt/$MAX_RETRIES) — rebasing"
-            git pull --rebase origin "${{ github.event.repository.default_branch }}"
-          done
-
-          echo "::warning::Failed to push manifest update after $MAX_RETRIES attempts"
-          exit 1
+      # Commits via GitHub's GraphQL API instead of raw `git commit`, so the
+      # commit is GPG-signed by GitHub (required by this repo's branch
+      # protection) without managing signing keys in CI. No local git
+      # add/commit/push: it's a no-op when container_version is unchanged,
+      # and it re-resolves the branch head through the API so it isn't
+      # affected by non-fast-forward races from concurrent connector releases.
+      - name: Commit container_version
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        with:
+          commit_message: "chore(manifest): update ${{ needs.resolve.outputs.connector_name }} container_version to ${{ needs.resolve.outputs.version }} [skip ci]"
+          repo: ${{ github.repository }}
+          branch: ${{ steps.target.outputs.branch }}
+          file_pattern: ${{ steps.patch.outputs.manifest }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ──────────────────────────────────────────────────────────
   # 6. Summary


### PR DESCRIPTION
### Proposed changes

* Comment out the CircleCI `build` job definition and its three workflow entries (`build_release`, `build_prerelease`, `build_rolling`) — connector images are now built and published by GitHub Actions (`build-all-connectors.yml` → `build-alpine.yml` / `build-ubi9.yml`), so the CircleCI dynamic-config path (`generate_ci.py` + `continuation/continue`) was duplicating that work. Commented rather than deleted so the previous behaviour can be restored quickly if a rollback is needed.
* Comment out the three `send_notifications_*` workflow entries, which only existed to report on the now-decommissioned build jobs and would otherwise reference a missing `requires` dependency.
* Restrict the tag trigger of the remaining CircleCI jobs (`ensure_formatting`, `base_linter`, `linter`, `test`, `build_manifest`) from `/.*/` to the anchored platform CalVer pattern `/^[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]+)?$/`. Per-connector release tags (`{connector}/{version}`) are pushed by `release-connector.yml` — potentially hundreds at once during a bulk release — and were previously spinning up that many redundant CircleCI pipelines. The pattern is anchored so a connector tag can never partially match a platform version.
* Set `push: true` for the Alpine build in `build-all-connectors.yml`. It was gated on `push: false` behind a `TODO` waiting for exactly this decommission, so GitHub Actions was building Alpine images without ever publishing them.
* Add a `Resolve target branch` step to the `update-manifest` job in `release-connector.yml`: the default branch on a tag push, `github.ref_name` on `workflow_dispatch`. `github.ref_name` is a *tag* name on tag push, so it cannot be used unconditionally; the checkout step now consumes `steps.target.outputs.branch` instead of hard-coding the default branch, which means a manual dispatch on a `release/*` or `lts/*` branch commits the manifest bump back to that branch rather than to `master`.
* Split `Patch and commit container_version` into an output-only `Patch container_version` step: it rewrites `container_version` with `jq`, validates the resulting JSON, and exposes the manifest path as `steps.patch.outputs.manifest`. No git state is mutated anymore.
* Replace the raw `git commit` + push-with-rebase-retry loop with the SHA-pinned `planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465` (v0.2.22), so the `chore(manifest): … [skip ci]` bump is created through GitHub's GraphQL API and lands as a GitHub-signed commit.

* Scope a `concurrency` group to the `update-manifest` job, keyed on the resolved target branch (`release-connector-manifest-<branch>`) with `cancel-in-progress: false`. A bulk release dispatches one workflow run per connector in parallel and every one of them commits its manifest bump to the same branch; serializing only this job — builds and releases stay fully parallel — prevents concurrent runs from racing `ghcommit-action`'s branch-HEAD check. Cancellation is disabled so no queued bump is dropped.

CircleCI keeps all of its quality gates — formatting, linting, tests and manifest build still run on branches and platform tags. Only the image build and Slack notification jobs are decommissioned.

### Related issues

* Closes #7460

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

**Why `ghcommit-action` instead of `git push`.** The manifest bump is written by CI to a protected branch, and this repository requires signed commits — the `github-actions[bot]` identity cannot produce one with a plain `git commit` without provisioning and storing a signing key in the workflow. Commits created through GitHub's GraphQL API are signed by GitHub itself, so the bump satisfies branch protection with no key management. The action is pinned to a full commit SHA (with the version in a trailing comment) per our supply-chain policy for third-party actions.

**Why the retry loop was removable.** The old loop existed because concurrent connector releases race on the same branch and produce non-fast-forward rejections. The API-based commit re-resolves the branch head server-side at commit time, so there is no stale local ref to rebase; the loop, the `git config` identity setup and the "nothing to commit" early exit all become dead code (the action is a no-op when `container_version` is already at the target value). The job keeps `continue-on-error: true`, so a failed bump still cannot fail the release.

**Why the CircleCI blocks are commented rather than deleted.** This is the cut-over point where GitHub Actions becomes the sole publisher of connector images; keeping the previous definitions inline makes a rollback a one-commit revert. They should be deleted in a follow-up once the GitHub Actions pipeline has produced a few successful releases. Note that `.circleci/config.yml` still declares `setup: true` and the `continuation` orb even though nothing calls `continuation/continue` anymore, and the `notify` job / `ci_notifications` executor / `resolve_release_ref` command are now unreferenced — left in place for the same rollback reason, and worth cleaning up in that same follow-up.
