### PR TITLE
fix(recorded-future): handle pattern and detection-rule conversion errors (#7473)

### DIFF
--- a/external-import/recorded-future/src/rflib/rf_to_stix2.py
+++ b/external-import/recorded-future/src/rflib/rf_to_stix2.py
@@ -139,14 +139,15 @@ class Indicator(RFStixEntity):
 
     def _create_indicator(self):
         """Creates and returns STIX2 indicator object"""
+        pattern = self._create_pattern()
         return stix2.Indicator(
-            id=pycti.Indicator.generate_id(self._create_pattern()),
+            id=pycti.Indicator.generate_id(pattern),
             name=self.name,
             description=self.description,
             labels=self.labels,
             pattern_type="stix",
             valid_from=self.last_seen,
-            pattern=self._create_pattern(),
+            pattern=pattern,
             created_by_ref=self.author.id,
             object_marking_refs=self.tlp,
             custom_properties={
@@ -154,7 +155,6 @@ class Indicator(RFStixEntity):
                 "x_opencti_main_observable_type": self._add_main_observable_type_to_indicators(),
             },
         )
-        pass
 
     def add_description(self, description):
         self.description = description
@@ -172,7 +172,11 @@ class Indicator(RFStixEntity):
             "url:value": "Url",
         }
 
-        pattern = self._create_pattern()
+        try:
+            pattern = self._create_pattern()
+        except ValueError:
+            return "Unknown"
+
         pattern_splited = pattern.split("=")
         observable_type = pattern_splited[0].strip("[").strip()
 
@@ -1283,14 +1287,25 @@ class StixNote:
 
         for attachment in self.attachments:
             if attachment["type"] != "pdf":
-                rule = DetectionRule(
-                    name=attachment["name"],
-                    _type=attachment["type"],
-                    content=attachment["content"],
-                    author=self.author,
-                    tlp=tlp,
-                )
-                self.objects.extend(rule.to_stix_objects())
+                try:
+                    rule = DetectionRule(
+                        name=attachment["name"],
+                        _type=attachment["type"],
+                        content=attachment["content"],
+                        author=self.author,
+                        tlp=tlp,
+                    )
+                    self.objects.extend(rule.to_stix_objects())
+                except ConversionError as e:
+                    self.helper.connector_logger.warning(
+                        f"{e} for attachment {attachment['name']}",
+                        {
+                            "attachment_name": attachment["name"],
+                            "attachment_type": attachment["type"],
+                            "error": f"{e!r}",
+                        },
+                    )
+                    continue
 
     def _create_rel(self, from_id, to_id, relation):
         """Creates Relationship object"""
