### PR TITLE
feat(virustotal): enrich with Google TI information (#7644)

### DIFF
--- a/internal-enrichment/virustotal/README.md
+++ b/internal-enrichment/virustotal/README.md
@@ -89,6 +89,12 @@ Key features:
 | `virustotal_domain_add_relationships` | `VIRUSTOTAL_DOMAIN_ADD_RELATIONSHIPS` | No | Add IP resolution relationships |
 | `virustotal_url_upload_unseen` | `VIRUSTOTAL_URL_UPLOAD_UNSEEN` | No | Upload unknown URLs for analysis |
 | `virustotal_url_indicator_create_positives` | `VIRUSTOTAL_URL_INDICATOR_CREATE_POSITIVES` | No | URL indicator creation threshold |
+| `virustotal_gti_enrichment_enabled` | `VIRUSTOTAL_GTI_ENRICHMENT_ENABLED` | No | Master switch for all GTI-driven behavior: score/verdict logic and the `gti_include_*` relationships below. Requires GTI access (default: false) |
+| `virustotal_gti_include_malware_families` | `VIRUSTOTAL_GTI_INCLUDE_MALWARE_FAMILIES` | No | Enrich with related GTI malware families, as Malware entities (default: false) |
+| `virustotal_gti_include_threat_actors` | `VIRUSTOTAL_GTI_INCLUDE_THREAT_ACTORS` | No | Enrich with related GTI threat actors, as Intrusion-Set entities (default: false) |
+| `virustotal_gti_include_campaigns` | `VIRUSTOTAL_GTI_INCLUDE_CAMPAIGNS` | No | Enrich with related GTI campaigns, as Campaign entities (default: false) |
+| `virustotal_gti_include_reports` | `VIRUSTOTAL_GTI_INCLUDE_REPORTS` | No | Enrich with related GTI reports, as Report entities (default: false) |
+| `virustotal_gti_relationship_limit` | `VIRUSTOTAL_GTI_RELATIONSHIP_LIMIT` | No | Max related objects pulled per GTI relationship, per observable (default: 10) |
 
 ---
 
@@ -165,6 +171,25 @@ flowchart LR
 | URL | Detection count | Indicator based-on |
 | Hostname | Detection count | Similar to domain |
 
+GTI (Google Threat Intelligence) collection enrichment requires
+`gti_enrichment_enabled: true` (master switch, default `false`). With that
+set, the `gti_include_*` settings below control the four relationships
+individually, applying uniformly across all five observable types above.
+The GTI-driven score/verdict logic (using `gti_assessment` in place of the
+legacy multi-engine score, and letting a malicious GTI verdict trigger
+Indicator creation) is also gated by `gti_enrichment_enabled` alone.
+
+| GTI Relationship | Entity Created | Relationship |
+|-------------------|-----------------|---------------|
+| `malware_families` | Malware (`is_family=true`) | related-to (from the observable), plus indicates (from the Indicator, if one was created - see below) |
+| `threat_actors` | Intrusion-Set | related-to (from the observable), plus indicates (from the Indicator, if one was created - see below) |
+| `campaigns` | Campaign | related-to (from the observable), plus indicates (from the Indicator, if one was created - see below) |
+| `reports` | Report | observable added to the Report's `object_refs`, plus the Indicator's id (if one was created - see below) |
+
+When enriching an Indicator directly rather than an Observable, the link
+to Malware/Intrusion-Set/Campaign is `indicates` only (the correct STIX
+relationship type for an Indicator source), not `related-to`.
+
 ### Indicator Creation
 
 | Observable Type | Default Threshold | Detection Flag |
@@ -173,6 +198,14 @@ flowchart LR
 | IPv4-Addr | 10 positives | TRUE |
 | Domain-Name | 10 positives | TRUE |
 | URL | 10 positives | TRUE |
+
+An Indicator is created once the multi-engine positive count meets the
+threshold above, **or**, when `gti_enrichment_enabled` is `true`, as soon as
+GTI's own assessment already calls the observable malicious
+(`gti_assessment.verdict.value == "VERDICT_MALICIOUS"`), whichever comes
+first — this catches samples GTI has scored as malicious before traditional
+AV engines have caught up. Setting a threshold to `0` still fully disables
+indicator creation for that observable type, regardless of the GTI verdict.
 
 ### Generated STIX Objects
 
@@ -183,6 +216,10 @@ flowchart LR
 | YARA Indicator | Crowdsourced YARA rules (for files) |
 | Autonomous System | ASN for IP addresses |
 | Location | Geolocation for IPs |
+| Malware | GTI malware family, when `gti_include_malware_families` is enabled |
+| Intrusion-Set | GTI threat actor, when `gti_include_threat_actors` is enabled |
+| Campaign | GTI campaign, when `gti_include_campaigns` is enabled |
+| Report | GTI report, when `gti_include_reports` is enabled |
 | Relationship | Various entity links |
 
 ---

--- a/internal-enrichment/virustotal/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/internal-enrichment/virustotal/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -35,3 +35,9 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | VIRUSTOTAL_URL_INDICATOR_VALID_MINUTES | `integer` |  | integer | `2880` | How long the indicator is valid for in minutes. |
 | VIRUSTOTAL_URL_INDICATOR_DETECT | `boolean` |  | boolean | `true` | Whether or not to set detection for the indicator to true. |
 | VIRUSTOTAL_INCLUDE_ATTRIBUTES_IN_NOTE | `boolean` |  | boolean | `false` | Whether or not to include the attributes info in Note. |
+| VIRUSTOTAL_GTI_ENRICHMENT_ENABLED | `boolean` |  | boolean | `false` | Whether to use GTI assessment data (score/verdict) and enable GTI relationship enrichment. Requires a VirusTotal account with GTI access. |
+| VIRUSTOTAL_GTI_INCLUDE_MALWARE_FAMILIES | `boolean` |  | boolean | `false` | Whether or not to enrich with related GTI malware families (created as Malware entities). |
+| VIRUSTOTAL_GTI_INCLUDE_THREAT_ACTORS | `boolean` |  | boolean | `false` | Whether or not to enrich with related GTI threat actors (created as Intrusion-Set entities). |
+| VIRUSTOTAL_GTI_INCLUDE_CAMPAIGNS | `boolean` |  | boolean | `false` | Whether or not to enrich with related GTI campaigns (created as Campaign entities). |
+| VIRUSTOTAL_GTI_INCLUDE_REPORTS | `boolean` |  | boolean | `false` | Whether or not to enrich with related GTI reports (created as Report entities). |
+| VIRUSTOTAL_GTI_RELATIONSHIP_LIMIT | `integer` |  | integer | `10` | Maximum number of related objects to pull per GTI relationship, per observable. |

--- a/internal-enrichment/virustotal/__metadata__/connector_config_schema.json
+++ b/internal-enrichment/virustotal/__metadata__/connector_config_schema.json
@@ -176,6 +176,36 @@
       "default": false,
       "description": "Whether or not to include the attributes info in Note.",
       "type": "boolean"
+    },
+    "VIRUSTOTAL_GTI_ENRICHMENT_ENABLED": {
+      "default": false,
+      "description": "Whether to use GTI assessment data (score/verdict) and enable GTI relationship enrichment. Requires a VirusTotal account with GTI access.",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_GTI_INCLUDE_MALWARE_FAMILIES": {
+      "default": false,
+      "description": "Whether or not to enrich with related GTI malware families (created as Malware entities).",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_GTI_INCLUDE_THREAT_ACTORS": {
+      "default": false,
+      "description": "Whether or not to enrich with related GTI threat actors (created as Intrusion-Set entities).",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_GTI_INCLUDE_CAMPAIGNS": {
+      "default": false,
+      "description": "Whether or not to enrich with related GTI campaigns (created as Campaign entities).",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_GTI_INCLUDE_REPORTS": {
+      "default": false,
+      "description": "Whether or not to enrich with related GTI reports (created as Report entities).",
+      "type": "boolean"
+    },
+    "VIRUSTOTAL_GTI_RELATIONSHIP_LIMIT": {
+      "default": 10,
+      "description": "Maximum number of related objects to pull per GTI relationship, per observable.",
+      "type": "integer"
     }
   },
   "required": [

--- a/internal-enrichment/virustotal/__metadata__/connector_manifest.json
+++ b/internal-enrichment/virustotal/__metadata__/connector_manifest.json
@@ -2,7 +2,7 @@
   "title": "VirusTotal",
   "slug": "virustotal",
   "description": "VirusTotal is a comprehensive service that aggregates data from numerous antivirus products and online scanners to analyze suspicious files and URLs for potential threats. By providing collective analysis results, VirusTotal helps security teams identify malicious content quickly and effectively, supporting more comprehensive cybersecurity efforts.\n\nIntegrating VirusTotal with OpenCTI enhances threat intelligence by providing access to the collective insights of numerous security vendors. This integration allows for the automatic import of analysis results for files and URLs, enriching the threat intelligence platform with detailed threat data. Security teams can leverage VirusTotal data to confirm, investigate, and respond to potential threats more efficiently, fortifying their overall security posture.",
-  "short_description": "VirusTotal aggregates data from antivirus products and scanners to analyze files and URLs, aiding the quick identification of malicious content. Its OpenCTI integration imports analysis results, enriching threat intelligence for efficient response.",
+  "short_description": "VirusTotal aggregates data from antivirus products and scanners to analyze files and URLs, aiding in the quick identification of malicious content. Its integration with OpenCTI imports analysis results, enriching threat intelligence for efficient threat confirmation and response.",
   "logo": "internal-enrichment/virustotal/__metadata__/logo.png",
   "use_cases": [
     "Infrastructure & Attack Surface Visibility"

--- a/internal-enrichment/virustotal/docker-compose.yml
+++ b/internal-enrichment/virustotal/docker-compose.yml
@@ -39,6 +39,13 @@ services:
 #      - VIRUSTOTAL_URL_INDICATOR_DETECT=true # Whether or not to set detection for the indicator to true
 #      # Generic config settings for File, IP, Domain, URL
 #      - VIRUSTOTAL_INCLUDE_ATTRIBUTES_IN_NOTE=false # Whether or not to include the attributes info in Note
+#      # Google Threat Intelligence enrichment settings
+#      - VIRUSTOTAL_GTI_ENRICHMENT_ENABLED=false # Whether to use GTI assessment data (score/verdict) and enable GTI relationship enrichment. Requires a VirusTotal account with GTI access.
+#      - VIRUSTOTAL_GTI_INCLUDE_MALWARE_FAMILIES=false # Whether or not to enrich with related GTI malware families (created as Malware entities).
+#      - VIRUSTOTAL_GTI_INCLUDE_THREAT_ACTORS=false # Whether or not to enrich with related GTI threat actors (created as Intrusion-Set entities).
+#      - VIRUSTOTAL_GTI_INCLUDE_CAMPAIGNS=false # Whether or not to enrich with related GTI campaigns (created as Campaign entities).
+#      - VIRUSTOTAL_GTI_INCLUDE_REPORTS=false # Whether or not to enrich with related GTI reports (created as Report entities).
+#      - VIRUSTOTAL_GTI_RELATIONSHIP_LIMIT=10 # Maximum number of related objects to pull per GTI relationship, per observable.
     deploy:
       mode: replicated
       replicas: 1

--- a/internal-enrichment/virustotal/src/config.yml.sample
+++ b/internal-enrichment/virustotal/src/config.yml.sample
@@ -44,3 +44,11 @@ virustotal:
 
   # Generic config settings for File, IP, Domain, URL
 #  include_attributes_in_note: false # Whether or not to include the attributes info in Note
+
+  # GTI collection enrichment settings (applies to File, IP, Domain, URL)
+#  gti_enrichment_enabled: false # Master switch for all GTI-driven behavior (score/verdict logic and the gti_include_* relationships below). Requires a VirusTotal account with GTI access.
+#  gti_include_malware_families: false # Whether or not to enrich with related GTI malware families (created as Malware entities)
+#  gti_include_threat_actors: false # Whether or not to enrich with related GTI threat actors (created as Intrusion-Set entities)
+#  gti_include_campaigns: false # Whether or not to enrich with related GTI campaigns (created as Campaign entities)
+#  gti_include_reports: false # Whether or not to enrich with related GTI reports (created as Report entities)
+#  gti_relationship_limit: 10 # Maximum number of related objects to pull per GTI relationship, per observable

--- a/internal-enrichment/virustotal/src/virustotal/builder.py
+++ b/internal-enrichment/virustotal/src/virustotal/builder.py
@@ -9,11 +9,15 @@ import stix2
 from pycti import (
     STIX_EXT_OCTI,
     STIX_EXT_OCTI_SCO,
+    Campaign,
     Indicator,
+    IntrusionSet,
     Location,
+    Malware,
     Note,
     OpenCTIConnectorHelper,
     OpenCTIStix2,
+    Report,
     StixCoreRelationship,
 )
 from virustotal.models.configs.virustotal_configs import IndicatorConfig
@@ -34,6 +38,7 @@ class VirusTotalBuilder:
         include_attributes_in_note: bool = False,
         url_related_object_data: dict = {},
         is_indicator: bool = False,
+        gti_enabled: bool = False,
     ) -> None:
         """Initialize Virustotal builder."""
         self.helper = helper
@@ -43,6 +48,8 @@ class VirusTotalBuilder:
         self.opencti_entity = opencti_entity
         self.stix_entity = stix_entity
         self.attributes = data["attributes"]
+        # Read before _compute_score, which consults it.
+        self.gti_enabled = gti_enabled
         self.score = self._compute_score(
             self.attributes["last_analysis_stats"],
             self.attributes.get("gti_assessment"),
@@ -50,6 +57,10 @@ class VirusTotalBuilder:
         self.include_attributes_in_note = include_attributes_in_note
         self.url_related_object_data = url_related_object_data
         self.is_indicator = is_indicator
+        # Set by create_indicator_based_on if it creates a fresh Indicator
+        # this run; used to also link that Indicator to any GTI entities
+        # (see _gti_relationships_for).
+        self.indicator: stix2.Indicator | None = None
 
         # Indicators use STIX_EXT_OCTI (SDO extension); observables use STIX_EXT_OCTI_SCO.
         self._stix_ext = STIX_EXT_OCTI if is_indicator else STIX_EXT_OCTI_SCO
@@ -86,9 +97,11 @@ class VirusTotalBuilder:
         int
             Score, in percent, rounded.
         """
-        # Retrieve score from GTI assessment if it exists
+        # Retrieve score from GTI assessment if it exists and GTI enrichment
+        # is enabled (gti_enrichment_enabled config flag).
         if (
-            gti_assessment is not None
+            self.gti_enabled
+            and gti_assessment is not None
             and (threat_score := gti_assessment.get("threat_score")) is not None
         ):
             self.helper.log_debug(
@@ -192,13 +205,51 @@ class VirusTotalBuilder:
         )
         return external_reference
 
+    def _gti_verdict_is_malicious(self) -> bool:
+        """True when GTI's own assessment (not the legacy engine count) calls this malicious.
+
+        GTI's verdict/severity model is a richer signal than a raw
+        multi-engine detection count: a sample can be brand new (zero
+        traditional AV detections, since most engines haven't scanned it
+        yet) while GTI's ML scoring + Mandiant attribution already call it
+        malicious with high confidence. Relying on the legacy count alone
+        misses exactly these cases.
+        """
+        if not self.gti_enabled:
+            return False
+        gti_assessment = self.attributes.get("gti_assessment")
+        if not gti_assessment:
+            return False
+        verdict = gti_assessment.get("verdict") or {}
+        return verdict.get("value") == "VERDICT_MALICIOUS"
+
+    def _meets_indicator_threshold(self, indicator_config: IndicatorConfig) -> bool:
+        """Whether this observable warrants creating an Indicator.
+
+        A threshold of 0 is documented as fully disabling indicator
+        creation for this observable type, so that always wins. Otherwise,
+        an Indicator is created either when GTI's own verdict says
+        malicious, or (falling back to the legacy behavior) when the
+        multi-engine malicious count meets the configured threshold.
+        """
+        if indicator_config.threshold <= 0:
+            return False
+        if self._gti_verdict_is_malicious():
+            return True
+        return (
+            self.attributes["last_analysis_stats"]["malicious"]
+            >= indicator_config.threshold
+        )
+
     def create_indicator_based_on(
         self,
         indicator_config: IndicatorConfig,
         pattern: str,
     ):
         """
-        Create an Indicator if the positives hits >= threshold specified in the config.
+        Create an Indicator if the positive hits >= threshold specified in
+        the config, or if GTI's own verdict already calls this malicious
+        (see _meets_indicator_threshold).
 
         Objects created are added in the bundle.
 
@@ -219,12 +270,7 @@ class VirusTotalBuilder:
 
         now_time = datetime.datetime.now(datetime.timezone.utc)
 
-        # Create an Indicator if positive hits >= ip_indicator_create_positives specified in config
-        if (
-            self.attributes["last_analysis_stats"]["malicious"]
-            >= indicator_config.threshold
-            > 0
-        ):
+        if self._meets_indicator_threshold(indicator_config):
             self.helper.log_debug(
                 f"[VirusTotal] creating indicator with pattern {pattern}"
             )
@@ -239,8 +285,12 @@ class VirusTotalBuilder:
                 created_by_ref=self.author,
                 name=self.opencti_entity["observable_value"],
                 description=(
-                    "Created by VirusTotal connector as the positive count "
-                    f"was >= {indicator_config.threshold}"
+                    "Created by VirusTotal connector: GTI verdict is malicious"
+                    if self._gti_verdict_is_malicious()
+                    else (
+                        "Created by VirusTotal connector as the positive count "
+                        f"was >= {indicator_config.threshold}"
+                    )
                 ),
                 confidence=self.helper.connect_confidence_level,
                 pattern=pattern,
@@ -273,6 +323,7 @@ class VirusTotalBuilder:
                 allow_custom=True,
             )
             self.bundle += [indicator, relationship]
+            self.indicator = indicator
 
     def create_ip_resolves_to(self, ipv4: str):
         """
@@ -339,6 +390,245 @@ class VirusTotalBuilder:
                     "entity_value": self.stix_entity.get("value", None),
                 },
             )
+
+    def _create_gti_collection_external_reference(self, collection_data: dict) -> dict:
+        """
+        Build an external reference to a GTI collection object's page on
+        the VirusTotal GUI.
+
+        Unlike `_create_external_reference`, this does not mutate
+        `self.stix_entity` - it's meant for the new SDOs created from GTI
+        collection relationships (malware families, threat actors,
+        campaigns, reports), not the primary observable being enriched.
+
+        Parameters
+        ----------
+        collection_data : dict
+            A single object from a GTI collection relationship response.
+
+        Returns
+        -------
+        dict
+            External reference dict.
+        """
+        collection_id = collection_data.get("id", "")
+        attributes = collection_data.get("attributes", {})
+        return {
+            "source_name": "VirusTotal",
+            "url": f"https://www.virustotal.com/gui/collection/{collection_id}",
+            "description": attributes.get("name", collection_id),
+        }
+
+    def _build_relationship(
+        self, relationship_type: str, source_ref: str, target_ref: str
+    ) -> stix2.Relationship:
+        return stix2.Relationship(
+            id=StixCoreRelationship.generate_id(
+                relationship_type, source_ref, target_ref
+            ),
+            relationship_type=relationship_type,
+            created_by_ref=self.author,
+            source_ref=source_ref,
+            target_ref=target_ref,
+            confidence=self.helper.connect_confidence_level,
+            allow_custom=True,
+        )
+
+    def _gti_relationships_for(self, target_id: str) -> list:
+        """Build the relationship(s) linking this enrichment to a GTI-derived
+        entity (Malware/Intrusion-Set/Campaign).
+
+        - Enriching an Indicator directly (`is_indicator=True`): a single
+          `indicates` edge from the Indicator. `indicates` is the STIX
+          relationship for Indicator -> Malware/Intrusion-Set/Campaign
+          so it replaces `related-to` here rather than adding to it.
+        - Enriching an Observable: keep the existing `related-to` edge
+          from the observable, and *additionally* add an `indicates` edge
+          from any Indicator create_indicator_based_on already created
+          earlier in this same run. The two are different source
+          entities, so both edges carry distinct, non-redundant meaning.
+        """
+        if self.is_indicator:
+            return [
+                self._build_relationship("indicates", self.stix_entity["id"], target_id)
+            ]
+        relationships = [
+            self._build_relationship("related-to", self.stix_entity["id"], target_id)
+        ]
+        if self.indicator is not None:
+            relationships.append(
+                self._build_relationship("indicates", self.indicator.id, target_id)
+            )
+        return relationships
+
+    def create_malware_family(self, collection_data: dict):
+        """
+        Create a Malware SDO (is_family=True) from a GTI `malware_families`
+        relationship item and link it to the observable (and to the
+        Indicator, if one was created this run - see
+        _gti_relationships_for).
+
+        Parameters
+        ----------
+        collection_data : dict
+            A single object from the `malware_families` relationship response.
+        """
+        attributes = collection_data.get("attributes", {})
+        name = attributes.get("name")
+        if not name:
+            self.helper.log_debug(
+                f"[VirusTotal] skipping GTI malware family with no name: {collection_data}"
+            )
+            return
+
+        self.helper.log_debug(f"[VirusTotal] creating GTI malware family {name}")
+        malware = stix2.Malware(
+            id=Malware.generate_id(name),
+            name=name,
+            is_family=True,
+            description=attributes.get("description"),
+            created_by_ref=self.author,
+            confidence=self.helper.connect_confidence_level,
+            external_references=[
+                self._create_gti_collection_external_reference(collection_data)
+            ],
+            allow_custom=True,
+        )
+        self.bundle += [malware] + self._gti_relationships_for(malware.id)
+
+    def create_intrusion_set(self, collection_data: dict):
+        """
+        Create an Intrusion-Set SDO from a GTI `threat_actors` relationship
+        item and link it to the observable (and to the Indicator, if one
+        was created this run - see _gti_relationships_for).
+
+        GTI's "threat actor" concept is a tracked adversary group, which
+        maps onto OpenCTI's Intrusion-Set - matching how the
+        google-ti-feeds connector maps this same GTI data, so both
+        GTI-consuming connectors produce a consistent graph shape.
+
+        Parameters
+        ----------
+        collection_data : dict
+            A single object from the `threat_actors` relationship response.
+        """
+        attributes = collection_data.get("attributes", {})
+        name = attributes.get("name")
+        if not name:
+            self.helper.log_debug(
+                f"[VirusTotal] skipping GTI threat actor with no name: {collection_data}"
+            )
+            return
+
+        self.helper.log_debug(
+            f"[VirusTotal] creating GTI threat actor (intrusion-set) {name}"
+        )
+        intrusion_set = stix2.IntrusionSet(
+            id=IntrusionSet.generate_id(name),
+            name=name,
+            description=attributes.get("description"),
+            aliases=attributes.get("aliases"),
+            created_by_ref=self.author,
+            confidence=self.helper.connect_confidence_level,
+            external_references=[
+                self._create_gti_collection_external_reference(collection_data)
+            ],
+            allow_custom=True,
+        )
+        self.bundle += [intrusion_set] + self._gti_relationships_for(intrusion_set.id)
+
+    def create_campaign(self, collection_data: dict):
+        """
+        Create a Campaign SDO from a GTI `campaigns` relationship item and
+        link it to the observable (and to the Indicator, if one was
+        created this run - see _gti_relationships_for).
+
+        Parameters
+        ----------
+        collection_data : dict
+            A single object from the `campaigns` relationship response.
+        """
+        attributes = collection_data.get("attributes", {})
+        name = attributes.get("name")
+        if not name:
+            self.helper.log_debug(
+                f"[VirusTotal] skipping GTI campaign with no name: {collection_data}"
+            )
+            return
+
+        self.helper.log_debug(f"[VirusTotal] creating GTI campaign {name}")
+        campaign = stix2.Campaign(
+            id=Campaign.generate_id(name),
+            name=name,
+            description=attributes.get("description"),
+            created_by_ref=self.author,
+            confidence=self.helper.connect_confidence_level,
+            external_references=[
+                self._create_gti_collection_external_reference(collection_data)
+            ],
+            allow_custom=True,
+        )
+        self.bundle += [campaign] + self._gti_relationships_for(campaign.id)
+
+    def create_report(self, collection_data: dict):
+        """
+        Create a Report SDO from a GTI `reports` relationship item and add
+        the enriched observable (and the Indicator, if one was created
+        this run) to its `object_refs`.
+
+        Reports link via containment (`object_refs`), not a separate
+        relationship - that's how STIX Reports represent "this observable
+        is covered by this report". When an Indicator was also created for
+        this observable this run, it's added alongside it for the same
+        reason _gti_relationships_for adds an `indicates` edge for the
+        other GTI entities: the Indicator is otherwise left out of the
+        Report entirely.
+
+        Parameters
+        ----------
+        collection_data : dict
+            A single object from the `reports` relationship response.
+        """
+        attributes = collection_data.get("attributes", {})
+        name = attributes.get("name")
+        if not name:
+            self.helper.log_debug(
+                f"[VirusTotal] skipping GTI report with no name: {collection_data}"
+            )
+            return
+
+        # Report ids are (name, published)-keyed - a stable date is required
+        # so repeat enrichment runs merge into the same Report instead of
+        # spawning a new one every run. Fall back to a fixed epoch sentinel,
+        # never "now", when GTI doesn't provide a creation date.
+        creation_date = attributes.get("creation_date")
+        published = (
+            datetime.datetime.fromtimestamp(creation_date, datetime.timezone.utc)
+            if creation_date is not None
+            else datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
+        )
+        published_str = self.helper.api.stix2.format_date(published)
+
+        object_refs = [self.stix_entity["id"]]
+        if self.indicator is not None:
+            object_refs.append(self.indicator.id)
+
+        self.helper.log_debug(f"[VirusTotal] creating GTI report {name}")
+        report = stix2.Report(
+            id=Report.generate_id(name, published_str),
+            name=name,
+            description=attributes.get("description"),
+            report_types=["threat-report"],
+            published=published_str,
+            object_refs=object_refs,
+            created_by_ref=self.author,
+            confidence=self.helper.connect_confidence_level,
+            external_references=[
+                self._create_gti_collection_external_reference(collection_data)
+            ],
+            allow_custom=True,
+        )
+        self.bundle.append(report)
 
     def create_note(self, abstract: str, content: str):
         """
@@ -547,26 +837,41 @@ class VirusTotalBuilder:
             self.helper.log_debug(f"[VirusTotal] sending bundle: {self.bundle}")
             self.helper.metric.inc("record_send", len(self.bundle))
             serialized_bundle = self.helper.stix2_create_bundle(self.bundle)
-            bundles_sent = self.helper.send_stix2_bundle(serialized_bundle)
+            # update=True is required so the worker overwrites scalar fields (e.g.
+            # x_opencti_score) on entities that already exist in the platform. With
+            # the default update=False, the worker only creates brand-new objects -
+            # updates to pre-existing entities are silently dropped with no audit
+            # trail. Every other internal-enrichment connector in this repo that
+            # needs to update existing data sets this explicitly (vulners,
+            # team-cymru-scout, osint-industries, anyrun-task, anyrun-lookup,
+            # polyswarm-enrichment, polyswarm-sandbox).
+            bundles_sent = self.helper.send_stix2_bundle(serialized_bundle, update=True)
             return f"Sent {len(bundles_sent)} stix bundle(s) for worker import"
         return "Nothing to attach"
 
     def update_hashes(self):
         """Update the hashes (md5 and sha1) of the file."""
+        # VT omits individual hash fields for hashes it has only seen "in
+        # the wild" but never analysed - same root cause as update_size, see
+        # the comment there. Skip any algo VT didn't return instead of
+        # raising KeyError and aborting the rest of enrichment.
         for algo in ("MD5", "SHA-1", "SHA-256"):
-            self.helper.log_debug(
-                f"[VirusTotal] updating hash {algo}: {self.attributes[algo.lower().replace('-', '')]}"
-            )
-            self.stix_entity["hashes"][algo] = self.attributes[
-                algo.lower().replace("-", "")
-            ]
+            value = self.attributes.get(algo.lower().replace("-", ""))
+            if value is None:
+                self.helper.log_debug(
+                    f"[VirusTotal] no {algo} attribute in VT report; skipping"
+                )
+                continue
+            self.helper.log_debug(f"[VirusTotal] updating hash {algo}: {value}")
+            self.stix_entity["hashes"][algo] = value
 
     def update_labels(self):
         """Update the labels of the file using the tags."""
-        self.helper.log_debug(
-            f"[VirusTotal] updating labels with {self.attributes['tags']}"
-        )
-        for tag in self.attributes["tags"]:
+        # See update_size: VT may omit "tags" entirely for unanalysed
+        # hashes, so default to an empty list rather than raising KeyError.
+        tags = self.attributes.get("tags", [])
+        self.helper.log_debug(f"[VirusTotal] updating labels with {tags}")
+        for tag in tags:
             if self.is_indicator:
                 # Labels on Indicators are a standard STIX field, not an SCO extension.
                 if "labels" not in self.stix_entity:
@@ -591,10 +896,10 @@ class VirusTotalBuilder:
         main : bool
             If True, update the main name.
         """
-        self.helper.log_debug(
-            f"[VirusTotal] updating names with {self.attributes['names']}"
-        )
-        names = self.attributes["names"]
+        # See update_size: VT may omit "names" entirely for unanalysed
+        # hashes, so default to an empty list rather than raising KeyError.
+        names = self.attributes.get("names", [])
+        self.helper.log_debug(f"[VirusTotal] updating names with {names}")
         if len(names) > 0 and main:
             self.stix_entity["name"] = names[0]
             del names[0]
@@ -612,10 +917,23 @@ class VirusTotalBuilder:
 
     def update_size(self):
         """Update the size of the file."""
-        self.helper.log_debug(
-            f"[VirusTotal] updating size with {self.attributes['size']}"
-        )
-        self.stix_entity["size"] = self.attributes["size"]
+        # Pre-existing bug (present since this method was introduced): VT
+        # returns no "size" attribute for hashes it has only seen "in the
+        # wild" but never actually analysed (e.g. no scan engines have run).
+        # The unguarded dict access below used to raise KeyError here, which
+        # aborted _enrich() before any of the score/labels/external
+        # reference/note writes that follow it in FileProcessor._enrich, so
+        # the whole enrichment silently failed for any such file even though
+        # VT still had useful metadata (names, tags, first/last seen) to
+        # offer.
+        size = self.attributes.get("size")
+        if size is None:
+            self.helper.log_debug(
+                "[VirusTotal] no size attribute in VT report; skipping"
+            )
+            return
+        self.helper.log_debug(f"[VirusTotal] updating size with {size}")
+        self.stix_entity["size"] = size
 
     def create_notes_attributes_content(self):
         attributes_content = ""

--- a/internal-enrichment/virustotal/src/virustotal/client.py
+++ b/internal-enrichment/virustotal/src/virustotal/client.py
@@ -338,7 +338,7 @@ class VirusTotalClient:
         """
         return base64.b64encode(contents.encode()).decode().replace("=", "")
 
-    def get_url_related_objects(self, url, relationship):
+    def get_url_related_objects(self, url, relationship, extra_query=""):
         """
         Retrieve URL report based on the given URL.
 
@@ -348,17 +348,95 @@ class VirusTotalClient:
             Url.
         relationship : str
             Relationship to Url
+        extra_query : str
+            Additional query string to append to the request (e.g. "limit=10").
 
         Returns
         -------
         dict
             URL Object, see https://developers.virustotal.com/reference/url-object
         """
-        base64_url = f"{self.url}/urls/{VirusTotalClient.base64_encode_no_padding(url)}/{relationship}"
+        suffix = f"?{extra_query}" if extra_query else ""
+        base64_url = (
+            f"{self.url}/urls/{VirusTotalClient.base64_encode_no_padding(url)}"
+            f"/{relationship}{suffix}"
+        )
         results = self._query(base64_url)
         if results is None:
             return None
         if "error" in results:
-            sha256_url = f"{self.url}/urls/{hashlib.sha256(url.encode()).hexdigest()}/{relationship}"
+            sha256_url = (
+                f"{self.url}/urls/{hashlib.sha256(url.encode()).hexdigest()}"
+                f"/{relationship}{suffix}"
+            )
             results = self._query(sha256_url)
         return results
+
+    def get_gti_relationship(
+        self, endpoint_type: str, identifier: str, relationship: str, limit: int
+    ) -> dict | None:
+        """
+        Retrieve a GTI collection relationship (malware_families,
+        threat_actors, campaigns, or reports) for the given entity,
+        following pagination until `limit` items are collected.
+
+        Parameters
+        ----------
+        endpoint_type : str
+            VirusTotal endpoint path segment for the entity type
+            (`ip_addresses`, `domains`, `files`, or `urls`).
+        identifier : str
+            Entity identifier (IP, domain, file hash, or URL value).
+        relationship : str
+            Relationship name, e.g. `malware_families`.
+        limit : int
+            Maximum number of related objects to return.
+
+        Returns
+        -------
+        dict or None
+            VirusTotal list response with `data` truncated to `limit` items.
+        """
+        if limit <= 0:
+            return {"data": []}
+
+        page_size = min(limit, 40)
+        if endpoint_type == "urls":
+            first_page = self.get_url_related_objects(
+                identifier, relationship, extra_query=f"limit={page_size}"
+            )
+        else:
+            url = f"{self.url}/{endpoint_type}/{identifier}/{relationship}?limit={page_size}"
+            first_page = self._query(url)
+        return self._collect_paginated(first_page, limit)
+
+    def _collect_paginated(self, first_page: dict | None, limit: int) -> dict | None:
+        """
+        Follow `links.next` on a VirusTotal list response until `limit`
+        items have been collected or there are no more pages.
+
+        Parameters
+        ----------
+        first_page : dict, optional
+            First page of a VirusTotal list response.
+        limit : int
+            Maximum number of items to collect across all pages.
+
+        Returns
+        -------
+        dict or None
+            `first_page` with `data` extended across pages and truncated to `limit`.
+        """
+        if first_page is None or "error" in first_page:
+            return first_page
+
+        data = list(first_page.get("data", []))
+        page = first_page
+        while len(data) < limit and page.get("links", {}).get("next"):
+            page = self._query(page["links"]["next"])
+            if page is None or "error" in page:
+                break
+            data.extend(page.get("data", []))
+
+        first_page["data"] = data[:limit]
+        return first_page

--- a/internal-enrichment/virustotal/src/virustotal/models/configs/virustotal_configs.py
+++ b/internal-enrichment/virustotal/src/virustotal/models/configs/virustotal_configs.py
@@ -137,6 +137,32 @@ class ConfigLoaderVirusTotal(ConfigBaseSettings):
         description="Whether or not to include the attributes info in Note.",
     )
 
