### PR TITLE
fix(import-document): discard phone matches containing an ipv4 address (#6677)

### DIFF
--- a/internal-import-file/import-document/src/reportimporter/report_parser.py
+++ b/internal-import-file/import-document/src/reportimporter/report_parser.py
@@ -2,6 +2,7 @@ import io
 import ipaddress
 import logging
 import os
+import re
 from typing import IO, Dict, Iterable, List, Pattern, Tuple
 
 import chardet
@@ -35,6 +36,11 @@ class ReportParser(object):
     """
     Report parser based on IOCParser
     """
+
+    # Dotted-quad candidates used to detect an IPv4 address embedded in a
+    # phone-number match (e.g. when a neighbouring number is pulled into the
+    # match). Each candidate is validated with ``ipaddress`` before use.
+    _IPV4_CANDIDATE_REGEX = re.compile(r"\d{1,3}(?:\.\d{1,3}){3}")
 
     def __init__(
         self,
@@ -70,21 +76,28 @@ class ReportParser(object):
                 return True
         return False
 
+    def _contains_ipv4_address(self, value: str) -> bool:
+        for candidate in self._IPV4_CANDIDATE_REGEX.findall(value):
+            try:
+                ipaddress.IPv4Address(candidate)
+            except ValueError:
+                continue
+            return True
+        return False
+
     def _post_parse_observables(
         self, ind_match: str, observable: Observable, match_range: Tuple
     ) -> Dict:
         self.helper.log_debug(f"Observable match: {ind_match}")
 
-        if observable.stix_target == "Phone-Number.value":
-            try:
-                ipaddress.ip_address(ind_match)
-            except ValueError:
-                pass
-            else:
-                self.helper.log_debug(
-                    f"Discarding phone number match for IP address '{ind_match}'"
-                )
-                return {}
+        if (
+            observable.stix_target == "Phone-Number.value"
+            and self._contains_ipv4_address(ind_match)
+        ):
+            self.helper.log_debug(
+                f"Discarding phone number match for IP address '{ind_match}'"
+            )
+            return {}
 
         if self._is_whitelisted(observable.filter_regex, ind_match):
             return {}

--- a/internal-import-file/import-document/tests/test_report_parser_observables.py
+++ b/internal-import-file/import-document/tests/test_report_parser_observables.py
@@ -50,6 +50,23 @@ def test_filtered_ipv4_address_is_not_reclassified_as_phone_number():
 
 
 @pytest.mark.parametrize(
+    "address",
+    [
+        "119.139.117.171",
+        "198.51.100.234",
+        "255.255.255.255",
+    ],
+)
+def test_ipv4_address_adjacent_to_number_is_not_reclassified_as_phone_number(address):
+    result = _build_parser().parse(f"Log line id 5 {address} host reported.")
+
+    assert result[address][RESULT_FORMAT_CATEGORY] == "IPv4-Addr.value"
+    assert not any(
+        info[RESULT_FORMAT_CATEGORY] == "Phone-Number.value" for info in result.values()
+    )
+
+
+@pytest.mark.parametrize(
     "phone_number",
     [
         # ACMA fictional-use number


### PR DESCRIPTION
### Proposed changes

* Discard any phone-number match that *contains* a valid IPv4 address, not only when the whole match is an IP (via a new `_contains_ipv4_address` helper).
* Add a regression test covering IPv4 addresses adjacent to another number (e.g. `id 5 119.139.117.171`).

### Related issues

* Fixes #6677

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The previous fix only rejected a `Phone-Number` match when the entire captured string was a valid IP address (`ipaddress.ip_address(ind_match)`). When a neighbouring number was pulled into the match — for instance `5 119.139.117.171` — the validation failed and a real IPv4 address was still emitted as a `Phone-Number`.

The match still contains a valid IPv4, so the guard now scans the match for dotted-quad candidates and validates each with `ipaddress.IPv4Address`; if any is valid, the phone match is discarded and the IPv4 observable is kept. Legitimate phone numbers are unaffected since they don't contain a three-dot dotted-quad.