### PR TITLE
fix(elastic-security-incidents): stop duplicating investigation guide notes per alert

### DIFF
--- a/external-import/elastic-security-incidents/src/connector/converter_to_stix.py
+++ b/external-import/elastic-security-incidents/src/connector/converter_to_stix.py
@@ -258,8 +258,11 @@ class ConverterToStix:
         note_title = f"Investigation Guide - {rule_name}"
         created_at = alert.get("@timestamp", datetime.now(timezone.utc).isoformat())
 
-        # Generate predictive ID for the note
-        note_id = Note.generate_id(created_at, investigation_guide)
+        # The investigation guide is rule-level content, not alert-level: every
+        # alert fired by the same rule carries the same note. Generating the ID
+        # from the per-alert timestamp made each occurrence a distinct STIX
+        # object; keying on content alone lets OpenCTI merge repeats into one.
+        note_id = Note.generate_id(None, investigation_guide)
 
         # Create the note with predictive ID
         note = stix2.Note(

--- a/external-import/elastic-security-incidents/tests/tests_connector/test_converter_to_stix.py
+++ b/external-import/elastic-security-incidents/tests/tests_connector/test_converter_to_stix.py
@@ -1,0 +1,69 @@
+import uuid
+from unittest.mock import MagicMock
+
+import stix2
+from connector.converter_to_stix import ConverterToStix
+
+INCIDENT_ID = f"incident--{uuid.uuid4()}"
+
+
+def _make_converter() -> ConverterToStix:
+    helper = MagicMock()
+    helper.connect_name = "Elastic Security Incidents"
+    return ConverterToStix(helper, MagicMock(), stix2.TLP_AMBER)
+
+
+def _make_alert(**overrides):
+    alert = {
+        "kibana.alert.rule.note": "Check the source IP against the allowlist.",
+        "kibana.alert.rule.name": "Suspicious login",
+        "kibana.alert.uuid": "alert-1",
+        "@timestamp": "2026-01-01T00:00:00.000Z",
+    }
+    alert.update(overrides)
+    return alert
+
+
+def test_investigation_note_id_is_stable_across_alerts_from_same_rule():
+    # Two different alerts fired by the same rule carry the same investigation
+    # guide text; they should collapse into the same STIX Note rather than
+    # each alert minting its own duplicate.
+    converter = _make_converter()
+
+    first = converter.create_investigation_note(
+        _make_alert(
+            **{"kibana.alert.uuid": "alert-1", "@timestamp": "2026-01-01T00:00:00.000Z"}
+        ),
+        incident_id=INCIDENT_ID,
+    )
+    second = converter.create_investigation_note(
+        _make_alert(
+            **{"kibana.alert.uuid": "alert-2", "@timestamp": "2026-01-02T00:00:00.000Z"}
+        ),
+        incident_id=INCIDENT_ID,
+    )
+
+    assert first.id == second.id
+
+
+def test_investigation_note_id_differs_for_different_guide_text():
+    converter = _make_converter()
+
+    first = converter.create_investigation_note(
+        _make_alert(**{"kibana.alert.rule.note": "Guide A"}), incident_id=INCIDENT_ID
+    )
+    second = converter.create_investigation_note(
+        _make_alert(**{"kibana.alert.rule.note": "Guide B"}), incident_id=INCIDENT_ID
+    )
+
+    assert first.id != second.id
+
+
+def test_investigation_note_returns_none_without_a_guide():
+    converter = _make_converter()
+
+    note = converter.create_investigation_note(
+        _make_alert(**{"kibana.alert.rule.note": ""}), incident_id=INCIDENT_ID
+    )
+
+    assert note is None


### PR DESCRIPTION
Every alert fired by a detection rule carries the same investigation guide text (kibana.alert.rule.note), but create_investigation_note() generated the note's predictive STIX ID from the alert's own @timestamp plus the guide text. Since each alert has a different timestamp, every occurrence got a different ID and OpenCTI created a new Note instead of recognizing the repeat.

Fix is one line: drop the timestamp from the ID generation and key on the guide content alone, so alerts sharing a rule resolve to the same Note.

Added a test file for this connector's converter (tests/tests_connector/test_converter_to_stix.py, none existed before) covering ID stability across alerts from the same rule, ID divergence for different guide text, and the existing no-guide early return. Confirmed the new test actually catches the bug by reverting the fix and re-running it first.

Ran the full connector suite (pytest tests/, 11 passed), plus black, isort --profile black --line-length 88, and flake8 --ignore=E,W against the touched files.

Fixes #4934