### PR TITLE
fix(ci): harden buildx push/cache retry and manifest commit resilience (#7460)

### DIFF
--- a/.github/scripts/buildx_with_retry.sh
+++ b/.github/scripts/buildx_with_retry.sh
@@ -48,16 +48,14 @@ INITIAL_DELAY="${INITIAL_DELAY:-60}"
 
 METADATA_FILE="$(mktemp)"
 
-# Assemble the shared buildx argument list (everything except cache-to, which
-# is applied only to the separate cache-export attempt below).
+# Assemble the shared buildx argument list. --push is added only to the image
+# invocation below (step 1): the cache-export invocation (step 2) omits it so
+# it doesn't needlessly re-push the already-published image, just the cache.
 base_args=(build "$CONTEXT" --file "$DOCKERFILE" --platform "$PLATFORMS")
 base_args+=(--provenance "$PROVENANCE" --metadata-file "$METADATA_FILE")
 
 if [ "$PULL" = "true" ]; then
   base_args+=(--pull)
-fi
-if [ "$PUSH" = "true" ]; then
-  base_args+=(--push)
 fi
 
 while IFS= read -r tag; do
@@ -137,7 +135,11 @@ run_with_retry() {
 }
 
 # Step 1: build + push the actual image. Must succeed.
-if ! run_with_retry "${base_args[@]}"; then
+image_args=("${base_args[@]}")
+if [ "$PUSH" = "true" ]; then
+  image_args+=(--push)
+fi
+if ! run_with_retry "${image_args[@]}"; then
   echo "❌ buildx image push failed after ${MAX_ATTEMPTS} attempts"
   rm -f "$METADATA_FILE"
   exit 1
@@ -149,10 +151,13 @@ if [ -n "${DIGEST_OUT:-}" ]; then
   echo "📋 Digest: ${DIGEST:-(none)}"
 fi
 
-# Step 2: export the registry build cache, isolated from the image push so a
-# transient registry write failure here can't discard the already-pushed
-# image. Everything is already cached locally from step 1, so this is fast.
-# Failure is non-fatal: it only slows down the *next* CI build.
+# Step 2: export the registry build cache only — no --push, so BuildKit
+# produces no image output and doesn't redundantly re-push what step 1
+# already published. Everything is already cached locally from step 1 (same
+# context/args), so BuildKit reuses it and this just uploads the cache
+# manifest/layers. Isolated from the image push so a transient registry write
+# failure here can't discard the already-pushed image. Failure is non-fatal:
+# it only slows down the *next* CI build.
 if [ -n "${CACHE_TO:-}" ]; then
   cache_args=("${base_args[@]}" --cache-to "$CACHE_TO")
   if ! run_with_retry "${cache_args[@]}"; then

--- a/.github/scripts/buildx_with_retry.sh
+++ b/.github/scripts/buildx_with_retry.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 # Build (and optionally push) a connector image with docker buildx, retrying
 # transient failures (e.g. registry 5xx/timeouts, rate limiting) with
-# exponential backoff.
+# exponential backoff, honoring the registry's "retry-after" hint as a floor.
+#
+# The image push and the registry build-cache export are run as two separate
+# buildx invocations. Bundling them in one invocation is fragile: if the cache
+# export hits a transient registry error (e.g. ghcr.io "toomanyrequests" write
+# rate limiting, which is common when many connectors build concurrently),
+# BuildKit cancels the *entire* solve, including an image export that had
+# already succeeded — turning a harmless cache-write hiccup into a full build
+# failure. Since the build-cache export is only a CI speed optimization (not
+# required to ship the connector image), its failures are retried but treated
+# as non-fatal once the image itself has been pushed successfully.
 #
 # Required environment variables:
 #   CONTEXT      - Build context directory
@@ -15,7 +25,8 @@
 #   BUILD_ARGS   - Newline-separated list of KEY=VALUE build args
 #   LABELS       - Newline-separated list of KEY=VALUE OCI labels
 #   CACHE_FROM   - buildx --cache-from value (skipped when empty)
-#   CACHE_TO     - buildx --cache-to value (skipped when empty)
+#   CACHE_TO     - buildx --cache-to value (skipped when empty). Pushed in a
+#                  separate, non-fatal retry loop after the image push succeeds.
 #   PROVENANCE   - buildx --provenance value (default: false, matches
 #                  docker/build-push-action so per-arch images stay
 #                  single-manifest for the imagetools merge)
@@ -33,68 +44,120 @@ PUSH="${PUSH:-false}"
 PULL="${PULL:-true}"
 PROVENANCE="${PROVENANCE:-false}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-5}"
-INITIAL_DELAY="${INITIAL_DELAY:-15}"
+INITIAL_DELAY="${INITIAL_DELAY:-60}"
 
 METADATA_FILE="$(mktemp)"
 
-# Assemble the buildx argument list.
-args=(build "$CONTEXT" --file "$DOCKERFILE" --platform "$PLATFORMS")
-args+=(--provenance "$PROVENANCE" --metadata-file "$METADATA_FILE")
+# Assemble the shared buildx argument list (everything except cache-to, which
+# is applied only to the separate cache-export attempt below).
+base_args=(build "$CONTEXT" --file "$DOCKERFILE" --platform "$PLATFORMS")
+base_args+=(--provenance "$PROVENANCE" --metadata-file "$METADATA_FILE")
 
 if [ "$PULL" = "true" ]; then
-  args+=(--pull)
+  base_args+=(--pull)
 fi
 if [ "$PUSH" = "true" ]; then
-  args+=(--push)
+  base_args+=(--push)
 fi
 
 while IFS= read -r tag; do
-  [ -n "$tag" ] && args+=(--tag "$tag")
+  [ -n "$tag" ] && base_args+=(--tag "$tag")
 done <<< "$TAGS"
 
 if [ -n "${BUILD_ARGS:-}" ]; then
   while IFS= read -r ba; do
-    [ -n "$ba" ] && args+=(--build-arg "$ba")
+    [ -n "$ba" ] && base_args+=(--build-arg "$ba")
   done <<< "$BUILD_ARGS"
 fi
 
 if [ -n "${LABELS:-}" ]; then
   while IFS= read -r label; do
-    [ -n "$label" ] && args+=(--label "$label")
+    [ -n "$label" ] && base_args+=(--label "$label")
   done <<< "$LABELS"
 fi
 
 if [ -n "${CACHE_FROM:-}" ]; then
-  args+=(--cache-from "$CACHE_FROM")
-fi
-if [ -n "${CACHE_TO:-}" ]; then
-  args+=(--cache-to "$CACHE_TO")
+  base_args+=(--cache-from "$CACHE_FROM")
 fi
 
-attempt=1
-delay="$INITIAL_DELAY"
-while true; do
-  echo "🐳 docker buildx (attempt ${attempt}/${MAX_ATTEMPTS})"
-  if docker buildx "${args[@]}"; then
-    break
-  fi
-  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
-    echo "❌ buildx failed after ${attempt} attempts"
-    rm -f "$METADATA_FILE"
-    exit 1
-  fi
-  jitter=$((RANDOM % 5))
-  sleep_for=$((delay + jitter))
-  echo "⚠️  buildx attempt ${attempt} failed, retrying in ${sleep_for}s..."
-  sleep "$sleep_for"
-  attempt=$((attempt + 1))
-  delay=$((delay * 2))
-done
+# Extracts the largest "retry-after: <n>(ms|s)" hint from buildx output, in
+# whole seconds (rounded up). Registries return this per-request, so under
+# heavy matrix concurrency it's usually far smaller than our own backoff
+# (e.g. "retry-after: 17ms" while 200 other jobs hammer the same quota) — it's
+# only used as a floor, never to shrink the exponential backoff.
+parse_retry_after_seconds() {
+  local log_file="$1"
+  awk '
+    match($0, /retry-after: [0-9.]+(ms|s)/) {
+      s = substr($0, RSTART, RLENGTH)
+      sub(/retry-after: /, "", s)
+      unit = (s ~ /ms$/) ? "ms" : "s"
+      gsub(/[a-z]/, "", s)
+      val = s + 0
+      if (unit == "ms") val = val / 1000
+      if (val > max) max = val
+    }
+    END { if (max > 0) printf "%d\n", (max == int(max)) ? max : int(max) + 1 }
+  ' "$log_file"
+}
+
+# Runs `docker buildx "${@}"` with exponential backoff + jitter.
+# Returns 1 after exhausting MAX_ATTEMPTS (caller decides fatal vs non-fatal).
+run_with_retry() {
+  local attempt=1
+  local delay="$INITIAL_DELAY"
+  local log_file
+  log_file="$(mktemp)"
+  while true; do
+    echo "🐳 docker buildx (attempt ${attempt}/${MAX_ATTEMPTS}): $*"
+    : > "$log_file"
+    if docker buildx "$@" 2>&1 | tee "$log_file"; then
+      rm -f "$log_file"
+      return 0
+    fi
+    if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+      rm -f "$log_file"
+      return 1
+    fi
+    # Wide, randomized jitter so many connectors building concurrently in the
+    # same matrix don't retry in lockstep and re-collide on the same
+    # registry rate-limit window.
+    jitter=$((RANDOM % 30))
+    sleep_for=$((delay + jitter))
+    retry_after="$(parse_retry_after_seconds "$log_file")"
+    if [ -n "$retry_after" ] && [ "$retry_after" -gt "$sleep_for" ]; then
+      echo "⏱️  registry requested retry-after ${retry_after}s, honoring it"
+      sleep_for="$((retry_after + jitter))"
+    fi
+    echo "⚠️  buildx attempt ${attempt} failed, retrying in ${sleep_for}s..."
+    sleep "$sleep_for"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
+# Step 1: build + push the actual image. Must succeed.
+if ! run_with_retry "${base_args[@]}"; then
+  echo "❌ buildx image push failed after ${MAX_ATTEMPTS} attempts"
+  rm -f "$METADATA_FILE"
+  exit 1
+fi
 
 if [ -n "${DIGEST_OUT:-}" ]; then
   DIGEST="$(jq -r '.["containerimage.digest"] // empty' "$METADATA_FILE")"
   echo "$DIGEST" > "$DIGEST_OUT"
   echo "📋 Digest: ${DIGEST:-(none)}"
+fi
+
+# Step 2: export the registry build cache, isolated from the image push so a
+# transient registry write failure here can't discard the already-pushed
+# image. Everything is already cached locally from step 1, so this is fast.
+# Failure is non-fatal: it only slows down the *next* CI build.
+if [ -n "${CACHE_TO:-}" ]; then
+  cache_args=("${base_args[@]}" --cache-to "$CACHE_TO")
+  if ! run_with_retry "${cache_args[@]}"; then
+    echo "⚠️  buildx cache export failed after ${MAX_ATTEMPTS} attempts, continuing anyway (image was already pushed)"
+  fi
 fi
 
 rm -f "$METADATA_FILE"

--- a/.github/workflows/build-all-connectors.yml
+++ b/.github/workflows/build-all-connectors.yml
@@ -1,6 +1,22 @@
 name: Build Connector Images
 
 on:
+  workflow_dispatch:
+    inputs:
+      build_mode:
+        description: "Build mode (rolling, prerelease, release)"
+        required: true
+        default: "rolling"
+        type: choice
+        options:
+          - rolling
+          - prerelease
+          - release
+      push:
+        description: "Push images to registries"
+        required: true
+        default: "true"
+        type: boolean
   push:
     branches:
       - master

--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -89,6 +89,25 @@ jobs:
 
           echo "branch=${REF_NAME}" >> "$GITHUB_OUTPUT"
 
+      - name: Check branch is still at the expected commit
+        id: freshness
+        if: steps.target.outputs.branch != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ steps.target.outputs.branch }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          current_sha=$(gh api "repos/${REPO}/git/refs/heads/${BRANCH}" --jq '.object.sha')
+          if [ "$current_sha" != "$EXPECTED_SHA" ]; then
+            echo "::warning::Branch '${BRANCH}' moved from ${EXPECTED_SHA} to ${current_sha} while this workflow was running. Skipping manifest commit to avoid committing on top of newer changes."
+            echo "still_head=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "still_head=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # Commits via GitHub's GraphQL API instead of raw `git commit`, so the
       # commit is GPG-signed by GitHub (required by this repo's branch
       # protection) without managing signing keys in CI. No local git
@@ -100,8 +119,15 @@ jobs:
       # scoped to the generated artifacts so the virtualenvs and temp files
       # created by the generation scripts never enter the commit. Untracked
       # (new) schemas and deletions are both picked up.
+      #
+      # continue-on-error: this repo's branch protection rules are currently
+      # too strict for the bot commit to always go through. That's a
+      # separate, known issue — it must not turn this whole build red; the
+      # step below just surfaces a warning instead.
       - name: Commit manifest if changed
-        if: steps.target.outputs.branch != ''
+        id: commit
+        if: steps.target.outputs.branch != '' && steps.freshness.outputs.still_head == 'true'
+        continue-on-error: true
         uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
         with:
           commit_message: "chore(manifest): build and update manifest [skip ci]"
@@ -110,3 +136,8 @@ jobs:
           file_pattern: "manifest.json */__metadata__/connector_config_schema.json */__metadata__/CONNECTOR_CONFIG_DOC.md"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Warn if manifest commit failed
+        if: steps.target.outputs.branch != '' && steps.freshness.outputs.still_head == 'true' && steps.commit.outcome == 'failure'
+        run: |
+          echo "::warning::Failed to commit the updated manifest/schemas back to '${{ steps.target.outputs.branch }}' (likely blocked by branch protection rules). This does not fail the build — investigate/commit manually if needed."


### PR DESCRIPTION
### Proposed changes

* Harden `.github/scripts/buildx_with_retry.sh`: the image push and the registry build-cache export now run as two separate, independently-retried `docker buildx` invocations instead of one. Previously, a transient cache-export failure (e.g. `ghcr.io` write rate limiting under concurrent matrix builds) made BuildKit cancel the whole solve — discarding an image push that had already succeeded. The cache export is now retried but treated as non-fatal once the image itself is pushed. Retries also parse and honor the registry's `retry-after` hint (ms or s) as a floor on top of the existing exponential backoff + jitter, and the default initial delay was raised from 15s to 60s.
* Add a `workflow_dispatch` trigger to `.github/workflows/build-all-connectors.yml` with `build_mode` (rolling/prerelease/release) and `push` inputs, so the full connector build can be re-run manually (e.g. to retry after a transient failure or validate the retry logic above) without needing a new push to `master`.
* In `.github/workflows/build-manifest.yml` (unchanged sequential/non-matrix workflow), avoid failing the build when the generated manifest/schemas can't be committed back: a new freshness check confirms the target branch is still at the commit this run started from before committing (skipping with a `::warning::` if it moved), and the `planetscale/ghcommit-action` step is now `continue-on-error: true` with a follow-up step that turns a failed commit into a `::warning::` instead of a red build.

### Related issues

* Closes #7460

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This is **PR1 of a 2-PR stack** on top of the CI migration merged in #7460. It only hardens the *existing* sequential manifest workflow and the buildx retry script — it does **not** touch schema-generation performance or parallelization. PR2 (branch `ci/7460-parallelize-manifest-schema`, opened against this PR's branch) adds matrix-based parallelization of manifest/schema generation on top of these changes.

Two design choices worth calling out since they aren't obvious from the diff alone:
- **Freshness check before committing the manifest**: since the commit step now tolerates failure, we added an explicit check (via `gh api`) that the target branch hasn't moved since this run started. Without it, a stale run could still succeed in committing on top of newer commits pushed in the meantime.
- **Non-blocking manifest commit**: this repo's branch protection rules are currently too strict for the bot's manifest commit to always go through; that's a known, separate issue that shouldn't turn the whole build red, so failures here now surface as a `::warning::` instead.

This is a CI-only change (bash script + workflow YAML), so it hasn't been "tested" in the traditional sense of exercising application functionality; the retry logic was reasoned through and reviewed line-by-line against prior buildx failures, and the manifest workflow change is a minimal, surgical addition to existing conditionals/steps.
