### PR TITLE
fix(import-document): drop phone matches overlapping ip addresses (#7622)

### DIFF
--- a/internal-import-file/import-document/src/reportimporter/report_parser.py
+++ b/internal-import-file/import-document/src/reportimporter/report_parser.py
@@ -85,6 +85,32 @@ class ReportParser(object):
             return True
         return False
 
+    def _drop_phone_numbers_overlapping_ip_addresses(
+        self, list_matches: Dict[str, Dict]
+    ) -> Dict[str, Dict]:
+        ip_ranges = [
+            info[RESULT_FORMAT_RANGE]
+            for info in list_matches.values()
+            if info[RESULT_FORMAT_CATEGORY] in ("IPv4-Addr.value", "IPv6-Addr.value")
+        ]
+        if not ip_ranges:
+            return list_matches
+
+        filtered_matches = {}
+        for match, info in list_matches.items():
+            if info[RESULT_FORMAT_CATEGORY] == "Phone-Number.value":
+                phone_start, phone_end = info[RESULT_FORMAT_RANGE]
+                if any(
+                    phone_start < ip_end and ip_start < phone_end
+                    for ip_start, ip_end in ip_ranges
+                ):
+                    self.helper.log_debug(
+                        f"Discarding phone number match '{match}' overlapping an IP address"
+                    )
+                    continue
+            filtered_matches[match] = info
+        return filtered_matches
+
     def _post_parse_observables(
         self, ind_match: str, observable: Observable, match_range: Tuple
     ) -> Dict:
@@ -114,6 +140,8 @@ class ReportParser(object):
 
         for observable in self.observable_list:
             list_matches.update(self._extract_observable(observable, data))
+
+        list_matches = self._drop_phone_numbers_overlapping_ip_addresses(list_matches)
 
         for entity in self.entity_list:
             list_matches = self._extract_entity(entity, list_matches, data)

--- a/internal-import-file/import-document/tests/test_report_parser_observables.py
+++ b/internal-import-file/import-document/tests/test_report_parser_observables.py
@@ -66,6 +66,17 @@ def test_ipv4_address_adjacent_to_number_is_not_reclassified_as_phone_number(add
     )
 
 
+def test_adjacent_ipv4_addresses_do_not_produce_a_phone_number():
+    addresses = ["1.2.3.4", "194.213.18.38", "194.213.18.67", "213.232.236.135"]
+    result = _build_parser().parse(f"Indicators: {' '.join(addresses)} end.")
+
+    for address in addresses:
+        assert result[address][RESULT_FORMAT_CATEGORY] == "IPv4-Addr.value"
+    assert not any(
+        info[RESULT_FORMAT_CATEGORY] == "Phone-Number.value" for info in result.values()
+    )
+
+
 @pytest.mark.parametrize(
     "phone_number",
     [


### PR DESCRIPTION
### Proposed changes

* Drop any `Phone-Number` match whose character span overlaps an already-extracted IPv4/IPv6 address, so IP fragments are never emitted as phone numbers.
* This covers both cross-boundary fragments spanning two adjacent IPs (e.g. `32.156 104.16.132`) and substrings of a single IP (e.g. `199.108.153`, `34.120.177`) — cases the previous digit/`ipaddress` guard missed.
* Add a regression test reproducing the adjacent-IPv4 false positive.

### Related issues

* Fixes #7622

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Follow-up to #6677 / PR #7522. The first fix only discarded a phone match when the whole match (or an embedded full dotted-quad) was a valid IP. In larger documents the phone regex (which accepts `.` and whitespace as separators) crosses IP boundaries and produces fragments such as `18.38 194.213.18` that contain no complete IPv4, so they slipped through.

The parser now post-filters phone matches by span overlap against the IPv4/IPv6 observables already extracted from the same text. Verified against the exact IP list from the issue screenshots: across multiple separators (space, newline, comma, semicolon) and 300 random orderings, zero phone numbers survive and all IPv4 addresses are extracted correctly. Legitimate phone numbers (no overlap with an IP) are unaffected.