### PR TITLE
fix(import-document): route parsing errors through connector_logger (#6345)

### DIFF
--- a/internal-import-file/import-document/src/reportimporter/report_parser.py
+++ b/internal-import-file/import-document/src/reportimporter/report_parser.py
@@ -3,6 +3,7 @@ import ipaddress
 import logging
 import os
 import re
+import traceback
 from typing import IO, Dict, Iterable, List, Pattern, Tuple
 
 import chardet
@@ -147,7 +148,9 @@ class ReportParser(object):
                 parse_info.update(self.parse(no_newline_text))
 
         except Exception as e:
-            self.helper.connector_logger.error("Pdf Parsing Error", {"error": str(e)})
+            self.helper.connector_logger.error(
+                "Pdf Parsing Error", {"error": str(e), "trace": traceback.format_exc()}
+            )
 
         return parse_info
 
@@ -176,7 +179,9 @@ class ReportParser(object):
                         if text:
                             parse_info.update(self.parse(text))
         except Exception as e:
-            self.helper.connector_logger.error("Docx Parsing Error", {"error": str(e)})
+            self.helper.connector_logger.error(
+                "Docx Parsing Error", {"error": str(e), "trace": traceback.format_exc()}
+            )
         return parse_info
 
     def _parse_html(self, file_data: IO) -> Dict[str, Dict]:
@@ -204,7 +209,12 @@ class ReportParser(object):
                 parsing_results = file_parser(file_data)
         except Exception as e:
             self.helper.connector_logger.error(
-                "Parsing Error", {"file_path": file_path, "error": str(e)}
+                "Parsing Error",
+                {
+                    "file_path": file_path,
+                    "error": str(e),
+                    "trace": traceback.format_exc(),
+                },
             )
 
         return parsing_results

--- a/internal-import-file/import-document/src/reportimporter/report_parser.py
+++ b/internal-import-file/import-document/src/reportimporter/report_parser.py
@@ -147,7 +147,7 @@ class ReportParser(object):
                 parse_info.update(self.parse(no_newline_text))
 
         except Exception as e:
-            logging.exception(f"Pdf Parsing Error: {e}")
+            self.helper.connector_logger.error("Pdf Parsing Error", {"error": str(e)})
 
         return parse_info
 
@@ -176,7 +176,7 @@ class ReportParser(object):
                         if text:
                             parse_info.update(self.parse(text))
         except Exception as e:
-            logging.exception(f"Docx Parsing Error: {e}")
+            self.helper.connector_logger.error("Docx Parsing Error", {"error": str(e)})
         return parse_info
 
     def _parse_html(self, file_data: IO) -> Dict[str, Dict]:
@@ -203,7 +203,9 @@ class ReportParser(object):
             with open(file_path, "rb") as file_data:
                 parsing_results = file_parser(file_data)
         except Exception as e:
-            logging.exception(f"Parsing Error: {e}")
+            self.helper.connector_logger.error(
+                "Parsing Error", {"file_path": file_path, "error": str(e)}
+            )
 
         return parsing_results
 

--- a/internal-import-file/import-document/src/reportimporter/util.py
+++ b/internal-import-file/import-document/src/reportimporter/util.py
@@ -1,9 +1,12 @@
 import configparser
+import logging
 import re
 from typing import Dict, List
 
 import ioc_finder
 from dateparser.search import search_dates
+
+logger = logging.getLogger(__name__)
 
 
 class MyConfigParser(configparser.ConfigParser):
@@ -55,11 +58,11 @@ def custom_asnparse(text: str) -> List:
                 asn_value = int(asn_value[0])
                 output.append(asn_value)
             except SyntaxError:
-                print(
-                    f"Error ReportParser: Could not convert ASN match to int from {value}"
+                logger.error(
+                    "Could not convert ASN match to int", extra={"value": value}
                 )
         else:
-            print(f"Error ReportParser: Could not extract ASN number from {value}")
+            logger.error("Could not extract ASN number", extra={"value": value})
 
     return output
 

--- a/internal-import-file/import-document/src/reportimporter/util.py
+++ b/internal-import-file/import-document/src/reportimporter/util.py
@@ -57,7 +57,7 @@ def custom_asnparse(text: str) -> List:
             try:
                 asn_value = int(asn_value[0])
                 output.append(asn_value)
-            except SyntaxError:
+            except ValueError:
                 logger.error(
                     "Could not convert ASN match to int", extra={"value": value}
                 )


### PR DESCRIPTION
Three exception handlers in `reportimporter/report_parser.py` (PDF, DOCX,
and the generic file-parsing catch-all) called `logging.exception()`
directly instead of going through `self.helper.connector_logger`, which is
how every other log line in this connector gets its structured JSON shape.
`logging.exception()` still ends up JSON (Python's root logger propagation
means it hits the same handler), but with `name: "root"` instead of the
connector's name and the error text stuffed into `message` instead of a
separate field, so it doesn't line up with the rest of the connector's logs
in Grafana.

The two `print()` calls in `util.py`'s `custom_asnparse` had the same
problem, more directly: `print()` never touches the logging pipeline at
all, so those never showed up as structured logs either. Routed them
through a module logger instead, since `custom_asnparse` is called through
a shared `Callable[[str], List]` lookup table with third-party `ioc_finder`
functions and can't take `self.helper` as an argument without changing that
interface.

Fixes #6345.

Ran the existing test suite (16 passed) plus this repo's pinned black /
isort / flake8 pre-commit checks against both files.