### PR TITLE
fix(kaspersky): parse non-standard yara dates and compare rule names case-insensitively (#5941)

### DIFF
--- a/external-import/kaspersky/src/kaspersky/models.py
+++ b/external-import/kaspersky/src/kaspersky/models.py
@@ -10,6 +10,27 @@ from pydantic.v1.errors import DateError, DateTimeError
 
 log = logging.getLogger(__name__)
 
+# Additional Kaspersky-specific date formats not handled by pydantic parsers.
+_EXTRA_DATE_FORMATS = (
+    "%d-%m-%Y",  # 12-10-2018
+    "%d.%m.%Y",  # 12.10.2018
+    "%Y.%m.%d",  # 2018.10.12
+    "%Y-%m",  # 2018-10
+    "%b %d %Y",  # Oct 12 2018
+    "%b %d, %Y",  # Oct 12, 2018
+    "%B %d %Y",  # October 12 2018
+    "%B %d, %Y",  # October 12, 2018
+)
+
+
+def _clean_last_modified(value: str) -> str:
+    """Normalize list-string values such as ['2020-03-05'] to 2020-03-05."""
+    cleaned = value.strip()
+    if cleaned.startswith("[") and cleaned.endswith("]"):
+        cleaned = cleaned[1:-1].strip()
+        cleaned = cleaned.strip("\"'").strip()
+    return cleaned
+
 
 class Base(BaseModel):
     """Kaspersky base model."""
@@ -89,7 +110,9 @@ class YaraRule(Base):
         if not isinstance(value, str):
             raise ValueError("must be a string")
 
-        if value.strip() == "-":
+        value = _clean_last_modified(value)
+
+        if not value or value == "-":
             return None
 
         try:
@@ -107,8 +130,18 @@ class YaraRule(Base):
                 date_value, datetime.min.time(), tzinfo=timezone.utc
             )
         except DateError:
-            log.error("Unable to parse last_modified value: %s", value)
-            return None
+            # Ignore
+            pass
+
+        for date_format in _EXTRA_DATE_FORMATS:
+            try:
+                parsed_datetime = datetime.strptime(value, date_format)
+                return parsed_datetime.replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue
+
+        log.error("Unable to parse last_modified value: %s", value)
+        return None
 
 
 class Yara(Base):

--- a/external-import/kaspersky/src/kaspersky/utils/yara.py
+++ b/external-import/kaspersky/src/kaspersky/utils/yara.py
@@ -140,7 +140,7 @@ class YaraRuleUpdater:
             return False
 
     def _needs_updating(self, current_rule: YaraRule, new_rule: YaraRule) -> bool:
