### PR TITLE
fix(kaspersky): skip publications without any intelligence (#5943)

### DIFF
--- a/external-import/kaspersky/src/kaspersky/publication/builder.py
+++ b/external-import/kaspersky/src/kaspersky/publication/builder.py
@@ -16,7 +16,6 @@ from kaspersky.utils import (
     create_indicates_relationships,
     create_intrusion_set,
     create_object_refs,
-    create_organization,
     create_region,
     create_report,
     create_sector,
@@ -43,8 +42,6 @@ log = logging.getLogger(__name__)
 
 class PublicationBundleBuilder:
     """Kaspersky publication bundle builder."""
-
-    _DUMMY_OBJECT_NAME = "KASPERSKY EMPTY REPORT"
 
     def __init__(
         self,
@@ -144,13 +141,12 @@ class PublicationBundleBuilder:
             indicator_indicates_entities,
         )
 
-        # TODO: Ignore reports without any references or not?
-        # Hack, the report must have at least one object reference.
+        # A report requires at least one object reference. A publication without
+        # any reference carries no actionable intelligence (no IOCs, no YARA
+        # rules and no taggable metadata), so skip it instead of creating an
+        # empty report.
         if not object_refs:
-            dummy_object = self._create_dummy_object()
-
-            bundle_objects.append(dummy_object)
-            object_refs.append(dummy_object)
+            return None
 
         # Create report and add to bundle.
         report = self._create_report(object_refs)
@@ -246,11 +242,6 @@ class PublicationBundleBuilder:
         created_by = self.author
 
         return create_country(name, created_by=created_by)
-
-    def _create_dummy_object(self) -> Identity:
-        created_by = self.author
-
-        return create_organization(self._DUMMY_OBJECT_NAME, created_by=created_by)
 
     def _create_report(
         self, objects: List[Union[_DomainObject, _RelationshipObject]]

--- a/external-import/kaspersky/src/kaspersky/publication/importer.py
+++ b/external-import/kaspersky/src/kaspersky/publication/importer.py
@@ -1,6 +1,7 @@
 """Kaspersky publication importer module."""
 
 from datetime import datetime
+from enum import Enum
 from typing import Any, List, Mapping, Optional, Set
 
 from kaspersky.client import KasperskyClient
@@ -11,6 +12,14 @@ from kaspersky.utils import datetime_to_timestamp, timestamp_to_datetime
 from pycti import OpenCTIConnectorHelper
 from stix2 import Bundle, Identity, MarkingDefinition
 from stix2.exceptions import STIXError
+
+
+class PublicationResult(Enum):
+    """Kaspersky publication processing result."""
+
+    SUCCESS = "success"
+    SKIPPED = "skipped"
+    FAILED = "failed"
 
 
 class PublicationImporter(BaseImporter):
@@ -85,21 +94,25 @@ class PublicationImporter(BaseImporter):
         )
 
         failed_count = 0
+        skipped_count = 0
 
         for publication in publications:
             result = self._process_publication(publication)
-            if not result:
+            if result is PublicationResult.FAILED:
                 failed_count += 1
+            elif result is PublicationResult.SKIPPED:
+                skipped_count += 1
 
             publication_updated = publication.updated
             if publication_updated > latest_publication_datetime:
                 latest_publication_datetime = publication_updated
 
-        success_count = publication_count - failed_count
+        success_count = publication_count - failed_count - skipped_count
 
         self._info(
-            "Kaspersky publication importer completed (imported: {0}, failed: {1}, total: {2})",  # noqa: E501
+            "Kaspersky publication importer completed (imported: {0}, skipped: {1}, failed: {2}, total: {3})",  # noqa: E501
             success_count,
+            skipped_count,
             failed_count,
             publication_count,
         )
@@ -166,23 +179,39 @@ class PublicationImporter(BaseImporter):
 
         return list(filter(_ignored_prefix_filter, publications))
 
-    def _process_publication(self, publication: Publication) -> bool:
+    def _process_publication(self, publication: Publication) -> PublicationResult:
         self._info(
             "Processing publication {0} ({1})...", publication.name, publication.id
         )
 
         publication_details = self._fetch_publication_details(publication.id)
 
-        publication_bundle = self._create_publication_bundle(publication_details)
+        try:
+            publication_bundle = self._create_publication_bundle(publication_details)
+        except STIXError as e:
+            self.helper.metric.inc("error_count")
+            self._error(
+                "Failed to build publication bundle for '{0}' ({1}): {2}",
+                publication.name,
+                publication.id,
+                e,
+            )
+            return PublicationResult.FAILED
+
         if publication_bundle is None:
-            return False
+            self._info(
+                "Discarding publication without any intelligence '{0}' ({1}).",
+                publication.name,
+                publication.id,
+            )
+            return PublicationResult.SKIPPED
 
         # with open(f"publication_bundle_{publication_details.id}.json", "w") as f:
         #     f.write(publication_bundle.serialize(pretty=True))
 
         self._send_bundle(publication_bundle)
 
-        return True
+        return PublicationResult.SUCCESS
 
     def _create_publication_bundle(self, publication: Publication) -> Optional[Bundle]:
         author = self.author
@@ -210,17 +239,7 @@ class PublicationImporter(BaseImporter):
             opencti_regions,
         )
 
-        try:
-            return bundle_builder.build()
-        except STIXError as e:
-            self.helper.metric.inc("error_count")
-            self._error(
-                "Failed to build publication bundle for '{0}' ({1}): {2}",
-                publication.name,
-                publication.id,
-                e,
-            )
-            return None
+        return bundle_builder.build()
 
     def _load_opencti_regions(self) -> None:
         self.opencti_regions.clear()


### PR DESCRIPTION
> **⚠️ Stacked PR** — this PR is stacked on top of #7641 (`fix(kaspersky): import YARA rules without description metadata`). Its base branch is `fix/5943-kaspersky-yara-description`, **not** `master`. Please review and merge #7641 first; the diff shown here is only the second commit of the stack. Once #7641 is merged, this PR retargets to `master` automatically.

### Proposed changes

* Return `None` from `PublicationBundleBuilder.build()` when `object_refs` is empty (`src/kaspersky/publication/builder.py`): a publication with no IOCs, no YARA rules and no taggable metadata (`tags_actors`, `tags_industry`, `tags_geo`) carries no actionable intelligence, so no Report is emitted at all. Publications that still have meaningful metadata keep producing a Report as before.
* Remove the `_create_dummy_object()` hack and the `KASPERSKY EMPTY REPORT` organization, along with the now-unused `create_organization` import. A STIX Report requires at least one `object_refs` entry, and the previous workaround satisfied that constraint by injecting a meaningless Identity, polluting OpenCTI with empty reports plus a bogus organization. This also resolves the long-standing `TODO` that acknowledged the gap.
* Introduce a `PublicationResult` enum (`SUCCESS` / `SKIPPED` / `FAILED`) in `src/kaspersky/publication/importer.py`, replacing the boolean return of `_process_publication()`. Skipped publications were previously indistinguishable from genuine failures and were miscounted as errors.
* Move `STIXError` handling from `_create_publication_bundle()` up into `_process_publication()`, so a real bundle-build failure is reported as `FAILED` (and still increments the `error_count` metric) while an intentionally empty publication is reported as `SKIPPED` at info level.
* Report the new counters in the completion log: `imported / skipped / failed / total`, giving operators an accurate picture of what the run actually did.
* Keep advancing the importer state for skipped publications: the latest publication datetime is still updated, so skipped publications are not refetched on every subsequent run.

### Related issues

* Closes #5943 (completes the issue; the first defect is fixed by the stacked parent PR #7641)

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

**Design choice — skip instead of dummy object.** The alternative was to keep creating the Report and attach some placeholder reference. We chose skipping because a Report whose only content is a synthetic Identity is not intelligence: it costs ingestion time, clutters the knowledge base and creates an entity analysts must learn to ignore. Skipping is lossless with regard to real data and reversible if the feed later gains content for that publication.

**Deliberate consequence.** A publication whose only content is a PDF attachment, with no object references and no tags, is now skipped and its PDF is no longer imported. This is intentional: a STIX Report cannot exist with zero object references, so there is no valid container to attach the file to.

Tested manually: a fully empty publication now yields `None` from `build()` and is logged as skipped; a metadata-only publication (industry tag, no IOC, no YARA) still yields a bundle containing only the author, the TLP marking, the sector and the report — with no dummy identity.