+    # GTI collection enrichment settings (applies to File, IP, Domain, URL)
+    gti_enrichment_enabled: bool = Field(
+        default=False,
+        description="Whether to use GTI assessment data (score/verdict) and enable GTI relationship enrichment. Requires a VirusTotal account with GTI access.",
+    )
+    gti_include_malware_families: bool = Field(
+        default=False,
+        description="Whether or not to enrich with related GTI malware families (created as Malware entities).",
+    )
+    gti_include_threat_actors: bool = Field(
+        default=False,
+        description="Whether or not to enrich with related GTI threat actors (created as Intrusion-Set entities).",
+    )
+    gti_include_campaigns: bool = Field(
+        default=False,
+        description="Whether or not to enrich with related GTI campaigns (created as Campaign entities).",
+    )
+    gti_include_reports: bool = Field(
+        default=False,
+        description="Whether or not to enrich with related GTI reports (created as Report entities).",
+    )
+    gti_relationship_limit: int = Field(
+        default=10,
+        description="Maximum number of related objects to pull per GTI relationship, per observable.",
+    )
+
     @model_validator(mode="before")
     def auto_build_configs(cls, values: dict):
         """

--- a/internal-enrichment/virustotal/src/virustotal/processors/entity.py
+++ b/internal-enrichment/virustotal/src/virustotal/processors/entity.py
@@ -16,6 +16,23 @@ class EntityProcessor(ABC):
     dispatch — is handled here once.
     """
 
