### PR TITLE
fix(recorded-future): include context_entities so their threat actors aren't dropped (#6943)

### DIFF
--- a/external-import/recorded-future/src/rflib/rf_to_stix2.py
+++ b/external-import/recorded-future/src/rflib/rf_to_stix2.py
@@ -1228,7 +1228,24 @@ class StixNote:
         self.report_types = self._create_report_types(attr.get("topic", []))
         self.labels = [topic["name"] for topic in attr.get("topic", [])]
         self.attachments = attr["attachments"]
-        for entity in attr.get("note_entities", []):
+        # Recorded Future Analyst Notes carry two entity arrays: "note_entities"
+        # are the primary entities the note is directly about, while
+        # "context_entities" are related/referenced entities (which can include
+        # threat actors) discussed in the note's context but not tagged as
+        # primary. Both need to be converted, or a threat actor mentioned only
+        # in context is silently dropped from the resulting STIX bundle,
+        # producing an incomplete knowledge graph. Entities are deduplicated by
+        # id in case the same entity appears in both arrays.
+        seen_entity_ids = set()
+        all_entities = attr.get("note_entities", []) + attr.get(
+            "context_entities", []
+        )
+        for entity in all_entities:
+            entity_id = entity.get("id")
+            if entity_id is not None:
+                if entity_id in seen_entity_ids:
+                    continue
+                seen_entity_ids.add(entity_id)
             type_ = entity["type"]
             name = entity["name"]
             if self.person_to_ta and type_ == "Person":

--- a/external-import/recorded-future/tests/tests_connector/test_rf_to_stix2.py
+++ b/external-import/recorded-future/tests/tests_connector/test_rf_to_stix2.py
@@ -295,6 +295,39 @@ def test_analyst_note_report_does_not_reference_the_author():
     assert len(report.object_refs) == 2
 
 
+# Scenario: An entity present only in context_entities is not dropped (issue #6943)
+def test_analyst_note_includes_context_entities():
+    # Given an analyst note whose note_entities holds a Malware, and whose
+    # context_entities holds a Threat Actor referenced only in context
+    note = _given_stix_note()
+    _when_note_converted_from_json(note, _given_analyst_note_json_with_context_entities())
+
+    # When the note is converted to STIX objects
+    stix_objects = note.to_stix_objects()
+    report = _then_single_report(stix_objects)
+
+    # Then the context-only entity is present among the report's referenced objects
+    assert len(report.object_refs) == 2
+    _then_contains_threat_actor(stix_objects)
+
+
+# Scenario: An entity present in both note_entities and context_entities is not duplicated
+def test_analyst_note_deduplicates_entities_shared_between_both_arrays():
+    # Given an analyst note where the same entity id appears in both
+    # note_entities and context_entities
+    note = _given_stix_note()
+    _when_note_converted_from_json(
+        note, _given_analyst_note_json_with_duplicate_entity()
+    )
+
+    # When the note is converted to STIX objects
+    stix_objects = note.to_stix_objects()
+    report = _then_single_report(stix_objects)
+
+    # Then the entity is only referenced once by the report
+    assert len(report.object_refs) == 1
+
+
 # ── Given helpers ────────────────────────────────────────────────────────────
 
 
@@ -338,6 +371,44 @@ def _given_analyst_note_json():
             "note_entities": [
                 {"id": "entity-1", "type": "Malware", "name": "Test malware"},
                 {"id": "entity-2", "type": "Company", "name": "Test company"},
+            ],
+        },
+    }
+
+
+def _given_analyst_note_json_with_context_entities():
+    return {
+        "id": "note-id",
+        "attributes": {
+            "title": "Test analyst note",
+            "text": "Some intelligence content",
+            "published": "2026-08-20T00:00:00.000Z",
+            "topic": [{"name": "Flash Report"}],
+            "attachments": [],
+            "note_entities": [
+                {"id": "entity-1", "type": "Malware", "name": "Test malware"},
+            ],
+            "context_entities": [
+                {"id": "entity-2", "type": "Threat Actor", "name": "APT99"},
+            ],
+        },
+    }
+
+
+def _given_analyst_note_json_with_duplicate_entity():
+    return {
+        "id": "note-id",
+        "attributes": {
+            "title": "Test analyst note",
+            "text": "Some intelligence content",
+            "published": "2026-08-20T00:00:00.000Z",
+            "topic": [{"name": "Flash Report"}],
+            "attachments": [],
+            "note_entities": [
+                {"id": "entity-1", "type": "Malware", "name": "Test malware"},
+            ],
+            "context_entities": [
+                {"id": "entity-1", "type": "Malware", "name": "Test malware"},
             ],
         },
     }


### PR DESCRIPTION
Fixes #6943

## Problem

Recorded Future Analyst Notes carry two entity arrays on `attributes`: `note_entities` (the primary entities the note is directly about) and `context_entities` (related/referenced entities discussed in the note's context, which can include threat actors, but are not tagged as primary).

`StixNote.from_json()` in `external-import/recorded-future/src/rflib/rf_to_stix2.py` only ever iterated `attr.get("note_entities", [])`. When Recorded Future classified a threat actor named in a report's narrative as a context entity rather than a primary one, that entity was silently dropped: the report was still created referencing the actor in its text, but no corresponding STIX Threat Actor/Intrusion Set object (or relationship to it) ever made it into the bundle sent to OpenCTI, leaving an incomplete knowledge graph for that report.

## Fix

Process `note_entities` and `context_entities` together through the same existing per-entity conversion logic (type mapping, `self.tas` lookup, `person_to_ta`, `ta_to_intrusion_set`, risk-score/threshold handling, etc.), deduplicating by entity id in case the same entity appears in both arrays so no duplicate STIX objects are produced for it.

## Tests

Added to `tests/tests_connector/test_rf_to_stix2.py`:
- `test_analyst_note_includes_context_entities`: a Threat Actor present only in `context_entities` is now converted and referenced by the report.
- `test_analyst_note_deduplicates_entities_shared_between_both_arrays`: an entity id appearing in both `note_entities` and `context_entities` is only referenced once by the report.

Verified locally with a Python 3.13 venv (installed `pycti`, `stix2`, `stix2-patterns`, `pydantic`, etc. directly, since `connectors-sdk` requires `<3.13` and isn't needed by this module): all 66 tests in `tests/tests_connector/` pass with the fix.

Also did a revert-check: temporarily reverted just the `from_json()` loop change (keeping the new tests), and `test_analyst_note_includes_context_entities` fails with `assert 1 == 2` because the context-only Threat Actor is missing from `report.object_refs` — confirming the bug is real and the new test catches it. Restoring the fix makes all tests pass again.

Signed-off-by: agu2347 <agu2347@users.noreply.github.com>