### PR TITLE
chore(import-document-ai): replace the MinIO image by pgsty/silo in the dev stack (#7684)

### DIFF
--- a/internal-import-file/import-document-ai/dev/docker-compose.yml
+++ b/internal-import-file/import-document-ai/dev/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - dev-opencti
 
   minio:
-    image: minio/minio:latest
+    image: pgsty/silo:latest
     volumes:
       - s3data4:/data
     ports:


### PR DESCRIPTION
### Proposed changes

The `minio/minio` image can no longer be pulled: the upstream MinIO repository was archived on 24 April 2026 (the community edition is now source-only), and Docker Hub has since removed the `minio/minio` and `minio/mc` repositories altogether - every tag answers 404 and `docker pull` fails with `pull access denied for minio/minio`. Every fresh deployment or CI run of a stack that still references these images is broken today.

Following OpenCTI-Platform/opencti#18239, the stack moves to [Silo](https://github.com/pgsty/silo), the community-maintained fork of the MinIO server published by Pigsty (`pgsty/silo` on Docker Hub, amd64 and arm64). Silo keeps the S3 API, the `MINIO_*` variables, the `server /data --console-address` command, the `/minio/health/live` route, the bundled `mc` client (so `mc ready local` healthchecks keep working) and the on-disk format unchanged, so an existing data volume is reused as is.

The `latest` tag is used on purpose: the MinIO-style dated release tags are not tracked anymore, and the whole Filigran ecosystem is aligned on `pgsty/silo:latest` (and `pgsty/mc:latest` for the client).

* `internal-import-file/import-document-ai/dev/docker-compose.yml`: the `minio` service runs `pgsty/silo:latest` instead of `minio/minio:latest`. Service name, ports, `MINIO_ROOT_*` variables (still read from the `.env` documented in `dev/README.md`), `server /data` command, `s3data4` volume and network are untouched, so the OpenCTI platform of the dev stack keeps its `MINIO__*` settings as they are. An existing volume is reused as is (same on-disk format).

### Related issues

* Closes #7684
* Same change across the ecosystem: OpenCTI-Platform/opencti#18239, OpenCTI-Platform/docker#607, OpenAEV-Platform/docker#163, FiligranHQ/xtm-docker#44

### How to test

```bash
cd internal-import-file/import-document-ai/dev
cp .env.sample .env   # or create the .env described in README.md
docker compose up -d minio
curl -f http://localhost:9000/minio/health/live
```

Verified locally with Docker 29.6 on `pgsty/silo:RELEASE.2026-09-03T13-18-01Z` (the current `latest`) with the exact compose settings of the stack: the container reaches `healthy` through `mc ready local`, `/minio/health/live` and the console on 9001 answer 200, and a bucket create / upload / read round trip works with `pgsty/mc`. The image ships `/usr/bin/mc`, `/usr/bin/mcli` and `/usr/bin/curl`, so both healthcheck styles used across the Filigran stacks are supported.

### Checklist

- [x] I consider the submitted work as finished
- [x] I have signed my commits using GPG key.
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The `latest` tag is used on purpose: the dated MinIO-style release tags are not tracked anymore and the whole Filigran ecosystem is aligned on `pgsty/silo:latest`.