### PR TITLE
ci: re-enable build_manifest circleci job (#7566)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,20 +307,20 @@ workflows:
                 - master
                 - /release\/.*/
                 - /lts\/.*/
-      # - build_manifest:
-      #     requires:
-      #       - ensure_formatting
-      #       - base_linter
-      #       - linter
-      #       - test
-      #     filters:
-      #       tags:
-      #         only: /^[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]+)?$/
-      #       branches:
-      #         only:
-      #           - master
-      #           - /release\/.*/
-      #           - /lts\/.*/
+      - build_manifest:
+          requires:
+            - ensure_formatting
+            - base_linter
+            - linter
+            - test
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]+)?$/
+            branches:
+              only:
+                - master
+                - /release\/.*/
+                - /lts\/.*/
       # - build:
       #     name: "build_release"
       #     ci_executor:


### PR DESCRIPTION
### Proposed changes

* Re-enabled the `build_manifest` CircleCI job in `.circleci/config.yml`, restoring its `requires` (ensure_formatting, base_linter, linter, test) and branch/tag filters (master, release/*, lts/*)

### Related issues

* Closes #7566

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The `build_manifest` job was previously commented out to avoid duplicate/conflicting commits to master from both CircleCI and GitHub Actions. Now that GitHub Actions is allowed to commit directly on master, that conflict no longer applies, so the job can be safely re-enabled.