### PR TITLE
chore(import-document-ai): bind the object storage console to the published port 9001 in the dev stack (#7686)

### DIFF
--- a/internal-import-file/import-document-ai/dev/docker-compose.yml
+++ b/internal-import-file/import-document-ai/dev/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}    
-    command: server /data
+    command: server /data --console-address ":9001"
     networks:
       - dev-opencti
 


### PR DESCRIPTION
## Summary

Follow-up to #7685: the import-document-ai dev stack publishes `9001:9001` for the object storage web console but started the server with `command: server /data`. Without `--console-address` the server binds its WebUI to a random port on every start (checked with `pgsty/silo:latest`: `WebUI: http://172.17.0.2:44095`), so the published port never reached it. The command now passes `--console-address ":9001"`.

Closes #7686

## Checks

- Dev-only compose file; the S3 API port (9000), credentials, volume and network are unchanged.