+    # VirusTotal endpoint path segment for this entity type (e.g.
+    # "ip_addresses"), used to fetch GTI collection relationships. Set by
+    # each subclass.
+    _GTI_ENDPOINT_TYPE: str = ""
+
+    # Maps each GTI collection relationship to the connector config flag
+    # gating it and the VirusTotalBuilder method that builds it. Shared
+    # across all entity types since VirusTotal/GTI exposes the same four
+    # relationships (malware_families, threat_actors, campaigns, reports)
+    # uniformly on IP, domain, URL, and file objects.
+    _GTI_RELATIONSHIPS: dict[str, tuple[str, str]] = {
+        "malware_families": ("gti_include_malware_families", "create_malware_family"),
+        "threat_actors": ("gti_include_threat_actors", "create_intrusion_set"),
+        "campaigns": ("gti_include_campaigns", "create_campaign"),
+        "reports": ("gti_include_reports", "create_report"),
+    }
+
     def __init__(
         self,
         connector: "VirusTotalConnector",
@@ -48,6 +65,7 @@ class EntityProcessor(ABC):
         self._check_response(json_data)
         builder = self._make_builder(json_data)
         self._enrich(builder, json_data)
+        self._enrich_gti_relationships(builder)
         return builder.send_bundle()
 
     # ------------------------------------------------------------------
@@ -63,6 +81,46 @@ class EntityProcessor(ABC):
         if "data" not in json_data or "attributes" not in json_data["data"]:
             raise ValueError("An error has occurred.")
 
+    def _gti_identifier(self) -> str:
+        """Return the identifier to use for GTI relationship lookups.
+
+        Defaults to the observable's value; overridden by FileProcessor
+        since files are looked up by hash, not by their raw SCO value.
+        """
+        return self.opencti_entity["observable_value"]
+
+    def _enrich_gti_relationships(self, builder: VirusTotalBuilder) -> None:
+        """Fetch and build any enabled GTI collection relationships.
+
+        For each of malware_families/threat_actors/campaigns/reports whose
+        config flag is enabled, fetches the relationship and calls the
+        matching VirusTotalBuilder method for every item returned.
+
+        No-ops entirely when the gti_enrichment_enabled master flag is off,
+        regardless of the individual gti_include_* flags below.
+        """
+        if not self.connector.gti_enrichment_enabled:
+            return
+        identifier = None
+        for relationship, (
+            flag_name,
+            builder_method,
+        ) in self._GTI_RELATIONSHIPS.items():
+            if not getattr(self.connector, flag_name):
+                continue
+            if identifier is None:
+                identifier = self._gti_identifier()
+            response = self.client.get_gti_relationship(
+                self._GTI_ENDPOINT_TYPE,
+                identifier,
+                relationship,
+                self.connector.gti_relationship_limit,
+            )
+            if not response or "data" not in response:
+                continue
+            for item in response["data"]:
+                getattr(builder, builder_method)(item)
+
     def _make_builder(self, json_data: dict, **kwargs) -> VirusTotalBuilder:
         """Construct a :class:`VirusTotalBuilder` with connector-level settings."""
         return VirusTotalBuilder(
@@ -75,6 +133,7 @@ class EntityProcessor(ABC):
             json_data["data"],
             include_attributes_in_note=self.connector.include_attributes_in_note,
             is_indicator=self.is_indicator,
+            gti_enabled=self.connector.gti_enrichment_enabled,
             **kwargs,
         )
 

--- a/internal-enrichment/virustotal/src/virustotal/processors/file.py
+++ b/internal-enrichment/virustotal/src/virustotal/processors/file.py
@@ -9,6 +9,12 @@ if TYPE_CHECKING:
 class FileProcessor(EntityProcessor):
     """Enriches StixFile, Artifact, and file-type Indicators."""
 
+    _GTI_ENDPOINT_TYPE = "files"
+
+    def _gti_identifier(self) -> str:
+        """Files are looked up by hash, not by the raw SCO value."""
+        return self._resolve_hash()
+
     def _fetch_data(self) -> dict | None:
         hash_value = self._resolve_hash()
         json_data = self.client.get_file_info(hash_value)

--- a/internal-enrichment/virustotal/src/virustotal/processors/hostname.py
+++ b/internal-enrichment/virustotal/src/virustotal/processors/hostname.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
 class HostnameProcessor(EntityProcessor):
     """Enriches Domain-Name and Hostname observables and Indicators."""
 
+    _GTI_ENDPOINT_TYPE = "domains"
+
     def _fetch_data(self) -> dict:
         return self.client.get_domain_info(self.opencti_entity["observable_value"])
 

--- a/internal-enrichment/virustotal/src/virustotal/processors/ip_address.py
+++ b/internal-enrichment/virustotal/src/virustotal/processors/ip_address.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
 class IPProcessor(EntityProcessor):
     """Enriches IPv4-Addr observables and Indicators."""
 
+    _GTI_ENDPOINT_TYPE = "ip_addresses"
+
     def _fetch_data(self) -> dict:
         return self.client.get_ip_info(self.opencti_entity["observable_value"])
 

--- a/internal-enrichment/virustotal/src/virustotal/processors/url.py
+++ b/internal-enrichment/virustotal/src/virustotal/processors/url.py
@@ -34,7 +34,7 @@ class URLProcessor(EntityProcessor):
         # relationship holds no object, so the key is present and the `get`
         # default never applies: normalise with `or` rather than a default.
         url_related_object_data = (
-            related.get("data", {}) if isinstance(related, dict) else {}
+            (related.get("data") or {}) if isinstance(related, dict) else {}
         )
         return super()._make_builder(
             json_data, url_related_object_data=url_related_object_data, **kwargs

--- a/internal-enrichment/virustotal/src/virustotal/processors/url.py
+++ b/internal-enrichment/virustotal/src/virustotal/processors/url.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
 class URLProcessor(EntityProcessor):
     """Enriches Url observables and Indicators."""
 
+    _GTI_ENDPOINT_TYPE = "urls"
+
     def _fetch_data(self) -> dict:
         url = self.opencti_entity["observable_value"]
         json_data = self.client.get_url_info(url)
@@ -32,7 +34,7 @@ class URLProcessor(EntityProcessor):
         # relationship holds no object, so the key is present and the `get`
         # default never applies: normalise with `or` rather than a default.
         url_related_object_data = (
-            (related.get("data") or {}) if isinstance(related, dict) else {}
+            related.get("data", {}) if isinstance(related, dict) else {}
         )
         return super()._make_builder(
             json_data, url_related_object_data=url_related_object_data, **kwargs

--- a/internal-enrichment/virustotal/src/virustotal/virustotal.py
+++ b/internal-enrichment/virustotal/src/virustotal/virustotal.py
@@ -103,6 +103,18 @@ class VirusTotalConnector:
             self.config.virustotal.include_attributes_in_note
         )
 
+        # GTI collection enrichment settings
+        self.gti_enrichment_enabled = self.config.virustotal.gti_enrichment_enabled
+        self.gti_include_malware_families = (
+            self.config.virustotal.gti_include_malware_families
+        )
+        self.gti_include_threat_actors = (
+            self.config.virustotal.gti_include_threat_actors
+        )
+        self.gti_include_campaigns = self.config.virustotal.gti_include_campaigns
+        self.gti_include_reports = self.config.virustotal.gti_include_reports
+        self.gti_relationship_limit = self.config.virustotal.gti_relationship_limit
+
     # ------------------------------------------------------------------
     # YARA cache (shared across processor instances)
     # ------------------------------------------------------------------

--- a/internal-enrichment/virustotal/tests/tests_virustotal/resources/vt_test_gti_campaigns.json
+++ b/internal-enrichment/virustotal/tests/tests_virustotal/resources/vt_test_gti_campaigns.json
@@ -1,0 +1,19 @@
+{
+  "data": [
+    {
+      "id": "campaign--23-021",
+      "type": "collection",
+      "attributes": {
+        "name": "Espionage-Motivated Actor Exploits Outlook Vulnerability CVE-2023-23397",
+        "collection_type": "campaign",
+        "description": "Campaign attributed to APT28 exploiting CVE-2023-23397."
+      },
+      "links": {
+        "self": "https://www.virustotal.com/api/v3/collections/campaign--23-021"
+      }
+    }
+  ],
+  "links": {
+    "self": "https://www.virustotal.com/api/v3/ip_addresses/101.255.119.42/campaigns?limit=40"
+  }
+}

--- a/internal-enrichment/virustotal/tests/tests_virustotal/resources/vt_test_gti_malware_families.json
+++ b/internal-enrichment/virustotal/tests/tests_virustotal/resources/vt_test_gti_malware_families.json
@@ -1,0 +1,31 @@
+{
+  "data": [
+    {
+      "id": "malware--c89e3c92-0000-0000-0000-000000000001",
+      "type": "collection",
+      "attributes": {
+        "name": "LUMMAC.V2",
+        "collection_type": "malware-family",
+        "description": "Mandiant-tracked malware family: a credential-stealing malware family."
+      },
+      "links": {
+        "self": "https://www.virustotal.com/api/v3/collections/malware--c89e3c92-0000-0000-0000-000000000001"
+      }
+    },
+    {
+      "id": "threatfox_win_lumma",
+      "type": "collection",
+      "attributes": {
+        "name": "Lumma Stealer",
+        "collection_type": "malware-family",
+        "description": "ThreatFox-tracked malware family."
+      },
+      "links": {
+        "self": "https://www.virustotal.com/api/v3/collections/threatfox_win_lumma"
+      }
+    }
+  ],
+  "links": {
+    "self": "https://www.virustotal.com/api/v3/ip_addresses/144.76.173.247/malware_families?limit=40"
+  }
+}

--- a/internal-enrichment/virustotal/tests/tests_virustotal/resources/vt_test_gti_reports.json
+++ b/internal-enrichment/virustotal/tests/tests_virustotal/resources/vt_test_gti_reports.json
@@ -1,0 +1,21 @@
+{
+  "data": [
+    {
+      "id": "report--23-00005535",
+      "type": "collection",
+      "attributes": {
+        "name": "Lumma Stealer actively deployed in multiple campaigns",
+        "collection_type": "report",
+        "description": "Intrinsec writeup on Lumma Stealer infrastructure.",
+        "creation_date": 1700000000,
+        "origin": "Crowdsourced"
+      },
+      "links": {
+        "self": "https://www.virustotal.com/api/v3/collections/report--23-00005535"
+      }
+    }
+  ],
+  "links": {
+    "self": "https://www.virustotal.com/api/v3/ip_addresses/144.76.173.247/reports?limit=40"
+  }
+}

--- a/internal-enrichment/virustotal/tests/tests_virustotal/resources/vt_test_gti_threat_actors.json
+++ b/internal-enrichment/virustotal/tests/tests_virustotal/resources/vt_test_gti_threat_actors.json
@@ -1,0 +1,20 @@
+{
+  "data": [
+    {
+      "id": "threat-actor--8211bc17-9216-5e83-b54d-d1b04add12f3",
+      "type": "collection",
+      "attributes": {
+        "name": "APT28",
+        "collection_type": "threat-actor",
+        "aliases": ["Fancy Bear", "Sofacy"],
+        "description": "Russia-nexus espionage and attack/destruction actor."
+      },
+      "links": {
+        "self": "https://www.virustotal.com/api/v3/collections/threat-actor--8211bc17-9216-5e83-b54d-d1b04add12f3"
+      }
+    }
+  ],
+  "links": {
+    "self": "https://www.virustotal.com/api/v3/ip_addresses/101.255.119.42/threat_actors?limit=40"
+  }
+}

--- a/internal-enrichment/virustotal/tests/tests_virustotal/test_builder.py
+++ b/internal-enrichment/virustotal/tests/tests_virustotal/test_builder.py
@@ -4,10 +4,10 @@ import datetime
 import json
 import os
 import unittest
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import stix2
-from pycti import STIX_EXT_OCTI, Identity
+from pycti import STIX_EXT_OCTI, Identity, Indicator
 from virustotal.builder import VirusTotalBuilder
 from virustotal.models.configs.virustotal_configs import IndicatorConfig
 
@@ -46,6 +46,58 @@ class VirusTotalBuilderTest(unittest.TestCase):
         self.assertEqual(builder.bundle[0].name, "VirusTotal")
         self.assertEqual(builder.bundle[0].confidence, 49)
 
+    def test_send_bundle_uses_update_true(self):
+        # update=True is required so the worker overwrites scalar fields (e.g.
+        # x_opencti_score) on entities that already exist in the platform - see
+        # the comment on VirusTotalBuilder.send_bundle for the full rationale.
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            [],
+            {"id": "fakeid"},
+            {"id": "fakeid"},
+            self.load_file("vt_test_file.json")["data"],
+        )
+        self.helper.reset_mock()
+        builder.send_bundle()
+        self.helper.send_stix2_bundle.assert_called_once()
+        _, kwargs = self.helper.send_stix2_bundle.call_args
+        self.assertTrue(kwargs.get("update"))
+
+    def test_update_size_sets_size_when_present(self):
+        stix_entity = {"id": "fakeid"}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            [],
+            stix_entity,
+            {"id": "fakeid"},
+            self.load_file("vt_test_file.json")["data"],
+        )
+        builder.update_size()
+        self.assertEqual(stix_entity["size"], 87040)
+
+    def test_update_size_skips_when_absent(self):
+        """VT returns no "size" for hashes it has only ever seen "in the
+        wild" but never analysed; update_size must not raise KeyError in
+        that case (see comment on VirusTotalBuilder.update_size)."""
+        data = self.load_file("vt_test_file.json")["data"]
+        del data["attributes"]["size"]
+        stix_entity = {"id": "fakeid"}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            [],
+            stix_entity,
+            {"id": "fakeid"},
+            data,
+        )
+        builder.update_size()  # should not raise
+        self.assertNotIn("size", stix_entity)
+
     def test_compute_score(self):
         builder = VirusTotalBuilder(
             self.helper,
@@ -70,12 +122,33 @@ class VirusTotalBuilderTest(unittest.TestCase):
             {"id": "fakeid"},
             {"id": "fakeid"},
             self.load_file("vt_test_file.json")["data"],
+            gti_enabled=True,
         )
         attributes = self.load_file("vt_test_file.json")["data"]["attributes"]
         gti_assessment = {"threat_score": {"value": 85}}
         self.assertEqual(
             builder._compute_score(attributes["last_analysis_stats"], gti_assessment),
             85,
+        )
+
+    def test_compute_score_ignores_gti_assessment_when_disabled(self):
+        """gti_enabled=False must ignore a present, usable gti_assessment
+        entirely and fall back to the legacy stats-based score."""
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            [],
+            {"id": "fakeid"},
+            {"id": "fakeid"},
+            self.load_file("vt_test_file.json")["data"],
+            gti_enabled=False,
+        )
+        attributes = self.load_file("vt_test_file.json")["data"]["attributes"]
+        gti_assessment = {"threat_score": {"value": 85}}
+        self.assertEqual(
+            builder._compute_score(attributes["last_analysis_stats"], gti_assessment),
+            72,
         )
 
     def test_compute_score_gti_assessment_no_threat_score(self):
