### PR TITLE
fix(import-document): allow INTERNAL_ANALYSIS connector type (#7494)

### DIFF
--- a/internal-import-file/import-document/README.md
+++ b/internal-import-file/import-document/README.md
@@ -114,6 +114,8 @@ The connector will parse the document, extract entities and observables, and imp
 The connector supports two processing modes:
 
 > **Note**: Setting `CONNECTOR_ONLY_CONTEXTUAL` to `true` is what triggers the **Internal Analysis** mode for this connector. While this option is generic at the pycti level (it only tells the platform whether the connector processes contextual data), for this connector it is specifically used to switch it into the "Internal Analysis" use case rather than the standard "File Import" mode.
+>
+> A deployment running in **Internal Analysis** mode must also set `CONNECTOR_TYPE` to `INTERNAL_ANALYSIS`, so that the platform registers it as an analysis connector. `CONNECTOR_TYPE` defaults to `INTERNAL_IMPORT_FILE` for the standard "File Import" mode.
 
 ```mermaid
 flowchart TD

--- a/internal-import-file/import-document/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-import-file/import-document/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -11,7 +11,7 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | CONNECTOR_NAME | `string` |  | string | `"ImportDocument"` | The name of the connector. |
 | CONNECTOR_SCOPE | `array` |  | string | `["application/pdf", "text/plain", "text/csv", "text/html", "text/markdown", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
-| CONNECTOR_TYPE | `const` |  | `INTERNAL_IMPORT_FILE` | `"INTERNAL_IMPORT_FILE"` |  |
+| CONNECTOR_TYPE | `string` |  | `INTERNAL_IMPORT_FILE` `INTERNAL_ANALYSIS` | `"INTERNAL_IMPORT_FILE"` | The type of the connector. Use `INTERNAL_ANALYSIS` to run the connector in content mapping mode, along with `only_contextual` set to `true`. |
 | CONNECTOR_AUTO | `boolean` |  | boolean | `false` | Whether the connector should run automatically when an entity is created or updated. |
 | CONNECTOR_VALIDATE_BEFORE_IMPORT | `boolean` |  | boolean | `true` | Validate any bundle before import. |
 | CONNECTOR_ONLY_CONTEXTUAL | `boolean` |  | boolean | `false` | If `true`, only extract data when an entity context is provided. |

--- a/internal-import-file/import-document/__metadata__/connector_config_schema.json
+++ b/internal-import-file/import-document/__metadata__/connector_config_schema.json
@@ -49,8 +49,12 @@
       "type": "string"
     },
     "CONNECTOR_TYPE": {
-      "const": "INTERNAL_IMPORT_FILE",
       "default": "INTERNAL_IMPORT_FILE",
+      "description": "The type of the connector. Use `INTERNAL_ANALYSIS` to run the connector in content mapping mode, along with `only_contextual` set to `true`.",
+      "enum": [
+        "INTERNAL_IMPORT_FILE",
+        "INTERNAL_ANALYSIS"
+      ],
       "type": "string"
     },
     "CONNECTOR_AUTO": {

--- a/internal-import-file/import-document/docker-compose.yml
+++ b/internal-import-file/import-document/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - OPENCTI_TOKEN=ChangeMe
       - CONNECTOR_ID=ChangeMe
       # - CONNECTOR_NAME=ImportDocument
+      # - CONNECTOR_TYPE=INTERNAL_IMPORT_FILE # Set to INTERNAL_ANALYSIS for the content mapping mode
+      # - CONNECTOR_ONLY_CONTEXTUAL=false # Set to true along with CONNECTOR_TYPE=INTERNAL_ANALYSIS for the content mapping mode
       # - CONNECTOR_VALIDATE_BEFORE_IMPORT=true # Validate any bundle before import
       # - CONNECTOR_SCOPE=application/pdf,text/plain,text/csv,text/html,text/markdown,application/vnd.openxmlformats-officedocument.wordprocessingml.document
       # - CONNECTOR_AUTO=false # Enable/disable auto-import of file

--- a/internal-import-file/import-document/src/reportimporter/settings.py
+++ b/internal-import-file/import-document/src/reportimporter/settings.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from connectors_sdk import (
     BaseConfigModel,
     BaseConnectorSettings,
@@ -17,6 +19,13 @@ class InternalImportFileConnectorConfig(BaseInternalImportFileConnectorConfig):
     name: str = Field(
         description="The name of the connector.",
         default="ImportDocument",
+    )
+    type: Literal["INTERNAL_IMPORT_FILE", "INTERNAL_ANALYSIS"] = Field(
+        description=(
+            "The type of the connector. Use `INTERNAL_ANALYSIS` to run the connector "
+            "in content mapping mode, along with `only_contextual` set to `true`."
+        ),
+        default="INTERNAL_IMPORT_FILE",
     )
     scope: ListFromString = Field(
         description="The scope of the connector.",

--- a/internal-import-file/import-document/tests/test_settings.py
+++ b/internal-import-file/import-document/tests/test_settings.py
@@ -1,0 +1,22 @@
+import pytest
+from pydantic import ValidationError
+from reportimporter.settings import InternalImportFileConnectorConfig
+
+
+@pytest.mark.parametrize(
+    "connector_type", ["INTERNAL_IMPORT_FILE", "INTERNAL_ANALYSIS"]
+)
+def test_supported_connector_types_are_accepted(connector_type: str) -> None:
+    """The connector runs as INTERNAL_IMPORT_FILE or, in content mapping mode, as INTERNAL_ANALYSIS."""
+    config = InternalImportFileConnectorConfig(type=connector_type)
+
+    assert config.type == connector_type
+
+
+def test_connector_type_defaults_to_internal_import_file() -> None:
+    assert InternalImportFileConnectorConfig().type == "INTERNAL_IMPORT_FILE"
+
+
+def test_unsupported_connector_type_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        InternalImportFileConnectorConfig(type="INTERNAL_ENRICHMENT")


### PR DESCRIPTION
### Proposed changes

* Allow `CONNECTOR_TYPE=INTERNAL_ANALYSIS` in `reportimporter/settings.py` by overriding `type` with `Literal["INTERNAL_IMPORT_FILE", "INTERNAL_ANALYSIS"]`. The default stays `INTERNAL_IMPORT_FILE` and any other value is still rejected. The override is done on the connector side, so `BaseInternalImportFileConnectorConfig` keeps its strict validation for every other internal-import-file connector.
* Regenerate `__metadata__/connector_config_schema.json` and `__metadata__/CONNECTOR_CONFIG_DOC.md` with the official generators: `CONNECTOR_TYPE` becomes an `enum` instead of a `const`.
* Document in `README.md` and `docker-compose.yml` that the Internal Analysis (content mapping) mode requires both `CONNECTOR_TYPE=INTERNAL_ANALYSIS` and `CONNECTOR_ONLY_CONTEXTUAL=true`.
* Add `tests/test_settings.py` covering the accepted types, the default, and the rejection of unsupported values.

### Related issues

* Fixes #7494
* Regression introduced by #7219 (`3cca9e8909`)

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Two options were considered:

1. Widen the field on the connector (this PR).
2. Add a dedicated `BaseInternalAnalysisConnectorConfig` to the SDK.

Option 1 was chosen because `INTERNAL_ANALYSIS` is, today, an `import-document` specificity: the mode is selected by `CONNECTOR_ONLY_CONTEXTUAL` and dispatched in `core.py` on `event_type == "INTERNAL_ANALYSIS"`. Loosening the SDK base class would wrongly widen the accepted type for all internal-import-file connectors. An SDK-level model can still be introduced later if other connectors need the same mode.

**Validation performed**

* `ConnectorSettings()` loads successfully with `CONNECTOR_TYPE=INTERNAL_ANALYSIS` and with `INTERNAL_IMPORT_FILE`, and still raises `ConfigValidationError` on an unsupported value. `to_helper_config()` forwards the configured type to pycti.
* `bash run_test.sh ./internal-import-file/import-document/tests/test-requirements.txt` -> 16 passed.
* `isort`, `black` and `flake8 --ignore=E,W` are clean.

**Out of scope**

`__metadata__/connector_manifest.json` still declares `"container_type": "INTERNAL_IMPORT_FILE"`. Migrating an existing `INTERNAL_ANALYSIS` connector to manager-supported mode is therefore still rejected platform-side by `connector-migration.ts` with `Connector type mismatch`. That part needs a platform-side decision and is tracked in #7494.
