### PR TITLE
feat(docker): adopt the FIPS 140-3 validated alpine-python-fips base image (#7467)

### DIFF
--- a/internal-export-file/export-file-csv/Dockerfile_fips
+++ b/internal-export-file/export-file-csv/Dockerfile_fips
@@ -1,4 +1,4 @@
-FROM filigran/python-fips:latest
+FROM filigran/alpine-python-fips:python3.12
 ENV CONNECTOR_TYPE=INTERNAL_EXPORT_FILE
 
 # Copy the worker

--- a/internal-export-file/export-file-stix/Dockerfile_fips
+++ b/internal-export-file/export-file-stix/Dockerfile_fips
@@ -1,4 +1,4 @@
-FROM filigran/python-fips:latest
+FROM filigran/alpine-python-fips:python3.12
 ENV CONNECTOR_TYPE=INTERNAL_EXPORT_FILE
 
 # Copy the worker

--- a/internal-export-file/export-file-txt/Dockerfile_fips
+++ b/internal-export-file/export-file-txt/Dockerfile_fips
@@ -1,4 +1,4 @@
-FROM filigran/python-fips:latest
+FROM filigran/alpine-python-fips:python3.12
 ENV CONNECTOR_TYPE=INTERNAL_EXPORT_FILE
 
 # Copy the worker

--- a/internal-import-file/import-document/Dockerfile_fips
+++ b/internal-import-file/import-document/Dockerfile_fips
@@ -1,4 +1,4 @@
-FROM filigran/python-fips:latest
+FROM filigran/alpine-python-fips:python3.12
 ENV CONNECTOR_TYPE=INTERNAL_IMPORT_FILE
 
 # Copy the connector

--- a/internal-import-file/import-file-stix/Dockerfile_fips
+++ b/internal-import-file/import-file-stix/Dockerfile_fips
@@ -1,4 +1,4 @@
-FROM filigran/python-fips:latest
+FROM filigran/alpine-python-fips:python3.12
 ENV CONNECTOR_TYPE=INTERNAL_IMPORT_FILE
 # stixmarx (pulled in by stix2-elevator) builds a "~/.stixmarx" cache on first
 # import. Use a dedicated HOME (not /tmp, which may be shadowed by a mounted

--- a/internal-import-file/import-file-yara/Dockerfile_fips
+++ b/internal-import-file/import-file-yara/Dockerfile_fips
@@ -1,4 +1,4 @@
-FROM filigran/python-fips:latest
+FROM filigran/alpine-python-fips:python3.12
 ENV CONNECTOR_TYPE=INTERNAL_IMPORT_FILE
 
 # Copy the connector

--- a/internal-import-file/import-ttps-file-navigator/Dockerfile_fips
+++ b/internal-import-file/import-ttps-file-navigator/Dockerfile_fips
@@ -1,4 +1,4 @@
-FROM filigran/python-fips:latest
+FROM filigran/alpine-python-fips:python3.12
 ENV CONNECTOR_TYPE=INTERNAL_IMPORT_FILE
 
 # Copy the connector


### PR DESCRIPTION
### Proposed changes

* Switch the seven `Dockerfile_fips` to the reworked FIPS base image, renamed and referenced by its versioned tag: `filigran/python-fips:latest` → [`filigran/alpine-python-fips`](https://hub.docker.com/r/filigran/alpine-python-fips)`:python3.12`.

This adopts the reworked FIPS base image ([FiligranHQ/docker-python-nodejs-fips#45](https://github.com/FiligranHQ/docker-python-nodejs-fips/pull/45)), whose OpenSSL FIPS provider is built from FIPS 140-3 validated sources under CMVP certificate #4985. That is the point of the change, not the rename: the previous image's provider is built from the same sources as the OpenSSL libraries it ships and so carries no certificate at all. Timing matters too — certificate #4282, covering the FIPS 140-2 validated sources, moves to the CMVP *Historical* list on 21 September 2026.

It is the same migration [OpenCTI-Platform/opencti#17909](https://github.com/OpenCTI-Platform/opencti/pull/17909) performs for the platform and worker images.

The previous name stays published from a legacy branch as a migration window, but that workflow is meant to be deleted, so remaining on it is not an option.

The tag is versioned rather than `latest`, so the Python line each connector builds on is stated in the Dockerfile instead of following wherever `latest` moves. The base image's daily rebuild republishes that tag, so Alpine security updates still reach us — the pin fixes the language version, not the patch level.

### Why no other adaptation was needed

The new image installs OpenSSL and Python from Alpine packages rather than compiling them, which drops three side effects of the previous source build that a `Dockerfile_fips` could have been relying on implicitly — the Python development headers, the permanently installed `rust`/`cargo`/`pkgconfig`, and the `/usr/local` Python prefix. This is what forced extra changes on the platform image in the OpenCTI PR.

None of the seven connectors here depends on them: each already installs its own toolchain (`build-base`, and `rust cargo` for `import-document`), none references `/usr/local` or the OpenSSL environment variables the legacy image exported, and no wheel in their dependency trees needs `Python.h`. Verified by building and running all seven, below.

The one thing that did need checking is `cryptography`: the base image ships it built from source against the system OpenSSL so that it sits inside the FIPS boundary, and a dependency resolution pulling a `cryptography` wheel over it would silently move it back out, since a wheel bundles its own OpenSSL. It does not happen in any of the seven — each still reports the system OpenSSL.

### Related issues

* closes #7467

### How to test this PR

The base image is published, so no local base build is needed. All seven images build and run:

```bash
for d in internal-export-file/export-file-csv internal-export-file/export-file-stix \
         internal-export-file/export-file-txt internal-import-file/import-document \
         internal-import-file/import-file-stix internal-import-file/import-file-yara \
         internal-import-file/import-ttps-file-navigator; do
  docker build --pull -f "$d/Dockerfile_fips" -t "fipstest-$(basename $d)" "$d" || echo "FAILED $d"
done
```

Then, on each resulting image, check that FIPS is enforced and that `cryptography` is still the one linked against the system OpenSSL rather than a wheel with its own:

```bash
docker run --rm --entrypoint sh fipstest-export-file-csv -c '
  echo test | openssl dgst -md5 >/dev/null 2>&1 && echo "MD5 ACCEPTED - FIPS NOT ENFORCED" || echo "md5 refused, as expected"
  python3 -c "
import ssl
from cryptography.hazmat.backends.openssl.backend import backend
print(ssl.OPENSSL_VERSION, backend.openssl_version_text(), sep=\"\n\")
print(\"boundary OK\" if backend.openssl_version_text() == ssl.OPENSSL_VERSION else \"BOUNDARY MISMATCH\")"'
```

I ran both across all seven: every image builds, refuses MD5, reports the OpenSSL FIPS Provider 3.1.2, and has `cryptography` on the system OpenSSL 3.5.8.

Starting each connector with no configuration takes the whole import chain — `pycti`, `connectors-sdk`, and the per-connector libraries (`stix2-elevator`, `plyara`, `pdfminer.six`, `python-docx`) — and fails only on the absent OpenCTI URL, which is the expected outcome without config:

```bash
docker run --rm fipstest-export-file-csv
```

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)