### PR TITLE
ci(build-manifest): use GitHub App token to commit generated manifest (#7568)

### DIFF
--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -30,7 +30,7 @@ jobs:
     name: Build and Commit Manifest
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -108,6 +108,22 @@ jobs:
             echo "still_head=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # GITHUB_TOKEN cannot push to the default branch: the `filigran`
+      # enterprise ruleset requires a pull request there, and `github-actions`
+      # is not an eligible bypass actor at enterprise level (only GitHub Apps
+      # are). The `Connectors Manifest Bot` App is registered in that ruleset's
+      # bypass list, so its installation token is what allows the commit back.
+      #
+      # Resolved right before the commit: installation tokens live for one
+      # hour, and the generation steps above can be slow.
+      - name: Generate GitHub App token
+        id: app-token
+        if: steps.target.outputs.branch != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_COMMIT_GITHUB_APP_ID }}
+          private-key: ${{ secrets.RELEASE_COMMIT_GITHUB_APP_PRIVATE_KEY }}
+
       # Commits via GitHub's GraphQL API instead of raw `git commit`, so the
       # commit is GPG-signed by GitHub (required by this repo's branch
       # protection) without managing signing keys in CI. No local git
@@ -135,7 +151,7 @@ jobs:
           branch: ${{ steps.target.outputs.branch }}
           file_pattern: "manifest.json */__metadata__/connector_config_schema.json */__metadata__/CONNECTOR_CONFIG_DOC.md"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Warn if manifest commit failed
         if: steps.target.outputs.branch != '' && steps.freshness.outputs.still_head == 'true' && steps.commit.outcome == 'failure'


### PR DESCRIPTION
### Proposed changes

* Update `.github/workflows/build-manifest.yml` to generate and use a `Connectors Manifest Bot` GitHub App installation token (via `actions/create-github-app-token`) instead of the default `GITHUB_TOKEN` when committing generated manifest/config-schema artifacts back to the target branch.
* Drop the now-unneeded `contents: write` permission (changed to `contents: read`), since the commit is now authenticated with the App token instead of the workflow's own `GITHUB_TOKEN`.
* This is required because the `filigran` enterprise ruleset requires a pull request to push to `master`, and `github-actions` is not an eligible bypass actor at the enterprise level — only GitHub Apps are. The `Connectors Manifest Bot` App is registered in that ruleset's bypass list, so its installation token is what allows the commit to succeed.

### Related issues

* Closes #7568

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This is the first of a stacked pair of PRs for #7568. The follow-up PR (reverting the conflicting CircleCI `build_manifest` job) is based on this branch and should be merged right after this one.