### PR TITLE
revert: re-enable build_manifest circleci job (#7568)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,20 +307,20 @@ workflows:
                 - master
                 - /release\/.*/
                 - /lts\/.*/
-      - build_manifest:
-          requires:
-            - ensure_formatting
-            - base_linter
-            - linter
-            - test
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]+)?$/
-            branches:
-              only:
-                - master
-                - /release\/.*/
-                - /lts\/.*/
+      # - build_manifest:
+      #     requires:
+      #       - ensure_formatting
+      #       - base_linter
+      #       - linter
+      #       - test
+      #     filters:
+      #       tags:
+      #         only: /^[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]+)?$/
+      #       branches:
+      #         only:
+      #           - master
+      #           - /release\/.*/
+      #           - /lts\/.*/
       # - build:
       #     name: "build_release"
       #     ci_executor:


### PR DESCRIPTION
### Proposed changes

* Revert "ci: re-enable build_manifest circleci job (#7566)" (commit 1f7da334535b8ab73dcc19e23604fdbb36278fa2, from #7567), commenting out the `build_manifest` CircleCI job block rather than deleting it, so it can be easily restored once the underlying commit-permission issue is fixed.
* This job was re-enabled on the assumption that CI could commit generated manifest/config-schema artifacts directly to `master`, but it now conflicts/duplicates with the GitHub Actions `build-manifest.yml` workflow that does the same thing, causing conflicting commit attempts.

### Related issues

* Closes #7568

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This is the second of a stacked pair of PRs for #7568, based on `fix/7568-build-manifest-app-token`. It should be merged right after (or together with) the first PR.