### PR TITLE
feat(hunt-io): add support for hunt v3 api while keeping v2 (#7678)

### DIFF
--- a/external-import/hunt-io/README.md
+++ b/external-import/hunt-io/README.md
@@ -62,9 +62,27 @@ Below are the parameters you'll need to set for the connector:
 
 | Parameter    | config.yml   | Docker environment variable | Default | Mandatory | Description                                                                                                               |
 |--------------|--------------|-----------------------------|---------|-----------|---------------------------------------------------------------------------------------------------------------------------|
+| API version  | api_version  | `HUNT_IO_API_VERSION`       | v2      | No        | Which Hunt.io C2 feed API to target. Valid values: `v2`, `v3`. Must be changed together with `api_base_url` — see below.  |
 | API base URL | api_base_url | `HUNT_IO_API_BASE_URL`      |         | Yes       |                                                                                                                           |
 | API key      | api_key      | `HUNT_IO_API_KEY`           |         | Yes       |                                                                                                                           |
 | TLP level    | tlp_level    | `HUNT_IO_TLP_LEVEL`         | amber   | No        | The Traffic Light Protocol level for data being ingested. Valid values: `white`, `green`, `amber`, `amber+strict`, `red`. |
+
+#### Choosing an API version
+
+The two Hunt.io APIs use mutually exclusive authentication, so `api_version` and `api_base_url` must
+always be set together:
+
+| `api_version` | `api_base_url`                     | Authentication                    | Key format     |
+|---------------|------------------------------------|-----------------------------------|----------------|
+| `v2` (default)| `https://api.hunt.io/v1/feeds/c2`  | `token` header                    | any            |
+| `v3`          | `https://a.hunt.io/feeds/c2`       | `Authorization: Bearer`           | `ak_`-prefixed |
+
+> **Changing only the base URL will not work.** Pointing `HUNT_IO_API_BASE_URL` at the V3 endpoint
+> while leaving `HUNT_IO_API_VERSION` at `v2` keeps sending the `token` header, and V3 answers with
+> an HTTP 401 that is indistinguishable from a missing key. The same applies in reverse.
+
+Existing deployments are unaffected: `api_version` defaults to `v2`, which is the behaviour prior to
+this setting being introduced.
 
 ## Deployment
 
@@ -88,6 +106,7 @@ Configure the connector in `docker-compose.yml`:
       - CONNECTOR_NAME=Hunt.io
       - CONNECTOR_SCOPE=hunt-io
       - CONNECTOR_LOG_LEVEL=info
+      - HUNT_IO_API_VERSION=v2
       - HUNT_IO_API_BASE_URL=ChangeMe
       - HUNT_IO_API_KEY=ChangeMe
     restart: always

--- a/external-import/hunt-io/__metadata__/CONNECTOR_CONFIG_DOC.md
+++ b/external-import/hunt-io/__metadata__/CONNECTOR_CONFIG_DOC.md
@@ -15,10 +15,13 @@ Below is an exhaustive enumeration of all configurable parameters available, eac
 | CONNECTOR_TYPE | `const` |  | `EXTERNAL_IMPORT` |  | `"EXTERNAL_IMPORT"` |  |
 | CONNECTOR_DURATION_PERIOD | `string` |  | Format: [`duration`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | `"P1D"` | Time interval between consecutive data imports from Hunt.io. Controls how frequently the connector runs |
 | HUNT_IO_API_BASE_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  | `"https://api.hunt.io/v1/feeds/c2"` | Hunt.io API endpoint URL for the C2 threat intelligence feeds |
+| HUNT_IO_API_VERSION | `string` |  | `v2` `v3` |  | `"v2"` | Which Hunt.io C2 feed API to target. 'v2' authenticates with a 'token' header against https://api.hunt.io/v1/feeds/c2. 'v3' authenticates with 'Authorization: Bearer' against https://a.hunt.io/feeds/c2 and requires an 'ak_'-prefixed key. The two APIs are mutually exclusive: set api_base_url to match the version, as changing one without the other returns HTTP 401 |
 | HUNT_IO_TLP_LEVEL | `string` |  | `white` `clear` `green` `amber` `amber+strict` `red` |  | `"amber"` | Traffic Light Protocol (TLP) marking level to apply to imported data, controlling information sharing restrictions |
 | CONNECTOR_HUNT_UI_API_BASE_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | ⛔️ | `"https://api.hunt.io/v1/feeds/c2"` | Use HUNT_IO_API_BASE_URL instead. |
+| CONNECTOR_HUNT_UI_API_VERSION | `string` |  | `v2` `v3` | ⛔️ | `"v2"` | Use HUNT_IO_API_VERSION instead. |
 | CONNECTOR_HUNT_UI_API_KEY | `string` |  | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | ⛔️ |  | Use HUNT_IO_API_KEY instead. |
 | CONNECTOR_HUNT_UI_TLP_LEVEL | `string` |  | `white` `clear` `green` `amber` `amber+strict` `red` | ⛔️ | `"amber"` | Use HUNT_IO_TLP_LEVEL instead. |
 | CONNECTOR_HUNT_IO_API_BASE_URL | `string` |  | Format: [`uri`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | ⛔️ | `"https://api.hunt.io/v1/feeds/c2"` | Use HUNT_IO_API_BASE_URL instead. |
+| CONNECTOR_HUNT_IO_API_VERSION | `string` |  | `v2` `v3` | ⛔️ | `"v2"` | Use HUNT_IO_API_VERSION instead. |
 | CONNECTOR_HUNT_IO_API_KEY | `string` |  | Format: [`password`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) | ⛔️ |  | Use HUNT_IO_API_KEY instead. |
 | CONNECTOR_HUNT_IO_TLP_LEVEL | `string` |  | `white` `clear` `green` `amber` `amber+strict` `red` | ⛔️ | `"amber"` | Use HUNT_IO_TLP_LEVEL instead. |

--- a/external-import/hunt-io/__metadata__/connector_config_schema.json
+++ b/external-import/hunt-io/__metadata__/connector_config_schema.json
@@ -63,6 +63,16 @@
       "type": "string",
       "deprecated": true
     },
+    "CONNECTOR_HUNT_UI_API_VERSION": {
+      "default": "v2",
+      "description": "Use HUNT_IO_API_VERSION instead.",
+      "enum": [
+        "v2",
+        "v3"
+      ],
+      "type": "string",
+      "deprecated": true
+    },
     "CONNECTOR_HUNT_UI_API_KEY": {
       "description": "Use HUNT_IO_API_KEY instead.",
       "format": "password",
@@ -93,6 +103,16 @@
       "type": "string",
       "deprecated": true
     },
+    "CONNECTOR_HUNT_IO_API_VERSION": {
+      "default": "v2",
+      "description": "Use HUNT_IO_API_VERSION instead.",
+      "enum": [
+        "v2",
+        "v3"
+      ],
+      "type": "string",
+      "deprecated": true
+    },
     "CONNECTOR_HUNT_IO_API_KEY": {
       "description": "Use HUNT_IO_API_KEY instead.",
       "format": "password",
@@ -120,6 +140,15 @@
       "format": "uri",
       "maxLength": 2083,
       "minLength": 1,
+      "type": "string"
+    },
+    "HUNT_IO_API_VERSION": {
+      "default": "v2",
+      "description": "Which Hunt.io C2 feed API to target. 'v2' authenticates with a 'token' header against https://api.hunt.io/v1/feeds/c2. 'v3' authenticates with 'Authorization: Bearer' against https://a.hunt.io/feeds/c2 and requires an 'ak_'-prefixed key. The two APIs are mutually exclusive: set api_base_url to match the version, as changing one without the other returns HTTP 401",
+      "enum": [
+        "v2",
+        "v3"
+      ],
       "type": "string"
     },
     "HUNT_IO_API_KEY": {

--- a/external-import/hunt-io/config.yml.sample
+++ b/external-import/hunt-io/config.yml.sample
@@ -19,5 +19,9 @@ connector:
   #send_to_directory_retention: 7
 
 hunt_io:
+  # 'v2' pairs with https://api.hunt.io/v1/feeds/c2 and a plain API key.
+  # 'v3' pairs with https://a.hunt.io/feeds/c2 and an 'ak_'-prefixed key.
+  # api_version and api_base_url must be changed together, or the API returns 401.
+  api_version: 'v2'
   api_base_url: 'https://api.hunt.io/v1/feeds/c2'
   api_key: 'ChangeMe'

--- a/external-import/hunt-io/docker-compose.yml
+++ b/external-import/hunt-io/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - CONNECTOR_DURATION_PERIOD=PT24H
 
       # Connector's custom execution parameters
+      - HUNT_IO_API_VERSION=${HUNT_IO_API_VERSION:-v2}
       - HUNT_IO_API_BASE_URL=${CONNECTOR_HUNT_UI_API_BASE_URL}
       - HUNT_IO_API_KEY=${CONNECTOR_HUNT_UI_API_KEY}
     restart: always

--- a/external-import/hunt-io/src/external_import_connector/client_api.py
+++ b/external-import/hunt-io/src/external_import_connector/client_api.py
@@ -31,10 +31,18 @@ class HTTPSessionManager:
     def __init__(self, helper: OpenCTIConnectorHelper):
         self.helper = helper
 
-    def create_session(self, api_key: str) -> requests.Session:
-        """Create a new HTTP session with resilience features."""
+    def create_session(self, api_key: str, api_version: str) -> requests.Session:
+        """Create a new HTTP session with resilience features.
+
+        The two Hunt.io APIs use mutually exclusive auth schemes: V2 expects a `token`
+        header and rejects bearer auth, V3 expects `Authorization: Bearer` and rejects
+        the `token` header. Both return HTTP 401 on a mismatch.
+        """
         session = requests.Session()
-        session.headers.update({"token": api_key})
+        if api_version == "v3":
+            session.headers.update({"Authorization": f"Bearer {api_key}"})
+        else:
+            session.headers.update({"token": api_key})
 
         # Configure retry strategy
         retry_strategy = Retry(
@@ -195,7 +203,8 @@ class ConnectorClient:
 
         # Create HTTP session with resilience features
         self.session = self.session_manager.create_session(
-            self.config.hunt_io.api_key.get_secret_value()
+            self.config.hunt_io.api_key.get_secret_value(),
+            self.config.hunt_io.api_version,
         )
 
     @property
@@ -322,7 +331,8 @@ class ConnectorClient:
 
             # Create new session with same configuration
             self.session = self.session_manager.create_session(
-                self.config.hunt_io.api_key.get_secret_value()
+                self.config.hunt_io.api_key.get_secret_value(),
+                self.config.hunt_io.api_version,
             )
 
             self.helper.connector_logger.info(

--- a/external-import/hunt-io/src/external_import_connector/settings.py
+++ b/external-import/hunt-io/src/external_import_connector/settings.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Literal
+from typing import Annotated, Any, Literal
 
 from connectors_sdk import (
     BaseConfigModel,
@@ -8,13 +8,52 @@ from connectors_sdk import (
     DeprecatedField,
     ListFromString,
 )
-from pydantic import Field, HttpUrl, SecretStr, SkipValidation
+from pydantic import (
+    BeforeValidator,
+    Field,
+    HttpUrl,
+    SecretStr,
+    SkipValidation,
+    model_validator,
+)
+
+DEFAULT_API_VERSION = "v2"
+
+
+def _normalize_api_version(value: Any) -> Any:
+    """Normalize an api_version coming from an environment variable.
+
+    A compose passthrough such as `HUNT_IO_API_VERSION=${HUNT_IO_API_VERSION}` sets the
+    variable to an empty string when it is not defined, which would otherwise fail
+    validation instead of falling back to the default. Case is normalized too, since
+    environment variables are commonly written in upper case.
+    """
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        return normalized or DEFAULT_API_VERSION
+    return value
+
+
+ApiVersion = Annotated[
+    Literal["v2", "v3"],
+    BeforeValidator(_normalize_api_version),
+]
 
 
 class HuntIoConfig(BaseConfigModel):
     api_base_url: HttpUrl = Field(
         description="Hunt.io API endpoint URL for the C2 threat intelligence feeds",
         default=HttpUrl("https://api.hunt.io/v1/feeds/c2"),
+    )
+    api_version: ApiVersion = Field(
+        description=(
+            "Which Hunt.io C2 feed API to target. 'v2' authenticates with a 'token' "
+            "header against https://api.hunt.io/v1/feeds/c2. 'v3' authenticates with "
+            "'Authorization: Bearer' against https://a.hunt.io/feeds/c2 and requires an "
+            "'ak_'-prefixed key. The two APIs are mutually exclusive: set api_base_url "
+            "to match the version, as changing one without the other returns HTTP 401"
+        ),
+        default=DEFAULT_API_VERSION,
     )
     api_key: SecretStr = Field(
         description=(
@@ -31,6 +70,25 @@ class HuntIoConfig(BaseConfigModel):
             default="amber",
         )
     )
+
+    @model_validator(mode="after")
+    def _validate_api_key_matches_version(self) -> "HuntIoConfig":
+        """Fail fast when a V3 key is malformed.
+
+        The V3 API rejects any key without an `ak_` prefix using the same opaque 401 it
+        returns for a missing key, which makes a typo indistinguishable from an
+        entitlement problem at runtime. V2 has no documented prefix rule, so this check
+        is deliberately scoped to V3 only.
+        """
+        if self.api_version == "v3" and not self.api_key.get_secret_value().startswith(
+            "ak_"
+        ):
+            raise ValueError(
+                "api_version 'v3' requires an 'ak_'-prefixed API key; the V3 API "
+                "rejects other keys with an HTTP 401 indistinguishable from a "
+                "missing key"
+            )
+        return self
 
 
 class ExternalImportConfig(BaseExternalImportConnectorConfig):

--- a/external-import/hunt-io/tests/conftest.py
+++ b/external-import/hunt-io/tests/conftest.py
@@ -32,6 +32,48 @@ def correct_config():
 
 
 @pytest.fixture
+def v3_config():
+    with patch(
+        "os.environ",
+        {
+            "OPENCTI_URL": "http://url",
+            "OPENCTI_TOKEN": "token",
+            "CONNECTOR_ID": "connector_id",
+            "CONNECTOR_NAME": "connector_name",
+            "CONNECTOR_TYPE": "EXTERNAL_IMPORT",
+            "CONNECTOR_LOG_LEVEL": "error",
+            "CONNECTOR_SCOPE": "scope",
+            "CONNECTOR_DURATION_PERIOD": "PT5M",
+            "HUNT_IO_API_VERSION": "v3",
+            "HUNT_IO_API_BASE_URL": "https://a.hunt.io/feeds/c2",
+            "HUNT_IO_API_KEY": "ak_api_key_value",
+        },
+    ):
+        yield
+
+
+@pytest.fixture
+def deprecated_v3_config():
+    with patch(
+        "os.environ",
+        {
+            "OPENCTI_URL": "http://url",
+            "OPENCTI_TOKEN": "token",
+            "CONNECTOR_ID": "connector_id",
+            "CONNECTOR_NAME": "connector_name",
+            "CONNECTOR_TYPE": "EXTERNAL_IMPORT",
+            "CONNECTOR_LOG_LEVEL": "error",
+            "CONNECTOR_SCOPE": "scope",
+            "CONNECTOR_DURATION_PERIOD": "PT5M",
+            "CONNECTOR_HUNT_IO_API_VERSION": "v3",
+            "CONNECTOR_HUNT_IO_API_BASE_URL": "https://a.hunt.io/feeds/c2",
+            "CONNECTOR_HUNT_IO_API_KEY": "ak_api_key_value",
+        },
+    ):
+        yield
+
+
+@pytest.fixture
 def deprecated_config():
     with patch(
         "os.environ",

--- a/external-import/hunt-io/tests/tests_connector/test_client_api.py
+++ b/external-import/hunt-io/tests/tests_connector/test_client_api.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock
+
+import pytest
+from external_import_connector.client_api import ConnectorClient, HTTPSessionManager
+from external_import_connector.settings import ConnectorSettings
+
+V2_KEY = "api_key_value"
+V3_KEY = "ak_api_key_value"
+
+
+@pytest.mark.parametrize(
+    "api_version, api_key, expected_header, expected_value, absent_header",
+    [
+        pytest.param("v2", V2_KEY, "token", V2_KEY, "Authorization", id="v2_token"),
+        pytest.param(
+            "v3",
+            V3_KEY,
+            "Authorization",
+            f"Bearer {V3_KEY}",
+            "token",
+            id="v3_bearer",
+        ),
+    ],
+)
+def test_create_session_sets_auth_header_matching_api_version(
+    api_version, api_key, expected_header, expected_value, absent_header
+):
+    """
+    The two Hunt.io APIs use mutually exclusive auth schemes and each answers 401 when
+    sent the other one's header, so the session must carry exactly one of them.
+    """
+    session_manager = HTTPSessionManager(MagicMock())
+
+    session = session_manager.create_session(api_key, api_version)
+
+    assert session.headers[expected_header] == expected_value
+    assert absent_header not in session.headers
+
+
+def test_api_version_is_accepted_through_deprecated_namespace(deprecated_v3_config):
+    """
+    `api_version` is a new field, so its deprecated spellings exist only because the SDK
+    namespace shim forwards every key. Guard that, since the naming decision relies on it.
+    """
+    client = ConnectorClient(helper=MagicMock(), config=ConnectorSettings())
+
+    assert client.session.headers["Authorization"] == f"Bearer {V3_KEY}"
+
+
+def test_refresh_session_on_timeout_keeps_v3_bearer_header(v3_config):
+    """
+    `_refresh_session_on_timeout` rebuilds the session independently of `__init__`, so a
+    missed argument there would silently drop authentication after a connection timeout.
+    """
+    client = ConnectorClient(helper=MagicMock(), config=ConnectorSettings())
+    assert client.session.headers["Authorization"] == f"Bearer {V3_KEY}"
+
+    client._refresh_session_on_timeout()
+
+    assert client.session.headers["Authorization"] == f"Bearer {V3_KEY}"
+    assert "token" not in client.session.headers

--- a/external-import/hunt-io/tests/tests_connector/test_settings.py
+++ b/external-import/hunt-io/tests/tests_connector/test_settings.py
@@ -45,6 +45,59 @@ from external_import_connector.settings import ConnectorSettings
             },
             id="minimal_valid_settings_dict",
         ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "Hunt IO",
+                },
+                "hunt_io": {
+                    "api_version": "v3",
+                    "api_base_url": "https://a.hunt.io/feeds/c2",
+                    "api_key": "ak_test-api-key",
+                },
+            },
+            id="valid_v3_settings_dict",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "Hunt IO",
+                },
+                "hunt_io": {
+                    "api_version": "",
+                    "api_key": "test-api-key",
+                },
+            },
+            id="blank_api_version_falls_back_to_default",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "Hunt IO",
+                },
+                "hunt_io": {
+                    "api_version": "V3",
+                    "api_base_url": "https://a.hunt.io/feeds/c2",
+                    "api_key": "ak_test-api-key",
+                },
+            },
+            id="uppercase_api_version_is_normalized",
+        ),
     ],
 )
 def test_settings_should_accept_valid_input(settings_dict):
