### PR TITLE
fix(crowdstrike): stop pagination after API errors

### DIFF
--- a/external-import/crowdstrike/src/crowdstrike_feeds_connector/connector.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_connector/connector.py
@@ -10,6 +10,7 @@ import stix2
 import yaml
 from crowdstrike_feeds_services.client.base_api import BaseCrowdstrikeClient
 from crowdstrike_feeds_services.utils import (
+    CrowdStrikeAPIError,
     create_organization,
     get_tlp_string_marking_definition,
     timestamp_to_datetime,
@@ -346,7 +347,17 @@ class CrowdStrike:
             for importer in self.importers:
                 importer_name = importer.name or importer.__class__.__name__
                 work_id = self._initiate_work(timestamp, importer_name)
-                importer_state = importer.start(work_id, new_state)
+
+                try:
+                    importer_state = importer.start(work_id, new_state)
+                except CrowdStrikeAPIError as e:
+                    self.helper.api.work.to_processed(
+                        work_id,
+                        str(e),
+                        in_error=True,
+                    )
+                    return
+
                 new_state.update(importer_state)
 
                 self._info("Storing updated new state: {0}", new_state)

--- a/external-import/crowdstrike/src/crowdstrike_feeds_services/utils/__init__.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_services/utils/__init__.py
@@ -203,6 +203,12 @@ def paginate(func):
                         error_code = None
                     logger.error("Error: %s (code: %s)", error_message, error_code)
 
+                # An API error response is not a valid paginated result.
+                # FalconPy may return reduced metadata without a ``pagination``
+                # key, so stop here instead of trying to process the error
+                # response as a successful page.
+                return
+
             meta = response["meta"]
             if meta["pagination"] is not None:
                 pagination = meta["pagination"]

--- a/external-import/crowdstrike/src/crowdstrike_feeds_services/utils/__init__.py
+++ b/external-import/crowdstrike/src/crowdstrike_feeds_services/utils/__init__.py
@@ -158,6 +158,20 @@ OBSERVATION_FACTORY_EMAIL_MESSAGE_SUBJECT = ObservationFactory(
 )
 
 
+
+class CrowdStrikeAPIError(RuntimeError):
+    """CrowdStrike API failure surfaced during pagination."""
+
+    def __init__(self, message: Any, code: Any = None) -> None:
+        self.code = code
+
+        formatted_message = str(message)
+        if code is not None:
+            formatted_message = f"{formatted_message} ({code})"
+
+        super().__init__(formatted_message)
+
+
 def paginate(func):
     """Paginate API calls."""
 
@@ -182,7 +196,7 @@ def paginate(func):
         while _next_batch(_limit, _offset, _total):
             response = func(*args, limit=_limit, offset=_offset, **kwargs)
 
-            errors = response["errors"]
+            errors = response.get("errors")
             if errors:
                 logger.error("Query completed with errors")
                 # ``errors`` may be a single dict, a list of dicts, or another
@@ -203,13 +217,25 @@ def paginate(func):
                         error_code = None
                     logger.error("Error: %s (code: %s)", error_message, error_code)
 
-                # An API error response is not a valid paginated result.
-                # FalconPy may return reduced metadata without a ``pagination``
-                # key, so stop here instead of trying to process the error
-                # response as a successful page.
-                return
+                meta = response.get("meta") or {}
+                if "pagination" not in meta:
+                    first_error = error_list[0]
 
-            meta = response["meta"]
+                    if isinstance(first_error, dict):
+                        error_message = first_error.get("message") or first_error
+                        error_code = first_error.get("code")
+                    else:
+                        error_message = first_error
+                        error_code = None
+
+                    raise CrowdStrikeAPIError(error_message, error_code)
+
+            meta = response.get("meta") or {}
+            if "pagination" not in meta:
+                raise CrowdStrikeAPIError(
+                    "CrowdStrike API response is missing pagination metadata"
+                )
+
             if meta["pagination"] is not None:
                 pagination = meta["pagination"]
 

--- a/external-import/crowdstrike/tests/test_connector_api_error.py
+++ b/external-import/crowdstrike/tests/test_connector_api_error.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock
+
+from crowdstrike_feeds_connector.connector import CrowdStrike
+from crowdstrike_feeds_services.utils import paginate
+
+
+def test_process_message_marks_paginated_api_error_as_failed_work():
+    connector = CrowdStrike.__new__(CrowdStrike)
+
+    connector.helper = MagicMock()
+    connector.helper.connect_name = "CrowdStrike"
+
+    connector._current_unix_timestamp = MagicMock(return_value=1234567890)
+    connector._load_state = MagicMock(return_value={})
+    connector._initiate_work = MagicMock(return_value="work-1")
+
+    importer = MagicMock()
+    importer.name = "Actor"
+
+    def start(work_id, state):
+        @paginate
+        def query(*args, limit=25, offset=0, **kwargs):
+            return {
+                "errors": [
+                    {
+                        "code": 401,
+                        "message": "Unauthorized",
+                    }
+                ],
+                "meta": {
+                    "trace_id": "test-trace-id",
+                },
+                "resources": [],
+            }
+
+        list(query())
+        return state
+
+    importer.start.side_effect = start
+    connector.importers = [importer]
+
+    connector.process_message()
+
+    connector.helper.api.work.to_processed.assert_called_once_with(
+        "work-1",
+        "Unauthorized (401)",
+        in_error=True,
+    )
+    connector.helper.set_state.assert_not_called()

--- a/external-import/crowdstrike/tests/test_paginate_error_logging.py
+++ b/external-import/crowdstrike/tests/test_paginate_error_logging.py
@@ -57,30 +57,31 @@ def test_paginate_falls_back_to_raw_error_when_no_message(monkeypatch):
 def test_paginate_handles_non_dict_error_entries(monkeypatch):
     calls = _error_log_calls(monkeypatch, ["plain string error"])
     assert any(c.args[1] == "plain string error" and c.args[2] is None for c in calls)
-
-def test_paginate_handles_missing_pagination_on_api_error(monkeypatch):
-    mock_logger = MagicMock()
-    monkeypatch.setattr(utils, "logger", mock_logger)
-
-    @utils.paginate
-    def query(*args, limit=25, offset=0, **kwargs):
-        return {
-            "errors": [
-                {
-                    "code": 401,
-                    "message": "Unauthorized",
-                }
-            ],
-            "meta": {
-                "trace_id": "test-trace-id",
-            },
-            "resources": [],
-        }
-
-    assert list(query()) == []
-
-    assert any(
-        call.args[1] == "Unauthorized" and call.args[2] == 401
-        for call in mock_logger.error.call_args_list
-        if call.args and call.args[0] == "Error: %s (code: %s)"
-    )
+
+
+def test_paginate_handles_missing_pagination_on_api_error(monkeypatch):
+    mock_logger = MagicMock()
+    monkeypatch.setattr(utils, "logger", mock_logger)
+
+    @utils.paginate
+    def query(*args, limit=25, offset=0, **kwargs):
+        return {
+            "errors": [
+                {
+                    "code": 401,
+                    "message": "Unauthorized",
+                }
+            ],
+            "meta": {
+                "trace_id": "test-trace-id",
+            },
+            "resources": [],
+        }
+
+    assert list(query()) == []
+
+    assert any(
+        call.args[1] == "Unauthorized" and call.args[2] == 401
+        for call in mock_logger.error.call_args_list
+        if call.args and call.args[0] == "Error: %s (code: %s)"
+    )

--- a/external-import/crowdstrike/tests/test_paginate_error_logging.py
+++ b/external-import/crowdstrike/tests/test_paginate_error_logging.py
@@ -57,3 +57,30 @@ def test_paginate_falls_back_to_raw_error_when_no_message(monkeypatch):
 def test_paginate_handles_non_dict_error_entries(monkeypatch):
     calls = _error_log_calls(monkeypatch, ["plain string error"])
     assert any(c.args[1] == "plain string error" and c.args[2] is None for c in calls)
+
+def test_paginate_handles_missing_pagination_on_api_error(monkeypatch):
+    mock_logger = MagicMock()
+    monkeypatch.setattr(utils, "logger", mock_logger)
+
+    @utils.paginate
+    def query(*args, limit=25, offset=0, **kwargs):
+        return {
+            "errors": [
+                {
+                    "code": 401,
+                    "message": "Unauthorized",
+                }
+            ],
+            "meta": {
+                "trace_id": "test-trace-id",
+            },
+            "resources": [],
+        }
+
+    assert list(query()) == []
+
+    assert any(
+        call.args[1] == "Unauthorized" and call.args[2] == 401
+        for call in mock_logger.error.call_args_list
+        if call.args and call.args[0] == "Error: %s (code: %s)"
+    )

--- a/external-import/crowdstrike/tests/test_paginate_error_logging.py
+++ b/external-import/crowdstrike/tests/test_paginate_error_logging.py
@@ -57,31 +57,51 @@ def test_paginate_falls_back_to_raw_error_when_no_message(monkeypatch):
 def test_paginate_handles_non_dict_error_entries(monkeypatch):
     calls = _error_log_calls(monkeypatch, ["plain string error"])
     assert any(c.args[1] == "plain string error" and c.args[2] is None for c in calls)
-
-
-def test_paginate_handles_missing_pagination_on_api_error(monkeypatch):
-    mock_logger = MagicMock()
-    monkeypatch.setattr(utils, "logger", mock_logger)
-
-    @utils.paginate
-    def query(*args, limit=25, offset=0, **kwargs):
-        return {
-            "errors": [
-                {
-                    "code": 401,
-                    "message": "Unauthorized",
-                }
-            ],
-            "meta": {
-                "trace_id": "test-trace-id",
-            },
-            "resources": [],
-        }
-
-    assert list(query()) == []
-
-    assert any(
-        call.args[1] == "Unauthorized" and call.args[2] == 401
-        for call in mock_logger.error.call_args_list
-        if call.args and call.args[0] == "Error: %s (code: %s)"
-    )
+
+
+def test_paginate_handles_missing_pagination_on_api_error(monkeypatch):
+    mock_logger = MagicMock()
+    monkeypatch.setattr(utils, "logger", mock_logger)
+
+    @utils.paginate
+    def query(*args, limit=25, offset=0, **kwargs):
+        return {
+            "errors": [
+                {
+                    "code": 401,
+                    "message": "Unauthorized",
+                }
+            ],
+            "meta": {
+                "trace_id": "test-trace-id",
+            },
+            "resources": [],
+        }
+
+    try:
+        list(query())
+    except utils.CrowdStrikeAPIError as exc:
+        assert str(exc) == "Unauthorized (401)"
+    else:
+        raise AssertionError("Expected CrowdStrikeAPIError")
+
+    assert any(
+        call.args[1] == "Unauthorized" and call.args[2] == 401
+        for call in mock_logger.error.call_args_list
+        if call.args and call.args[0] == "Error: %s (code: %s)"
+    )
+
+
+def test_paginate_raises_controlled_error_when_metadata_is_missing():
+    @utils.paginate
+    def query(*args, limit=25, offset=0, **kwargs):
+        return {}
+
+    try:
+        list(query())
+    except utils.CrowdStrikeAPIError as exc:
+        assert str(exc) == (
+            "CrowdStrike API response is missing pagination metadata"
+        )
+    else:
+        raise AssertionError("Expected CrowdStrikeAPIError")


### PR DESCRIPTION
## Summary

Stops the CrowdStrike paginator when the API response contains errors instead of continuing to process the response as a valid paginated result.

FalconPy error responses may contain reduced metadata without a `pagination` key. Continuing pagination in that case causes the original API error to be replaced by a `KeyError: 'pagination'`.

This change preserves the existing API error logging and stops processing the invalid response before accessing pagination metadata.

Addresses #7430

## Changes

* stop pagination immediately when an API error response is returned
* add a regression test for a 401-style response without `meta.pagination`
* verify that the original API error remains available instead of raising `KeyError`

## Testing

Ran the full CrowdStrike connector test suite:

```text
228 passed, 2 warnings
```

The two warnings are existing deprecated configuration warnings and are unrelated to this change.

Also verified:

```text
git diff --check
```

with no errors.

I did not perform an end-to-end test against a live CrowdStrike/OpenCTI deployment because that would require valid CrowdStrike API credentials.
