### PR TITLE
feat(accenture-acti): resolve attack-patterns to their mitre att&ck technique (#7492)

### DIFF
--- a/external-import/accenture-acti/src/accenture_connector/connector.py
+++ b/external-import/accenture-acti/src/accenture_connector/connector.py
@@ -378,7 +378,9 @@ class ConnectorAccenture:
                 if "custom_properties" in stix_object:
                     stix_object["custom_properties"]["x_mitre_id"] = stix_object["name"]
                 else:
-                    stix_object["custom_properties"] = {"x_mitre_id": stix_object["name"]}
+                    stix_object["custom_properties"] = {
+                        "x_mitre_id": stix_object["name"]
+                    }
 
         stix_objects.extend(new_entities_for_bundle)
 

--- a/external-import/accenture-acti/src/accenture_connector/connector.py
+++ b/external-import/accenture-acti/src/accenture_connector/connector.py
@@ -371,6 +371,15 @@ class ConnectorAccenture:
                 # Remove items after iteration
                 for item in items_to_remove:
                     stix_objects.remove(item)
+
+            if stix_object.get("type") == "attack-pattern":
+                # rework attack-pattern stix entity
+                stix_object["name"] = stix_object["name"].capitalize()
+                if "custom_properties" in stix_object:
+                    stix_object["custom_properties"]["x_mitre_id"] = stix_object["name"]
+                else:
+                    stix_object["custom_properties"] = {"x_mitre_id": stix_object["name"]}
+
         stix_objects.extend(new_entities_for_bundle)
 
         if self.config.threat_actor_as_intrusion_set:


### PR DESCRIPTION
### Proposed changes

* Normalize the MITRE technique identifier carried as the name of the attack-patterns delivered in the Accenture ACTI bundles, and expose it as x_mitre_id so OpenCTI resolves them to the existing ATT&CK technique instead of creating a duplicate entity for every txxxx.
* Apply the treatment during bundle processing, consistently with the attack-patterns already generated from the connector taxonomy.

### Related issues

* closes #7492

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
<!-- To sign commits with a GPG key, you can refer to https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