@@ -113,6 +166,43 @@ def test_settings_should_accept_valid_input(settings_dict):
             "hunt_io.api_key",
             id="missing_hunt_io_api_key",
         ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "Hunt IO",
+                },
+                "hunt_io": {
+                    "api_version": "v4",
+                    "api_key": "test-api-key",
+                },
+            },
+            "hunt_io.api_version",
+            id="unknown_hunt_io_api_version",
+        ),
+        pytest.param(
+            {
+                "opencti": {
+                    "url": "http://localhost:8080",
+                    "token": "test-token",
+                },
+                "connector": {
+                    "id": "connector-id",
+                    "scope": "Hunt IO",
+                },
+                "hunt_io": {
+                    "api_version": "v3",
+                    "api_base_url": "https://a.hunt.io/feeds/c2",
+                    "api_key": "test-api-key",
+                },
+            },
+            "hunt_io.api_key",
+            id="v3_api_key_missing_ak_prefix",
+        ),
     ],
 )
 def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
@@ -138,3 +228,36 @@ def test_settings_should_raise_when_invalid_input(settings_dict, field_name):
     with pytest.raises(ConfigValidationError) as err:
         FakeConnectorSettings()
     assert str("Error validating configuration") in str(err)
+
+
+@pytest.mark.parametrize(
+    "raw_api_version, expected",
+    [
+        pytest.param("", "v2", id="blank_falls_back_to_default"),
+        pytest.param("  ", "v2", id="whitespace_falls_back_to_default"),
+        pytest.param("V3", "v3", id="uppercase_is_normalized"),
+        pytest.param(" v2 ", "v2", id="surrounding_whitespace_is_stripped"),
+    ],
+)
+def test_api_version_normalization(raw_api_version, expected):
+    """
+    A compose passthrough like `HUNT_IO_API_VERSION=${HUNT_IO_API_VERSION}` sets the
+    variable to an empty string when it is undefined, which must fall back to the
+    default rather than fail validation.
+    """
+    settings_dict = {
+        "opencti": {"url": "http://localhost:8080", "token": "test-token"},
+        "connector": {"id": "connector-id", "scope": "Hunt IO"},
+        "hunt_io": {
+            "api_version": raw_api_version,
+            "api_base_url": "https://a.hunt.io/feeds/c2",
+            "api_key": "ak_test-api-key",
+        },
+    }
+
+    class FakeConnectorSettings(ConnectorSettings):
+        @classmethod
+        def _load_config_dict(cls, _, handler) -> dict[str, Any]:
+            return handler(settings_dict)
+
+    assert FakeConnectorSettings().hunt_io.api_version == expected


