### PR TITLE
fix(recorded-future): enrich all threat map entities with their links in batches of 100 (#7483)

### DIFF
--- a/external-import/recorded-future/src/rflib/rf_client.py
+++ b/external-import/recorded-future/src/rflib/rf_client.py
@@ -271,24 +271,26 @@ class RFClient:
         return threat_map_data
 
     def get_entities_links(self, entities_id: list):
-        try:
-            # The Links API doesn't allow more than 100 links between entities.
-            # The connector will retrieve only the 100 first links.
-            entities_params = {"entities": entities_id[:1]}
+        # The Links API accepts at most 100 entities per request,
+        # so all mapped entities are enriched in batches of 100.
+        entity_links = []
+        for batch_start in range(0, len(entities_id), 100):
+            entities_batch = entities_id[batch_start : batch_start + 100]
+            try:
+                res = self.session.post(LINKS_PATH, json={"entities": entities_batch})
+                res.raise_for_status()
 
-            res = self.session.post(LINKS_PATH, json=entities_params)
-            res.raise_for_status()
-
-            entity_links = res.json()["data"]
-
-            return entity_links
-        except requests.RequestException as err:
-            error_msg = f"[API] Error while fetching data from {LINKS_PATH}: {str(err)}"
-            error_response = err.response.json()
-            self.helper.connector_logger.error(
-                error_msg, {"error_response": str(error_response["message"])}
-            )
-            return None
+                entity_links.extend(res.json()["data"])
+            except requests.RequestException as err:
+                error_msg = (
+                    f"[API] Error while fetching data from {LINKS_PATH}: {str(err)}"
+                )
+                error_response = err.response.json()
+                self.helper.connector_logger.error(
+                    error_msg, {"error_response": str(error_response["message"])}
+                )
+                return None
+        return entity_links
 
     def check_vul_entitlement(self):
         try:

--- a/external-import/recorded-future/tests/tests_connector/test_rf_client.py
+++ b/external-import/recorded-future/tests/tests_connector/test_rf_client.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock
+
+from rflib.rf_client import LINKS_PATH, RFClient
+
+
+def _build_client():
+    helper = MagicMock()
+    client = RFClient(token="test-token", helper=helper)
+    client.session = MagicMock()
+    return client
+
+
+def _response(data):
+    response = MagicMock()
+    response.json.return_value = {"data": data}
+    return response
+
+
+# Scenario: entities are enriched in batches of 100 and all results are aggregated
+def test_get_entities_links_processes_all_entities_in_batches_of_100():
+    client = _build_client()
+    entities_id = [f"id-{i}" for i in range(250)]
+    client.session.post.side_effect = [
+        _response([{"entity": {"id": "batch-0"}, "links": []}]),
+        _response([{"entity": {"id": "batch-1"}, "links": []}]),
+        _response([{"entity": {"id": "batch-2"}, "links": []}]),
+    ]
+
+    result = client.get_entities_links(entities_id)
+
+    assert client.session.post.call_count == 3
+    sent_batches = [
+        call.kwargs["json"]["entities"] for call in client.session.post.call_args_list
+    ]
+    assert [len(batch) for batch in sent_batches] == [100, 100, 50]
+    assert sent_batches[0] == entities_id[:100]
+    assert sent_batches[2] == entities_id[200:]
+    assert result == [
+        {"entity": {"id": "batch-0"}, "links": []},
+        {"entity": {"id": "batch-1"}, "links": []},
+        {"entity": {"id": "batch-2"}, "links": []},
+    ]
+
+
+# Scenario: a single request is made when there are 100 or fewer entities
+def test_get_entities_links_single_batch_below_limit():
+    client = _build_client()
+    entities_id = ["id-0", "id-1", "id-2"]
+    client.session.post.return_value = _response([{"entity": {"id": "id-0"}}])
+
+    result = client.get_entities_links(entities_id)
+
+    client.session.post.assert_called_once_with(
+        LINKS_PATH, json={"entities": entities_id}
+    )
+    assert result == [{"entity": {"id": "id-0"}}]


### PR DESCRIPTION
### Proposed changes

* Fix `RFClient.get_entities_links()` which only enriched the **first** entity of each threat map (`entities_id[:1]`), leaving every other Threat Actor / Malware imported with almost no relationships
* Process **all** mapped entities in batches of 100 (the Links API limit) and aggregate the results, so every threat map entity gets its attack patterns, malware, vulnerabilities and observables
* Add unit tests covering the batching behaviour (250 entities -> 3 requests of 100/100/50, and a single request below the limit)

### Related issues

* Fixes #7483

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The regression was introduced when `{"entities": entities_id}` was changed to `entities_id[:1]` with a comment intending to cap the number of entities at 100. The slice value was `1` instead of `100`, so only the first mapped entity of each threat map was queried against the Links API.

Validated against the live Recorded Future API: for the threat actor PurpleDelta the Links API returns 139 links including 42 MITRE ATT&CK techniques (T1583.006, T1583.003, T1588.002, …). Reproducing the threat map conversion and importing the resulting bundle into OpenCTI attached all 42 `uses` relationships to attack patterns. A batch request with the actor placed in a non-first position confirmed every entity is now enriched.