### PR TITLE
fix(intel471-hunt): bump pycti to version 7.260828.0 (#7480)

### DIFF
--- a/internal-enrichment/intel471-hunt/README.md
+++ b/internal-enrichment/intel471-hunt/README.md
@@ -92,7 +92,7 @@ The full `/es/query` parameter specification is published at
 ### Requirements
 
 - Python >= 3.11
-- OpenCTI Platform >= 7.260824.0
+- OpenCTI Platform >= 7.260828.0
 - [`pycti`](https://pypi.org/project/pycti/) library matching your OpenCTI version
 - [`connectors-sdk`](https://github.com/OpenCTI-Platform/connectors/tree/master/connectors-sdk) library matching your OpenCTI version
 - An Intel 471 Hunter subscription and API key (see above)

--- a/internal-enrichment/intel471-hunt/__metadata__/connector_manifest.json
+++ b/internal-enrichment/intel471-hunt/__metadata__/connector_manifest.json
@@ -17,7 +17,7 @@
   "last_verified_date": null,
   "playbook_supported": true,
   "max_confidence_level": 75,
-  "support_version": ">=7.260824.0",
+  "support_version": ">=7.260828.0",
   "subscription_link": null,
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/internal-enrichment/intel471-hunt",
   "manager_supported": false,

--- a/internal-enrichment/intel471-hunt/pyproject.toml
+++ b/internal-enrichment/intel471-hunt/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Intel 471" }]
 dependencies = [
-    "pycti==7.260824.0",
+    "pycti==7.260828.0",
     "pydantic>=2.10, <3",
     "connectors-sdk @ git+https://github.com/OpenCTI-Platform/connectors.git@master#subdirectory=connectors-sdk",
     "stix2==3.0.1",


### PR DESCRIPTION
### Proposed changes

* bump pycti to version 7.260828.0

### Related issues

* fixes #7480

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
