### PR TITLE
feat(spur): migrate connector to the catalog (#7559)

### DIFF
--- a/external-import/spur/Dockerfile
+++ b/external-import/spur/Dockerfile
@@ -13,9 +13,8 @@ RUN cd /opt/opencti-connector-spur && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 
-# Expose and entrypoint
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh && \
-    addgroup -S connector && adduser -S -G connector connector
+RUN addgroup -S connector && adduser -S -G connector connector
 USER connector
-ENTRYPOINT ["/entrypoint.sh"]
+WORKDIR /opt/opencti-connector-spur
+
+CMD ["python3", "main.py"]

--- a/external-import/spur/README.md
+++ b/external-import/spur/README.md
@@ -42,36 +42,10 @@ This connector will upsert anonymizer/proxy context into existing observables or
 
 ## Configuration variables
 
-### OpenCTI environment variables
+Find all the configuration variables available here: [Connector Configurations](./__metadata__/CONNECTOR_CONFIG_DOC.md)
 
-| Parameter     | config.yml | Docker env var  | Mandatory | Description                           |
-|---------------|------------|-----------------|-----------|---------------------------------------|
-| OpenCTI URL   | `url`      | `OPENCTI_URL`   | Yes       | URL of the OpenCTI platform.          |
-| OpenCTI Token | `token`    | `OPENCTI_TOKEN` | Yes       | Admin token for the OpenCTI platform. |
-
-### Base connector environment variables
-
-| Parameter | config.yml | Docker env var | Default | Mandatory | Description |
-| --- | --- | --- | --- | --- | --- |
-| Connector ID | `id` | `CONNECTOR_ID` | — | Yes | A unique UUIDv4 identifier for this connector instance. |
-| Connector Type | `type` | `CONNECTOR_TYPE` | `EXTERNAL_IMPORT` | Yes | Must be `EXTERNAL_IMPORT`. |
-| Connector Name | `name` | `CONNECTOR_NAME` | `Spur` | No | Display name in the OpenCTI UI. |
-| Connector Scope | `scope` | `CONNECTOR_SCOPE` | — | Yes | Scope of imported data (e.g. `IPv4-Addr,IPv6-Addr`). |
-| Log Level | `log_level` | `CONNECTOR_LOG_LEVEL` | `info` | No | Verbosity: `debug`, `info`, `warn`, or `error`. |
-| Duration Period | `duration_period` | `CONNECTOR_DURATION_PERIOD` | `PT24H` | No | How often the feed runs (ISO-8601 duration). Default is 24 hours. |
-
-### Connector extra parameters environment variables
-
-| Parameter | config.yml | Docker env var | Default | Mandatory | Description |
-| --- | --- | --- | --- | --- | --- |
-| API Key | `spur.api_key` | `SPUR_API_KEY` | — | Yes | Your Spur API token. Must have feed download access. |
-| Feed URLs | `spur.feed_urls` | `SPUR_FEED_URLS` | See note | No | Comma-separated Spur feed URLs. Defaults to anonymous and residential feeds. Adjust to match your license. |
-| TLP Level | `spur.tlp_level` | `SPUR_TLP_LEVEL` | `amber` | No | TLP marking on all imported objects. Options: `clear`, `white`, `green`, `amber`, `amber+strict`, `red`. |
-| Create Indicators | `spur.create_indicators` | `SPUR_CREATE_INDICATORS` | `true` | No | Create STIX Indicators for flagged IPs. Only created for IPs with risks or tunnel data. |
-| Create ASNs | `spur.create_asns` | `SPUR_CREATE_ASNS` | `true` | No | Create `AutonomousSystem` objects with `belongs-to` relationships. |
-| Create Locations | `spur.create_locations` | `SPUR_CREATE_LOCATIONS` | `true` | No | Create `Location` objects with `located-at` relationships. |
-| Default Score | `spur.default_score` | `SPUR_DEFAULT_SCORE` | `70` | No | Base OpenCTI score (0–100). Each risk flag adds 5 points, capped at 100. |
-| Batch Size | `spur.batch_size` | `SPUR_BATCH_SIZE` | `5000` | No | IP records per STIX bundle sent to OpenCTI. Reduce if you encounter memory pressure. |
+_The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as for any other connector.
+For more information regarding variables, please refer to [OpenCTI's documentation on connectors](https://docs.opencti.io/latest/deployment/connectors/)._
 
 Default feed URLs:
 

--- a/external-import/spur/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/spur/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -1,0 +1,23 @@
+# Connector Configurations
+
+Below is an exhaustive enumeration of all configurable parameters available, each accompanied by detailed explanations of their purposes, default behaviors, and usage guidelines to help you understand and utilize them effectively.
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
+| OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
+| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'indicator, vulnerability'. |
+| SPUR_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Spur API token. |
+| CONNECTOR_NAME | `string` |  | string | `"Spur"` |  |
+| CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
+| CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
+| CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"P1D"` | Interval between feed runs (ISO-8601). |
+| SPUR_FEED_URLS | `array` |  | string | `["https://feeds.spur.us/v2/anonymous/feed.json.gz", "https://feeds.spur.us/v2/residential/feed.json.gz"]` | Comma-separated list of Spur feed URLs to download. |
+| SPUR_TLP_LEVEL | `string` |  | `clear` `white` `green` `amber` `amber+strict` `red` | `"amber"` | TLP marking applied to all imported objects. |
+| SPUR_CREATE_INDICATORS | `boolean` |  | boolean | `true` | Create STIX Indicators for flagged IPs. |
+| SPUR_CREATE_ASNS | `boolean` |  | boolean | `true` | Create AutonomousSystem objects and belongs-to relationships. |
+| SPUR_CREATE_LOCATIONS | `boolean` |  | boolean | `true` | Create Location objects and located-at relationships. |
+| SPUR_DEFAULT_SCORE | `integer` |  | `0 <= x <= 100` | `70` | Base OpenCTI score for Spur observables (0-100). |
+| SPUR_BATCH_SIZE | `integer` |  | `100 <= x ` | `5000` | Number of IP records per STIX bundle sent to OpenCTI. |

--- a/external-import/spur/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/spur/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -8,9 +8,9 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | -------- | ---- | -------- | --------------- | ------- | ----------- |
 | OPENCTI_URL | `string` | ✅ | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The base URL of the OpenCTI instance. |
 | OPENCTI_TOKEN | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | The API token to connect to OpenCTI. |
-| CONNECTOR_SCOPE | `array` | ✅ | string |  | The scope of the connector, e.g. 'indicator, vulnerability'. |
 | SPUR_API_KEY | `string` | ✅ | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | Spur API token. |
 | CONNECTOR_NAME | `string` |  | string | `"Spur"` |  |
+| CONNECTOR_SCOPE | `array` |  | string | `["spur"]` | The scope of the connector. |
 | CONNECTOR_LOG_LEVEL | `string` |  | `debug` `info` `warn` `warning` `error` | `"error"` | The minimum level of logs to display. |
 | CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` | `"EXTERNAL_IMPORT"` |  |
 | CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | `"P1D"` | Interval between feed runs (ISO-8601). |

--- a/external-import/spur/__metadata__/connector_config_schema.json
+++ b/external-import/spur/__metadata__/connector_config_schema.json
@@ -21,7 +21,10 @@
       "type": "string"
     },
     "CONNECTOR_SCOPE": {
-      "description": "The scope of the connector, e.g. 'indicator, vulnerability'.",
+      "default": [
+        "spur"
+      ],
+      "description": "The scope of the connector.",
       "items": {
         "type": "string"
       },
@@ -112,7 +115,6 @@
   "required": [
     "OPENCTI_URL",
     "OPENCTI_TOKEN",
-    "CONNECTOR_SCOPE",
     "SPUR_API_KEY"
   ],
   "additionalProperties": true

--- a/external-import/spur/__metadata__/connector_config_schema.json
+++ b/external-import/spur/__metadata__/connector_config_schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.filigran.io/connectors/spur_config.schema.json",
+  "type": "object",
+  "properties": {
+    "OPENCTI_URL": {
+      "description": "The base URL of the OpenCTI instance.",
+      "format": "uri",
+      "maxLength": 2083,
+      "minLength": 1,
+      "type": "string"
+    },
+    "OPENCTI_TOKEN": {
+      "description": "The API token to connect to OpenCTI.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "CONNECTOR_NAME": {
+      "default": "Spur",
+      "type": "string"
+    },
+    "CONNECTOR_SCOPE": {
+      "description": "The scope of the connector, e.g. 'indicator, vulnerability'.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "CONNECTOR_LOG_LEVEL": {
+      "default": "error",
+      "description": "The minimum level of logs to display.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "CONNECTOR_TYPE": {
+      "const": "EXTERNAL_IMPORT",
+      "default": "EXTERNAL_IMPORT",
+      "type": "string"
+    },
+    "CONNECTOR_DURATION_PERIOD": {
+      "default": "P1D",
+      "description": "Interval between feed runs (ISO-8601).",
+      "format": "duration",
+      "type": "string"
+    },
+    "SPUR_API_KEY": {
+      "description": "Spur API token.",
+      "format": "password",
+      "type": "string",
+      "writeOnly": true
+    },
+    "SPUR_FEED_URLS": {
+      "default": [
+        "https://feeds.spur.us/v2/anonymous/feed.json.gz",
+        "https://feeds.spur.us/v2/residential/feed.json.gz"
+      ],
+      "description": "Comma-separated list of Spur feed URLs to download.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "SPUR_TLP_LEVEL": {
+      "default": "amber",
+      "description": "TLP marking applied to all imported objects.",
+      "enum": [
+        "clear",
+        "white",
+        "green",
+        "amber",
+        "amber+strict",
+        "red"
+      ],
+      "type": "string"
+    },
+    "SPUR_CREATE_INDICATORS": {
+      "default": true,
+      "description": "Create STIX Indicators for flagged IPs.",
+      "type": "boolean"
+    },
+    "SPUR_CREATE_ASNS": {
+      "default": true,
+      "description": "Create AutonomousSystem objects and belongs-to relationships.",
+      "type": "boolean"
+    },
+    "SPUR_CREATE_LOCATIONS": {
+      "default": true,
+      "description": "Create Location objects and located-at relationships.",
+      "type": "boolean"
+    },
+    "SPUR_DEFAULT_SCORE": {
+      "default": 70,
+      "description": "Base OpenCTI score for Spur observables (0-100).",
+      "maximum": 100,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "SPUR_BATCH_SIZE": {
+      "default": 5000,
+      "description": "Number of IP records per STIX bundle sent to OpenCTI.",
+      "minimum": 100,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "OPENCTI_URL",
+    "OPENCTI_TOKEN",
+    "CONNECTOR_SCOPE",
+    "SPUR_API_KEY"
+  ],
+  "additionalProperties": true
+}

--- a/external-import/spur/__metadata__/connector_manifest.json
+++ b/external-import/spur/__metadata__/connector_manifest.json
@@ -22,7 +22,7 @@
   "support_version": ">=6.8.12",
   "subscription_link": "https://spur.us",
   "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/spur",
-  "manager_supported": false,
+  "manager_supported": true,
   "container_version": "rolling",
   "container_image": "opencti/connector-spur",
   "container_type": "EXTERNAL_IMPORT"

--- a/external-import/spur/config.yml.sample
+++ b/external-import/spur/config.yml.sample
@@ -6,7 +6,7 @@ connector:
   type: 'EXTERNAL_IMPORT'
   id: 'ChangeMe'
   name: 'Spur'
-  scope: 'ChangeMe'
+  scope: 'spur'
   log_level: 'info'
   duration_period: 'PT24H'
 

--- a/external-import/spur/docker-compose.yml
+++ b/external-import/spur/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       # Connector settings
       - CONNECTOR_ID=CHANGEME
       - CONNECTOR_NAME=Spur
-      - CONNECTOR_SCOPE=CHANGEME
+      # - CONNECTOR_SCOPE=spur
       - CONNECTOR_LOG_LEVEL=info
       - CONNECTOR_DURATION_PERIOD=PT24H
       # Spur feed settings

--- a/external-import/spur/entrypoint.sh
+++ b/external-import/spur/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Go to the right directory
-cd /opt/opencti-connector-spur
-
-# Launch the worker
-python3 main.py

--- a/external-import/spur/src/__init__.py
+++ b/external-import/spur/src/__init__.py
@@ -1,0 +1,3 @@
+from connector.settings import ConnectorSettings
+
+__all__ = ["ConnectorSettings"]

--- a/external-import/spur/src/connector/settings.py
+++ b/external-import/spur/src/connector/settings.py
@@ -14,6 +14,10 @@ class ExternalImportConnectorConfig(
     BaseExternalImportConnectorConfig
 ):  # pylint: disable=too-few-public-methods
     name: str = Field(default="Spur")
+    scope: ListFromString = Field(
+        description="The scope of the connector.",
+        default=["spur"],
+    )
     duration_period: timedelta = Field(
         description="Interval between feed runs (ISO-8601).",
         default=timedelta(hours=24),

--- a/external-import/spur/src/requirements.txt
+++ b/external-import/spur/src/requirements.txt
@@ -1,4 +1,4 @@
-pycti==7.260904.0
+pycti==7.260907.0
 pydantic~=2.13.5
 requests~=2.33.0
 validators==0.35.0


### PR DESCRIPTION
### Proposed changes

* Add connector to catalog (manager-supported)
* Set `manager_supported: true` in the connector manifest
* Add default connector scope (`spur`)
* Switch Dockerfile to `CMD` and remove `entrypoint.sh`
* Add `src/__init__.py` and generate config JSON schema + config doc
* Align `pycti` pin with `connectors-sdk` (`7.260907.0`)

### Related issues

* Closes: #7559

### Checklist
- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments
Tested without creds