### PR TITLE
fix(flashpoint): guard against None fields in alert name and media_id concatenation (#7268, #7269)

### DIFF
--- a/external-import/flashpoint/src/flashpoint_connector/connector.py
+++ b/external-import/flashpoint/src/flashpoint_connector/connector.py
@@ -391,10 +391,9 @@ class FlashpointConnector:
                                 )
                                 processed_alert["media_content"] = media_content
                                 processed_alert["media_type"] = media_type
-                                processed_alert["media_name"] = (
-                                    alert_document.get("media_id")
-                                    + guess_file_extension
-                                )
+                                processed_alert["media_name"] = str(
+                                    alert_document.get("media_id") or ""
+                                ) + (guess_file_extension or "")
 
                         stix_alert_objects = self.converter_to_stix.alert_to_incident(
                             alert=processed_alert,

--- a/external-import/flashpoint/src/flashpoint_connector/converter_to_stix.py
+++ b/external-import/flashpoint/src/flashpoint_connector/converter_to_stix.py
@@ -357,13 +357,13 @@ class ConverterToStix:
         """
         name = (
             "Alert: "
-            + alert.get("alert_reason")
+            + str(alert.get("alert_reason") or "")
             + " - "
-            + alert.get("channel_type")
+            + str(alert.get("channel_type") or "")
             + " - "
-            + alert.get("channel_name")
+            + str(alert.get("channel_name") or "")
             + " - "
-            + alert.get("alert_id")
+            + str(alert.get("alert_id") or "")
         )
         return name
 

--- a/external-import/flashpoint/tests/test_flashpoint_connector/test_connector.py
+++ b/external-import/flashpoint/tests/test_flashpoint_connector/test_connector.py
@@ -394,7 +394,31 @@ def test_import_alerts_media_source():
     helper.api.work.to_processed.assert_called_once()
 
 
-def test_import_alerts_data_exposure_source():
+def test_import_alerts_media_source_none_media_id():
+    helper = _build_helper()
+    connector = _build_connector(helper=helper)
+    connector.client.get_alerts.return_value = [
+        {
+            "id": "alert-2",
+            "source": "media",
+            "created_at": "2026-03-06T12:00:00Z",
+            "resource": {
+                "id": "media-1",
+                "site": {"title": "media_site"},
+                "site_actor": {"names": {"handle": ""}},
+            },
+        }
+    ]
+    connector.client.get_media_doc.return_value = {
+        "storage_uri": "https://storage.example.com/file",
+        "media_id": None,
+    }
+    connector.client.get_media.return_value = (b"content", "image/png")
+    connector.converter_to_stix.alert_to_incident = Mock(return_value=[])
+
+    connector._import_alerts(datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    helper.api.work.to_processed.assert_called_once()
     helper = _build_helper()
     connector = _build_connector(helper=helper)
     connector.client.get_alerts.return_value = [

--- a/external-import/flashpoint/tests/test_flashpoint_connector/test_converter_to_stix.py
+++ b/external-import/flashpoint/tests/test_flashpoint_connector/test_converter_to_stix.py
@@ -94,3 +94,22 @@ def test_converter_to_stix_convert_ccm_alert_to_incident(
             if isinstance(stix_object, stix2.MarkingDefinition)
         ]
     )
+
+
+def test_generate_incident_name_with_none_fields():
+    alert = {
+        "alert_reason": "Credential leak",
+        "channel_type": None,
+        "channel_name": None,
+        "alert_id": "alert-123",
+    }
+
+    name = ConverterToStix._generate_incident_name(alert)
+
+    assert name == "Alert: Credential leak -  -  - alert-123"
+
+
+def test_generate_incident_name_with_all_none_fields():
+    name = ConverterToStix._generate_incident_name({})
+
+    assert name == "Alert:  -  -  - "


### PR DESCRIPTION
### Proposed changes

* Fix an uncaught `TypeError: can only concatenate str (not "NoneType") to str` in `_generate_incident_name` by wrapping each alert field (`alert_reason`, `channel_type`, `channel_name`, `alert_id`) with `str(field or "")` before concatenation
* Fix the same class of error in `_import_alerts` when building `media_name`, by guarding both `media_id` and the guessed file extension against `None`
* Add unit tests covering incident-name generation with partial/all-None fields, and alert import with a `None` `media_id`

### Related issues

* Fixes #7268
* Fixes #7269

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Both issues share the same root cause: alert fields returned by the Flashpoint API can be `null`, and they were concatenated directly into strings. When any field was `None`, the connector's error handler logged the failure but silently dropped the alert, so it was never converted into an OpenCTI incident and never retried. Guarding the concatenations with a fallback empty string keeps the incident name / media name well-formed while ensuring every alert is ingested.