### PR TITLE
docs(tweetfeed): remove the outdated unmaintained notice (#7525)

### DIFF
--- a/external-import/tweetfeed/README.md
+++ b/external-import/tweetfeed/README.md
@@ -10,7 +10,6 @@ Tweetfeed connect is a project aimed to collect evidences from Tweetfeed project
 
 This connector ingests [Tweetfeed](https://tweetfeed.live/) IOC in order to import Observables and Indicator collected from different researchers. Tweetfeed was developed by [Daniel López](https://twitter.com/0xDanielLopez).  
 This connector was built using the TAXII2 connector for [OpenCTI](https://github.com/OpenCTI-Platform/opencti) as a base.
-> **IMPORTANT**: Due to changes in the Twitter/X API, TweetFeed is no longer maintainable. Be aware that no new information beyond July 19, 2023 will be retrieved via this connector.
 
 ### Prerequisites
 


### PR DESCRIPTION
### Proposed changes

* Remove the "no longer maintainable" notice from `external-import/tweetfeed/README.md`.

The README tells users that this connector returns nothing new since July 2023:

> **IMPORTANT**: Due to changes in the Twitter/X API, TweetFeed is no longer maintainable. Be aware that no new information beyond July 19, 2023 will be retrieved via this connector.

I maintain TweetFeed, and that is not correct. The feed has published new indicators every day since then, and it still does.

The connector reads this URL (`external-import/tweetfeed/src/tweetfeed.py`, line 73):

https://raw.githubusercontent.com/0xDanielLopez/TweetFeed/master/today.csv

That file returns HTTP 200 with rows dated today. The data repository gets a commit every 15 minutes, and https://tweetfeed.live and https://api.tweetfeed.live/v1/today are up.

The notice came in with 8dbaebb22dbd on 2023-12-12 and stayed through the documentation passes of 2024-01-31 and 2026-01-05. The Filigran hub page for this connector does not show it. Only the README does, so this pull request deletes one line and changes no code.

### Related issues

* Closes #7525

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The connector code needs no change. I only ask you to remove a statement about my project that is no longer true, because a user who reads it disables a connector that works.
