### PR TITLE
fix(kaspersky): import YARA rules without description metadata (#5943)

### DIFF
--- a/external-import/kaspersky/src/kaspersky/models.py
+++ b/external-import/kaspersky/src/kaspersky/models.py
@@ -75,7 +75,7 @@ class YaraRule(Base):
     """Kaspersky YARA rule model."""
 
     name: str
-    description: str
+    description: Optional[str] = None
     report: Optional[str]
     last_modified: Optional[datetime]
     rule: str

--- a/external-import/kaspersky/src/kaspersky/utils/yara.py
+++ b/external-import/kaspersky/src/kaspersky/utils/yara.py
@@ -281,8 +281,7 @@ def _parse_yara_rule(yara_rule: str) -> Optional[Mapping[str, Any]]:
 
     description = _get_description(yara_rule)
     if description is None:
-        log.error("No description for rule: %s", yara_rule)
-        return None
+        log.debug("No description for rule: %s", name)
 
     report = _get_report(yara_rule)
     if report is None:


### PR DESCRIPTION
### Proposed changes

* Make `YaraRule.description` optional (`Optional[str] = None`) in `src/kaspersky/models.py`: the model previously required a non-optional `description`, so any rule without that metadata key would have been rejected by pydantic validation even if parsing had let it through.
* Stop discarding rules in `_parse_yara_rule()` (`src/kaspersky/utils/yara.py`): a missing `description`/`desc` metadata key no longer returns `None` and silently drops the whole rule. Many legitimate rules from the Kaspersky feed simply do not carry a description, and they were never imported into OpenCTI.
* Downgrade the missing-description log from `error` to `debug` and log the rule `name` instead of the full rule body, for consistency with how the already-optional `report` and `last_modified` metadata are handled, and to keep connector logs readable.
* No change was needed in `create_yara_indicator()`, which already accepts `Optional[str]`: when the description is absent the resulting STIX Indicator simply omits the `description` property, and the deterministic ID is unaffected.

### Related issues

* Closes to #5943 (fixes the first of the two defects described in the issue; the second one — empty reports — is handled in the follow-up PR stacked on this branch)

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Tested manually against a two-rule YARA sample where one rule declares a `description` and the other does not: both rules are now parsed, validated and converted into valid indicators with deterministic IDs, whereas previously only the described rule survived. The undescribed one produces an Indicator without a `description` property, which is valid STIX.