@@ -88,6 +161,7 @@ class VirusTotalBuilderTest(unittest.TestCase):
             {"id": "fakeid"},
             {"id": "fakeid"},
             self.load_file("vt_test_file.json")["data"],
+            gti_enabled=True,
         )
         attributes = self.load_file("vt_test_file.json")["data"]["attributes"]
         self.assertEqual(
@@ -104,6 +178,7 @@ class VirusTotalBuilderTest(unittest.TestCase):
             {"id": "fakeid"},
             {"id": "fakeid"},
             self.load_file("vt_test_file.json")["data"],
+            gti_enabled=True,
         )
         attributes = self.load_file("vt_test_file.json")["data"]["attributes"]
         self.assertEqual(
@@ -191,6 +266,190 @@ class VirusTotalBuilderTest(unittest.TestCase):
             "ipv4-addr--90a03625-500c-5813-abd1-5d5519f833d2",
         )
         self.assertEqual(builder.bundle[3].target_ref, builder.bundle[2].id)
+
+    def _make_gti_builder(self):
+        """Build a VirusTotalBuilder against a fake IPv4-Addr, for GTI collection tests."""
+        stix_entity = {"id": "ipv4-addr--90a03625-500c-5813-abd1-5d5519f833d2"}
+        return stix_entity, VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            stix_objects=[stix_entity],
+            stix_entity=stix_entity,
+            opencti_entity={"id": "fakeid"},
+            data=self.load_file("vt_test_ipv4.json")["data"],
+        )
+
+    def test_create_malware_family(self):
+        stix_entity, builder = self._make_gti_builder()
+        collection_data = self.load_file("vt_test_gti_malware_families.json")["data"][0]
+        builder.create_malware_family(collection_data)
+        # Bundle: [stix_entity, author, malware, relationship].
+        self.assertEqual(len(builder.bundle), 4)
+        malware = builder.bundle[2]
+        self.assertEqual(malware.name, "LUMMAC.V2")
+        self.assertTrue(malware.is_family)
+        self.assertEqual(malware.created_by_ref, self.author.id)
+        relationship = builder.bundle[3]
+        self.assertEqual(relationship.relationship_type, "related-to")
+        self.assertEqual(relationship.source_ref, stix_entity["id"])
+        self.assertEqual(relationship.target_ref, malware.id)
+
+    def test_create_malware_family_also_indicates_from_created_indicator(self):
+        """When create_indicator_based_on already created an Indicator this
+        run, GTI entities must also get an `indicates` edge from it, in
+        addition to the observable's own `related-to` edge."""
+        stix_entity, builder = self._make_gti_builder()
+        builder.indicator = stix2.Indicator(
+            id=Indicator.generate_id("[ipv4-addr:value = '1.2.3.4']"),
+            pattern="[ipv4-addr:value = '1.2.3.4']",
+            pattern_type="stix",
+            valid_from=datetime.datetime.now(datetime.timezone.utc),
+        )
+        collection_data = self.load_file("vt_test_gti_malware_families.json")["data"][0]
+        builder.create_malware_family(collection_data)
+        # Bundle: [stix_entity, author, malware, related-to, indicates].
+        self.assertEqual(len(builder.bundle), 5)
+        malware = builder.bundle[2]
+        related_to = builder.bundle[3]
+        self.assertEqual(related_to.relationship_type, "related-to")
+        self.assertEqual(related_to.source_ref, stix_entity["id"])
+        indicates = builder.bundle[4]
+        self.assertEqual(indicates.relationship_type, "indicates")
+        self.assertEqual(indicates.source_ref, builder.indicator.id)
+        self.assertEqual(indicates.target_ref, malware.id)
+
+    def test_create_malware_family_indicates_when_enriching_indicator_directly(self):
+        """When is_indicator=True, self.stix_entity IS the Indicator, so the
+        link to a GTI entity should be `indicates`, not `related-to`."""
+        indicator_entity = {"id": "indicator--357c4d50-72a2-40f8-8b7e-3bb59d1fa5db"}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            stix_objects=[indicator_entity],
+            stix_entity=indicator_entity,
+            opencti_entity={"id": "fakeid"},
+            data=self.load_file("vt_test_ipv4.json")["data"],
+            is_indicator=True,
+        )
+        collection_data = self.load_file("vt_test_gti_malware_families.json")["data"][0]
+        builder.create_malware_family(collection_data)
+        # Bundle: [indicator_entity, author, malware, indicates] - no related-to.
+        self.assertEqual(len(builder.bundle), 4)
+        malware = builder.bundle[2]
+        relationship = builder.bundle[3]
+        self.assertEqual(relationship.relationship_type, "indicates")
+        self.assertEqual(relationship.source_ref, indicator_entity["id"])
+        self.assertEqual(relationship.target_ref, malware.id)
+
+    def test_create_malware_family_skips_when_no_name(self):
+        _, builder = self._make_gti_builder()
+        builder.create_malware_family({"id": "threatfox_win_lumma", "attributes": {}})
+        self.assertEqual(len(builder.bundle), 2)  # unchanged: stix_entity + author only
+
+    def test_create_intrusion_set(self):
+        stix_entity, builder = self._make_gti_builder()
+        collection_data = self.load_file("vt_test_gti_threat_actors.json")["data"][0]
+        builder.create_intrusion_set(collection_data)
+        self.assertEqual(len(builder.bundle), 4)
+        intrusion_set = builder.bundle[2]
+        self.assertEqual(intrusion_set.name, "APT28")
+        self.assertEqual(list(intrusion_set.aliases), ["Fancy Bear", "Sofacy"])
+        relationship = builder.bundle[3]
+        self.assertEqual(relationship.relationship_type, "related-to")
+        self.assertEqual(relationship.source_ref, stix_entity["id"])
+        self.assertEqual(relationship.target_ref, intrusion_set.id)
+
+    def test_create_intrusion_set_also_indicates_from_created_indicator(self):
+        stix_entity, builder = self._make_gti_builder()
+        builder.indicator = stix2.Indicator(
+            id=Indicator.generate_id("[ipv4-addr:value = '1.2.3.4']"),
+            pattern="[ipv4-addr:value = '1.2.3.4']",
+            pattern_type="stix",
+            valid_from=datetime.datetime.now(datetime.timezone.utc),
+        )
+        collection_data = self.load_file("vt_test_gti_threat_actors.json")["data"][0]
+        builder.create_intrusion_set(collection_data)
+        self.assertEqual(len(builder.bundle), 5)
+        indicates = builder.bundle[4]
+        self.assertEqual(indicates.relationship_type, "indicates")
+        self.assertEqual(indicates.source_ref, builder.indicator.id)
+
+    def test_create_campaign(self):
+        stix_entity, builder = self._make_gti_builder()
+        collection_data = self.load_file("vt_test_gti_campaigns.json")["data"][0]
+        builder.create_campaign(collection_data)
+        self.assertEqual(len(builder.bundle), 4)
+        campaign = builder.bundle[2]
+        self.assertEqual(
+            campaign.name,
+            "Espionage-Motivated Actor Exploits Outlook Vulnerability CVE-2023-23397",
+        )
+        relationship = builder.bundle[3]
+        self.assertEqual(relationship.relationship_type, "related-to")
+        self.assertEqual(relationship.source_ref, stix_entity["id"])
+        self.assertEqual(relationship.target_ref, campaign.id)
+
+    def test_create_campaign_also_indicates_from_created_indicator(self):
+        stix_entity, builder = self._make_gti_builder()
+        builder.indicator = stix2.Indicator(
+            id=Indicator.generate_id("[ipv4-addr:value = '1.2.3.4']"),
+            pattern="[ipv4-addr:value = '1.2.3.4']",
+            pattern_type="stix",
+            valid_from=datetime.datetime.now(datetime.timezone.utc),
+        )
+        collection_data = self.load_file("vt_test_gti_campaigns.json")["data"][0]
+        builder.create_campaign(collection_data)
+        self.assertEqual(len(builder.bundle), 5)
+        indicates = builder.bundle[4]
+        self.assertEqual(indicates.relationship_type, "indicates")
+        self.assertEqual(indicates.source_ref, builder.indicator.id)
+
+    def test_create_report(self):
+        stix_entity, builder = self._make_gti_builder()
+        collection_data = self.load_file("vt_test_gti_reports.json")["data"][0]
+        builder.create_report(collection_data)
+        # Reports link via object_refs, not a separate relationship:
+        # bundle is [stix_entity, author, report].
+        self.assertEqual(len(builder.bundle), 3)
+        report = builder.bundle[2]
+        self.assertEqual(
+            report.name, "Lumma Stealer actively deployed in multiple campaigns"
+        )
+        self.assertEqual(list(report.object_refs), [stix_entity["id"]])
+
+    def test_create_report_also_includes_created_indicator(self):
+        """When create_indicator_based_on already created an Indicator this
+        run, the Report's object_refs must include it alongside the
+        observable - otherwise the Indicator is silently left out of the
+        Report entirely."""
+        stix_entity, builder = self._make_gti_builder()
+        builder.indicator = stix2.Indicator(
+            id=Indicator.generate_id("[ipv4-addr:value = '1.2.3.4']"),
+            pattern="[ipv4-addr:value = '1.2.3.4']",
+            pattern_type="stix",
+            valid_from=datetime.datetime.now(datetime.timezone.utc),
+        )
+        collection_data = self.load_file("vt_test_gti_reports.json")["data"][0]
+        builder.create_report(collection_data)
+        report = builder.bundle[2]
+        self.assertEqual(
+            list(report.object_refs), [stix_entity["id"], builder.indicator.id]
+        )
+
+    def test_create_report_uses_fixed_sentinel_when_no_creation_date(self):
+        """A report with no creation_date must fall back to a fixed sentinel
+        date, never datetime.now(), so repeat enrichment runs against the
+        same report produce the same id instead of a new one every time."""
+        _, builder = self._make_gti_builder()
+        collection_data = {
+            "id": "report--no-date",
+            "attributes": {"name": "No Date Report"},
+        }
+        builder.create_report(collection_data)
+        published_arg = self.helper.api.stix2.format_date.call_args[0][0]
+        self.assertLess(published_arg.year, 2000)
 
     def test_create_notes(self):
         observable = {
@@ -390,6 +649,154 @@ class VirusTotalBuilderTest(unittest.TestCase):
         ext_data = stix_entity.get("extensions", {}).get(STIX_EXT_OCTI, {})
         self.assertIn("score", ext_data)
 
+    def test_create_indicator_gti_verdict_malicious_overrides_low_legacy_count(self):
+        """A GTI-malicious verdict must trigger indicator creation even when
+        the legacy multi-engine count is well below the configured
+        threshold (see _meets_indicator_threshold)."""
+        data = self.load_file("vt_test_ipv4.json")["data"]
+        data["attributes"]["gti_assessment"] = {
+            "verdict": {"value": "VERDICT_MALICIOUS"}
+        }
+        self.assertLess(data["attributes"]["last_analysis_stats"]["malicious"], 10)
+        stix_entity = {"id": "ipv4-addr--357c4d50-72a2-40f8-8b7e-3bb59d1fa5db"}
+        opencti_entity = {"entity_type": "IPv4-Addr", "observable_value": "1.2.3.4"}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            [],
+            stix_entity,
+            opencti_entity,
+            data,
+            gti_enabled=True,
+        )
+        initial_bundle_len = len(builder.bundle)
+        config = IndicatorConfig(threshold=10, valid_minutes=2880, detect=True)
+        # format_date is mocked class-wide to a timestamp fixed at setup_class
+        # time; scope it to the real valid_until here so it stays after
+        # stix2's own valid_from default (also "now") regardless of how much
+        # wall-clock time has passed since setup_class ran.
+        with patch.object(
+            self.helper.api.stix2, "format_date", side_effect=lambda dt: dt
+        ):
+            builder.create_indicator_based_on(config, "[ipv4-addr:value = '1.2.3.4']")
+        self.assertEqual(len(builder.bundle), initial_bundle_len + 2)
+        indicator = builder.bundle[initial_bundle_len]
+        self.assertIn("GTI verdict is malicious", indicator.description)
+        # builder.indicator must be set so GTI-derived entities created
+        # later in this same run can link to it via `indicates`.
+        self.assertEqual(builder.indicator.id, indicator.id)
+
+    def test_create_indicator_gti_verdict_ignored_when_disabled(self):
+        """gti_enabled=False must ignore a malicious GTI verdict entirely,
+        even when the legacy count is below threshold."""
+        data = self.load_file("vt_test_ipv4.json")["data"]
+        data["attributes"]["gti_assessment"] = {
+            "verdict": {"value": "VERDICT_MALICIOUS"}
+        }
+        self.assertLess(data["attributes"]["last_analysis_stats"]["malicious"], 10)
+        stix_entity = {"id": "ipv4-addr--357c4d50-72a2-40f8-8b7e-3bb59d1fa5db"}
+        opencti_entity = {"entity_type": "IPv4-Addr", "observable_value": "1.2.3.4"}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            [],
+            stix_entity,
+            opencti_entity,
+            data,
+            gti_enabled=False,
+        )
+        initial_bundle_len = len(builder.bundle)
+        config = IndicatorConfig(threshold=10, valid_minutes=2880, detect=True)
+        builder.create_indicator_based_on(config, "[ipv4-addr:value = '1.2.3.4']")
+        self.assertEqual(len(builder.bundle), initial_bundle_len)
+
+    def test_create_indicator_not_created_leaves_builder_indicator_none(self):
+        """When the threshold isn't met, builder.indicator must stay None -
+        otherwise a later GTI entity would wrongly link to a stale/no-op
+        Indicator that was never actually added to the bundle."""
+        data = self.load_file("vt_test_ipv4.json")["data"]
+        stix_entity = {"id": "ipv4-addr--357c4d50-72a2-40f8-8b7e-3bb59d1fa5db"}
+        opencti_entity = {"entity_type": "IPv4-Addr", "observable_value": "1.2.3.4"}
+        builder = VirusTotalBuilder(
+            self.helper, self.author, True, [], stix_entity, opencti_entity, data
+        )
+        config = IndicatorConfig(threshold=1000, valid_minutes=2880, detect=True)
+        builder.create_indicator_based_on(config, "[ipv4-addr:value = '1.2.3.4']")
+        self.assertIsNone(builder.indicator)
+
+    def test_create_indicator_threshold_zero_disables_even_with_gti_verdict(self):
+        """threshold=0 is documented as fully disabling indicator creation;
+        that must still hold even when GTI's verdict is malicious."""
+        data = self.load_file("vt_test_ipv4.json")["data"]
+        data["attributes"]["gti_assessment"] = {
+            "verdict": {"value": "VERDICT_MALICIOUS"}
+        }
+        stix_entity = {"id": "fakeid"}
+        opencti_entity = {"entity_type": "IPv4-Addr", "observable_value": "1.2.3.4"}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            [],
+            stix_entity,
+            opencti_entity,
+            data,
+            gti_enabled=True,
+        )
+        initial_bundle_len = len(builder.bundle)
+        config = IndicatorConfig(threshold=0, valid_minutes=2880, detect=True)
+        builder.create_indicator_based_on(config, "[ipv4-addr:value = '1.2.3.4']")
+        self.assertEqual(len(builder.bundle), initial_bundle_len)
+
+    def test_create_indicator_legacy_threshold_without_gti_assessment(self):
+        """Without a gti_assessment at all, the legacy count-vs-threshold
+        behavior must be unchanged."""
+        data = self.load_file("vt_test_ipv4.json")["data"]
+        malicious_count = data["attributes"]["last_analysis_stats"]["malicious"]
+        stix_entity = {"id": "ipv4-addr--16f93f1a-5e85-44aa-9fa6-10ea5da66de3"}
+        opencti_entity = {"entity_type": "IPv4-Addr", "observable_value": "1.2.3.4"}
+        builder = VirusTotalBuilder(
+            self.helper, self.author, True, [], stix_entity, opencti_entity, data
+        )
+        initial_bundle_len = len(builder.bundle)
+        config = IndicatorConfig(
+            threshold=malicious_count, valid_minutes=2880, detect=True
+        )
+        with patch.object(
+            self.helper.api.stix2, "format_date", side_effect=lambda dt: dt
+        ):
+            builder.create_indicator_based_on(config, "[ipv4-addr:value = '1.2.3.4']")
+        self.assertEqual(len(builder.bundle), initial_bundle_len + 2)
+        indicator = builder.bundle[initial_bundle_len]
+        self.assertIn("positive count was >=", indicator.description)
+
+    def test_create_indicator_gti_verdict_not_malicious_falls_back_to_legacy(self):
+        """A gti_assessment present but not malicious must not bypass the
+        legacy threshold check."""
+        data = self.load_file("vt_test_ipv4.json")["data"]
+        data["attributes"]["gti_assessment"] = {
+            "verdict": {"value": "VERDICT_HARMLESS"}
+        }
+        self.assertLess(data["attributes"]["last_analysis_stats"]["malicious"], 10)
+        stix_entity = {"id": "fakeid"}
+        opencti_entity = {"entity_type": "IPv4-Addr", "observable_value": "1.2.3.4"}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            [],
+            stix_entity,
+            opencti_entity,
+            data,
+            gti_enabled=True,
+        )
+        initial_bundle_len = len(builder.bundle)
+        config = IndicatorConfig(threshold=10, valid_minutes=2880, detect=True)
+        builder.create_indicator_based_on(config, "[ipv4-addr:value = '1.2.3.4']")
+        self.assertEqual(len(builder.bundle), initial_bundle_len)
+
     def test_update_labels_for_indicator(self):
         """When is_indicator=True, update_labels should set labels directly on stix_entity."""
         stix_entity = {"id": "indicator--aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}
@@ -412,6 +819,99 @@ class VirusTotalBuilderTest(unittest.TestCase):
         self.assertIn("labels", stix_entity)
         self.assertIsInstance(stix_entity["labels"], list)
         self.assertTrue(len(stix_entity["labels"]) > 0)
+
+    def test_update_hashes_sets_all_when_present(self):
+        stix_entity = {"id": "fakeid", "hashes": {}}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            [],
+            stix_entity,
+            {"id": "fakeid"},
+            self.load_file("vt_test_file.json")["data"],
+        )
+        builder.update_hashes()
+        self.assertEqual(
+            stix_entity["hashes"]["MD5"], "546bb6ef89bebfb053999777f6930d7e"
+        )
+        self.assertEqual(
+            stix_entity["hashes"]["SHA-1"], "44392b16e2db656104579e83d603b363bf91ccb2"
+        )
+        self.assertEqual(
+            stix_entity["hashes"]["SHA-256"],
+            "4bc00f7d638e042da764e8648c03c0db46700599dd4f08d117e3e9e8b538519b",
+        )
+
+    def test_update_hashes_skips_missing_algos(self):
+        """VT may omit some hash fields for unanalysed files; update_hashes
+        must not raise KeyError in that case (see comment on the method)."""
+        data = self.load_file("vt_test_file.json")["data"]
+        del data["attributes"]["md5"]
+        stix_entity = {"id": "fakeid", "hashes": {}}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            [],
+            stix_entity,
+            {"id": "fakeid"},
+            data,
+        )
+        builder.update_hashes()  # should not raise
+        self.assertNotIn("MD5", stix_entity["hashes"])
+        self.assertIn("SHA-1", stix_entity["hashes"])
+
+    def test_update_labels_skips_when_tags_absent(self):
+        """VT may omit "tags" entirely for unanalysed files; update_labels
+        must not raise KeyError in that case (see comment on the method)."""
+        data = self.load_file("vt_test_file.json")["data"]
+        del data["attributes"]["tags"]
+        stix_entity = {"id": "indicator--aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            [stix_entity],
+            stix_entity,
+            {"id": "fakeid"},
+            data,
+            is_indicator=True,
+        )
+        builder.update_labels()  # should not raise
+        self.assertNotIn("labels", stix_entity)
+
+    def test_update_names_sets_main_when_present(self):
+        stix_entity = {"id": "fakeid"}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            [],
+            stix_entity,
+            {"id": "fakeid"},
+            self.load_file("vt_test_file.json")["data"],
+        )
+        builder.update_names(main=True)
+        self.assertIn("name", stix_entity)
+
+    def test_update_names_skips_when_absent(self):
+        """VT may omit "names" entirely for unanalysed files; update_names
+        must not raise KeyError in that case (see comment on the method)."""
+        data = self.load_file("vt_test_file.json")["data"]
+        del data["attributes"]["names"]
+        stix_entity = {"id": "fakeid"}
+        builder = VirusTotalBuilder(
+            self.helper,
+            self.author,
+            True,
+            [],
+            stix_entity,
+            {"id": "fakeid"},
+            data,
+        )
+        builder.update_names(main=True)  # should not raise
+        self.assertNotIn("name", stix_entity)
 
     @staticmethod
     def load_file(filename: str):

