### PR TITLE
fix(taxii2): break pagination loop when added_after does not advance (#7604)

### DIFF
--- a/external-import/taxii2/src/connector/client_taxii.py
+++ b/external-import/taxii2/src/connector/client_taxii.py
@@ -190,6 +190,16 @@ class Taxii2:
                     # Check manifest size
                     if "objects" in manifest and len(manifest["objects"]) > 0:
                         date_added = manifest["objects"][0]["date_added"]
+                        # Some TAXII 2.0 servers treat `added_after` as inclusive.
+                        # When a batch of objects shares an identical date_added, the
+                        # filter stops advancing and the returned page is never empty,
+                        # so this loop never terminates. Break when no progress is made.
+                        if date_added == self.filters.get("added_after"):
+                            self.helper.log_info(
+                                f"added_after did not advance past {date_added}; "
+                                "end of collection reached. Stopping pagination."
+                            )
+                            break
                         self.filters["added_after"] = date_added
                         # Get the next set of objects
                         response = self.get_objects(collection)


### PR DESCRIPTION
<!--
PR TITLE (CI-enforced format):
  fix(taxii2): break pagination loop when added_after does not advance (#7604)
-->

### Proposed changes

* Add a no-progress guard to the TAXII 2.0 pagination loop in `Taxii2.poll()` (`external-import/taxii2/src/connector/client_taxii.py`). Full analysis and reproduction in #7604.
* In short: the loop advances by setting `added_after` to the `date_added` of the last object in the page and exits only when the next page is empty. Against a server that treats `added_after` as inclusive, a tail batch sharing one `date_added` makes the filter stop advancing while the page stays non-empty — so the loop never terminates, `poll()` never returns, and the connector silently ingests nothing.
* The guard breaks out when `added_after` fails to advance. Objects from the final page are already appended by `process_response` at the top of the loop, so no data is lost. It triggers only when `added_after` would be set to the value it already holds, so behaviour against servers with an exclusive `added_after` is unchanged.

### Related issues

* Fixes #7604
* TAXII 2.0 counterpart of #1683, which fixed the equivalent infinite loop in the TAXII 2.1 `next` branch. That branch gained a termination guard; the 2.0 branch never did.

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Tested in production against a live TAXII 2.0 feed exhibiting the bug. Before the fix `poll()` never returned; after it, the initial backfill completes in 6.6s (30 pages, 2843 objects, 2611 bundles sent, queue fully drained), a subsequent run with nothing new completes in ~155 ms without entering the loop, and connector memory goes from 237 MiB and climbing to a flat 67 MiB. Full figures in #7604.

Alternatives considered — advancing `added_after` by one microsecond (silently skips objects sharing the boundary timestamp), taking `max(date_added)` across the page (same fixed point), and tracking seen values in a set (equivalent for more state) — are covered in #7604.