-        if current_rule.name != new_rule.name:
+        if current_rule.name.lower() != new_rule.name.lower():
             self._error(
                 "Current ({0}) and new ({1}) YARA rules names do not match",
                 current_rule.name,

--- a/external-import/kaspersky/tests/conftest.py
+++ b/external-import/kaspersky/tests/conftest.py
@@ -1,0 +1,6 @@
+"""Pytest configuration for the Kaspersky connector tests."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/external-import/kaspersky/tests/test-requirements.txt
+++ b/external-import/kaspersky/tests/test-requirements.txt
@@ -1,0 +1,2 @@
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/external-import/kaspersky/tests/tests_connector/test_yara.py
+++ b/external-import/kaspersky/tests/tests_connector/test_yara.py
@@ -1,0 +1,88 @@
+"""Tests for the Kaspersky YARA rule date parsing and update logic (issue #5941)."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from kaspersky.models import YaraRule
+from kaspersky.utils.yara import YaraRuleUpdater
+
+
+def _make_rule(last_modified, name="apt_rule"):
+    return YaraRule(
+        name=name,
+        description="desc",
+        report=None,
+        last_modified=last_modified,
+        rule="rule apt_rule { condition: true }",
+    )
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("2018-10-12T00:00:00Z", datetime(2018, 10, 12, tzinfo=timezone.utc)),
+        ("2018-10-12", datetime(2018, 10, 12, tzinfo=timezone.utc)),
+        ("12-10-2018", datetime(2018, 10, 12, tzinfo=timezone.utc)),
+        ("12.10.2018", datetime(2018, 10, 12, tzinfo=timezone.utc)),
+        ("2018.10.12", datetime(2018, 10, 12, tzinfo=timezone.utc)),
+        ("2018-10", datetime(2018, 10, 1, tzinfo=timezone.utc)),
+        ("Oct 12 2018", datetime(2018, 10, 12, tzinfo=timezone.utc)),
+        ("Oct 12, 2018", datetime(2018, 10, 12, tzinfo=timezone.utc)),
+        ("October 12 2018", datetime(2018, 10, 12, tzinfo=timezone.utc)),
+        ("October 12, 2018", datetime(2018, 10, 12, tzinfo=timezone.utc)),
+        ("['2020-03-05']", datetime(2020, 3, 5, tzinfo=timezone.utc)),
+        ('["2020-03-05"]', datetime(2020, 3, 5, tzinfo=timezone.utc)),
+    ],
+)
+def test_parse_last_modified_supported_formats(value, expected):
+    rule = _make_rule(value)
+    assert rule.last_modified == expected
+
+
+@pytest.mark.parametrize("value", ["-", "", "   ", "not-a-date"])
+def test_parse_last_modified_returns_none_for_invalid(value):
+    rule = _make_rule(value)
+    assert rule.last_modified is None
+
+
+def test_parse_last_modified_accepts_none():
+    rule = _make_rule(None)
+    assert rule.last_modified is None
+
+
+def _make_updater():
+    helper = MagicMock()
+    return YaraRuleUpdater(helper=helper)
+
+
+def test_needs_updating_case_insensitive_name_and_newer_date():
+    updater = _make_updater()
+    current = _make_rule("2018-01-01", name="apt_Shadowpad_dropper")
+    new = _make_rule("2020-01-01", name="apt_ShadowPad_dropper")
+
+    assert updater._needs_updating(current, new) is True
+
+
+def test_needs_updating_same_date_not_updated():
+    updater = _make_updater()
+    current = _make_rule("2020-01-01", name="apt_rule")
+    new = _make_rule("2020-01-01", name="apt_rule")
+
+    assert updater._needs_updating(current, new) is False
+
+
+def test_needs_updating_none_date_not_updated():
+    updater = _make_updater()
+    current = _make_rule(None, name="apt_rule")
+    new = _make_rule("2020-01-01", name="apt_rule")
+
+    assert updater._needs_updating(current, new) is False
+
+
+def test_needs_updating_different_names_not_updated():
+    updater = _make_updater()
+    current = _make_rule("2018-01-01", name="apt_one")
+    new = _make_rule("2020-01-01", name="apt_two")
+
+    assert updater._needs_updating(current, new) is False


### PR DESCRIPTION
### Proposed changes

* Add a multi-format parser for YARA `last_modified` values so non-standard Kaspersky date formats (`DD-MM-YYYY`, `DD.MM.YYYY`, `YYYY.MM.DD`, `YYYY-MM`, `Oct 12 2018`, `October 12, 2018`) are parsed instead of dropped to `None`
* Normalize Python list-string values such as `['2020-03-05']` before parsing
* Compare current and new YARA rule names case-insensitively in `_needs_updating`, so rules differing only in casing (e.g. `apt_Shadowpad_dropper` -> `apt_ShadowPad_dropper`) are recognized as the same rule and updated
* Add unit tests covering all supported date formats, invalid inputs, and the `_needs_updating` update logic

### Related issues

* Fixes #5941

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Both defects caused `_needs_updating()` to return `False` when it should return `True`, silently skipping YARA rule updates:

1. **Date parsing** — `parse_last_modified` only used pydantic's `parse_datetime`/`parse_date`, which reject Kaspersky's non-standard formats. Failing values became `None`, and `_needs_updating` returns `False` whenever either side's `last_modified` is `None`. The date-format constants and the list-string cleaner are placed at module level to avoid interfering with pydantic v1 field collection.
2. **Name comparison** — strict `!=` on names rejected valid matches whenever Kaspersky changed casing between versions.

Validation was done via unit tests (21 passing). An end-to-end run against the live TIP API was attempted but the Master YARA feed returns HTTP 451 (Unavailable For Legal Reasons) for the available account, so the YARA data path cannot be exercised against production data regardless of the fix.