--- a/internal-enrichment/virustotal/tests/tests_virustotal/test_client.py
+++ b/internal-enrichment/virustotal/tests/tests_virustotal/test_client.py
@@ -1,8 +1,15 @@
 """Virustotal client unittest."""
 
 import unittest
+from unittest.mock import MagicMock, patch
 
 from virustotal.client import VirusTotalClient
+
+
+def _make_client() -> VirusTotalClient:
+    helper = MagicMock()
+    helper.connector_id = "test-connector-uuid"
+    return VirusTotalClient(helper, "https://www.virustotal.com/api/v3", "fake-api-key")
 
 
 class VirusTotalClientTest(unittest.TestCase):
@@ -13,10 +20,93 @@ class VirusTotalClientTest(unittest.TestCase):
         )
 
     def test_x_tool_header_set(self):
-        from unittest.mock import MagicMock
-
         helper = MagicMock()
         helper.connector_id = "test-connector-uuid"
         client = VirusTotalClient(helper, "https://www.virustotal.com", "fake-api-key")
         self.assertIn("x-tool", client.headers)
         self.assertIn("test-connector-uuid", client.headers["x-tool"])
+
+    def test_get_url_related_objects_extra_query_appended(self):
+        client = _make_client()
+        with patch.object(client, "_query", return_value={"data": []}) as mock_query:
+            client.get_url_related_objects(
+                "http://example.com", "malware_families", extra_query="limit=5"
+            )
+        called_url = mock_query.call_args[0][0]
+        self.assertTrue(called_url.endswith("/malware_families?limit=5"))
+
+    def test_get_url_related_objects_no_extra_query_unchanged(self):
+        client = _make_client()
+        with patch.object(client, "_query", return_value={"data": []}) as mock_query:
+            client.get_url_related_objects("http://example.com", "malware_families")
+        called_url = mock_query.call_args[0][0]
+        self.assertTrue(called_url.endswith("/malware_families"))
+        self.assertNotIn("?", called_url)
+
+    def test_get_gti_relationship_ip_addresses_single_page(self):
+        client = _make_client()
+        page = {"data": [{"id": "a"}, {"id": "b"}], "links": {}}
+        with patch.object(client, "_query", return_value=page) as mock_query:
+            result = client.get_gti_relationship(
+                "ip_addresses", "1.2.3.4", "malware_families", 10
+            )
+        mock_query.assert_called_once()
+        called_url = mock_query.call_args[0][0]
+        self.assertEqual(
+            called_url,
+            "https://www.virustotal.com/api/v3/ip_addresses/1.2.3.4/malware_families?limit=10",
+        )
+        self.assertEqual(len(result["data"]), 2)
+
+    def test_get_gti_relationship_urls_delegates_with_extra_query(self):
+        client = _make_client()
+        with patch.object(
+            client, "get_url_related_objects", return_value={"data": [{"id": "a"}]}
+        ) as mock_related:
+            client.get_gti_relationship("urls", "http://example.com", "reports", 7)
+        mock_related.assert_called_once_with(
+            "http://example.com", "reports", extra_query="limit=7"
+        )
+
+    def test_get_gti_relationship_limit_zero_skips_call(self):
+        client = _make_client()
+        with patch.object(client, "_query") as mock_query:
+            result = client.get_gti_relationship(
+                "ip_addresses", "1.2.3.4", "malware_families", 0
+            )
+        mock_query.assert_not_called()
+        self.assertEqual(result, {"data": []})
+
+    def test_get_gti_relationship_follows_pagination_up_to_limit(self):
+        client = _make_client()
+        page_1 = {
+            "data": [{"id": "a"}, {"id": "b"}],
+            "links": {"next": "https://www.virustotal.com/api/v3/next-page"},
+        }
+        page_2 = {"data": [{"id": "c"}, {"id": "d"}], "links": {}}
+        with patch.object(client, "_query", side_effect=[page_1, page_2]) as mock_query:
+            result = client.get_gti_relationship(
+                "ip_addresses", "1.2.3.4", "malware_families", 3
+            )
+        self.assertEqual(mock_query.call_count, 2)
+        # Truncated to the requested limit even though 4 items were fetched.
+        self.assertEqual(len(result["data"]), 3)
+        self.assertEqual([d["id"] for d in result["data"]], ["a", "b", "c"])
+
+    def test_get_gti_relationship_stops_when_no_next_link(self):
+        client = _make_client()
+        page = {"data": [{"id": "a"}], "links": {}}
+        with patch.object(client, "_query", return_value=page) as mock_query:
+            result = client.get_gti_relationship(
+                "ip_addresses", "1.2.3.4", "malware_families", 40
+            )
+        mock_query.assert_called_once()
+        self.assertEqual(len(result["data"]), 1)
+
+    def test_get_gti_relationship_returns_none_on_query_failure(self):
+        client = _make_client()
+        with patch.object(client, "_query", return_value=None):
+            result = client.get_gti_relationship(
+                "ip_addresses", "1.2.3.4", "malware_families", 10
+            )
+        self.assertIsNone(result)