### PR DESCRIPTION
### Proposed changes

* Add a `hunt_io.api_version` setting (`HUNT_IO_API_VERSION`, values `v2` / `v3`, default `v2`) that
  selects the authentication scheme for the Hunt.io C2 feed. V2 (`https://api.hunt.io/v1/feeds/c2`)
  authenticates with a `token` header; V3 (`https://a.hunt.io/feeds/c2`) requires
  `Authorization: Bearer` with an `ak_`-prefixed key. The two are mutually exclusive — each returns
  HTTP 401 when sent the other's header — so `HTTPSessionManager.create_session` now sets the header
  matching the selected version, at both construction and post-timeout session refresh.
* Reject a non-`ak_` key at startup when `v3` is selected. V3 returns an identical, opaque 401 for a
  missing key, a malformed key, and a wrong-scheme key, so this converts a confusing runtime failure
  into a clear configuration error. Deliberately scoped to V3 only, as V2 documents no prefix rule.
* Normalise blank and mixed-case values for the new setting. A declared-but-undefined Compose
  passthrough (`- HUNT_IO_API_VERSION=${HUNT_IO_API_VERSION}`) resolves to an empty string, which
  would otherwise fail validation instead of falling back to the default.
* Document both versions in the README (config table plus a version-selection section warning that
  `api_version` and `api_base_url` must change together), update `config.yml.sample`, and regenerate
  `__metadata__`.
