### PR TITLE
fix(mitre): accept marking-definition in CONNECTOR_SCOPE (#7558)

### DIFF
--- a/external-import/mitre/src/models/configs/config_loader.py
+++ b/external-import/mitre/src/models/configs/config_loader.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -18,19 +19,20 @@ from src.models.configs import (
 )
 
 VALID_SCOPE_VALUES = [
+    "attack-pattern",
+    "campaign",
+    "course-of-action",
+    "identity",
+    "intrusion-set",
+    "malware",
+    "marking-definition",
     "tool",
     "report",
-    "malware",
-    "identity",
-    "campaign",
-    "intrusion-set",
-    "attack-pattern",
-    "course-of-action",
-    "x-mitre-data-source",
+    "x-mitre-collection",
     "x-mitre-data-component",
+    "x-mitre-data-source",
     "x-mitre-matrix",
     "x-mitre-tactic",
-    "x-mitre-collection",
 ]
 
 
@@ -55,9 +57,10 @@ class ConfigLoaderConnector(_ConfigLoaderConnector):
     def validate_scope(cls, value: ListFromString) -> ListFromString:
         invalid_values = [item for item in value if item not in VALID_SCOPE_VALUES]
         if invalid_values:
-            raise ValueError(
+            warnings.warn(
                 f"Invalid scope value(s) {invalid_values}. "
-                f"CONNECTOR_SCOPE must only contain values from {VALID_SCOPE_VALUES}."
+                f"CONNECTOR_SCOPE must only contain values from {VALID_SCOPE_VALUES}.",
+                stacklevel=2,
             )
         return value
 

--- a/external-import/mitre/tests/test_config_loader.py
+++ b/external-import/mitre/tests/test_config_loader.py
@@ -1,5 +1,4 @@
 import pytest
-from pydantic import ValidationError
 from src.models.configs.config_loader import (
     VALID_SCOPE_VALUES,
     ConfigLoaderConnector,
@@ -47,9 +46,9 @@ def test_scope_accepts_valid_values(scope):
         pytest.param(["not-a-stix-type"], id="unknown_stix_type"),
     ],
 )
-def test_scope_rejects_invalid_values(scope):
-    """CONNECTOR_SCOPE must only contain values from the supported STIX type list."""
-    with pytest.raises(ValidationError) as err:
-        ConfigLoaderConnector(**_minimal_kwargs(scope=scope))
+def test_scope_warns_on_invalid_values(scope):
+    """CONNECTOR_SCOPE should only warn, not raise, when it contains unsupported STIX types."""
+    with pytest.warns(UserWarning, match="Invalid scope value\\(s\\)"):
+        config = ConfigLoaderConnector(**_minimal_kwargs(scope=scope))
 
-    assert "Invalid scope value(s)" in str(err.value)
+    assert config.scope == (scope if isinstance(scope, list) else [scope])


### PR DESCRIPTION
### Proposed changes

* Added `marking-definition` to `VALID_SCOPE_VALUES` in the MITRE connector config loader, and alphabetically resorted the list.
* Changed the `CONNECTOR_SCOPE` validator to emit a `UserWarning` instead of raising a pydantic `ValidationError` when unsupported scope values are configured, so the connector still starts instead of crashing at startup.
* Updated the unit test (`test_scope_rejects_invalid_values` → `test_scope_warns_on_invalid_values`) to assert on `pytest.warns(UserWarning, ...)` and to verify that the (now-tolerated) invalid scope value is preserved in `config.scope` rather than raising.

### Related issues

* Closes #7558

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

We chose to downgrade this from a hard `ValidationError` to a `UserWarning` to preserve backward compatibility: users with existing or legacy `CONNECTOR_SCOPE` configurations (including values like `marking-definition` that were previously missing from the allow-list) should not have their connector crash on startup. Instead, they get a clear warning about the unsupported value(s) while the connector continues to run normally.