--- a/internal-enrichment/virustotal/tests/tests_virustotal/test_virustotal.py
+++ b/internal-enrichment/virustotal/tests/tests_virustotal/test_virustotal.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, PropertyMock
 
 import stix2
 from pycti import Identity
+from virustotal.processors.ip_address import IPProcessor
 from virustotal.virustotal import VirusTotalConnector
 
 
@@ -20,6 +21,15 @@ def _make_connector() -> VirusTotalConnector:
     config.virustotal.domain_add_relationships = False
     config.virustotal.url_upload_unseen = False
     config.virustotal.include_attributes_in_note = False
+    # Default to True here so the existing per-relationship gti_include_*
+    # tests below don't need to also flip the master flag on; a dedicated
+    # test covers the master-flag-off behavior explicitly.
+    config.virustotal.gti_enrichment_enabled = True
+    config.virustotal.gti_include_malware_families = False
+    config.virustotal.gti_include_threat_actors = False
+    config.virustotal.gti_include_campaigns = False
+    config.virustotal.gti_include_reports = False
+    config.virustotal.gti_relationship_limit = 10
     config.virustotal.token.get_secret_value.return_value = "fake-token"
     config.virustotal.model_extra.get.return_value = MagicMock(
         threshold=10, valid_minutes=2880, detect=True
@@ -47,6 +57,14 @@ def _make_connector() -> VirusTotalConnector:
     connector.domain_add_relationships = config.virustotal.domain_add_relationships
     connector.url_upload_unseen = config.virustotal.url_upload_unseen
     connector.include_attributes_in_note = config.virustotal.include_attributes_in_note
+    connector.gti_enrichment_enabled = config.virustotal.gti_enrichment_enabled
+    connector.gti_include_malware_families = (
+        config.virustotal.gti_include_malware_families
+    )
+    connector.gti_include_threat_actors = config.virustotal.gti_include_threat_actors
+    connector.gti_include_campaigns = config.virustotal.gti_include_campaigns
+    connector.gti_include_reports = config.virustotal.gti_include_reports
+    connector.gti_relationship_limit = config.virustotal.gti_relationship_limit
     connector.file_indicator_config = MagicMock(
         threshold=10, valid_minutes=2880, detect=True
     )
@@ -185,3 +203,79 @@ class TestExtractObservableFromIndicator(unittest.TestCase):
         )
         results = self.connector._extract_observable_from_indicator(entity)
         self.assertEqual(results, [("IPv4-Addr", "1.2.3.4")])