* Extend the existing test suites: parametrised settings cases for an unknown version, a v3 key
  missing the `ak_` prefix, and blank/whitespace/uppercase normalisation; plus new `create_session`
  coverage asserting the correct header per version, that the deprecated namespace still forwards the
  new setting, and that a post-timeout session refresh retains bearer auth.

**Backward compatibility:** `api_version` defaults to `v2`, which reproduces existing behaviour
exactly. Nothing becomes mandatory — the generated schema's `required` list is unchanged — and no
existing variable is renamed or removed. The response payload is byte-identical between versions
(gzipped NDJSON, same record fields), so parsing, STIX conversion, and the entity pipeline are
untouched.

**Testing:** both paths verified end-to-end against the live APIs on OpenCTI `7.260910.0` —
authentication, feed fetch, conversion, and ingestion of observables, indicators, malware,
infrastructure and relationships, with no errors from the connector, workers, or platform. Switching
between versions was exercised in both directions. Unit tests pass, and `black`, `isort` and `flake8`
are clean for the changed files.

### Related issues

* Closes https://github.com/OpenCTI-Platform/connectors/issues/7678

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

`a.hunt.io` and `api.hunt.io` are separate services rather than two paths on one host, which is why a
single credential cannot address both and why the selector is an explicit setting rather than
something inferred from the base URL. Deriving the version from the URL was considered and rejected:
it couples behaviour to a hostname pattern and breaks for staging or custom hostnames.

The new setting is documented as `HUNT_IO_API_VERSION`, matching the current prefix convention. The
deprecated `CONNECTOR_HUNT_UI_*` and `CONNECTOR_HUNT_IO_*` namespaces still resolve it through the
existing SDK shim, and all three spellings appear in the regenerated config schema.