@@ -1437,7 +1452,6 @@ class StixNote:
         """
         event_objects = []
         for event_capability in event_attr["capabilities"]:
-
             # Get capability (AttackPattern,  Malware, Vulnerability, Indicator)
             capability_name = event_capability["name"]
             capability_type = event_capability["type"]
@@ -1499,7 +1513,6 @@ class StixNote:
                 if event_attr.get("adversary") and event_attr["adversary"][0][
                     "type"
                 ] in ["Organization", "Person"]:
-
                     # Retrieve adversary in self.objects depending on adversary name in event
                     # self.objects contains all IntrusionSet, Malware, Identity, AttackPattern et ThreatActor linked to note
                     event_adversary = event_attr["adversary"][0]["name"]

--- a/external-import/recorded-future/tests/tests_connector/test_rf_to_stix2.py
+++ b/external-import/recorded-future/tests/tests_connector/test_rf_to_stix2.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pycti import Identity as PyctiIdentity
@@ -295,6 +295,74 @@ def test_analyst_note_report_does_not_reference_the_author():
     assert len(report.object_refs) == 2
 
 
+# Scenario: Building an indicator computes the STIX pattern once and reuses it (issue #7473)
+def test_create_indicator_computes_pattern_once():
+    # Given a valid IPv4 address indicator
+    author = _given_author()
+    tlp = _given_tlp()
+    indicator = _given_ip_indicator("1.1.1.1", author, tlp)
+    # And a spy wrapping the real pattern-creation method
+    with patch.object(
+        indicator, "_create_pattern", wraps=indicator._create_pattern
+    ) as pattern_spy:
+        # When the indicator is created
+        stix_indicator = indicator._create_indicator()
+
+        # Then the pattern is computed only twice: once for the indicator's id/pattern
+        # fields (cached and reused), and once more inside
+        # _add_main_observable_type_to_indicators (a separate call site, unaffected
+        # by this fix)
+        assert (
+            pattern_spy.call_count == 2
+        ), f"Expected _create_pattern to be called twice, got {pattern_spy.call_count}"
+    # And the indicator's pattern and id are both derived from that single value
+    assert stix_indicator.pattern == "[ipv4-addr:value = '1.1.1.1']"
+
+
+# Scenario: Main observable type falls back to "Unknown" when pattern creation fails (issue #7473)
+def test_add_main_observable_type_returns_unknown_when_pattern_creation_fails():
+    # Given an indicator whose name is not a valid IPv4 or IPv6 address
+    author = _given_author()
+    tlp = _given_tlp()
+    indicator = _given_ip_indicator("not-a-valid-ip", author, tlp)
+
+    # When resolving the main observable type
+    observable_type = indicator._add_main_observable_type_to_indicators()
+
+    # Then it falls back to "Unknown" instead of raising
+    assert observable_type == "Unknown"
+
+
+# Scenario: A single unsupported detection-rule attachment is skipped without aborting note conversion (issue #7473)
+def test_from_json_skips_invalid_attachment_and_keeps_processing_valid_ones():
+    # Given a StixNote
+    note = _given_stix_note()
+    # And an analyst note with one unsupported attachment (docx) and one valid YARA attachment
+    note_json = _given_analyst_note_json_with_attachments(
+        [
+            {"name": "malware.docx", "type": "docx", "content": "not a rule"},
+            {
+                "name": "rule.yar",
+                "type": "yara",
+                "content": "rule test { condition: true }",
+            },
+        ]
+    )
+
+    # When the note is converted from JSON
+    _when_note_converted_from_json(note, note_json)
+
+    # Then a warning is logged for the unsupported attachment
+    note.helper.connector_logger.warning.assert_called_once()
+    warning_message = note.helper.connector_logger.warning.call_args[0][0]
+    assert "malware.docx" in warning_message
+    # And the valid attachment still produced a STIX indicator
+    detection_rule_indicators = [
+        obj for obj in note.objects if getattr(obj, "pattern_type", None) == "yara"
+    ]
+    assert len(detection_rule_indicators) == 1
+
+
 # ── Given helpers ────────────────────────────────────────────────────────────
 
 
@@ -341,6 +409,13 @@ def _given_analyst_note_json():
             ],
         },
     }
+
+
+def _given_analyst_note_json_with_attachments(attachments):
+    note_json = _given_analyst_note_json()
+    note_json["attributes"]["attachments"] = attachments
+    note_json["attributes"]["note_entities"] = []
+    return note_json
 
 
 def _given_vuln_risk_row(risk, threat_actor_name):


### PR DESCRIPTION
### Proposed changes

* Compute the indicator pattern once in `_create_indicator` and reuse it for both `pycti.Indicator.generate_id` and the `pattern` field, avoiding a duplicate (and potentially inconsistent) call to `_create_pattern()`.
* Gracefully handle `ValueError` raised by `_create_pattern()` when determining the main observable type, returning "Unknown" instead of letting the exception propagate and crash the run.
* Gracefully handle `ConversionError` when building `DetectionRule` objects from attachments, logging a warning with the attachment name/type and skipping the faulty attachment instead of aborting the whole ingestion.

### Related issues

* Fixes #7473

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Previously, a single malformed pattern or detection-rule attachment could raise an unhandled exception and stop the entire connector run. These errors are now caught, logged, and the offending item is skipped, allowing the rest of the ingestion to complete successfully.