### PR TITLE
chore(renovate): stop ignoring tests directories so test-requirements.txt is scanned (#7576)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,13 @@
     "/^lts\\/.*/"
   ],
   "branchConcurrentLimit": 5,
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__fixtures__/**"
+  ],
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": [


### PR DESCRIPTION
### Proposed changes

* Added an explicit `ignorePaths` override in `renovate.json` since `config:recommended` implicitly extends Renovate's `:ignoreModulesAndTests` preset, which was silently excluding all `tests/`, `test/`, and `__tests__/` directories from dependency scanning.
* Kept ignoring `node_modules`, `bower_components`, `vendor`, `examples`, and `__fixtures__` directories, but removed the `test`/`tests`/`__tests__` patterns from the ignore list.
* As a result, Renovate will now scan and keep up to date each connector's `tests/test-requirements.txt` file (e.g. `internal-import-file/import-file-yara/tests/test-requirements.txt`), which were previously never picked up.

### Related issues

* Closes #7576

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

`ignorePaths` is a non-mergeable array in Renovate config, so it cannot be partially overridden — the full list had to be repeated here with only the test-related entries (`test`, `tests`, `__tests__`) removed. This is a repo-wide config change: it affects Renovate's dependency scanning for every connector's `tests/test-requirements.txt` file, not just one connector.