### PR TITLE
fix(tagger): validate and compile regex definitions at startup (#7389)

### DIFF
--- a/internal-enrichment/tagger/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/tagger/__metadata__/connector_config_schema.json
@@ -59,6 +59,7 @@
       "contentMediaType": "application/json",
       "contentSchema": {
         "items": {
+          "additionalProperties": false,
           "properties": {
             "scopes": {
               "items": {
@@ -69,7 +70,37 @@
             },
             "rules": {
               "items": {
-                "additionalProperties": true,
+                "additionalProperties": false,
+                "properties": {
+                  "label": {
+                    "title": "Label",
+                    "type": "string"
+                  },
+                  "search": {
+                    "title": "Search",
+                    "type": "string"
+                  },
+                  "flags": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Flags",
+                    "type": "array"
+                  },
+                  "attributes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Attributes",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "label",
+                  "search",
+                  "attributes"
+                ],
+                "title": "Rule",
                 "type": "object"
               },
               "title": "Rules",

--- a/internal-enrichment/tagger/src/connector.py
+++ b/internal-enrichment/tagger/src/connector.py
@@ -1,23 +1,9 @@
-import re
 from typing import Dict
 
 from pycti import OpenCTIConnectorHelper
 from settings import ConfigLoader
 
 CONTAINER_TYPE_LIST = ["report", "grouping", "case-incident", "case-rfi", "case-rft"]
-
-
-def load_re_flags(rule):
-    """Load the regular expression flags from a rule definition."""
-
-    config = rule.get("flags") or []
-
-    flags = 0
-    for flag in config:
-        flag = getattr(re, flag)
-        flags |= flag
-
-    return flags
 
 
 class TaggerConnector:
@@ -40,9 +26,7 @@ class TaggerConnector:
                     continue
 
                 for rule in definition.rules:
-                    flags = load_re_flags(rule)
-
-                    for attribute in rule["attributes"]:
+                    for attribute in rule.attributes:
                         if attribute.lower() in ["objects-type", "objects-name"]:
                             attr = enrichment_entity.get("objects")
                         else:
@@ -53,13 +37,11 @@ class TaggerConnector:
                         # Handles the case where the attribute is the list of labels
                         if attribute.lower() == "objectlabel":
                             for obj in attr:
-                                if not re.search(
-                                    rule["search"], obj["value"], flags=flags
-                                ):
+                                if not rule.pattern.search(obj["value"]):
                                     continue
 
                                 self.add_label(
-                                    enrichment_entity["standard_id"], rule["label"]
+                                    enrichment_entity["standard_id"], rule.label
                                 )
                                 break
 
@@ -74,13 +56,11 @@ class TaggerConnector:
                             # Handles the case where the attribute is the list of objects
                             if attribute.lower() == "objects-type":
                                 for obj in attr:
-                                    if not re.search(
-                                        rule["search"], obj["entity_type"], flags=flags
-                                    ):
+                                    if not rule.pattern.search(obj["entity_type"]):
                                         continue
 
                                     self.add_label(
-                                        enrichment_entity["standard_id"], rule["label"]
+                                        enrichment_entity["standard_id"], rule.label
                                     )
                                     break
 
@@ -95,20 +75,20 @@ class TaggerConnector:
                                     if name is None:
                                         continue
 
-                                    if not re.search(rule["search"], name, flags=flags):
+                                    if not rule.pattern.search(name):
                                         continue
 
                                     self.add_label(
-                                        enrichment_entity["standard_id"], rule["label"]
+                                        enrichment_entity["standard_id"], rule.label
                                     )
                                     break
 
                                 continue
 
-                        if not re.search(rule["search"], attr, flags=flags):
+                        if not rule.pattern.search(attr):
                             continue
 
-                        self.add_label(enrichment_entity["standard_id"], rule["label"])
+                        self.add_label(enrichment_entity["standard_id"], rule.label)
                         break
 
     def add_label(self, entity, label):

--- a/internal-enrichment/tagger/src/settings.py
+++ b/internal-enrichment/tagger/src/settings.py
@@ -1,17 +1,65 @@
-from typing import Any
+import re
 
 from connectors_sdk import (
     BaseConnectorSettings,
     BaseInternalEnrichmentConnectorConfig,
     ListFromString,
 )
-from pydantic import BaseModel, Field, Json
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    Json,
+    PrivateAttr,
+    model_validator,
+)
 from pydantic_settings import BaseSettings
 
 
+class Rule(BaseModel):
+    # Reject unknown keys so a typo (e.g. "flag") fails at load time instead of
+    # being silently dropped and leaving the rule misconfigured.
+    model_config = ConfigDict(extra="forbid")
+
+    label: str
+    search: str
+    flags: list[str] = Field(default_factory=list)
+    attributes: list[str]
+    # Compiled once at load time so patterns are validated before the connector
+    # starts consuming messages and are not re-resolved on every call. Kept as a
+    # private attribute so it stays out of model_dump() and the JSON schema.
+    _pattern: re.Pattern = PrivateAttr()
+
+    @model_validator(mode="after")
+    def compile_pattern(self) -> "Rule":
+        flags = 0
+        for flag_name in self.flags:
+            flag = getattr(re, flag_name, None)
+            if not isinstance(flag, re.RegexFlag):
+                raise ValueError(
+                    f"Invalid regex flag {flag_name!r} in rule {self.label!r}"
+                )
+            flags |= flag
+
+        try:
+            self._pattern = re.compile(self.search, flags)
+        except re.error as exc:
+            raise ValueError(
+                f"Invalid regular expression {self.search!r} in rule {self.label!r}: {exc}"
+            ) from exc
+
+        return self
+
+    @property
+    def pattern(self) -> re.Pattern:
+        return self._pattern
+
+
 class Definition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     scopes: list[str]
-    rules: list[dict[str, Any]]
+    rules: list[Rule]
 
 
 class ConnectorConfig(BaseInternalEnrichmentConnectorConfig):

--- a/internal-enrichment/tagger/tests/conftest.py
+++ b/internal-enrichment/tagger/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/internal-enrichment/tagger/tests/test-requirements.txt
+++ b/internal-enrichment/tagger/tests/test-requirements.txt
@@ -1,0 +1,3 @@
+# Main dependencies needed to import the connector under test.
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/internal-enrichment/tagger/tests/tests_connector/test_settings.py
+++ b/internal-enrichment/tagger/tests/tests_connector/test_settings.py
@@ -1,0 +1,98 @@
+import re
+
+import pytest
+from pydantic import ValidationError
+from settings import Definition, Rule
+
+
+def make_rule(**overrides):
+    rule = {
+        "label": "demo",
+        "search": "foo|bar",
+        "flags": ["IGNORECASE"],
+        "attributes": ["name", "description"],
+    }
+    rule.update(overrides)
+    return rule
+
+
+class TestRuleValidation:
+    def test_valid_rule_compiles_pattern_once(self):
+        rule = Rule(**make_rule())
+
+        assert isinstance(rule.pattern, re.Pattern)
+        assert rule.pattern.pattern == "foo|bar"
+        assert rule.pattern.flags & re.IGNORECASE
+
+    def test_flags_default_to_empty_list(self):
+        rule_config = make_rule()
+        del rule_config["flags"]
+
+        rule = Rule(**rule_config)
+
+        assert rule.flags == []
+        assert isinstance(rule.pattern, re.Pattern)
+
+    def test_pattern_is_excluded_from_serialization(self):
+        rule = Rule(**make_rule())
+
+        assert "pattern" not in rule.model_dump()
+        assert "pattern" not in Rule.model_json_schema()["properties"]
+
+    def test_invalid_regex_is_rejected_at_load_time(self):
+        with pytest.raises(ValidationError) as exc_info:
+            Rule(**make_rule(search="foo|?bar"))
+
+        message = str(exc_info.value)
+        assert "Invalid regular expression" in message
+        assert "'foo|?bar'" in message
+        assert "'demo'" in message
+
+    @pytest.mark.parametrize(
+        "flag",
+        ["ignorecase", "search", "G", "NOTAFLAG"],
+    )
+    def test_invalid_flag_is_rejected_at_load_time(self, flag):
+        with pytest.raises(ValidationError) as exc_info:
+            Rule(**make_rule(flags=[flag]))
+
+        message = str(exc_info.value)
+        assert "Invalid regex flag" in message
+        assert repr(flag) in message
+        assert "'demo'" in message
+
+    def test_flags_as_string_is_rejected(self):
+        with pytest.raises(ValidationError):
+            Rule(**make_rule(flags="IGNORECASE"))
+
+    def test_unknown_key_is_rejected(self):
+        rule_config = make_rule()
+        del rule_config["flags"]
+        rule_config["flag"] = ["IGNORECASE"]
+
+        with pytest.raises(ValidationError) as exc_info:
+            Rule(**rule_config)
+
+        assert "flag" in str(exc_info.value)
+
+
+class TestDefinitionValidation:
+    def test_definition_validates_nested_rules(self):
+        with pytest.raises(ValidationError):
+            Definition(
+                scopes=["Report"],
+                rules=[make_rule(search="foo|?bar")],
+            )
+
+    def test_definition_rejects_unknown_key(self):
+        with pytest.raises(ValidationError):
+            Definition(
+                scopes=["Report"],
+                rules=[make_rule()],
+                scope=["Report"],
+            )
+
+    def test_definition_exposes_compiled_rules(self):
+        definition = Definition(scopes=["Report"], rules=[make_rule()])
+
+        assert isinstance(definition.rules[0].pattern, re.Pattern)


### PR DESCRIPTION
### Proposed changes

* Add a `Rule` pydantic model that validates each definition rule at load time: `search` must be a compilable regular expression and every `flags` entry must be a real `re` flag name (`flags` must be a list). Invalid values now raise a clear configuration error naming the offending rule and pattern before the connector starts.
* Compile each rule pattern once when the configuration is read (stored on the model, excluded from serialization) instead of re-resolving it through `re`'s cache on every message, rule and attribute.
* Update the connector to use the pre-compiled `rule.pattern` and typed rule attributes, and remove the runtime `load_re_flags` helper.
* Add tests covering valid rules, invalid regex, invalid/malformed flags and nested definition validation.

### Related issues

* Fixes #7389

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Previously `rules` was typed as `list[dict[str, Any]]`, so pydantic accepted any content and neither the regex nor the flags were validated. An invalid pattern (or a `flags` value given as a string, lowercase, or a non-flag attribute) only surfaced at runtime and then failed on every single message, silently disabling the rule while the connector reported itself healthy.

The fix moves all validation to configuration load time. On an invalid regex the connector now stops immediately with e.g. `Invalid regular expression 'foo|?bar' in rule 'demo': nothing to repeat`, and on an invalid flag with `Invalid regex flag 'G' in rule 'demo'`. Patterns are also compiled a single time, removing the per-message recompilation.