### PR TITLE
fix(pan-cortex-xsoar-intel): drop dead Splunk query field (#5627)

### DIFF
--- a/stream/pan-cortex-xsoar-intel/src/pan-cortex-xsoar-intel.py
+++ b/stream/pan-cortex-xsoar-intel/src/pan-cortex-xsoar-intel.py
@@ -66,11 +66,11 @@ def compute_score(score: int | None):
 
 
 def sanitize_key(key):
-    """Sanitize key name for Splunk usage
+    """Sanitize an attribute name before it is used as an XSoar CustomFields key
 
-    Splunk KV store keys cannot contain ".". Also, keys containing
-    unusual characters like "'" make their usage less convenient
-    when writing SPL queries.
+    XSoar custom field keys cannot contain ".". Also, keys containing
+    unusual characters like "'" make the resulting indicator harder to
+    read in the XSoar UI.
 
     Args:
         key (str): value to sanitize
@@ -224,15 +224,10 @@ class XSoarConnector:
             if payload["type"] == "indicator" and payload["pattern_type"].startswith(
                 "stix"
             ):
-                # add splunk query
-                try:
-                    translation = stix_translation.StixTranslation()
-                    response = translation.translate(
-                        "splunk", "query", "{}", payload["pattern"]
-                    )
-                    payload["splunk_queries"] = response
-                except:
-                    pass
+                # stix-shifter has no XSoar target, so its splunk translator
+                # is reused here purely to parse the STIX pattern into
+                # attribute/value pairs
+                translation = stix_translation.StixTranslation()
 
                 # add mapped values
                 try:

--- a/stream/pan-cortex-xsoar-intel/src/pan-cortex-xsoar-intel.py
+++ b/stream/pan-cortex-xsoar-intel/src/pan-cortex-xsoar-intel.py
@@ -224,13 +224,12 @@ class XSoarConnector:
             if payload["type"] == "indicator" and payload["pattern_type"].startswith(
                 "stix"
             ):
-                # stix-shifter has no XSoar target, so its splunk translator
-                # is reused here purely to parse the STIX pattern into
-                # attribute/value pairs
-                translation = stix_translation.StixTranslation()
-
                 # add mapped values
                 try:
+                    # stix-shifter has no XSoar target, so its splunk
+                    # translator is reused here purely to parse the STIX
+                    # pattern into attribute/value pairs
+                    translation = stix_translation.StixTranslation()
                     parsed = translation.translate(
                         "splunk", "parse", "{}", payload["pattern"]
                     )


### PR DESCRIPTION
convert_payload() in the stream connector translates the STIX pattern
and stores the result as payload["splunk_queries"], which then rides
along into every indicator's XSoar CustomFields. Nothing in this
connector reads that field again after setting it.

This looks like a leftover from forking pan-cortex-xsoar-intel off the
splunk stream connector, where the same field is actually used (it
streams into Splunk, so a translated query is meaningful there). Here
it just shows up as a confusing Splunk-named custom field on indicators
pushed to XSoar, which is what #5627 flagged.

Also reworded sanitize_key()'s docstring, which described it as
sanitizing Splunk KV store keys when it's actually sanitizing XSoar
CustomFields keys.

The other "splunk" reference in convert_payload() (the STIX pattern
parser call) is not a leftover and is untouched here: stix-shifter has
no XSoar target, so this connector reuses its Splunk translator purely
to parse attribute/value pairs out of the STIX pattern. I added a
comment explaining that so it doesn't read like the same leftover.

No existing test suite covers this connector, and there's no XSoar/OpenCTI
instance available here to run an integration test against, so I verified
this by compiling the file and re-reading convert_payload() end to end to
confirm splunk_queries isn't referenced anywhere else.

Fixes #5627