### PR TITLE
fix(kaspersky): retry transient api errors with exponential backoff (#5942)

### DIFF
--- a/external-import/kaspersky/src/kaspersky/client.py
+++ b/external-import/kaspersky/src/kaspersky/client.py
@@ -11,7 +11,9 @@ from kaspersky.utils import datetime_to_timestamp, decode_base64_gzip_to_string
 from pycti import OpenCTIConnectorHelper
 from pydantic.v1.tools import parse_obj_as
 from requests import RequestException, Response
+from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectTimeout, ReadTimeout
+from urllib3.util.retry import Retry
 
 log = logging.getLogger(__name__)
 
@@ -27,6 +29,11 @@ class KasperskyClient:
     _TIMEOUT_READ_SEC = 30
 
     _TIMEOUTS = (_TIMEOUT_CONNECT_SEC, _TIMEOUT_READ_SEC)
+
+    # Retry transient errors (timeouts, rate limiting, 5xx) with exponential backoff.
+    _RETRY_TOTAL = 5
+    _RETRY_BACKOFF_FACTOR = 5
+    _RETRY_STATUS_FORCELIST = (429, 500, 502, 503, 504)
 
     _RESPONSE_FIELD_STATUS = "status"
     _RESPONSE_FIELD_STATUS_MSG = "status_msg"
@@ -67,6 +74,21 @@ class KasperskyClient:
         self.session = requests.Session()
         self.session.auth = (user, password)
         self.session.cert = certificate_path
+
+        self._mount_retry_adapter()
+
+    def _mount_retry_adapter(self) -> None:
+        retry_strategy = Retry(
+            total=self._RETRY_TOTAL,
+            backoff_factor=self._RETRY_BACKOFF_FACTOR,
+            status_forcelist=self._RETRY_STATUS_FORCELIST,
+            allowed_methods=frozenset({"GET", "POST"}),
+            respect_retry_after_header=True,
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
 
     def close(self) -> None:
         """Close Kaspersky client."""

--- a/external-import/kaspersky/tests/conftest.py
+++ b/external-import/kaspersky/tests/conftest.py
@@ -1,0 +1,6 @@
+"""Pytest configuration for the Kaspersky connector tests."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/external-import/kaspersky/tests/test-requirements.txt
+++ b/external-import/kaspersky/tests/test-requirements.txt
@@ -1,0 +1,2 @@
+-r ../src/requirements.txt
+pytest==9.0.3

--- a/external-import/kaspersky/tests/tests_connector/test_client.py
+++ b/external-import/kaspersky/tests/tests_connector/test_client.py
@@ -1,0 +1,63 @@
+"""Tests for the Kaspersky client retry/backoff configuration (issue #5942)."""
+
+from unittest.mock import MagicMock
+
+from kaspersky.client import KasperskyClient
+
+
+def _make_client():
+    helper = MagicMock()
+    return KasperskyClient(
+        helper=helper,
+        base_url="https://tip.kaspersky.com",
+        user="user",
+        password="password",
+        certificate_path="",
+    )
+
+
+def test_retry_adapter_mounted_for_http_and_https():
+    client = _make_client()
+
+    https_adapter = client.session.get_adapter("https://tip.kaspersky.com")
+    http_adapter = client.session.get_adapter("http://tip.kaspersky.com")
+
+    assert https_adapter is not None
+    assert http_adapter is not None
+
+
+def test_retry_strategy_configuration():
+    client = _make_client()
+
+    retries = client.session.get_adapter("https://tip.kaspersky.com").max_retries
+
+    assert retries.total == 5
+    assert retries.backoff_factor == 5
+    assert retries.respect_retry_after_header is True
+    assert retries.raise_on_status is False
+
+
+def test_transient_statuses_are_retried():
+    client = _make_client()
+
+    retries = client.session.get_adapter("https://tip.kaspersky.com").max_retries
+
+    for status in (429, 500, 502, 503, 504):
+        assert status in retries.status_forcelist
+
+
+def test_permanent_statuses_are_not_retried():
+    client = _make_client()
+
+    retries = client.session.get_adapter("https://tip.kaspersky.com").max_retries
+
+    for status in (400, 401, 403, 404):
+        assert status not in retries.status_forcelist
+
+
+def test_post_requests_are_retried():
+    client = _make_client()
+
+    retries = client.session.get_adapter("https://tip.kaspersky.com").max_retries
+
+    assert "POST" in retries.allowed_methods


### PR DESCRIPTION
### Proposed changes

* Mount a `requests` `HTTPAdapter` configured with `urllib3` `Retry` on the Kaspersky client session (both `http://` and `https://`)
* Retry transient errors (`429`, `500`, `502`, `503`, `504` and connect/read timeouts) up to 5 times with exponential backoff, honoring the `Retry-After` header
* Keep permanent errors (`400`, `401`, `403`, `404`) failing immediately, and preserve the existing `KasperskyClientException` behavior once retries are exhausted (`raise_on_status=False`)
* Add unit tests covering the retry adapter and its configuration

### Related issues

* Fixes #5942

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments