### PR TITLE
feat(tweetfeed): replace hardcoded TLP:GREEN with configurable value (#7286)

### DIFF
--- a/external-import/tweetfeed/README.md
+++ b/external-import/tweetfeed/README.md
@@ -33,7 +33,7 @@ There are a number of configuration options, which are set either in `docker-com
 | TWEETFEED_UPDATE_EXISTING_DATA | update_existing_data |      |True or False , updates the data
 | TWEETFEED_ORG_DESCRIPTION      | org_description      | X    |Organization description, which will be refered to data injected
 | TWEETFEED_ORG_NAME             | org_name             | X    |Organization name, which will be refered to data injected
-| TWEETFEED_TLP_LEVEL            | tlp_level            |      |TLP marking applied to the imported observables and indicators. One of `clear`, `white`, `green`, `amber`, `amber+strict`, `red` - default is `clear`
+| TWEETFEED_TLP_LEVEL            | tlp_level            |      |TLP marking applied to the imported observables and indicators. One of `clear`, `white`, `green`, `amber`, `amber+strict`, `red` - default is `green`
 
 The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as any other Connector. You should consult the OpenCTI Connector documentation for questions about these values here: [https://filigran.notion.site/Connectors-4586c588462d4a1fb5e661f2d9837db8](https://filigran.notion.site/Connectors-4586c588462d4a1fb5e661f2d9837db8)._
 

--- a/external-import/tweetfeed/README.md
+++ b/external-import/tweetfeed/README.md
@@ -33,6 +33,7 @@ There are a number of configuration options, which are set either in `docker-com
 | TWEETFEED_UPDATE_EXISTING_DATA | update_existing_data |      |True or False , updates the data
 | TWEETFEED_ORG_DESCRIPTION      | org_description      | X    |Organization description, which will be refered to data injected
 | TWEETFEED_ORG_NAME             | org_name             | X    |Organization name, which will be refered to data injected
+| TWEETFEED_TLP_LEVEL            | tlp_level            |      |TLP marking applied to the imported observables and indicators. One of `clear`, `white`, `green`, `amber`, `amber+strict`, `red` - default is `clear`
 
 The `opencti` and `connector` options in the `docker-compose.yml` and `config.yml` are the same as any other Connector. You should consult the OpenCTI Connector documentation for questions about these values here: [https://filigran.notion.site/Connectors-4586c588462d4a1fb5e661f2d9837db8](https://filigran.notion.site/Connectors-4586c588462d4a1fb5e661f2d9837db8)._
 

--- a/external-import/tweetfeed/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/tweetfeed/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -21,3 +21,4 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | TWEETFEED_ORG_NAME | `string` |  | string | `"Tweetfeed"` | Name of the author organization created in OpenCTI. |
 | TWEETFEED_ORG_DESCRIPTION | `string` |  | string | `"Tweetfeed, a connector to import IOC from Twitter."` | Description of the author organization created in OpenCTI. |
 | TWEETFEED_DAYS_BACK_IN_TIME | `integer` |  | integer | `30` | Number of days to retrieve data back in time. |
+| TWEETFEED_TLP_LEVEL | `string` |  | `clear` `white` `green` `amber` `amber+strict` `red` | `"clear"` | TLP marking applied to imported observables and indicators (clear, white, green, amber, amber+strict, red). |

--- a/external-import/tweetfeed/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/tweetfeed/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -21,4 +21,4 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | TWEETFEED_ORG_NAME | `string` |  | string | `"Tweetfeed"` | Name of the author organization created in OpenCTI. |
 | TWEETFEED_ORG_DESCRIPTION | `string` |  | string | `"Tweetfeed, a connector to import IOC from Twitter."` | Description of the author organization created in OpenCTI. |
 | TWEETFEED_DAYS_BACK_IN_TIME | `integer` |  | integer | `30` | Number of days to retrieve data back in time. |
-| TWEETFEED_TLP_LEVEL | `string` |  | `clear` `white` `green` `amber` `amber+strict` `red` | `"clear"` | TLP marking applied to imported observables and indicators (clear, white, green, amber, amber+strict, red). |
+| TWEETFEED_TLP_LEVEL | `string` |  | `clear` `white` `green` `amber` `amber+strict` `red` | `"green"` | TLP marking applied to imported observables and indicators (clear, white, green, amber, amber+strict, red). |

--- a/external-import/tweetfeed/__metadata__/connector_config_schema.json
+++ b/external-import/tweetfeed/__metadata__/connector_config_schema.json
@@ -103,7 +103,7 @@
         "red"
       ],
       "type": "string",
-      "default": "clear"
+      "default": "green"
     }
   },
   "required": [

--- a/external-import/tweetfeed/__metadata__/connector_config_schema.json
+++ b/external-import/tweetfeed/__metadata__/connector_config_schema.json
@@ -91,6 +91,19 @@
       "default": 30,
       "description": "Number of days to retrieve data back in time.",
       "type": "integer"
+    },
+    "TWEETFEED_TLP_LEVEL": {
+      "description": "TLP marking applied to imported observables and indicators (clear, white, green, amber, amber+strict, red).",
+      "enum": [
+        "clear",
+        "white",
+        "green",
+        "amber",
+        "amber+strict",
+        "red"
+      ],
+      "type": "string",
+      "default": "clear"
     }
   },
   "required": [

--- a/external-import/tweetfeed/docker-compose.yml
+++ b/external-import/tweetfeed/docker-compose.yml
@@ -21,4 +21,5 @@ services:
       # - TWEETFEED_ORG_NAME=Tweetfeed
       # - "TWEETFEED_ORG_DESCRIPTION=Tweetfeed, a connector to import IOC from Twitter."
       # - TWEETFEED_DAYS_BACK_IN_TIME=30 # Number of days to retrieve data back in time
+      # - TWEETFEED_TLP_LEVEL=clear # Available values are: clear, white, green, amber, amber+strict, red
     restart: always

--- a/external-import/tweetfeed/docker-compose.yml
+++ b/external-import/tweetfeed/docker-compose.yml
@@ -21,5 +21,5 @@ services:
       # - TWEETFEED_ORG_NAME=Tweetfeed
       # - "TWEETFEED_ORG_DESCRIPTION=Tweetfeed, a connector to import IOC from Twitter."
       # - TWEETFEED_DAYS_BACK_IN_TIME=30 # Number of days to retrieve data back in time
-      # - TWEETFEED_TLP_LEVEL=clear # Available values are: clear, white, green, amber, amber+strict, red
+      # - TWEETFEED_TLP_LEVEL=green # Available values are: clear, white, green, amber, amber+strict, red
     restart: always

--- a/external-import/tweetfeed/src/config.yml.sample
+++ b/external-import/tweetfeed/src/config.yml.sample
@@ -18,3 +18,4 @@ connector:
 #   org_name: 'Tweetfeed'
 #   org_description: 'Tweetfeed, a connector to import IOC from Twitter.'
 #   days_back_in_time: 30
+#   tlp_level: 'clear' # Available values are: clear, white, green, amber, amber+strict, red - Default: "clear"

--- a/external-import/tweetfeed/src/config.yml.sample
+++ b/external-import/tweetfeed/src/config.yml.sample
@@ -18,4 +18,4 @@ connector:
 #   org_name: 'Tweetfeed'
 #   org_description: 'Tweetfeed, a connector to import IOC from Twitter.'
 #   days_back_in_time: 30
-#   tlp_level: 'clear' # Available values are: clear, white, green, amber, amber+strict, red - Default: "clear"
+#   tlp_level: 'green' # Available values are: clear, white, green, amber, amber+strict, red - Default: "green"

--- a/external-import/tweetfeed/src/settings.py
+++ b/external-import/tweetfeed/src/settings.py
@@ -72,7 +72,7 @@ class TweetFeedConfig(BaseConfigModel):
     tlp_level: TLPLevel = Field(
         description="TLP marking applied to imported observables and indicators "
         "(clear, white, green, amber, amber+strict, red).",
-        default=TLPLevel.CLEAR,
+        default=TLPLevel.GREEN,
     )
 
     @field_validator("tlp_level", mode="before")

--- a/external-import/tweetfeed/src/settings.py
+++ b/external-import/tweetfeed/src/settings.py
@@ -7,7 +7,8 @@ from connectors_sdk import (
     BaseExternalImportConnectorConfig,
     ListFromString,
 )
-from pydantic import Field
+from connectors_sdk.models.enums import TLPLevel
+from pydantic import Field, field_validator
 
 
 class ExternalImportConnectorConfig(BaseExternalImportConnectorConfig):
@@ -68,6 +69,16 @@ class TweetFeedConfig(BaseConfigModel):
         description="Number of days to retrieve data back in time.",
         default=30,
     )
+    tlp_level: TLPLevel = Field(
+        description="TLP marking applied to imported observables and indicators "
+        "(clear, white, green, amber, amber+strict, red).",
+        default=TLPLevel.CLEAR,
+    )
+
+    @field_validator("tlp_level", mode="before")
+    @classmethod
+    def _lowercase_tlp_level(cls, value: str) -> str:
+        return value.lower() if isinstance(value, str) else value
 
 
 class ConnectorSettings(BaseConnectorSettings):

--- a/external-import/tweetfeed/src/tweetfeed.py
+++ b/external-import/tweetfeed/src/tweetfeed.py
@@ -6,11 +6,21 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Mapping, Optional
 
 import requests
-import stix2
-from pycti import OpenCTIConnectorHelper
+from connectors_sdk.models.enums import TLPLevel
+from pycti import MarkingDefinition, OpenCTIConnectorHelper
 from settings import ConnectorSettings
 
 __version__ = "0.0.1"
+
+# OpenCTI defines a static marking-definition id for each TLP level.
+TLP_MARKING_IDS = {
+    TLPLevel.CLEAR: MarkingDefinition.generate_id("TLP", "TLP:CLEAR"),
+    TLPLevel.WHITE: MarkingDefinition.generate_id("TLP", "TLP:WHITE"),
+    TLPLevel.GREEN: MarkingDefinition.generate_id("TLP", "TLP:GREEN"),
+    TLPLevel.AMBER: MarkingDefinition.generate_id("TLP", "TLP:AMBER"),
+    TLPLevel.AMBER_STRICT: MarkingDefinition.generate_id("TLP", "TLP:AMBER+STRICT"),
+    TLPLevel.RED: MarkingDefinition.generate_id("TLP", "TLP:RED"),
+}
 BANNER = f"""
 
 ▄▄▄█████▓ █     █░▓█████ ▓█████▄▄▄█████▓  █████▒▓█████ ▓█████ ▓█████▄ 
@@ -103,6 +113,7 @@ class TweetFeed:
         self.update = self.config.tweetfeed.update_existing_data
         self.org_name = self.config.tweetfeed.org_name
         self.org_desc = self.config.tweetfeed.org_description
+        self.tlp_marking_id = TLP_MARKING_IDS[self.config.tweetfeed.tlp_level]
         external_reference_org = self.helper.api.external_reference.create(
             source_name="TWEETFEEED",
             url="https://tweetfeed.live/",
@@ -277,7 +288,7 @@ class TweetFeed:
                 simple_observable_key=f"{type_observable}",
                 simple_observable_value=observable["value"],
                 simple_observable_description="TWEETFEED IOC " + observable["value"],
-                objectMarking=[stix2.TLP_GREEN["id"]],
+                objectMarking=[self.tlp_marking_id],
                 externalReferences=[external_reference["id"]],
                 createdBy=self.organization["id"],
                 update=self.update,
@@ -307,7 +318,7 @@ class TweetFeed:
                     pattern_type="stix",
                     pattern=f"[{type_ioc.lower()} = '" + ioc["value"] + "']",
                     x_opencti_main_observable_type=type_ioc.split(":")[0],
-                    objectMarking=[stix2.TLP_GREEN["id"]],
+                    objectMarking=[self.tlp_marking_id],
                     objectLabel=tags,
                     value=ioc["value"],
                     valid_from=self.data["Date"],
@@ -324,7 +335,7 @@ class TweetFeed:
                     pattern_type="stix",
                     pattern=f"[{type_ioc.lower()} = '" + ioc["value"] + "']",
                     x_opencti_main_observable_type=type_ioc.split(":")[0],
-                    objectMarking=[stix2.TLP_GREEN["id"]],
+                    objectMarking=[self.tlp_marking_id],
                     value=ioc["value"],
                     valid_from=self.data["Date"],
                     createdBy=self.organization["id"],

--- a/external-import/tweetfeed/tests/tests_connector/test_configuration.py
+++ b/external-import/tweetfeed/tests/tests_connector/test_configuration.py
@@ -151,11 +151,13 @@ class TestTweetFeedTLPMarking:
         "red": "marking-definition--5e57c739-391a-4eb3-b6be-7d15ca92d5ed",
     }
 
-    def test_defaults_to_tlp_clear(self, required_env, mocked_helper_class):
+    def test_defaults_to_tlp_green(self, required_env, mocked_helper_class):
+        """TLP:GREEN was the hardcoded marking before this setting existed, so it
+        stays the default to keep existing deployments unchanged."""
         connector = TweetFeed()
 
-        assert connector.config.tweetfeed.tlp_level == "clear"
-        assert connector.tlp_marking_id == self.MARKING_IDS["clear"]
+        assert connector.config.tweetfeed.tlp_level == "green"
+        assert connector.tlp_marking_id == self.MARKING_IDS["green"]
 
     @pytest.mark.parametrize("tlp_level", list(MARKING_IDS))
     def test_configured_level_is_mapped_to_its_marking_id(

--- a/external-import/tweetfeed/tests/tests_connector/test_configuration.py
+++ b/external-import/tweetfeed/tests/tests_connector/test_configuration.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+from connectors_sdk import ConfigValidationError
 from pytest_mock.plugin import MockerFixture
 from tweetfeed import TweetFeed
 
@@ -134,3 +135,82 @@ class TestTweetFeedIntervalBehavior:
         assert (
             connector.is_scheduled(last_run=0, current_time=one_day_in_seconds) is True
         )
+
+
+class TestTweetFeedTLPMarking:
+    """`TWEETFEED_TLP_LEVEL` drives the marking attached to every created
+    observable and indicator."""
+
+    # Static marking-definition ids used by the OpenCTI platform.
+    MARKING_IDS = {
+        "clear": "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9",
+        "white": "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9",
+        "green": "marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da",
+        "amber": "marking-definition--f88d31f6-486f-44da-b317-01333bde0b82",
+        "amber+strict": "marking-definition--826578e1-40ad-459f-bc73-ede076f81f37",
+        "red": "marking-definition--5e57c739-391a-4eb3-b6be-7d15ca92d5ed",
+    }
+
+    def test_defaults_to_tlp_clear(self, required_env, mocked_helper_class):
+        connector = TweetFeed()
+
+        assert connector.config.tweetfeed.tlp_level == "clear"
+        assert connector.tlp_marking_id == self.MARKING_IDS["clear"]
+
+    @pytest.mark.parametrize("tlp_level", list(MARKING_IDS))
+    def test_configured_level_is_mapped_to_its_marking_id(
+        self, required_env, monkeypatch, mocked_helper_class, tlp_level
+    ):
+        monkeypatch.setenv("TWEETFEED_TLP_LEVEL", tlp_level)
+
+        connector = TweetFeed()
+
+        assert connector.tlp_marking_id == self.MARKING_IDS[tlp_level]
+
+    def test_configured_level_is_case_insensitive(
+        self, required_env, monkeypatch, mocked_helper_class
+    ):
+        monkeypatch.setenv("TWEETFEED_TLP_LEVEL", "AMBER+STRICT")
+
+        connector = TweetFeed()
+
+        assert connector.tlp_marking_id == self.MARKING_IDS["amber+strict"]
+
+    def test_unknown_level_is_rejected(
+        self, required_env, monkeypatch, mocked_helper_class
+    ):
+        monkeypatch.setenv("TWEETFEED_TLP_LEVEL", "purple")
+
+        with pytest.raises(ConfigValidationError):
+            TweetFeed()
+
+    def test_observables_are_created_with_the_configured_marking(
+        self, required_env, monkeypatch, mocked_helper_class
+    ):
+        monkeypatch.setenv("TWEETFEED_TLP_LEVEL", "red")
+        connector = TweetFeed()
+
+        connector.create_observables_i(
+            {"type": "ip", "value": "1.2.3.4"},
+            {"id": "external-reference--id"},
+        )
+
+        _, kwargs = connector.helper.api.stix_cyber_observable.create.call_args
+        assert kwargs["objectMarking"] == [self.MARKING_IDS["red"]]
+
+    @pytest.mark.parametrize("tags", [[""], ["phishing"]])
+    def test_indicators_are_created_with_the_configured_marking(
+        self, required_env, monkeypatch, mocked_helper_class, tags
+    ):
+        monkeypatch.setenv("TWEETFEED_TLP_LEVEL", "amber")
+        connector = TweetFeed()
+        connector.data = {"Date": "2026-01-01T00:00:00.000Z"}
+
+        connector.create_indicators_i(
+            {"type": "ip", "value": "1.2.3.4", "tags": tags},
+            {"id": "external-reference--id"},
+            tags,
+        )
+
+        _, kwargs = connector.helper.api.indicator.create.call_args
+        assert kwargs["objectMarking"] == [self.MARKING_IDS["amber"]]


### PR DESCRIPTION
### Proposed changes

* Added a parameter TWEETFEED_TLP_LEVEL (default value TLP:CLEAR) that will be applied to all imported elements

### Related issues

* Closes #7286 

### Checklist

- [ x] I consider the submitted work as finished
- [x ] I have signed my commits using GPG key.
- [x ] I tested the code for its functionality using different use cases
- [x ] I added/update the relevant documentation (either on github or on notion)
- [x ] Where necessary I refactored code to improve the overall quality