+
+
+class TestEnrichGtiRelationships(unittest.TestCase):
+    """Tests for EntityProcessor._enrich_gti_relationships, via IPProcessor."""
+
+    def setUp(self):
+        self.connector = _make_connector()
+
+    def _make_processor(self) -> IPProcessor:
+        opencti_entity = {"entity_type": "IPv4-Addr", "observable_value": "1.2.3.4"}
+        return IPProcessor(self.connector, [], {"id": "x"}, opencti_entity, False)
+
+    def test_all_flags_off_skips_client_entirely(self):
+        processor = self._make_processor()
+        builder = MagicMock()
+        processor._enrich_gti_relationships(builder)
+        self.connector.client.get_gti_relationship.assert_not_called()
+        builder.create_malware_family.assert_not_called()
+        builder.create_intrusion_set.assert_not_called()
+        builder.create_campaign.assert_not_called()
+        builder.create_report.assert_not_called()
+
+    def test_enabled_flag_calls_client_with_expected_args_and_dispatches_items(self):
+        self.connector.gti_include_malware_families = True
+        self.connector.gti_relationship_limit = 5
+        self.connector.client.get_gti_relationship.return_value = {
+            "data": [{"id": "a"}, {"id": "b"}]
+        }
+        processor = self._make_processor()
+        builder = MagicMock()
+        processor._enrich_gti_relationships(builder)
+
+        self.connector.client.get_gti_relationship.assert_called_once_with(
+            "ip_addresses", "1.2.3.4", "malware_families", 5
+        )
+        self.assertEqual(builder.create_malware_family.call_count, 2)
+        builder.create_intrusion_set.assert_not_called()
+
+    def test_only_enabled_relationships_are_fetched(self):
+        self.connector.gti_include_threat_actors = True
+        self.connector.gti_include_reports = True
+        self.connector.client.get_gti_relationship.return_value = {"data": []}
+        processor = self._make_processor()
+        builder = MagicMock()
+        processor._enrich_gti_relationships(builder)
+
+        called_relationships = {
+            call.args[2]
+            for call in self.connector.client.get_gti_relationship.call_args_list
+        }
+        self.assertEqual(called_relationships, {"threat_actors", "reports"})
+
+    def test_empty_response_does_not_crash(self):
+        self.connector.gti_include_campaigns = True
+        self.connector.client.get_gti_relationship.return_value = None
+        processor = self._make_processor()
+        builder = MagicMock()
+        processor._enrich_gti_relationships(builder)  # should not raise
+        builder.create_campaign.assert_not_called()
+
+    def test_master_flag_off_skips_everything_even_with_sub_flags_on(self):
+        """gti_enrichment_enabled=False must disable all GTI relationship
+        fetching regardless of the individual gti_include_* flags."""
+        self.connector.gti_enrichment_enabled = False
+        self.connector.gti_include_malware_families = True
+        self.connector.gti_include_threat_actors = True
+        self.connector.gti_include_campaigns = True
+        self.connector.gti_include_reports = True
+        processor = self._make_processor()
+        builder = MagicMock()
+        processor._enrich_gti_relationships(builder)
+        self.connector.client.get_gti_relationship.assert_not_called()
+        builder.create_malware_family.assert_not_called()
+        builder.create_intrusion_set.assert_not_called()
+        builder.create_campaign.assert_not_called()
+        builder.create_report.assert_not_called()


### PR DESCRIPTION
### Proposed changes

Adds the following options to observable enrichment for VirusTotal enrichment connector using Google Threat Intelligence APIs:

* Related Malware Families
* Related Threat Actors (represented as Intrusion Sets)
* Related Campaigns
* Reports containing the observable

### Related issues

* #7644

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Google Threat Intelligence provides an abundance of possible relationships for observables. I have specifically ommited related collections as they can pull in many observables.

I'm not sure how to deal with this, and there's plenty of room for further expansion in the future to get more from the GTI subscription (e.g. related vulns, software/toolkits, collections as groupings, etc.). This PR covers the basics.